### PR TITLE
feat: intercept /init, reposition README around Claude-native integration, add wiki-maintenance rule

### DIFF
--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -192,6 +192,10 @@ Insert a new entry directly below the `# Log` heading (log is append-only, newes
 
 1. Remove the gaia-init command from the project to prevent accidental re-runs.
 
-2. Output: "GAIA React project is ready for development with a clean slate!"
+2. Remove the `/init` interceptor — it exists only to protect the template's curated CLAUDE.md, and is no longer needed once the template has been initialized:
+   - Delete `.claude/hooks/intercept-init.sh`
+   - Remove the entire `"UserPromptSubmit"` block from `.claude/settings.json` (the key and its array value)
 
-3. Output: "Please restart Claude."
+3. Output: "GAIA React project is ready for development with a clean slate!"
+
+4. Output: "Please restart Claude."

--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -194,7 +194,7 @@ Insert a new entry directly below the `# Log` heading (log is append-only, newes
 
 2. Remove the `/init` interceptor — it exists only to protect the template's curated CLAUDE.md, and is no longer needed once the template has been initialized:
    - Delete `.claude/hooks/intercept-init.sh`
-   - Remove the entire `"UserPromptSubmit"` block from `.claude/settings.json` (the key and its array value)
+   - Edit `.claude/settings.json`: from the `hooks.UserPromptSubmit` array, remove only the matcher entry whose inner `hooks[].command` is `.claude/hooks/intercept-init.sh`. Preserve any other entries the user may have added. If removing it leaves `UserPromptSubmit` as an empty array, also remove the `UserPromptSubmit` key itself.
 
 3. Output: "GAIA React project is ready for development with a clean slate!"
 

--- a/.claude/hooks/intercept-init.sh
+++ b/.claude/hooks/intercept-init.sh
@@ -2,6 +2,9 @@
 # Redirect the built-in /init command to /gaia-init on this template.
 # Fires on UserPromptSubmit. Exit 2 + stderr = blocking message to Claude.
 
+# If jq isn't installed, don't block — fail open so we never lock the user out.
+command -v jq >/dev/null 2>&1 || exit 0
+
 prompt=$(jq -r '.prompt // ""' < /dev/stdin)
 
 if [[ "$prompt" =~ ^/init([[:space:]]|$) ]]; then

--- a/.claude/hooks/intercept-init.sh
+++ b/.claude/hooks/intercept-init.sh
@@ -6,11 +6,9 @@ prompt=$(jq -r '.prompt // ""' < /dev/stdin)
 
 if [[ "$prompt" =~ ^/init([[:space:]]|$) ]]; then
   cat >&2 <<'MSG'
-This project is already configured for Claude Code (CLAUDE.md, .claude/commands, .claude/rules, .claude/hooks all present).
+The user's /init has been intercepted by a project hook. This is a GAIA React template — the built-in /init would overwrite the curated CLAUDE.md.
 
-Do NOT run the built-in /init — it would overwrite the curated CLAUDE.md.
-
-Instead, invoke the /gaia-init skill to strip the example scaffolding and give the user a clean slate.
+REQUIRED NEXT ACTION: Immediately call the Skill tool with skill="gaia-init" to run the template's initialization. Do not ask for confirmation. Do not tell the user to run it themselves. Do not explain what you are about to do beyond one short sentence. Just call the Skill tool now.
 MSG
   exit 2
 fi

--- a/.claude/hooks/intercept-init.sh
+++ b/.claude/hooks/intercept-init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Redirect the built-in /init command to /gaia-init on this template.
+# Fires on UserPromptSubmit. Exit 2 + stderr = blocking message to Claude.
+
+prompt=$(jq -r '.prompt // ""' < /dev/stdin)
+
+if [[ "$prompt" =~ ^/init([[:space:]]|$) ]]; then
+  cat >&2 <<'MSG'
+This project is already configured for Claude Code (CLAUDE.md, .claude/commands, .claude/rules, .claude/hooks all present).
+
+Do NOT run the built-in /init — it would overwrite the curated CLAUDE.md.
+
+Instead, invoke the /gaia-init skill to strip the example scaffolding and give the user a clean slate.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.claude/rules/wiki-maintenance.md
+++ b/.claude/rules/wiki-maintenance.md
@@ -1,0 +1,30 @@
+# Wiki Maintenance
+
+Before executing `git commit` (or any commit command), evaluate whether the work warrants a wiki update. Goal: keep `wiki/` current so Claude's future context loads reflect the project's real state — without thrashing the vault on every commit.
+
+## File a wiki update if the commit introduces any of:
+
+- A new service, component family, hook, or pattern other developers should know about
+- An added, updated, or removed dependency
+- A decision worth recording as an ADR (chose X over Y, rejected approach Z with reason)
+- A non-obvious invariant, gotcha, or workaround discovered while debugging
+- A breaking change to a documented interface
+
+## Do NOT file a wiki update for:
+
+- Bug fixes inside existing patterns
+- Refactors that don't change the mental model
+- Typos, formatting changes, additions to existing test suites
+- Changes that would duplicate existing wiki content (check `wiki/index.md` first)
+
+## Process
+
+1. Before commit, scan `wiki/index.md` to see what is already documented.
+2. If the commit qualifies, pick the right skill:
+   - `/save` — capture a chat insight as a new note
+   - `/wiki-ingest` — file a specific source (PR body, spec, external doc)
+   - Direct edit — update an existing module / concept / decision page
+3. Update `wiki/log.md` with a one-line entry (newest on top).
+4. The `claude-obsidian` Stop hook refreshes `wiki/hot.md` automatically when it detects wiki changes.
+
+Periodic drift cleanup: run `/audit-knowledge` every few weeks to find orphan pages, dead wikilinks, and stale claims.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,17 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "All",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/intercept-init.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ Most templates treat AI as an afterthought: drop a `CLAUDE.md` in the root and h
 
 ## What Claude Gets
 
-- **10 scaffolding commands** — `/new-route`, `/new-component`, `/new-hook`, `/new-service`, `/audit-code`, `/migrate`, `/handoff`, `/pickup`, `/audit-knowledge`, `/gaia-init`
+- **10 project commands** — scaffolding (`/new-route`, `/new-component`, `/new-hook`, `/new-service`), quality (`/audit-code`, `/audit-knowledge`), workflow (`/handoff`, `/pickup`), migration (`/migrate`), and template init (`/gaia-init`)
 - **10 path-scoped rules** — accessibility, API services, coding guidelines, component testing, ESLint fixes, i18n, route creation, PR merge workflow, quality gate, test runner; auto-loaded based on what Claude is editing
-- **5 pre-tool hooks** — block ESLint config edits, block vitest globals in `tsconfig.json`, intercept `/init` → `/gaia-init`, advise on missing i18n strings, advise on missing Storybook stories
+- **4 pre-tool hooks** — block ESLint config edits, block vitest globals in `tsconfig.json`, advise on missing i18n strings, advise on missing Storybook stories
 - **Code-review-audit agent** — required before every PR merge via the `pr-merge-workflow` rule
 - **72-page committed wiki** — architecture, modules, dependencies, decisions, flows; Claude reads `wiki/hot.md` (~200-word cache) at session start and fetches specific pages on demand
 - **Obsidian integration** — the [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian) plugin adds skills for ingesting sources, querying, linting, auto-research loops, and saving conversations directly into the vault
 - **4 bundled project skills** — `react-code`, `typescript`, `tailwind`, `skeleton-loaders`
-- **Hijacked `/init`** — runs `/gaia-init` instead of overwriting the curated `CLAUDE.md`
 
 ## What You Get (Foundation)
 
@@ -43,14 +42,13 @@ The traditional tooling Claude rides on top of:
 | Feature                       |                       GAIA                       | Vite React | RR Template | Next.js |
 | ----------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
 | **Claude integration**        |                                                  |            |             |         |
-| Claude scaffolding commands   |                        10                        |     ❌     |     ❌      |   ❌    |
+| Claude project commands       |                        10                        |     ❌     |     ❌      |   ❌    |
 | Auto-loaded project rules     |                        10                        |     ❌     |     ❌      |   ❌    |
-| Pre-tool enforcement hooks    |                   5 (3 block)                    |     ❌     |     ❌      |   ❌    |
+| Pre-tool enforcement hooks    |                   4 (2 block)                    |     ❌     |     ❌      |   ❌    |
 | Bundled project skills        |                        4                         |     ❌     |     ❌      |   ❌    |
 | Code-review agent (pre-merge) |                        ✅                        |     ❌     |     ❌      |   ❌    |
 | Committed LLM knowledge base  |                   72-page wiki                   |     ❌     |     ❌      |   ❌    |
 | Obsidian vault integration    |                        ✅                        |     ❌     |     ❌      |   ❌    |
-| `/init` hijacked for template |                        ✅                        |     ❌     |     ❌      |   ❌    |
 | **Traditional tooling**       |                                                  |            |             |         |
 | ESLint                        |                   20+ plugins                    |   basic    |    basic    |  basic  |
 | Prettier + Stylelint          |                  pre-configured                  |     ❌     |     ❌      |   ❌    |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,28 @@
 
 <img src="./app/assets/images/gaia-logo.svg" height="100" alt="GAIA"/>
 
-Starting a new React project means days of setup before writing a single feature. Linting, testing, i18n, auth, CI, pre-commit hooks, dark mode, Storybook. All of it needs to be configured, integrated, and wired together correctly.
+**The Claude-native React Router template.** Scaffolding commands, auto-loaded rules, enforcement hooks, a code-review agent, and a committed LLM knowledge base — your AI collaborator is a first-class citizen of the codebase, not a tool glued on top of it.
 
-GAIA React is the most thoroughly configured React Router 7 template available. Every tool is set up, every integration tested, every convention documented. You start writing features on day one.
+The full traditional stack — 20+ ESLint plugins, Prettier, Vitest, Playwright, Chromatic, Storybook, i18n, auth, Conform + Zod forms, dark mode, MSW, React Router 7 — is the foundation it's built on. You get both, and they're designed together.
 
-## What You Get
+## Why Claude-native?
+
+Most templates treat AI as an afterthought: drop a `CLAUDE.md` in the root and hope the model figures out the rest. GAIA is different. Every convention the template enforces is also a rule Claude auto-loads. Every scaffolding script is also a slash command. Every code review runs a dedicated agent. Every piece of project knowledge lives in a committed wiki that Claude fetches on demand instead of hauling a giant `CLAUDE.md` into every request. The result: Claude writes code that matches your patterns on day one, and it stops writing the wrong thing before you have to review it.
+
+## What Claude Gets
+
+- **10 scaffolding commands** — `/new-route`, `/new-component`, `/new-hook`, `/new-service`, `/audit-code`, `/migrate`, `/handoff`, `/pickup`, `/audit-knowledge`, `/gaia-init`
+- **10 path-scoped rules** — accessibility, API services, coding guidelines, component testing, ESLint fixes, i18n, route creation, PR merge workflow, quality gate, test runner; auto-loaded based on what Claude is editing
+- **5 pre-tool hooks** — block ESLint config edits, block vitest globals in `tsconfig.json`, intercept `/init` → `/gaia-init`, advise on missing i18n strings, advise on missing Storybook stories
+- **Code-review-audit agent** — required before every PR merge via the `pr-merge-workflow` rule
+- **72-page committed wiki** — architecture, modules, dependencies, decisions, flows; Claude reads `wiki/hot.md` (~200-word cache) at session start and fetches specific pages on demand
+- **Obsidian integration** — the [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian) plugin adds skills for ingesting sources, querying, linting, auto-research loops, and saving conversations directly into the vault
+- **4 bundled project skills** — `react-code`, `typescript`, `tailwind`, `skeleton-loaders`
+- **Hijacked `/init`** — runs `/gaia-init` instead of overwriting the curated `CLAUDE.md`
+
+## What You Get (Foundation)
+
+The traditional tooling Claude rides on top of:
 
 - **20+ ESLint plugins** pre-configured with [Prettier](https://prettier.io/) and [Stylelint](https://stylelint.io/) for consistent code from the first commit
 - **Pre-commit hooks** ([Husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged)) that typecheck, lint, and test before code reaches CI
@@ -18,45 +35,51 @@ GAIA React is the most thoroughly configured React Router 7 template available. 
 - **[Storybook](https://storybook.js.org/) with React Router support**, including i18n, dark mode, and [MSW](https://mswjs.io/) integration
 - **API mocking** with [Mock Service Worker](https://mswjs.io/) and [msw/data](https://github.com/mswjs/data), with working handlers for tests and Storybook
 - **Toast notifications** with [remix-toast](https://remix.run/resources/remix-toast) and [Sonner](https://sonner.emilkowal.ski/)
-- **Claude Code integration** with scaffolding commands, quality rules, and code review (see [Claude](#claude) section)
 - **Documentation site** via [VitePress](https://vitepress.dev/) with GitHub Pages deployment
-- **Knowledge base for LLMs**: a [committed `wiki/`](#wiki) of architecture, modules, decisions, and dependencies that Claude reads on demand — no token bloat, no stale CLAUDE.md sprawl
 - Built on [React Router 7](https://reactrouter.com/), [TailwindCSS](https://tailwindcss.com/), and [FontAwesome](https://fontawesome.com/) icons
-
-## Philosophy
-
-GAIA is a **base template**, not a full-stack kit. It deliberately does not include a component library. You choose what fits your project.
-
-- Configuring 20+ linting rules, four layers of testing, i18n, auth, and CI correctly takes days. GAIA solves that once.
-- **Every tool is pre-configured but removable.** Don't need i18n? Remove it. Prefer a different icon set? Swap it. Nothing is locked in.
-- Pre-commit hooks run typechecking, linting, and tests. The quality gate catches issues before they compound.
-- Best practices are baked into working examples you can follow and modify.
 
 ## How GAIA Compares
 
-| Feature                    |                       GAIA                       | Vite React | RR Template | Next.js |
-| -------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
-| ESLint                     |                   20+ plugins                    |   basic    |    basic    |  basic  |
-| Prettier + Stylelint       |                  pre-configured                  |     —      |      —      |    —    |
-| Pre-commit hooks           |             typecheck + lint + test              |     —      |      —      |    —    |
-| Unit + integration testing |                   Vitest + RTL                   |     —      |      —      |    —    |
-| E2E testing                |                    Playwright                    |     —      |      —      |    —    |
-| Visual regression testing  |                   Chromatic CI                   |     —      |      —      |    —    |
-| i18n                       |          2 languages, working examples           |     —      |      —      |    —    |
-| Auth example               |          login + session + route guards          |     —      |      —      |    —    |
-| Form validation            |            Conform + Zod + components            |     —      |      —      |    —    |
-| Storybook                  |         Router + i18n + dark mode + MSW          |     —      |      —      |    —    |
-| Dark mode                  | end-to-end (context + session + CSS + Storybook) |     —      |      —      |    —    |
-| API mocking (MSW)          |                tests + Storybook                 |     —      |      —      |    —    |
-| Claude Code integration    |             commands, skills, rules              |     —      |      —      |    —    |
-| LLM knowledge base         |            committed wiki + Obsidian             |     —      |      —      |    —    |
-| Documentation site         |           VitePress + GH Pages deploy            |     —      |      —      |    —    |
+| Feature                         |                       GAIA                       | Vite React | RR Template | Next.js |
+| ------------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
+| **Claude integration**          |                                                  |            |             |         |
+| Claude scaffolding commands     |                        10                        |     —      |      —      |    —    |
+| Auto-loaded project rules       |                        10                        |     —      |      —      |    —    |
+| Pre-tool enforcement hooks      |                   5 (3 block)                    |     —      |      —      |    —    |
+| Bundled project skills          |                        4                         |     —      |      —      |    —    |
+| Code-review agent (pre-merge)   |                       yes                        |     —      |      —      |    —    |
+| Committed LLM knowledge base    |                   72-page wiki                   |     —      |      —      |    —    |
+| Obsidian vault integration      |                       yes                        |     —      |      —      |    —    |
+| `/init` hijacked for template   |                       yes                        |     —      |      —      |    —    |
+| **Traditional tooling**         |                                                  |            |             |         |
+| ESLint                          |                   20+ plugins                    |   basic    |    basic    |  basic  |
+| Prettier + Stylelint            |                  pre-configured                  |     —      |      —      |    —    |
+| Pre-commit hooks                |             typecheck + lint + test              |     —      |      —      |    —    |
+| Unit + integration testing      |                   Vitest + RTL                   |     —      |      —      |    —    |
+| E2E testing                     |                    Playwright                    |     —      |      —      |    —    |
+| Visual regression testing       |                   Chromatic CI                   |     —      |      —      |    —    |
+| i18n                            |          2 languages, working examples           |     —      |      —      |    —    |
+| Auth example                    |          login + session + route guards          |     —      |      —      |    —    |
+| Form validation                 |            Conform + Zod + components            |     —      |      —      |    —    |
+| Storybook                       |         Router + i18n + dark mode + MSW          |     —      |      —      |    —    |
+| Dark mode                       | end-to-end (context + session + CSS + Storybook) |     —      |      —      |    —    |
+| API mocking (MSW)               |                tests + Storybook                 |     —      |      —      |    —    |
+| Documentation site              |           VitePress + GH Pages deploy            |     —      |      —      |    —    |
+
+## Philosophy
+
+GAIA is a **Claude-native base template**, not a full-stack kit or a component library. It sets up everything Claude needs to write your app correctly and leaves the product-layer choices to you.
+
+- Configuring 20+ linting rules, four layers of testing, i18n, auth, CI — **and** the full Claude toolchain (commands, rules, hooks, agents, wiki, plugins) — correctly takes days. GAIA solves that once.
+- **Every tool is pre-configured but removable.** Don't need i18n? Remove it. Prefer a different icon set? Swap it. Nothing is locked in — including the Claude layer.
+- Pre-commit hooks run typechecking, linting, and tests. Pre-tool hooks catch Claude mistakes before they reach disk. The quality gate catches issues before they compound.
+- Best practices are baked into working examples you can follow and modify — and into rules Claude loads automatically.
 
 ## Installation
 
 Make sure you have [Node.js](https://nodejs.org/en/) >=22.19.0 LTS installed, preferably via [nvm](https://github.com/nvm-sh/nvm).
 
-All you need to do is run this installation command and get to work.
+All you need to do is run this installation command and get to work:
 
 ```sh
 npx create-react-router@latest --template gaia-react/react-router
@@ -68,35 +91,41 @@ npx create-react-router@latest --template gaia-react/react-router
 npm install
 ```
 
-If you're using [Claude Code](https://code.claude.com/docs/en/overview), you can run `/gaia-init` (or just `/init` — it's intercepted and redirected) once you're ready (see below).
-
-If not, duplicate the `.env.example` file and name it `.env`, and you can optionally delete the `.claude` folder.
-
 ### Setup Fix on Save in your IDE
 
 Follow these [instructions](https://gaia-react.github.io/react-router/tech-stack/code-quality/#setup-fix-on-save).
 
-## Documentation
+### Initialize the template
 
-GAIA comes with the documentation included. Run it locally with:
+If you're using [Claude Code](https://code.claude.com/docs/en/overview), run `/gaia-init` (or just `/init` — it's intercepted and redirected). See [`/gaia-init`](#gaia-init--one-command-initialization) below for the full scope.
 
-```sh
-npm run docs
-```
+If you're not using Claude, duplicate `.env.example` to `.env`, then delete `.claude/`, `wiki/`, and any other Claude-specific artifacts you won't need.
 
-It is recommended that you keep these docs up to date as you build your project. There is also a GitHub action to deploy the docs to your repository's GitHub Pages.
+## `/gaia-init` — one-command initialization
 
-Claude knows how to reference the documentation when necessary.
+Running `/gaia-init` (or `/init` — they're interchangeable) initializes the template end-to-end in one command:
 
-## Claude
+- **Strips example code** — `things` service, `ExampleConsumer`/`ExampleProvider`, IndexPage examples + TechStack, GAIA branding assets
+- **Configures i18n** — prompts for your language set (English, Japanese, French, Spanish, German, or a custom list), scaffolds matching language files, updates `LanguageSelect` and Storybook globals
+- **Sets project metadata** — `package.json` name, `CLAUDE.md` title, `CODEOWNERS`, VitePress `base`
+- **Installs Claude skills** — [React Doctor](https://github.com/millionco/react-doctor), [Matt Pocock's TDD](https://www.aihero.dev/skill-test-driven-development-claude-code), [Playwright CLI](https://github.com/microsoft/playwright-cli)
+- **Installs Claude plugins** — `typescript-lsp` (from the official Claude Plugins marketplace) and [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian)
+- **Syncs the wiki** to the new project state (removes references to deleted example code)
+- **Verifies** via the quality gate: `typecheck && test:ci && lint && build`
 
-GAIA comes with [Claude Code](https://claude.ai/) support built-in: commands, rules, and a quality gate that work out of the box.
+After `/gaia-init` finishes, you have a clean app shell **and** a fully-configured Claude workflow ready to use.
+
+> **Why both `/init` and `/gaia-init` work:** the built-in `/init` would normally overwrite the curated `CLAUDE.md`. A `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) intercepts it and auto-invokes `/gaia-init` instead. The hook and its settings entry are removed automatically when `/gaia-init` finishes, so `/init` returns to its default behavior afterward.
+
+## Claude Workflow
+
+GAIA ships a complete, opinionated Claude Code workflow. Everything is wired in `.claude/` and visible in the repo.
 
 ### Commands
 
 | Command            | What it does                                                            |
 | ------------------ | ----------------------------------------------------------------------- |
-| `/gaia-init`       | Remove example code, configure languages, set up a clean slate          |
+| `/gaia-init`       | Full template initialization (see above)                                |
 | `/new-route`       | Scaffold a route with page component, test, story, and i18n keys        |
 | `/new-component`   | Scaffold a component with optional test and story                       |
 | `/new-service`     | Scaffold an API service with requests, Zod schemas, URLs, and MSW mocks |
@@ -109,21 +138,56 @@ GAIA comes with [Claude Code](https://claude.ai/) support built-in: commands, ru
 
 ### Rules
 
-Claude automatically follows project rules for coding guidelines, component testing patterns, ESLint fixes, i18n conventions, accessibility, API services, route creation, and the quality gate. These rules are in `.claude/rules/` and activate based on file paths.
+Claude follows project rules automatically based on file paths. Rules live in `.claude/rules/` and activate when Claude edits matching files.
 
-Once you're familiar with the GAIA framework, open Claude and run `/gaia-init` — or just `/init`, which works the same way on a fresh GAIA checkout. This will remove the example code and give you a clean slate for your project.
+| Rule                   | Enforces                                                                  |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `accessibility`        | Keyboard nav, alt text, ARIA, focus management (scope: `app/components/`) |
+| `api-service`          | Request / schema / mock patterns (scope: `app/services/`)                 |
+| `coding-guidelines`    | Simplicity, surgical edits, TDD (scope: `app/`)                           |
+| `component-testing`    | `composeStory` pattern for component tests                                |
+| `eslint-fixes`         | Fix ESLint errors in source, not in the ESLint config                     |
+| `i18n`                 | `t()` from `useTranslation()` for all user-facing strings                 |
+| `new-route`            | Thin routes, page component conventions, route groups                     |
+| `pr-merge-workflow`    | Run the code-review-audit agent before merging                            |
+| `quality-gate`         | Run `/audit-code` and fix all issues before every commit                  |
+| `test-runner`          | `npm run test -- --run` in CI; never bare `npm test`                      |
 
-> **Why both commands work:** the built-in `/init` would normally overwrite the curated `CLAUDE.md`. A `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) intercepts it and auto-invokes `/gaia-init` instead. The hook and its settings entry are removed automatically when `/gaia-init` finishes, so `/init` returns to its default behavior afterward.
+### Hooks
+
+Claude Code hooks let the template catch mistakes before they reach disk. GAIA ships five:
+
+| Hook                                 | Event            | What it does                                             |
+| ------------------------------------ | ---------------- | -------------------------------------------------------- |
+| `intercept-init.sh`                  | UserPromptSubmit | Blocks built-in `/init`, auto-invokes `/gaia-init`       |
+| `block-eslint-config-edit.sh`        | PreToolUse       | Blocks edits to `eslint.config.mjs`                      |
+| `block-vitest-globals-tsconfig.sh`   | PreToolUse       | Blocks adding `vitest/globals` to `tsconfig.json`        |
+| `check-i18n-strings.sh`              | PreToolUse       | Advisory: ensure user-facing strings use `t()`           |
+| `check-story-exists.sh`              | PreToolUse       | Advisory: remind to add a Storybook story for components |
+
+### Code review before merge
+
+The `pr-merge-workflow` rule makes the `code-review-audit` agent a required step before `gh pr merge`. The agent reviews the branch diff for security vulnerabilities, performance issues, code smells, and anti-patterns — and the workflow blocks the merge until reported issues are fixed and committed.
 
 ### Wiki
 
-GAIA ships with a `wiki/` knowledge base — architecture, modules, dependencies, decisions, flows, and concepts — committed to git and shared across the team. It is structured for LLM consumption: small focused pages, wikilinks, frontmatter, and a `wiki/index.md` catalog so Claude fetches only what it needs.
+GAIA ships with a `wiki/` knowledge base — architecture, modules, dependencies, decisions, flows, concepts, components — committed to git and shared across the team. It's structured for LLM consumption: small focused pages, wikilinks, frontmatter, and a `wiki/index.md` catalog so Claude fetches only what it needs.
 
 - **No token bloat.** Claude reads `wiki/hot.md` (~200-word recent context) at session start and pulls specific pages on demand instead of preloading the whole codebase.
 - **Survives across sessions and developers.** Unlike machine-local memory, the wiki is in git — every contributor gets the same context.
 - **Editable in Obsidian.** Pages are standard markdown with wikilinks; open `wiki/` as an [Obsidian](https://obsidian.md) vault for graph view, backlinks, and search.
 
-The [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian) plugin is installed automatically by `/gaia-init` and adds Claude skills for ingesting sources, querying, linting, and saving conversations into the vault.
+The [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian) plugin is installed automatically by `/gaia-init` and adds Claude skills for ingesting sources (`/wiki-ingest`), querying (`/wiki-query`), linting (`/wiki-lint`), auto-research loops (`/autoresearch`), and saving conversations into the vault (`/save`).
+
+## Documentation
+
+GAIA comes with a VitePress documentation site included. Run it locally with:
+
+```sh
+npm run docs
+```
+
+It is recommended that you keep these docs up to date as you build your project. There is also a GitHub action to deploy the docs to your repository's GitHub Pages.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Claude automatically follows project rules for coding guidelines, component test
 
 Once you're familiar with the GAIA framework, open Claude and run the `/gaia-init` command. This will remove the example code and give you a clean slate for your project.
 
+> **Note:** Don't run the built-in `/init` on a fresh GAIA checkout — it would overwrite the curated `CLAUDE.md`. A `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) intercepts `/init` and redirects to `/gaia-init`. Both the hook and its settings entry are removed automatically when `/gaia-init` finishes, so your project is free to use `/init` normally afterward.
+
 ### Wiki
 
 GAIA ships with a `wiki/` knowledge base — architecture, modules, dependencies, decisions, flows, and concepts — committed to git and shared across the team. It is structured for LLM consumption: small focused pages, wikilinks, frontmatter, and a `wiki/index.md` catalog so Claude fetches only what it needs.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ The full traditional stack — 20+ ESLint plugins, Prettier, Vitest, Playwright,
 
 ## Why Claude-native?
 
-Most templates treat AI as an afterthought: drop a `CLAUDE.md` in the root and hope the model figures out the rest. GAIA is different. Every convention the template enforces is also a rule Claude auto-loads. Every scaffolding script is also a slash command. Every code review runs a dedicated agent. Every piece of project knowledge lives in a committed wiki that Claude fetches on demand instead of hauling a giant `CLAUDE.md` into every request. The result: Claude writes code that matches your patterns on day one, and it stops writing the wrong thing before you have to review it.
+Most templates treat AI as an afterthought: drop a `CLAUDE.md` in the root and hope the model figures out the rest. GAIA is different. Every convention the template enforces is also a rule Claude auto-loads. Every scaffolding script is also a slash command. Every code review runs a dedicated agent. Every piece of project knowledge lives in a committed wiki that Claude fetches on demand instead of hauling a giant `CLAUDE.md` into every request.
+
+**GAIA prevents technical debt in your code — and in your Claude prompts.** The wiki and `/audit-knowledge` keep context lean, so Claude's effective attention isn't burned on stale memory and bloated auto-loaders. You spend fewer tokens per request and get sharper answers. Claude writes code that matches your patterns on day one, and stops writing the wrong thing before you have to review it.
 
 ## What Claude Gets
 
-- **10 project commands** — scaffolding (`/new-route`, `/new-component`, `/new-hook`, `/new-service`), quality (`/audit-code`, `/audit-knowledge`), workflow (`/handoff`, `/pickup`), migration (`/migrate`), and template init (`/gaia-init`)
+- **4 scaffolding commands** — `/new-route`, `/new-component`, `/new-hook`, `/new-service` match your project conventions out of the box
+- **6 project commands** — `/audit-code` (quality gate), `/audit-knowledge` (prompt-debt sweep), `/migrate` (package upgrades), `/handoff` + `/pickup` (session continuity), `/gaia-init` (template init)
 - **10 path-scoped rules** — accessibility, API services, coding guidelines, component testing, ESLint fixes, i18n, route creation, PR merge workflow, quality gate, test runner; auto-loaded based on what Claude is editing
 - **4 pre-tool hooks** — block ESLint config edits, block vitest globals in `tsconfig.json`, advise on missing i18n strings, advise on missing Storybook stories
 - **Code-review-audit agent** — required before every PR merge via the `pr-merge-workflow` rule
-- **72-page committed wiki** — architecture, modules, dependencies, decisions, flows; Claude reads `wiki/hot.md` (~200-word cache) at session start and fetches specific pages on demand
+- **LLM knowledge base (wiki)** — architecture, modules, dependencies, decisions, flows. Claude reads a ~200-word cache at session start and fetches specific pages on demand. Replaces bloated `CLAUDE.md` sprawl and keeps per-request token costs down.
 - **Obsidian integration** — the [`claude-obsidian`](https://github.com/AgriciDaniel/claude-obsidian) plugin adds skills for ingesting sources, querying, linting, auto-research loops, and saving conversations directly into the vault
 - **4 bundled project skills** — `react-code`, `typescript`, `tailwind`, `skeleton-loaders`
 
@@ -41,28 +44,28 @@ The traditional tooling Claude rides on top of:
 
 | Feature                       |                       GAIA                       | Vite React | RR Template | Next.js |
 | ----------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
-| **Claude integration**        |                                                  |            |             |         |
-| Claude project commands       |                        10                        |     ❌     |     ❌      |   ❌    |
-| Auto-loaded project rules     |                        10                        |     ❌     |     ❌      |   ❌    |
-| Pre-tool enforcement hooks    |                   4 (2 block)                    |     ❌     |     ❌      |   ❌    |
-| Bundled project skills        |                        4                         |     ❌     |     ❌      |   ❌    |
-| Code-review agent (pre-merge) |                        ✅                        |     ❌     |     ❌      |   ❌    |
-| Committed LLM knowledge base  |                   72-page wiki                   |     ❌     |     ❌      |   ❌    |
-| Obsidian vault integration    |                        ✅                        |     ❌     |     ❌      |   ❌    |
-| **Traditional tooling**       |                                                  |            |             |         |
-| ESLint                        |                   20+ plugins                    |   basic    |    basic    |  basic  |
-| Prettier + Stylelint          |                  pre-configured                  |     ❌     |     ❌      |   ❌    |
-| Pre-commit hooks              |             typecheck + lint + test              |     ❌     |     ❌      |   ❌    |
-| Unit + integration testing    |                   Vitest + RTL                   |     ❌     |     ❌      |   ❌    |
-| E2E testing                   |                    Playwright                    |     ❌     |     ❌      |   ❌    |
-| Visual regression testing     |                   Chromatic CI                   |     ❌     |     ❌      |   ❌    |
-| i18n                          |          2 languages, working examples           |     ❌     |     ❌      |   ❌    |
-| Auth example                  |          login + session + route guards          |     ❌     |     ❌      |   ❌    |
-| Form validation               |            Conform + Zod + components            |     ❌     |     ❌      |   ❌    |
-| Storybook                     |         Router + i18n + dark mode + MSW          |     ❌     |     ❌      |   ❌    |
-| Dark mode                     | end-to-end (context + session + CSS + Storybook) |     ❌     |     ❌      |   ❌    |
-| API mocking (MSW)             |                tests + Storybook                 |     ❌     |     ❌      |   ❌    |
-| Documentation site            |           VitePress + GH Pages deploy            |     ❌     |     ❌      |   ❌    |
+| **Claude Integration**        |                                                  |            |             |         |
+| Scaffolding Commands          |                        4                         |     ❌     |     ❌      |   ❌    |
+| Project Commands              |                        6                         |     ❌     |     ❌      |   ❌    |
+| Auto-Loaded Project Rules     |                        10                        |     ❌     |     ❌      |   ❌    |
+| Pre-Tool Enforcement Hooks    |                   4 (2 Block)                    |     ❌     |     ❌      |   ❌    |
+| Bundled Project Skills        |                        4                         |     ❌     |     ❌      |   ❌    |
+| Code-Review Agent (Pre-Merge) |                        ✅                        |     ❌     |     ❌      |   ❌    |
+| Obsidian Vault Integration    |                        ✅                        |     ❌     |     ❌      |   ❌    |
+| **Traditional Tooling**       |                                                  |            |             |         |
+| ESLint                        |                   20+ Plugins                    |   Basic    |    Basic    |  Basic  |
+| Prettier + Stylelint          |                  Pre-Configured                  |     ❌     |     ❌      |   ❌    |
+| Pre-Commit Hooks              |             Typecheck + Lint + Test              |     ❌     |     ❌      |   ❌    |
+| Unit + Integration Testing    |                   Vitest + RTL                   |     ❌     |     ❌      |   ❌    |
+| E2E Testing                   |                    Playwright                    |     ❌     |     ❌      |   ❌    |
+| Visual Regression Testing     |                   Chromatic CI                   |     ❌     |     ❌      |   ❌    |
+| i18n                          |          2 Languages, Working Examples           |     ❌     |     ❌      |   ❌    |
+| Auth Example                  |          Login + Session + Route Guards          |     ❌     |     ❌      |   ❌    |
+| Form Validation               |            Conform + Zod + Components            |     ❌     |     ❌      |   ❌    |
+| Storybook                     |         Router + i18n + Dark Mode + MSW          |     ❌     |     ❌      |   ❌    |
+| Dark Mode                     | End-to-End (Context + Session + CSS + Storybook) |     ❌     |     ❌      |   ❌    |
+| API Mocking (MSW)             |                Tests + Storybook                 |     ❌     |     ❌      |   ❌    |
+| Documentation Site            |           VitePress + GH Pages Deploy            |     ❌     |     ❌      |   ❌    |
 
 ## Philosophy
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most templates treat AI as an afterthought: drop a `CLAUDE.md` in the root and h
 
 - **4 scaffolding commands** — `/new-route`, `/new-component`, `/new-hook`, `/new-service` match your project conventions out of the box
 - **6 project commands** — `/audit-code` (quality gate), `/audit-knowledge` (prompt-debt sweep), `/migrate` (package upgrades), `/handoff` + `/pickup` (session continuity), `/gaia-init` (template init)
-- **10 path-scoped rules** — accessibility, API services, coding guidelines, component testing, ESLint fixes, i18n, route creation, PR merge workflow, quality gate, test runner; auto-loaded based on what Claude is editing
+- **11 path-scoped rules** — accessibility, API services, coding guidelines, component testing, ESLint fixes, i18n, route creation, PR merge workflow, quality gate, test runner, wiki maintenance; auto-loaded based on what Claude is editing
 - **4 pre-tool hooks** — block ESLint config edits, block vitest globals in `tsconfig.json`, advise on missing i18n strings, advise on missing Storybook stories
 - **Code-review-audit agent** — required before every PR merge via the `pr-merge-workflow` rule
 - **LLM knowledge base (wiki)** — architecture, modules, dependencies, decisions, flows. Claude reads a ~200-word cache at session start and fetches specific pages on demand. Replaces bloated `CLAUDE.md` sprawl and keeps per-request token costs down.
@@ -47,7 +47,7 @@ The traditional tooling Claude rides on top of:
 | **Claude Integration**        |                                                  |            |             |         |
 | Scaffolding Commands          |                        4                         |     ❌     |     ❌      |   ❌    |
 | Project Commands              |                        6                         |     ❌     |     ❌      |   ❌    |
-| Auto-Loaded Project Rules     |                        10                        |     ❌     |     ❌      |   ❌    |
+| Auto-Loaded Project Rules     |                        11                        |     ❌     |     ❌      |   ❌    |
 | Pre-Tool Enforcement Hooks    |                   4 (2 Block)                    |     ❌     |     ❌      |   ❌    |
 | Bundled Project Skills        |                        4                         |     ❌     |     ❌      |   ❌    |
 | Code-Review Agent (Pre-Merge) |                        ✅                        |     ❌     |     ❌      |   ❌    |
@@ -153,6 +153,7 @@ Claude follows project rules automatically based on file paths. Rules live in `.
 | `pr-merge-workflow`    | Run the code-review-audit agent before merging                            |
 | `quality-gate`         | Run `/audit-code` and fix all issues before every commit                  |
 | `test-runner`          | `npm run test -- --run` in CI; never bare `npm test`                      |
+| `wiki-maintenance`     | Before commit, update the wiki if the change introduces new knowledge     |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The traditional tooling Claude rides on top of:
 - **Unit, integration, E2E, and visual regression testing** with [Vitest](https://vitest.dev), [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/), [Playwright](https://playwright.dev/docs/intro), and [Chromatic](https://chromatic.com/), all sharing a common mocking layer
 - **i18n in 2 languages** via [remix-i18next](https://github.com/sergiodxa/remix-i18next) with working examples, not just the package installed
 - **Auth flow** with login, session management, and route guards via [remix-auth](https://remix.run/resources/remix-auth)
-- **Form components with validation** using [Conform](https://conform.guide/) + [Zod](https://zod.dev/), the star of the template
+- **Form components with validation** using [Conform](https://conform.guide/) + [Zod](https://zod.dev/)
 - **Dark mode end-to-end**: context, session, CSS, and Storybook all in sync
 - **[Storybook](https://storybook.js.org/) with React Router support**, including i18n, dark mode, and [MSW](https://mswjs.io/) integration
 - **API mocking** with [Mock Service Worker](https://mswjs.io/) and [msw/data](https://github.com/mswjs/data), with working handlers for tests and Storybook

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx create-react-router@latest --template gaia-react/react-router
 npm install
 ```
 
-If you're using [Claude Code](https://code.claude.com/docs/en/overview), you can run the `/gaia-init` command once you're ready (see below)
+If you're using [Claude Code](https://code.claude.com/docs/en/overview), you can run `/gaia-init` (or just `/init` — it's intercepted and redirected) once you're ready (see below).
 
 If not, duplicate the `.env.example` file and name it `.env`, and you can optionally delete the `.claude` folder.
 
@@ -111,9 +111,9 @@ GAIA comes with [Claude Code](https://claude.ai/) support built-in: commands, ru
 
 Claude automatically follows project rules for coding guidelines, component testing patterns, ESLint fixes, i18n conventions, accessibility, API services, route creation, and the quality gate. These rules are in `.claude/rules/` and activate based on file paths.
 
-Once you're familiar with the GAIA framework, open Claude and run the `/gaia-init` command. This will remove the example code and give you a clean slate for your project.
+Once you're familiar with the GAIA framework, open Claude and run `/gaia-init` — or just `/init`, which works the same way on a fresh GAIA checkout. This will remove the example code and give you a clean slate for your project.
 
-> **Note:** Don't run the built-in `/init` on a fresh GAIA checkout — it would overwrite the curated `CLAUDE.md`. A `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) intercepts `/init` and redirects to `/gaia-init`. Both the hook and its settings entry are removed automatically when `/gaia-init` finishes, so your project is free to use `/init` normally afterward.
+> **Why both commands work:** the built-in `/init` would normally overwrite the curated `CLAUDE.md`. A `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) intercepts it and auto-invokes `/gaia-init` instead. The hook and its settings entry are removed automatically when `/gaia-init` finishes, so `/init` returns to its default behavior afterward.
 
 ### Wiki
 

--- a/README.md
+++ b/README.md
@@ -40,31 +40,31 @@ The traditional tooling Claude rides on top of:
 
 ## How GAIA Compares
 
-| Feature                         |                       GAIA                       | Vite React | RR Template | Next.js |
-| ------------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
-| **Claude integration**          |                                                  |            |             |         |
-| Claude scaffolding commands     |                        10                        |     —      |      —      |    —    |
-| Auto-loaded project rules       |                        10                        |     —      |      —      |    —    |
-| Pre-tool enforcement hooks      |                   5 (3 block)                    |     —      |      —      |    —    |
-| Bundled project skills          |                        4                         |     —      |      —      |    —    |
-| Code-review agent (pre-merge)   |                       yes                        |     —      |      —      |    —    |
-| Committed LLM knowledge base    |                   72-page wiki                   |     —      |      —      |    —    |
-| Obsidian vault integration      |                       yes                        |     —      |      —      |    —    |
-| `/init` hijacked for template   |                       yes                        |     —      |      —      |    —    |
-| **Traditional tooling**         |                                                  |            |             |         |
-| ESLint                          |                   20+ plugins                    |   basic    |    basic    |  basic  |
-| Prettier + Stylelint            |                  pre-configured                  |     —      |      —      |    —    |
-| Pre-commit hooks                |             typecheck + lint + test              |     —      |      —      |    —    |
-| Unit + integration testing      |                   Vitest + RTL                   |     —      |      —      |    —    |
-| E2E testing                     |                    Playwright                    |     —      |      —      |    —    |
-| Visual regression testing       |                   Chromatic CI                   |     —      |      —      |    —    |
-| i18n                            |          2 languages, working examples           |     —      |      —      |    —    |
-| Auth example                    |          login + session + route guards          |     —      |      —      |    —    |
-| Form validation                 |            Conform + Zod + components            |     —      |      —      |    —    |
-| Storybook                       |         Router + i18n + dark mode + MSW          |     —      |      —      |    —    |
-| Dark mode                       | end-to-end (context + session + CSS + Storybook) |     —      |      —      |    —    |
-| API mocking (MSW)               |                tests + Storybook                 |     —      |      —      |    —    |
-| Documentation site              |           VitePress + GH Pages deploy            |     —      |      —      |    —    |
+| Feature                       |                       GAIA                       | Vite React | RR Template | Next.js |
+| ----------------------------- | :----------------------------------------------: | :--------: | :---------: | :-----: |
+| **Claude integration**        |                                                  |            |             |         |
+| Claude scaffolding commands   |                        10                        |     ❌     |     ❌      |   ❌    |
+| Auto-loaded project rules     |                        10                        |     ❌     |     ❌      |   ❌    |
+| Pre-tool enforcement hooks    |                   5 (3 block)                    |     ❌     |     ❌      |   ❌    |
+| Bundled project skills        |                        4                         |     ❌     |     ❌      |   ❌    |
+| Code-review agent (pre-merge) |                        ✅                        |     ❌     |     ❌      |   ❌    |
+| Committed LLM knowledge base  |                   72-page wiki                   |     ❌     |     ❌      |   ❌    |
+| Obsidian vault integration    |                        ✅                        |     ❌     |     ❌      |   ❌    |
+| `/init` hijacked for template |                        ✅                        |     ❌     |     ❌      |   ❌    |
+| **Traditional tooling**       |                                                  |            |             |         |
+| ESLint                        |                   20+ plugins                    |   basic    |    basic    |  basic  |
+| Prettier + Stylelint          |                  pre-configured                  |     ❌     |     ❌      |   ❌    |
+| Pre-commit hooks              |             typecheck + lint + test              |     ❌     |     ❌      |   ❌    |
+| Unit + integration testing    |                   Vitest + RTL                   |     ❌     |     ❌      |   ❌    |
+| E2E testing                   |                    Playwright                    |     ❌     |     ❌      |   ❌    |
+| Visual regression testing     |                   Chromatic CI                   |     ❌     |     ❌      |   ❌    |
+| i18n                          |          2 languages, working examples           |     ❌     |     ❌      |   ❌    |
+| Auth example                  |          login + session + route guards          |     ❌     |     ❌      |   ❌    |
+| Form validation               |            Conform + Zod + components            |     ❌     |     ❌      |   ❌    |
+| Storybook                     |         Router + i18n + dark mode + MSW          |     ❌     |     ❌      |   ❌    |
+| Dark mode                     | end-to-end (context + session + CSS + Storybook) |     ❌     |     ❌      |   ❌    |
+| API mocking (MSW)             |                tests + Storybook                 |     ❌     |     ❌      |   ❌    |
+| Documentation site            |           VitePress + GH Pages deploy            |     ❌     |     ❌      |   ❌    |
 
 ## Philosophy
 


### PR DESCRIPTION
## Summary

- Adds `UserPromptSubmit` hook (`.claude/hooks/intercept-init.sh`) that redirects the built-in `/init` to `/gaia-init`, protecting the template's curated `CLAUDE.md`. Hook fails open if `jq` is missing.
- `/gaia-init` self-removes the hook surgically at the end of initialization — only drops the matcher entry pointing at `intercept-init.sh`, preserves any other user-added `UserPromptSubmit` hooks.
- Full README rewrite: Claude-native framing, `/gaia-init` promoted to its own section, hooks/commands/rules/agent tables, comparison matrix expanded.
- New `.claude/rules/wiki-maintenance.md` — judgment-based criteria for deciding when a commit warrants a wiki update. Fires pre-commit alongside `quality-gate`.

## Test plan

- [x] Unit-tested `intercept-init.sh` locally: blocks `/init` and `/init --force`, passes `/initialize` / `/gaia-init` / unrelated prompts.
- [x] Verified live in Claude Code: typing `/init` in this repo now auto-invokes `/gaia-init` via the Skill tool.
- [x] `code-review-audit` run; 2 blockers fixed (jq guard + surgical self-removal), remaining nits documented.
- [ ] End-to-end `/gaia-init` run on a fresh clone — deferred; next PR or follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)