### PR TITLE
feat: add portable /audit-knowledge command

### DIFF
--- a/.claude/commands/audit-knowledge.md
+++ b/.claude/commands/audit-knowledge.md
@@ -1,0 +1,326 @@
+---
+name: audit-knowledge
+description: Audit memory + wiki + auto-loaded files for duplication and load cost; wiki wins as source of truth
+argument-hint: "[--apply]"
+allowed-tools: [Agent]
+---
+
+## Execution model — READ FIRST
+
+**Do not execute the playbook yourself in the current conversation.** Dispatch exactly one subagent via the `Agent` tool. The model depends on the mode. Each subagent runs in isolated context.
+
+### Branch on `$ARGUMENTS`
+
+**If `$ARGUMENTS` does NOT contain `--apply` → research mode**
+
+Spawn one `Agent`:
+- `subagent_type`: `"general-purpose"`
+- `model`: `"opus"`
+- `description`: `"Knowledge audit (research)"`
+- `prompt`: the string below (literal, no paraphrasing):
+
+  > `ultrathink.`
+  >
+  > `You are Stage 1 of a two-stage knowledge audit. Your job is to PRODUCE A REPORT ONLY — do not mutate any files outside .claude/audit/. A separate Sonnet agent will execute the actions later.`
+  >
+  > `Project root: /Users/stevensacks/Development/me/one-less-excuse`
+  >
+  > `Read .claude/commands/audit-knowledge.md and execute the "Research procedure" section (Steps 1–6). Write the report to .claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Every action you propose must be mechanical — include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that".`
+
+**If `$ARGUMENTS` contains `--apply` → apply mode**
+
+Spawn one `Agent`:
+- `subagent_type`: `"general-purpose"`
+- `model`: `"sonnet"`
+- `description`: `"Knowledge audit (apply)"`
+- `prompt`: the string below (literal):
+
+  > `You are Stage 2 of a two-stage knowledge audit. Stage 1 (Opus) produced a report. Your job is to execute the unchecked actions MECHANICALLY — do not reason about whether an action is correct, do not expand scope, do not merge or split actions.`
+  >
+  > `Project root: /Users/stevensacks/Development/me/one-less-excuse`
+  >
+  > `Read .claude/commands/audit-knowledge.md and execute the "Apply procedure" section (Step 7). For every action: verify the expected-current-content drift signal matches; if it does, apply the change verbatim; if it does not, SKIP and note it in the final summary. Never improvise. Never invent replacements. If anything is ambiguous, skip.`
+
+### After the subagent returns
+
+Relay its final summary verbatim (report path + action counts, or done/skipped/failed counts). Do not re-do the work. Do not inline the report body.
+
+---
+
+## Research procedure
+
+Audit the knowledge stores for duplication, stale entries, and auto-load bloat. **Wiki is the source of truth.** Memory is machine-local only. Auto-loaded files carry a token cost every session — keep them as pointers, push detail behind lazy wikilinks.
+
+The report you produce is a **contract** to a Sonnet-level executor. Assume it can read, edit, and run bash, but will not reason about intent. Every action needs a literal before/after.
+
+## Stores & load behavior
+
+| Store | Path | Auto-loaded? |
+|-------|------|--------------|
+| Machine-local project memory | `~/.claude/projects/-Users-stevensacks-Development-me-one-less-excuse/memory/` | `MEMORY.md` (first 200 lines), individual entries on demand |
+| Machine-local agent memory | `~/.claude/agent-memory/` | Per-agent, on demand |
+| Project agent memory | `.claude/agent-memory/` | Per-agent, on demand |
+| Project CLAUDE.md | root, `apps/web/`, `apps/ios/`, `wiki/` | Auto when cwd matches |
+| Project rules | `.claude/rules/*.md` | Auto by `paths:` frontmatter match |
+| Project commands | `.claude/commands/*.md` | On invocation only |
+| Wiki hot cache | `wiki/hot.md` | Auto at session start |
+| Wiki index | `wiki/index.md` | On demand |
+| Wiki domain pages | `wiki/app/`, `wiki/brand/`, etc. | On demand |
+
+## Step 0 — Prune old reports
+
+Before writing the new report, self-maintain `.claude/audit/`:
+
+- **Keep the newest 5 reports regardless of age** (floor — protects long gaps between runs).
+- Of anything beyond the newest 5, **delete reports older than 30 days**.
+
+```bash
+if [ -d .claude/audit ]; then
+  ls -t .claude/audit/KNOWLEDGE-*.md 2>/dev/null | tail -n +6 | while IFS= read -r f; do
+    if [ -n "$(find "$f" -mtime +30 -print 2>/dev/null)" ]; then
+      rm -- "$f"
+    fi
+  done
+fi
+```
+
+Report the count pruned in the summary line at the end of the run (e.g. `pruned 2 stale reports`).
+
+## Step 1 — Inventory
+
+Run in parallel:
+
+```bash
+# Machine-local memory
+find /Users/stevensacks/.claude/projects/-Users-stevensacks-Development-me-one-less-excuse/memory -type f -name "*.md"
+find /Users/stevensacks/.claude/agent-memory -type f -name "*.md" 2>/dev/null
+
+# Project-local
+find .claude/agent-memory -type f -name "*.md" 2>/dev/null
+find .claude/rules -type f -name "*.md"
+
+# Wiki
+find wiki -type f -name "*.md"
+
+# Word counts for auto-loaded files
+wc -w CLAUDE.md apps/web/CLAUDE.md apps/ios/CLAUDE.md wiki/CLAUDE.md wiki/hot.md .claude/rules/*.md
+```
+
+Record per file: path, word count, last-modified. Compute totals per store.
+
+## Step 2 — Cross-store duplication
+
+For every memory entry and every rules file, check whether the same fact lives in the wiki. Use `Grep` with 2–3 representative phrases from each entry. Classify each hit:
+
+- **DUPLICATE** — fact already canonical in wiki → mark memory/rules entry for deletion
+- **PROMOTE** — durable knowledge only in memory → propose moving to a specific wiki page (name the page)
+- **KEEP-LOCAL** — genuinely machine-local (personal pref, machine path, unique dev env) → keep in memory
+- **STALE** — references a file/branch/feature no longer present → mark for deletion
+
+Rules-vs-wiki: a `.claude/rules/*.md` file is allowed to duplicate wiki content **only** if it exists to enforce auto-loading for a specific `paths:` glob. Otherwise it should link to the wiki page.
+
+## Step 3 — Intra-wiki duplication
+
+Scan `wiki/` for pages covering the same topic. For each cluster:
+
+- Pick the most-complete page as canonical
+- Propose merging the others into it (or converting them to redirects: a one-line page with `→ see [[Canonical]]`)
+- Flag pages in `sources/` that duplicate content already synthesized in a domain page — `sources/` is archival, domain pages are active
+
+## Step 4 — Auto-load budget
+
+Targets (flag anything over):
+
+| File | Budget | Rationale |
+|------|--------|-----------|
+| `wiki/hot.md` | ≤200 words | Cache discipline per `wiki/hot.md` comment |
+| `CLAUDE.md` (root) | ≤400 words | Routing + principles only |
+| `apps/web/CLAUDE.md` | ≤400 words | Web-scoped routing |
+| `apps/ios/CLAUDE.md` | ≤400 words | iOS-scoped routing |
+| `wiki/CLAUDE.md` | ≤300 words | Wiki conventions only |
+| Any single `.claude/rules/*.md` | ≤200 lines | Focused rule |
+
+For each over-budget file, propose one of: inline facts → wiki, consolidate duplicated sections, or split into narrower files.
+
+## Step 5 — Link-efficiency audit
+
+In every auto-loaded file (CLAUDE.md hierarchy, `wiki/hot.md`, rules):
+
+- **Describes instead of points** — flag passages that restate content already in a wiki page (e.g. "palette is #0A0A0A / #…" instead of "see [[Visual Identity]]"). Propose replacing with wikilink.
+- **Broken wikilinks** — `Grep` every `[[Name]]` against `wiki/index.md`. Flag misses.
+- **Dead paths** — verify every file path referenced in auto-loaded files still exists.
+- **Inlined source excerpts** — flag wiki pages that inline raw text from `wiki/sources/` instead of linking.
+
+## Step 6 — Report
+
+Write `.claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md`. Create `.claude/audit/` if missing. Also snapshot `git status --short` into the report's frontmatter so Stage 2 can detect drift.
+
+### Report template (strict schema — Stage 2 parses this)
+
+```markdown
+---
+generated: {YYYY-MM-DD HH:MM}
+generator: audit-knowledge stage-1 opus-ultrathink
+project_root: /Users/stevensacks/Development/me/one-less-excuse
+git_head: {commit hash}
+git_status_snapshot: |
+  {verbatim output of `git status --short` at research time}
+---
+
+# Knowledge Audit — {YYYY-MM-DD HH:MM}
+
+## Summary
+- Stores scanned: {N files, M words total}
+- Cross-store duplicates: {X}
+- Intra-wiki duplicates: {Y}
+- Auto-load total: {Z words} (budget: {total budget})
+- Over-budget files: {list}
+- Stale entries: {count}
+- Broken links: {count}
+
+## Actions
+
+Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips the checkbox from `[ ]` to `[x]` on success, `[~]` on skip, `[!]` on failure. Every block MUST include `expect` (verbatim snippet of current target content) and where applicable `after` (verbatim replacement).
+
+### Delete
+
+- [ ] `delete-{nnn}`
+  ```yaml
+  type: delete
+  path: {absolute path}
+  reason: {one line — cite canonical wiki page + line range where the same fact lives}
+  expect_sha256: {sha256 of the file's current content}
+  ```
+
+### Delete-entry (remove a specific block from a multi-entry file, e.g. a heading section in MEMORY.md)
+
+- [ ] `delete-entry-{nnn}`
+  ```yaml
+  type: delete-entry
+  path: {absolute path}
+  expect: |
+    {verbatim block to remove, including heading — must match exactly}
+  reason: {…}
+  ```
+
+### Promote (memory → wiki)
+
+- [ ] `promote-{nnn}`
+  ```yaml
+  type: promote
+  source_path: {absolute path}
+  source_expect_sha256: {sha256 of source content}
+  target_page: {wiki path, e.g. wiki/app/dev-practices/Foo.md}
+  target_action: {append_section | insert_after_heading | create_new}
+  target_heading: {e.g. "## Bar" — only if insert_after_heading}
+  target_expect: |
+    {verbatim snippet at insertion point — omit for create_new}
+  body: |
+    {verbatim content to insert, frontmatter-ready if target_action=create_new}
+  index_entry: {one-line addition to wiki/index.md, or null}
+  log_entry: {one-line to prepend to wiki/log.md}
+  delete_source_after: true
+  ```
+
+### Shrink / Convert (replace inline content with a wikilink)
+
+- [ ] `shrink-{nnn}`
+  ```yaml
+  type: replace
+  path: {absolute path}
+  before: |
+    {verbatim current block — must match byte-for-byte}
+  after: |
+    {verbatim replacement, typically a wikilink line}
+  reason: {…}
+  ```
+
+### Merge (intra-wiki consolidation)
+
+- [ ] `merge-{nnn}`
+  ```yaml
+  type: merge
+  canonical: {wiki path}
+  canonical_expect_sha256: {sha256}
+  sources:
+    - path: {wiki path}
+      expect_sha256: {sha256}
+      append_as: |
+        {verbatim content to add to canonical}
+      redirect_body: |
+        ---
+        type: redirect
+        ---
+        → see [[Canonical Name]]
+  index_updates:
+    - {line to change in wiki/index.md}
+  log_entry: {one-line to prepend to wiki/log.md}
+  ```
+
+### Fix-link
+
+- [ ] `fixlink-{nnn}`
+  ```yaml
+  type: replace
+  path: {absolute path}
+  before: |
+    {verbatim line containing the broken link}
+  after: |
+    {verbatim corrected line, or empty string to delete the line}
+  reason: {broken target, correct target}
+  ```
+
+## Ordering
+
+Stage 2 must apply actions in this order: `fix-link` → `shrink` → `delete-entry` → `merge` → `promote` → `delete`. Rationale: shrinks never reference content that later gets merged; deletes come last so earlier pointers don't go stale.
+
+## To apply
+Run `/audit-knowledge --apply` within 24h.
+```
+
+End the research run by printing: report path, total actions per category, and the apply command.
+
+## Step 7 — Apply procedure (Stage 2, Sonnet)
+
+You are executing, not reasoning. Follow this loop exactly.
+
+### Pre-flight
+
+1. Find the newest `.claude/audit/KNOWLEDGE-*.md`. If none, or mtime >24h, stop and print `no fresh report — run /audit-knowledge first`.
+2. Parse the report's frontmatter. Run `git rev-parse HEAD` — if it differs from `git_head` in the report, print a warning but continue. Run `git status --short` — any file that is currently dirty AND appears as a target in the report is marked `SKIP (dirty)` before any action runs.
+3. Read the `## Ordering` section. Process actions in that order.
+
+### Per-action loop
+
+For each unchecked action block:
+
+1. Verify drift signal:
+   - If the action specifies `expect_sha256`: compute sha256 of the target file. If mismatch → mark `[~]` skipped, record reason `sha drift`, move on.
+   - If the action specifies `before:` or `expect:` snippet: read the file and confirm the snippet appears verbatim. If missing → `[~]` skipped, `snippet drift`.
+2. Apply the change using the exact operation:
+   - `type: delete` → remove the file
+   - `type: delete-entry` → read file, locate the `expect` block, remove it, write back
+   - `type: promote` → perform the `target_action` (use Edit or Write as appropriate), then prepend `log_entry` to `wiki/log.md`, then append `index_entry` to the right section of `wiki/index.md`, then delete `source_path` if `delete_source_after: true`
+   - `type: replace` → Edit with `old_string: before`, `new_string: after`. If `before` is not unique, prepend additional context from the file until unique.
+   - `type: merge` → for each source: append `append_as` into canonical at its tail (or an explicit position if the action specifies one), then overwrite the source with `redirect_body`. Then prepend `log_entry` to `wiki/log.md`. Apply `index_updates` to `wiki/index.md`.
+3. Flip the checkbox: `[ ]` → `[x]` on success, `[~]` on skip, `[!]` on error. Record the reason inline on the checkbox line.
+
+### Post-flight
+
+Print a final summary to stdout:
+
+```
+audit apply: {done}/{total} applied · {skipped} skipped · {failed} failed
+diff footprint:
+{git status --short}
+next: review diff, commit if satisfied
+```
+
+## Guardrails
+
+- Never delete a memory entry unless the action's `reason` cites a canonical wiki location. (Stage 1 must supply this; Stage 2 doesn't judge.)
+- Never edit `wiki/log.md` anywhere except prepending a new line at the top.
+- Never `git add` or `git commit` — leave changes in working tree for the human to review.
+- Never improvise: if drift-check fails, skip and report. Do not search for the "right" target.
+- Never merge two actions: each block is atomic.
+- If an action targets a path that doesn't exist, mark `[!]` with `target missing` and continue.

--- a/.claude/commands/audit-knowledge.md
+++ b/.claude/commands/audit-knowledge.md
@@ -1,7 +1,7 @@
 ---
 name: audit-knowledge
 description: Audit memory + wiki + auto-loaded files for duplication and load cost; wiki wins as source of truth
-argument-hint: "[--apply]"
+argument-hint: '[--apply]'
 allowed-tools: [Agent]
 ---
 
@@ -9,11 +9,24 @@ allowed-tools: [Agent]
 
 **Do not execute the playbook yourself in the current conversation.** Dispatch exactly one subagent via the `Agent` tool. The model depends on the mode. Each subagent runs in isolated context.
 
+### Path resolution (portable — no hardcoding)
+
+This command ships in a template and runs in many clones across many machines. Neither this file nor the subagent prompts may hardcode a project root or a user-scoped memory path. The subagent resolves both at the start of its run:
+
+```bash
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+MEMORY_DIR="$HOME/.claude/projects/$(echo "$PROJECT_ROOT" | sed 's|/|-|g')/memory"
+AGENT_MEMORY_DIR="$HOME/.claude/agent-memory"
+```
+
+Every path below referenced as `$PROJECT_ROOT/...`, `$MEMORY_DIR/...`, or `$AGENT_MEMORY_DIR/...` is resolved by the subagent, not by this file.
+
 ### Branch on `$ARGUMENTS`
 
 **If `$ARGUMENTS` does NOT contain `--apply` → research mode**
 
 Spawn one `Agent`:
+
 - `subagent_type`: `"general-purpose"`
 - `model`: `"opus"`
 - `description`: `"Knowledge audit (research)"`
@@ -23,13 +36,22 @@ Spawn one `Agent`:
   >
   > `You are Stage 1 of a two-stage knowledge audit. Your job is to PRODUCE A REPORT ONLY — do not mutate any files outside .claude/audit/. A separate Sonnet agent will execute the actions later.`
   >
-  > `Project root: /Users/stevensacks/Development/me/one-less-excuse`
+  > `Before doing anything else, resolve these variables and use them for every path in the playbook:`
   >
-  > `Read .claude/commands/audit-knowledge.md and execute the "Research procedure" section (Steps 1–6). Write the report to .claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Every action you propose must be mechanical — include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that".`
+  > ```bash
+  > PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+  > MEMORY_DIR="$HOME/.claude/projects/$(echo "$PROJECT_ROOT" | sed 's|/|-|g')/memory"
+  > AGENT_MEMORY_DIR="$HOME/.claude/agent-memory"
+  > ```
+  >
+  > `Record the resolved values at the top of the report (both frontmatter and a visible line) so Stage 2 uses the same bindings.`
+  >
+  > `Read $PROJECT_ROOT/.claude/commands/audit-knowledge.md and execute the "Research procedure" section (Steps 1–6). Write the report to $PROJECT_ROOT/.claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Every action you propose must be mechanical — include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that".`
 
 **If `$ARGUMENTS` contains `--apply` → apply mode**
 
 Spawn one `Agent`:
+
 - `subagent_type`: `"general-purpose"`
 - `model`: `"sonnet"`
 - `description`: `"Knowledge audit (apply)"`
@@ -37,9 +59,17 @@ Spawn one `Agent`:
 
   > `You are Stage 2 of a two-stage knowledge audit. Stage 1 (Opus) produced a report. Your job is to execute the unchecked actions MECHANICALLY — do not reason about whether an action is correct, do not expand scope, do not merge or split actions.`
   >
-  > `Project root: /Users/stevensacks/Development/me/one-less-excuse`
+  > `Before doing anything else, resolve these variables and use them for every path in the playbook:`
   >
-  > `Read .claude/commands/audit-knowledge.md and execute the "Apply procedure" section (Step 7). For every action: verify the expected-current-content drift signal matches; if it does, apply the change verbatim; if it does not, SKIP and note it in the final summary. Never improvise. Never invent replacements. If anything is ambiguous, skip.`
+  > ```bash
+  > PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+  > MEMORY_DIR="$HOME/.claude/projects/$(echo "$PROJECT_ROOT" | sed 's|/|-|g')/memory"
+  > AGENT_MEMORY_DIR="$HOME/.claude/agent-memory"
+  > ```
+  >
+  > `Compare these to the "project_root" / "memory_dir" fields recorded in the report's frontmatter. If they differ, STOP and print a clear error — do not improvise.`
+  >
+  > `Read $PROJECT_ROOT/.claude/commands/audit-knowledge.md and execute the "Apply procedure" section (Step 7). For every action: verify the expected-current-content drift signal matches; if it does, apply the change verbatim; if it does not, SKIP and note it in the final summary. Never improvise. Never invent replacements. If anything is ambiguous, skip.`
 
 ### After the subagent returns
 
@@ -55,28 +85,30 @@ The report you produce is a **contract** to a Sonnet-level executor. Assume it c
 
 ## Stores & load behavior
 
-| Store | Path | Auto-loaded? |
-|-------|------|--------------|
-| Machine-local project memory | `~/.claude/projects/-Users-stevensacks-Development-me-one-less-excuse/memory/` | `MEMORY.md` (first 200 lines), individual entries on demand |
-| Machine-local agent memory | `~/.claude/agent-memory/` | Per-agent, on demand |
-| Project agent memory | `.claude/agent-memory/` | Per-agent, on demand |
-| Project CLAUDE.md | root, `apps/web/`, `apps/ios/`, `wiki/` | Auto when cwd matches |
-| Project rules | `.claude/rules/*.md` | Auto by `paths:` frontmatter match |
-| Project commands | `.claude/commands/*.md` | On invocation only |
-| Wiki hot cache | `wiki/hot.md` | Auto at session start |
-| Wiki index | `wiki/index.md` | On demand |
-| Wiki domain pages | `wiki/app/`, `wiki/brand/`, etc. | On demand |
+| Store                                          | Path                                            | Auto-loaded?                                                |
+| ---------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| Machine-local project memory                   | `$MEMORY_DIR/`                                  | `MEMORY.md` (first 200 lines), individual entries on demand |
+| Machine-local agent memory                     | `$AGENT_MEMORY_DIR/`                            | Per-agent, on demand                                        |
+| Project agent memory                           | `$PROJECT_ROOT/.claude/agent-memory/`           | Per-agent, on demand                                        |
+| Project CLAUDE.md (root)                       | `$PROJECT_ROOT/CLAUDE.md`                       | Auto at session start                                       |
+| Project CLAUDE.md (wiki)                       | `$PROJECT_ROOT/wiki/CLAUDE.md`                  | Auto when cwd matches `wiki/`                               |
+| Project rules                                  | `$PROJECT_ROOT/.claude/rules/*.md`              | Auto by `paths:` frontmatter match                          |
+| Project commands                               | `$PROJECT_ROOT/.claude/commands/*.md`           | On invocation only                                          |
+| Wiki hot cache                                 | `$PROJECT_ROOT/wiki/hot.md`                     | Auto at session start                                       |
+| Wiki index                                     | `$PROJECT_ROOT/wiki/index.md`                   | On demand                                                   |
+| Wiki domain pages                              | `$PROJECT_ROOT/wiki/<domain>/`                  | On demand                                                   |
+| Nested `CLAUDE.md` files (any monorepo layout) | any `$PROJECT_ROOT/**/CLAUDE.md` below the root | Auto when cwd matches                                       |
 
 ## Step 0 — Prune old reports
 
-Before writing the new report, self-maintain `.claude/audit/`:
+Before writing the new report, self-maintain `$PROJECT_ROOT/.claude/audit/`:
 
 - **Keep the newest 5 reports regardless of age** (floor — protects long gaps between runs).
 - Of anything beyond the newest 5, **delete reports older than 30 days**.
 
 ```bash
-if [ -d .claude/audit ]; then
-  ls -t .claude/audit/KNOWLEDGE-*.md 2>/dev/null | tail -n +6 | while IFS= read -r f; do
+if [ -d "$PROJECT_ROOT/.claude/audit" ]; then
+  ls -t "$PROJECT_ROOT"/.claude/audit/KNOWLEDGE-*.md 2>/dev/null | tail -n +6 | while IFS= read -r f; do
     if [ -n "$(find "$f" -mtime +30 -print 2>/dev/null)" ]; then
       rm -- "$f"
     fi
@@ -91,19 +123,22 @@ Report the count pruned in the summary line at the end of the run (e.g. `pruned 
 Run in parallel:
 
 ```bash
-# Machine-local memory
-find /Users/stevensacks/.claude/projects/-Users-stevensacks-Development-me-one-less-excuse/memory -type f -name "*.md"
-find /Users/stevensacks/.claude/agent-memory -type f -name "*.md" 2>/dev/null
+# Machine-local memory (resolved dynamically)
+find "$MEMORY_DIR" -type f -name "*.md" 2>/dev/null
+find "$AGENT_MEMORY_DIR" -type f -name "*.md" 2>/dev/null
 
 # Project-local
-find .claude/agent-memory -type f -name "*.md" 2>/dev/null
-find .claude/rules -type f -name "*.md"
+find "$PROJECT_ROOT/.claude/agent-memory" -type f -name "*.md" 2>/dev/null
+find "$PROJECT_ROOT/.claude/rules" -type f -name "*.md"
 
 # Wiki
-find wiki -type f -name "*.md"
+find "$PROJECT_ROOT/wiki" -type f -name "*.md"
+
+# Auto-loaded CLAUDE.md set (covers root, wiki, and any downstream app subdirs)
+find "$PROJECT_ROOT" -maxdepth 3 -name CLAUDE.md -not -path '*/node_modules/*'
 
 # Word counts for auto-loaded files
-wc -w CLAUDE.md apps/web/CLAUDE.md apps/ios/CLAUDE.md wiki/CLAUDE.md wiki/hot.md .claude/rules/*.md
+wc -w "$PROJECT_ROOT"/CLAUDE.md "$PROJECT_ROOT"/wiki/CLAUDE.md "$PROJECT_ROOT"/wiki/hot.md "$PROJECT_ROOT"/.claude/rules/*.md 2>/dev/null
 ```
 
 Record per file: path, word count, last-modified. Compute totals per store.
@@ -121,24 +156,23 @@ Rules-vs-wiki: a `.claude/rules/*.md` file is allowed to duplicate wiki content 
 
 ## Step 3 — Intra-wiki duplication
 
-Scan `wiki/` for pages covering the same topic. For each cluster:
+Scan `$PROJECT_ROOT/wiki/` for pages covering the same topic. For each cluster:
 
 - Pick the most-complete page as canonical
 - Propose merging the others into it (or converting them to redirects: a one-line page with `→ see [[Canonical]]`)
-- Flag pages in `sources/` that duplicate content already synthesized in a domain page — `sources/` is archival, domain pages are active
+- Flag pages in `wiki/sources/` that duplicate content already synthesized in a domain page — `sources/` is archival, domain pages are active
 
 ## Step 4 — Auto-load budget
 
 Targets (flag anything over):
 
-| File | Budget | Rationale |
-|------|--------|-----------|
-| `wiki/hot.md` | ≤200 words | Cache discipline per `wiki/hot.md` comment |
-| `CLAUDE.md` (root) | ≤400 words | Routing + principles only |
-| `apps/web/CLAUDE.md` | ≤400 words | Web-scoped routing |
-| `apps/ios/CLAUDE.md` | ≤400 words | iOS-scoped routing |
-| `wiki/CLAUDE.md` | ≤300 words | Wiki conventions only |
-| Any single `.claude/rules/*.md` | ≤200 lines | Focused rule |
+| File                                                                               | Budget     | Rationale                                  |
+| ---------------------------------------------------------------------------------- | ---------- | ------------------------------------------ |
+| `wiki/hot.md`                                                                      | ≤200 words | Cache discipline per `wiki/hot.md` comment |
+| `CLAUDE.md` (root)                                                                 | ≤400 words | Routing + principles only                  |
+| `wiki/CLAUDE.md`                                                                   | ≤300 words | Wiki conventions only                      |
+| Any nested `CLAUDE.md` discovered in Step 1 (monorepo package, subapp, docs, etc.) | ≤400 words | Scoped routing                             |
+| Any single `.claude/rules/*.md`                                                    | ≤200 lines | Focused rule                               |
 
 For each over-budget file, propose one of: inline facts → wiki, consolidate duplicated sections, or split into narrower files.
 
@@ -146,22 +180,24 @@ For each over-budget file, propose one of: inline facts → wiki, consolidate du
 
 In every auto-loaded file (CLAUDE.md hierarchy, `wiki/hot.md`, rules):
 
-- **Describes instead of points** — flag passages that restate content already in a wiki page (e.g. "palette is #0A0A0A / #…" instead of "see [[Visual Identity]]"). Propose replacing with wikilink.
+- **Describes instead of points** — flag passages that restate content already in a wiki page (e.g. inlining a facts table instead of linking to the canonical wiki page). Propose replacing with wikilink.
 - **Broken wikilinks** — `Grep` every `[[Name]]` against `wiki/index.md`. Flag misses.
 - **Dead paths** — verify every file path referenced in auto-loaded files still exists.
 - **Inlined source excerpts** — flag wiki pages that inline raw text from `wiki/sources/` instead of linking.
 
 ## Step 6 — Report
 
-Write `.claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md`. Create `.claude/audit/` if missing. Also snapshot `git status --short` into the report's frontmatter so Stage 2 can detect drift.
+Write `$PROJECT_ROOT/.claude/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md`. Create `$PROJECT_ROOT/.claude/audit/` if missing. Also snapshot `git status --short` into the report's frontmatter so Stage 2 can detect drift.
 
 ### Report template (strict schema — Stage 2 parses this)
 
-```markdown
+````markdown
 ---
 generated: {YYYY-MM-DD HH:MM}
 generator: audit-knowledge stage-1 opus-ultrathink
-project_root: /Users/stevensacks/Development/me/one-less-excuse
+project_root: {resolved PROJECT_ROOT}
+memory_dir: {resolved MEMORY_DIR}
+agent_memory_dir: {resolved AGENT_MEMORY_DIR}
 git_head: {commit hash}
 git_status_snapshot: |
   {verbatim output of `git status --short` at research time}
@@ -169,7 +205,14 @@ git_status_snapshot: |
 
 # Knowledge Audit — {YYYY-MM-DD HH:MM}
 
+Resolved paths (Stage 2 must match these):
+
+- project_root: {resolved PROJECT_ROOT}
+- memory_dir: {resolved MEMORY_DIR}
+- agent_memory_dir: {resolved AGENT_MEMORY_DIR}
+
 ## Summary
+
 - Stores scanned: {N files, M words total}
 - Cross-store duplicates: {X}
 - Intra-wiki duplicates: {Y}
@@ -180,7 +223,7 @@ git_status_snapshot: |
 
 ## Actions
 
-Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips the checkbox from `[ ]` to `[x]` on success, `[~]` on skip, `[!]` on failure. Every block MUST include `expect` (verbatim snippet of current target content) and where applicable `after` (verbatim replacement).
+Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips the checkbox from `[ ]` to `[x]` on success, `[~]` on skip, `[!]` on failure. Every block MUST include `expect` (verbatim snippet of current target content) and where applicable `after` (verbatim replacement). Paths MUST be absolute (already expanded — no `$PROJECT_ROOT` placeholders in action bodies).
 
 ### Delete
 
@@ -188,9 +231,11 @@ Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips 
   ```yaml
   type: delete
   path: {absolute path}
-  reason: {one line — cite canonical wiki page + line range where the same fact lives}
+  reason:
+    {one line — cite canonical wiki page + line range where the same fact lives}
   expect_sha256: {sha256 of the file's current content}
   ```
+````
 
 ### Delete-entry (remove a specific block from a multi-entry file, e.g. a heading section in MEMORY.md)
 
@@ -210,7 +255,7 @@ Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips 
   type: promote
   source_path: {absolute path}
   source_expect_sha256: {sha256 of source content}
-  target_page: {wiki path, e.g. wiki/app/dev-practices/Foo.md}
+  target_page: {absolute wiki path}
   target_action: {append_section | insert_after_heading | create_new}
   target_heading: {e.g. "## Bar" — only if insert_after_heading}
   target_expect: |
@@ -240,10 +285,10 @@ Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips 
 - [ ] `merge-{nnn}`
   ```yaml
   type: merge
-  canonical: {wiki path}
+  canonical: {absolute wiki path}
   canonical_expect_sha256: {sha256}
   sources:
-    - path: {wiki path}
+    - path: {absolute wiki path}
       expect_sha256: {sha256}
       append_as: |
         {verbatim content to add to canonical}
@@ -275,7 +320,9 @@ Each action is a fenced YAML block prefixed with a checkbox line. Stage 2 flips 
 Stage 2 must apply actions in this order: `fix-link` → `shrink` → `delete-entry` → `merge` → `promote` → `delete`. Rationale: shrinks never reference content that later gets merged; deletes come last so earlier pointers don't go stale.
 
 ## To apply
+
 Run `/audit-knowledge --apply` within 24h.
+
 ```
 
 End the research run by printing: report path, total actions per category, and the apply command.
@@ -286,9 +333,10 @@ You are executing, not reasoning. Follow this loop exactly.
 
 ### Pre-flight
 
-1. Find the newest `.claude/audit/KNOWLEDGE-*.md`. If none, or mtime >24h, stop and print `no fresh report — run /audit-knowledge first`.
-2. Parse the report's frontmatter. Run `git rev-parse HEAD` — if it differs from `git_head` in the report, print a warning but continue. Run `git status --short` — any file that is currently dirty AND appears as a target in the report is marked `SKIP (dirty)` before any action runs.
-3. Read the `## Ordering` section. Process actions in that order.
+1. Find the newest `$PROJECT_ROOT/.claude/audit/KNOWLEDGE-*.md`. If none, or mtime >24h, stop and print `no fresh report — run /audit-knowledge first`.
+2. Parse the report's frontmatter. Verify `project_root`, `memory_dir`, and `agent_memory_dir` match the values you resolved at startup. If any differ, stop and print a clear error — the report was generated on a different machine or in a different clone.
+3. Run `git rev-parse HEAD` — if it differs from `git_head` in the report, print a warning but continue. Run `git status --short` — any file that is currently dirty AND appears as a target in the report is marked `SKIP (dirty)` before any action runs.
+4. Read the `## Ordering` section. Process actions in that order.
 
 ### Per-action loop
 
@@ -310,10 +358,12 @@ For each unchecked action block:
 Print a final summary to stdout:
 
 ```
+
 audit apply: {done}/{total} applied · {skipped} skipped · {failed} failed
 diff footprint:
 {git status --short}
 next: review diff, commit if satisfied
+
 ```
 
 ## Guardrails
@@ -324,3 +374,4 @@ next: review diff, commit if satisfied
 - Never improvise: if drift-check fails, skip and report. Do not search for the "right" target.
 - Never merge two actions: each block is atomic.
 - If an action targets a path that doesn't exist, mark `[!]` with `target missing` and continue.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ coverage
 .claude/audit/
 .claude/worktrees/
 .claude/handoff/
+.claude/scheduled_tasks.lock

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ coverage
 
 # Claude files
 .claude/agent-memory/
+.claude/audit/
 .claude/worktrees/
 .claude/handoff/

--- a/README.md
+++ b/README.md
@@ -94,17 +94,18 @@ GAIA comes with [Claude Code](https://claude.ai/) support built-in: commands, ru
 
 ### Commands
 
-| Command          | What it does                                                            |
-| ---------------- | ----------------------------------------------------------------------- |
-| `/gaia-init`     | Remove example code, configure languages, set up a clean slate          |
-| `/new-route`     | Scaffold a route with page component, test, story, and i18n keys        |
-| `/new-component` | Scaffold a component with optional test and story                       |
-| `/new-service`   | Scaffold an API service with requests, Zod schemas, URLs, and MSW mocks |
-| `/new-hook`      | Scaffold a custom hook with test file                                   |
-| `/audit-code`    | Run the full quality gate (typecheck, lint, test, E2E, build)           |
-| `/migrate`       | Upgrade a package to latest, apply breaking changes, run quality gate   |
-| `/handoff`       | Save a session handoff doc so the next session can resume cold          |
-| `/pickup`        | Resume from the latest handoff — reports state, drift, and next action  |
+| Command            | What it does                                                            |
+| ------------------ | ----------------------------------------------------------------------- |
+| `/gaia-init`       | Remove example code, configure languages, set up a clean slate          |
+| `/new-route`       | Scaffold a route with page component, test, story, and i18n keys        |
+| `/new-component`   | Scaffold a component with optional test and story                       |
+| `/new-service`     | Scaffold an API service with requests, Zod schemas, URLs, and MSW mocks |
+| `/new-hook`        | Scaffold a custom hook with test file                                   |
+| `/audit-code`      | Run the full quality gate (typecheck, lint, test, E2E, build)           |
+| `/audit-knowledge` | Audit memory, wiki, and auto-loaded files for duplication and bloat     |
+| `/migrate`         | Upgrade a package to latest, apply breaking changes, run quality gate   |
+| `/handoff`         | Save a session handoff doc so the next session can resume cold          |
+| `/pickup`          | Resume from the latest handoff — reports state, drift, and next action  |
 
 ### Rules
 

--- a/docs/general/claude.md
+++ b/docs/general/claude.md
@@ -12,17 +12,18 @@ GAIA comes with [Claude Code](https://claude.ai/) support built-in: commands, ru
 
 Scaffolding commands generate files that follow GAIA's established conventions.
 
-| Command          | What it does                                                              |
-| ---------------- | ------------------------------------------------------------------------- |
-| `/gaia-init`     | Remove example code, configure languages, set up a clean slate (run once) |
-| `/new-route`     | Scaffold a route with page component, test, story, and i18n keys          |
-| `/new-component` | Scaffold a component with optional test and story                         |
-| `/new-service`   | Scaffold an API service with requests, Zod schemas, URLs, and MSW mocks   |
-| `/new-hook`      | Scaffold a custom hook with test file                                     |
-| `/audit-code`    | Run the full quality gate (typecheck, lint, test, E2E, build)             |
-| `/migrate`       | Upgrade a package to latest, apply breaking changes, run quality gate     |
-| `/handoff`       | Save a session handoff doc so the next session can resume cold            |
-| `/pickup`        | Resume from the latest handoff — reports state, drift, and next action    |
+| Command            | What it does                                                              |
+| ------------------ | ------------------------------------------------------------------------- |
+| `/gaia-init`       | Remove example code, configure languages, set up a clean slate (run once) |
+| `/new-route`       | Scaffold a route with page component, test, story, and i18n keys          |
+| `/new-component`   | Scaffold a component with optional test and story                         |
+| `/new-service`     | Scaffold an API service with requests, Zod schemas, URLs, and MSW mocks   |
+| `/new-hook`        | Scaffold a custom hook with test file                                     |
+| `/audit-code`      | Run the full quality gate (typecheck, lint, test, E2E, build)             |
+| `/audit-knowledge` | Audit memory, wiki, and auto-loaded files for duplication and bloat       |
+| `/migrate`         | Upgrade a package to latest, apply breaking changes, run quality gate     |
+| `/handoff`         | Save a session handoff doc so the next session can resume cold            |
+| `/pickup`          | Resume from the latest handoff — reports state, drift, and next action    |
 
 ## Rules
 

--- a/wiki/concepts/audit-knowledge command.md
+++ b/wiki/concepts/audit-knowledge command.md
@@ -27,7 +27,7 @@ Stage 1 proposes actions — `delete`, `delete-entry`, `promote`, `shrink`, `mer
 
 ## What it catches
 
-- **Cross-store duplication** — fact lives in both memory and wiki → memory wins the deletion
+- **Cross-store duplication** — fact lives in both memory and wiki → wiki wins; the memory entry is deleted
 - **Promotable memory** — durable knowledge stuck in machine-local memory → moves to a specific wiki page
 - **Intra-wiki duplication** — merges overlapping pages into a canonical + redirects
 - **Auto-load bloat** — flags `wiki/hot.md`, `CLAUDE.md`, and rules over budget

--- a/wiki/concepts/audit-knowledge command.md
+++ b/wiki/concepts/audit-knowledge command.md
@@ -1,0 +1,52 @@
+---
+type: concept
+status: active
+created: 2026-04-20
+updated: 2026-04-20
+tags: [concept, claude, command, knowledge, hygiene]
+---
+
+# `/audit-knowledge` Command
+
+Source: `.claude/commands/audit-knowledge.md`. Two-stage audit over every knowledge store in the project — wiki, auto-loaded `CLAUDE.md` files, `.claude/rules/`, machine-local memory — checking for duplication, stale entries, and auto-load token bloat. **Wiki is the source of truth.**
+
+## When to use
+
+- After an ingestion spree that may have introduced overlap
+- When auto-load payload starts feeling heavy (CLAUDE.md, `wiki/hot.md`, or rules growing)
+- Periodic hygiene pass
+
+## Two-stage execution
+
+| Stage | Model  | Mode                         | Output                                                      |
+| ----- | ------ | ---------------------------- | ----------------------------------------------------------- |
+| 1     | Opus   | `/audit-knowledge`           | Research report at `.claude/audit/KNOWLEDGE-{timestamp}.md` |
+| 2     | Sonnet | `/audit-knowledge --apply`   | Applies unchecked actions mechanically                      |
+
+Stage 1 proposes actions — `delete`, `delete-entry`, `promote`, `shrink`, `merge`, `fix-link` — each with verbatim `expect` snippets and sha256 drift signals. Stage 2 reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising.
+
+## What it catches
+
+- **Cross-store duplication** — fact lives in both memory and wiki → memory wins the deletion
+- **Promotable memory** — durable knowledge stuck in machine-local memory → moves to a specific wiki page
+- **Intra-wiki duplication** — merges overlapping pages into a canonical + redirects
+- **Auto-load bloat** — flags `wiki/hot.md`, `CLAUDE.md`, and rules over budget
+- **Broken wikilinks** and **dead file paths**
+- **Stale entries** referencing removed code, branches, or features
+
+## Portability
+
+Project root and machine-local memory paths resolve at runtime — the subagent computes them from `$CLAUDE_PROJECT_DIR` (with `pwd` fallback) and derives the memory directory via path-to-dash substitution. Nothing is hardcoded, so the command works unchanged across every clone of the template and every developer's machine.
+
+## Guardrails
+
+- Stage 2 never deletes a memory entry unless Stage 1 cited the canonical wiki target
+- Only edit to `wiki/log.md` allowed is prepending a new line at the top
+- Never runs `git add` or `git commit` — human reviews the diff and commits
+- Reports are gitignored (`.claude/audit/`)
+- Oldest reports auto-pruned (keep newest 5, delete anything beyond that older than 30 days)
+
+## Pairs with
+
+- [[Claude Integration]] — registered alongside the other slash commands
+- [[Quality Gate]] — code-correctness counterpart; knowledge audit is the same idea for docs

--- a/wiki/concepts/audit-knowledge command.md
+++ b/wiki/concepts/audit-knowledge command.md
@@ -18,10 +18,10 @@ Source: `.claude/commands/audit-knowledge.md`. Two-stage audit over every knowle
 
 ## Two-stage execution
 
-| Stage | Model  | Mode                         | Output                                                      |
-| ----- | ------ | ---------------------------- | ----------------------------------------------------------- |
-| 1     | Opus   | `/audit-knowledge`           | Research report at `.claude/audit/KNOWLEDGE-{timestamp}.md` |
-| 2     | Sonnet | `/audit-knowledge --apply`   | Applies unchecked actions mechanically                      |
+| Stage | Model  | Mode                       | Output                                                      |
+| ----- | ------ | -------------------------- | ----------------------------------------------------------- |
+| 1     | Opus   | `/audit-knowledge`         | Research report at `.claude/audit/KNOWLEDGE-{timestamp}.md` |
+| 2     | Sonnet | `/audit-knowledge --apply` | Applies unchecked actions mechanically                      |
 
 Stage 1 proposes actions — `delete`, `delete-entry`, `promote`, `shrink`, `merge`, `fix-link` — each with verbatim `expect` snippets and sha256 drift signals. Stage 2 reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -104,6 +104,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Claude Skills]]
 - [[handoff command]]
 - [[pickup command]]
+- [[audit-knowledge command]]
 - [[Chromatic Opt-Out]]
 
 ## Sources

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -8,6 +8,13 @@ updated: 2026-04-20
 
 Append-only. New entries at the TOP.
 
+## [2026-04-20] update | /audit-knowledge command added
+
+- Adapted `.claude/commands/audit-knowledge.md` from another project; portable path resolution (no hardcoded user paths); `.claude/audit/` gitignored
+- Pages created: [[audit-knowledge command]]
+- Pages updated: [[Claude Integration]] (commands table), [[overview]] (Knowledge Hygiene section), [[index]]
+- Also referenced in `README.md` and `docs/general/claude.md` commands tables
+
 ## [2026-04-20] ingest | Form components deep dive + things service
 
 - Sources: `app/components/Form/*` (all 15 components + Field subparts + YearMonthDay utils), `app/services/gaia/things/*`

--- a/wiki/modules/Claude Integration.md
+++ b/wiki/modules/Claude Integration.md
@@ -28,18 +28,18 @@ GAIA ships with [Claude Code](https://claude.ai/) support out of the box. Everyt
 
 ## Commands (slash)
 
-| Command          | What it does                                                                                       |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| `/gaia-init`     | Remove example code, configure languages, clean slate (run once)                                   |
-| `/new-route`     | Scaffold a route + page + tests + i18n                                                             |
-| `/new-component` | Scaffold a component with optional test + story                                                    |
-| `/new-service`   | Scaffold an API service + Zod + URL constants + MSW mocks                                          |
-| `/new-hook`      | Scaffold a custom hook + test                                                                      |
-| `/audit-code`      | Run the full [[Quality Gate]]                                                                      |
+| Command            | What it does                                                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------------- |
+| `/gaia-init`       | Remove example code, configure languages, clean slate (run once)                                          |
+| `/new-route`       | Scaffold a route + page + tests + i18n                                                                    |
+| `/new-component`   | Scaffold a component with optional test + story                                                           |
+| `/new-service`     | Scaffold an API service + Zod + URL constants + MSW mocks                                                 |
+| `/new-hook`        | Scaffold a custom hook + test                                                                             |
+| `/audit-code`      | Run the full [[Quality Gate]]                                                                             |
 | `/audit-knowledge` | Audit memory + wiki + auto-loaded files for dupes, stale entries, and bloat ([[audit-knowledge command]]) |
-| `/migrate`         | Upgrade a package to latest, apply breaking changes, run audit                                     |
-| `/handoff`       | Generate a session handoff doc at `.claude/handoff/HANDOFF-{date}-{slug}.md` ([[handoff command]]) |
-| `/pickup`        | Resume from the latest handoff; falls back to `wiki/hot.md` ([[pickup command]])                   |
+| `/migrate`         | Upgrade a package to latest, apply breaking changes, run audit                                            |
+| `/handoff`         | Generate a session handoff doc at `.claude/handoff/HANDOFF-{date}-{slug}.md` ([[handoff command]])        |
+| `/pickup`          | Resume from the latest handoff; falls back to `wiki/hot.md` ([[pickup command]])                          |
 
 See individual rules for the patterns each command produces.
 

--- a/wiki/modules/Claude Integration.md
+++ b/wiki/modules/Claude Integration.md
@@ -35,8 +35,9 @@ GAIA ships with [Claude Code](https://claude.ai/) support out of the box. Everyt
 | `/new-component` | Scaffold a component with optional test + story                                                    |
 | `/new-service`   | Scaffold an API service + Zod + URL constants + MSW mocks                                          |
 | `/new-hook`      | Scaffold a custom hook + test                                                                      |
-| `/audit-code`    | Run the full [[Quality Gate]]                                                                      |
-| `/migrate`       | Upgrade a package to latest, apply breaking changes, run audit                                     |
+| `/audit-code`      | Run the full [[Quality Gate]]                                                                      |
+| `/audit-knowledge` | Audit memory + wiki + auto-loaded files for dupes, stale entries, and bloat ([[audit-knowledge command]]) |
+| `/migrate`         | Upgrade a package to latest, apply breaking changes, run audit                                     |
 | `/handoff`       | Generate a session handoff doc at `.claude/handoff/HANDOFF-{date}-{slug}.md` ([[handoff command]]) |
 | `/pickup`        | Resume from the latest handoff; falls back to `wiki/hot.md` ([[pickup command]])                   |
 

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -73,6 +73,10 @@ See [[Routing]] and [[Auth Flow]].
 
 Every change passes through [[Quality Gate]]: typecheck → lint → unit test → E2E → dev smoke → build. Pre-commit hooks enforce a subset on every commit; the `/audit-code` command runs the full pipeline. **Zero tolerance for warnings.**
 
+## Knowledge Hygiene
+
+`/audit-knowledge` runs a two-stage audit (Opus researches → Sonnet applies) over memory, wiki, auto-loaded `CLAUDE.md` files, and `.claude/rules/`. Flags duplication, stale entries, broken wikilinks, and auto-load bloat — with wiki as the source of truth. See [[audit-knowledge command]].
+
 ## What's Different vs. Other Templates
 
 | Feature            |           GAIA            | Vite React | RR Template | Next.js |


### PR DESCRIPTION
## Summary
- Adapts the two-stage knowledge audit command from another project; Opus produces a machine-readable report, Sonnet applies it.
- Path resolution is portable: `$CLAUDE_PROJECT_DIR` + `pwd` + sed-derived memory path — no hardcoded user paths, works for every clone and collaborator.
- Adds references in `README.md`, `docs/general/claude.md`, and wiki (`Claude Integration`, `overview`, new `audit-knowledge command` concept page). `.claude/audit/` gitignored.

## Test plan
- [x] Review portability logic — confirm `PROJECT_ROOT` / `MEMORY_DIR` formulas match Claude Code's project-memory path convention
- [x] Verify `.claude/audit/` ignore works (run command, see report written outside git tracking)
- [x] Spot-check updated tables render cleanly on GitHub and in VitePress docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)