### PR TITLE
docs: remove exact counts of rules/commands/hooks/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Opinionated starter templates solve different slices of the "day-zero engineerin
 
 ### Claude-native
 
-Epic Stack, create-t3-app, and RedwoodJS don't ship Claude tooling at all. GAIA adds 15 path-scoped rules, 7 enforcement hooks, 11 Claude Code commands, 6 bundled skills, a code-review audit agent, Obsidian wiki integration, and MCP integrations out of the box.
+Epic Stack, create-t3-app, and RedwoodJS don't ship Claude tooling at all. GAIA adds path-scoped rules, enforcement hooks, Claude Code commands, bundled skills, a code-review audit agent, Obsidian wiki integration, and MCP integrations out of the box.
 
 ## Agentic Design
 
@@ -141,9 +141,9 @@ GAIA ships a complete, opinionated Claude Code workflow. Everything is wired in 
 
 ### Rules, hooks, skills
 
-- **15 path-scoped rules** cover TypeScript, React, Tailwind, testing, i18n, accessibility, and state management. Ask Claude about any of them — they're in `.claude/rules/`.
-- **7 hooks** guard the quality gate and keep the wiki fresh. Ask Claude what they do.
-- **6 bundled skills** (`typescript`, `react-code`, `tailwind`, `skeleton-loaders`, `tdd`, `playwright-cli`) auto-load for matching tasks.
+- **Path-scoped rules** cover TypeScript, React, Tailwind, testing, i18n, accessibility, and state management. Ask Claude about any of them — they're in `.claude/rules/`.
+- **Hooks** guard the quality gate and keep the wiki fresh. Ask Claude what they do.
+- **Bundled skills** (`typescript`, `react-code`, `tailwind`, `skeleton-loaders`, `tdd`, `playwright-cli`) autoload for matching tasks.
 
 ### Code review before merge
 

--- a/wiki/sources/Initial Ingest.md
+++ b/wiki/sources/Initial Ingest.md
@@ -38,7 +38,7 @@ tags: [source, initial]
   - TypeScript language files instead of JSON. ([[TypeScript Language Files]])
   - Husky runs tests on commit, not just lint. ([[Pre-commit Hooks]])
   - Form components are the headline feature. ([[Form Components]])
-- **Claude integration is first-class**: 8 commands, 10 rules, 4 hooks, 1 review agent + 3 specialists, 4 skills. ([[Claude Integration]])
+- **Claude integration is first-class**: commands, rules, hooks, a review agent + specialists, and skills — see [[Claude Integration]] for the current inventory.
 
 ## Pages created
 


### PR DESCRIPTION
## Summary

- Counts in README and wiki go stale on every addition/removal
- Replaced "15 path-scoped rules", "7 hooks", "6 bundled skills", "11 Claude Code commands" with generic terms throughout
- Updated `wiki/sources/Initial Ingest.md` to point to [[Claude Integration]] for the live inventory instead of embedding stale counts

## Test plan

- [x] README renders correctly — no broken links or formatting issues