### PR TITLE
Rename: gaia-react/react-router → gaia-react/gaia (in-tree references)

### DIFF
--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -79,7 +79,7 @@ Note: by default only `en` and `ja` folders exist in `app/languages/`.
 Use the project title from Step 2.
 
 - `package.json` `"name"` field → kebab-case of project title (e.g. `"hello-world"`)
-- `CLAUDE.md` — replace the `# GAIA React Template` heading with `# <Project Title>` (Title Case, e.g. `# Hello World`)
+- `CLAUDE.md` — replace the `# GAIA React` heading with `# <Project Title>` (Title Case, e.g. `# Hello World`)
 - `app/languages/en/pages/_index.ts` — update `meta.title`, `title`, and `heroTitle` to the project title
 - `app/languages/en/common.ts` — update `meta.siteName` to the project title
 - Do the same for every other `app/languages/<lang>/pages/_index.ts` and `common.ts` file (translate the title if appropriate, otherwise use the English project title)

--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -39,7 +39,7 @@ In `CHANGELOG.md`:
 2. If the section below it is empty (no Added/Changed/Fixed bullets), stop and ask the maintainer to write release notes first.
 3. Replace `## [Unreleased]` with `## [NEW_VERSION] — YYYY-MM-DD` (today's ISO date).
 4. Insert a fresh `## [Unreleased]` section (empty) above the newly-dated section.
-5. Update the comparison link footer at the bottom of the file — add a line like `[NEW_VERSION]: https://github.com/gaia-react/react-router/releases/tag/vNEW_VERSION` and update the `[Unreleased]` link to compare from the new tag.
+5. Update the comparison link footer at the bottom of the file — add a line like `[NEW_VERSION]: https://github.com/gaia-react/gaia/releases/tag/vNEW_VERSION` and update the `[Unreleased]` link to compare from the new tag.
 
 ## Step 6: Scrub `wiki/hot.md`
 
@@ -177,5 +177,5 @@ The tag push triggers `.github/workflows/release.yml`, which builds the scrubbed
 Print:
 
 - Tag name and short SHA of the release commit.
-- Expected GitHub Release URL: `https://github.com/gaia-react/react-router/releases/tag/v<NEW_VERSION>` — workflow takes ~1 minute.
+- Expected GitHub Release URL: `https://github.com/gaia-react/gaia/releases/tag/v<NEW_VERSION>` — workflow takes ~1 minute.
 - Reminder: if publishing `create-gaia` as well, bump its pinned default version to `v<NEW_VERSION>` and publish.

--- a/.claude/commands/gaia-update.md
+++ b/.claude/commands/gaia-update.md
@@ -22,7 +22,7 @@ Persist the trimmed version as `BASELINE` (e.g., `1.0.0`).
 ## Step 2: Resolve latest release
 
 ```bash
-gh release list --repo gaia-react/react-router --limit 1 --json tagName --jq '.[0].tagName'
+gh release list --repo gaia-react/gaia --limit 1 --json tagName --jq '.[0].tagName'
 ```
 
 Persist as `LATEST_TAG` (e.g., `v1.0.1`) and `LATEST` (strip leading `v`).
@@ -30,7 +30,7 @@ Persist as `LATEST_TAG` (e.g., `v1.0.1`) and `LATEST` (strip leading `v`).
 If `gh` is unavailable, fall back to:
 
 ```bash
-curl -fsSL https://api.github.com/repos/gaia-react/react-router/releases/latest | jq -r .tag_name
+curl -fsSL https://api.github.com/repos/gaia-react/gaia/releases/latest | jq -r .tag_name
 ```
 
 If both fail, stop and ask the user to supply the target version explicitly.
@@ -45,7 +45,7 @@ If both fail, stop and ask the user to supply the target version explicitly.
 Fetch the release body for `LATEST_TAG`:
 
 ```bash
-gh release view "$LATEST_TAG" --repo gaia-react/react-router --json body --jq .body
+gh release view "$LATEST_TAG" --repo gaia-react/gaia --json body --jq .body
 ```
 
 Print the notes to the user. Then use `AskUserQuestion`:
@@ -66,7 +66,7 @@ for tag in "v$BASELINE" "$LATEST_TAG"; do
   if [ ! -d "$dir" ]; then
     mkdir -p "$dir"
     gh release download "$tag" \
-      --repo gaia-react/react-router \
+      --repo gaia-react/gaia \
       --pattern "gaia-${tag}.tar.gz" \
       --dir "$dir"
     tar -xzf "$dir/gaia-${tag}.tar.gz" -C "$dir" --strip-components=1

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and discussion
-    url: https://github.com/gaia-react/react-router/discussions
+    url: https://github.com/gaia-react/gaia/discussions
     about: Ask questions, share tips, or discuss ideas before opening an issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the GAIA React Template are documented here.
+All notable changes to GAIA React are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -70,5 +70,5 @@ First public release. The template pivots from an example-app starter to a Claud
 - `tsconfig` paths and import resolution cleanup.
 - Login redirect issues uncovered during the auth removal.
 
-[Unreleased]: https://github.com/gaia-react/react-router/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/gaia-react/react-router/releases/tag/v1.0.0
+[Unreleased]: https://github.com/gaia-react/gaia/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/gaia-react/gaia/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# GAIA React Template
+# GAIA React
 
 When reporting information to me, be extremely concise and sacrifice grammar for the sake of concision.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <img src="./app/assets/images/gaia-logo.svg" height="100" alt="GAIA"/>
 
 [![Claude](https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff)](https://claude.com/claude-code)
-[![Tests](https://img.shields.io/github/actions/workflow/status/gaia-react/react-router/tests.yml?event=pull_request&label=tests)](https://github.com/gaia-react/react-router/actions/workflows/tests.yml)
-[![License: MIT](https://img.shields.io/github/license/gaia-react/react-router)](./LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/gaia-react/gaia/tests.yml?event=pull_request&label=tests)](https://github.com/gaia-react/gaia/actions/workflows/tests.yml)
+[![License: MIT](https://img.shields.io/github/license/gaia-react/gaia)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.19.0-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -20,7 +20,7 @@ const Footer: FC<FooterProps> = ({className}) => {
         <span>&copy;2026 GAIA Framework</span>
         <a
           className="hover:text-body transition-colors"
-          href="https://github.com/gaia-react/react-router?tab=MIT-1-ov-file#readme"
+          href="https://github.com/gaia-react/gaia?tab=MIT-1-ov-file#readme"
           rel="noreferrer"
           target="_blank"
         >

--- a/app/languages/en/pages/_index.ts
+++ b/app/languages/en/pages/_index.ts
@@ -2,7 +2,7 @@ export default {
   componentsLabel: 'Component Testing',
   componentsValue: 'Storybook + Chromatic',
   cta: 'View on GitHub',
-  eyebrow: 'GAIA React Template',
+  eyebrow: 'GAIA React',
   formsLabel: 'Forms',
   formsValue: 'Conform + Zod',
   frameworkLabel: 'Framework',

--- a/app/languages/ja/pages/_index.ts
+++ b/app/languages/ja/pages/_index.ts
@@ -2,7 +2,7 @@ export default {
   componentsLabel: 'コンポーネントテスト',
   componentsValue: 'Storybook + Chromatic',
   cta: 'GitHubで見る',
-  eyebrow: 'GAIA Reactテンプレート',
+  eyebrow: 'GAIA React',
   formsLabel: 'フォーム',
   formsValue: 'Conform + Zod',
   frameworkLabel: 'フレームワーク',

--- a/app/pages/Public/IndexPage/index.tsx
+++ b/app/pages/Public/IndexPage/index.tsx
@@ -58,7 +58,7 @@ const IndexPage: FC = () => {
               className="border-claude-500 text-claude-500 hover:bg-claude-500/10 dark:border-claude-400 dark:text-claude-300 dark:hover:bg-claude-500/15"
               icon={faGithub}
               size="lg"
-              to="https://github.com/gaia-react/react-router"
+              to="https://github.com/gaia-react/gaia"
               variant="secondary"
             >
               {t('cta')}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gaia-react-template",
+  "name": "gaia-react",
   "version": "1.0.0",
   "description": "Claude-native React Router template with TypeScript, Tailwind v4, Vitest, Playwright, and Storybook pre-configured.",
   "author": "Steven Sacks <stevensacks@gmail.com>",

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -9,7 +9,7 @@ tags: [release, claude, maintainer, versioning]
 
 # Release Workflow
 
-How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/react-router`) and the bootstrapper (`gaia-react/create-gaia`) — ship on independent cadences.
+How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/gaia`) and the bootstrapper (`gaia-react/create-gaia`) — ship on independent cadences.
 
 > [!note] Audience
 > The `/gaia-release` command is **maintainer-only** and stripped from distribution tarballs by `.gaia/release-exclude`. Adopters never see it. This page documents the flow so adopters understand what each GAIA release contains and why `/gaia-update` behaves the way it does.
@@ -69,7 +69,7 @@ Adopters who download the v1.0.0 tarball get 348 files, ~550 KB. The scrubbed `w
 Separate repo, separate npm package (`create-gaia`). Zero runtime deps. When an adopter runs `npx create-gaia my-app`:
 
 1. Resolves the target version (flag, or latest GitHub release).
-2. Downloads the release tarball from `github.com/gaia-react/react-router/releases/download/vX.Y.Z/gaia-vX.Y.Z.tar.gz`.
+2. Downloads the release tarball from `github.com/gaia-react/gaia/releases/download/vX.Y.Z/gaia-vX.Y.Z.tar.gz`.
 3. Extracts into `my-app/`.
 4. `git init` + initial commit (unless `--no-git`).
 5. `pnpm install` (after `corepack enable pnpm`), unless `--no-install`. The scaffolded project pins pnpm via `packageManager` in `package.json`; corepack provisions the matching version transparently.

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -37,7 +37,7 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 ## Flow
 
 1. Read `.gaia/VERSION`. Missing → tell user to run `/gaia-init` on a fresh `create-gaia` scaffold.
-2. Resolve latest release via `gh release list --repo gaia-react/react-router` (or GitHub API fallback).
+2. Resolve latest release via `gh release list --repo gaia-react/gaia` (or GitHub API fallback).
 3. Compare to baseline. Same or older → exit. Never downgrade.
 4. Show the adopter the release notes and **confirm** before touching anything.
 5. Download baseline + latest tarballs to `.gaia/cache/`.
@@ -76,7 +76,7 @@ Files deleted upstream (in baseline, not in latest):
 
 ## When to run
 
-After a new GAIA release is announced (watch releases on `gaia-react/react-router`). Cadence is fully at the adopter's discretion — skipping versions is fine; the three-way diff works with any gap.
+After a new GAIA release is announced (watch releases on `gaia-react/gaia`). Cadence is fully at the adopter's discretion — skipping versions is fine; the three-way diff works with any gap.
 
 ## See also
 

--- a/wiki/entities/GAIA.md
+++ b/wiki/entities/GAIA.md
@@ -11,7 +11,7 @@ tags: [entity, project]
 
 ## What it is
 
-GAIA React is a thoroughly-configured React Router 7 starter template. The current iteration (`gaia-template-react-router`, version `1.0.0-beta`) is a spiritual successor to the original GAIA Flash Framework.
+GAIA React is a thoroughly-configured React Router 7 starter template. The current iteration (`gaia-react`, version `1.0.0`) is a spiritual successor to the original GAIA Flash Framework.
 
 ## Authors / maintainers
 
@@ -19,7 +19,7 @@ GAIA React is a thoroughly-configured React Router 7 starter template. The curre
 
 ## Repos & resources
 
-- npm template: `npx create-react-router@latest --template gaia-react/react-router`
+- npm template: `npx create-react-router@latest --template gaia-react/gaia`
 - Background article on the philosophy: [react-japan.dev: ESLint fix-on-save](https://react-japan.dev/en/blog/eslint-fix-on-save)
 
 ## History
@@ -28,6 +28,6 @@ The original GAIA was a Flash framework — the most popular Flash framework wor
 
 ## Naming convention
 
-The package name in `package.json` is `gaia-template-react-router`. Code/wiki refer to it as **GAIA** (the brand) or **GAIA React** (the React iteration).
+The package name in `package.json` is `gaia-react`. Code/wiki refer to it as **GAIA** (the brand) or **GAIA React** (the React iteration).
 
 See [[GAIA Philosophy]].

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -40,7 +40,7 @@ Append-only. New entries at the TOP.
 - Added `.gaia/` directory: `VERSION` (adopter baseline marker), `manifest.json` (349 files classified as `owned`/`shared`/`wiki-owned`), `release-exclude` (tar-exclude list of maintainer-only paths), `scripts/generate-manifest.mjs` (classifier).
 - Added `/gaia-release` — maintainer-only (stripped from tarball via release-exclude). 12-step orchestrator: verify clean, bump, audit, graduate CHANGELOG, scrub `wiki/hot.md` + `wiki/log.md`, regenerate manifest, commit, tag, confirm, push.
 - Added `/gaia-update` — adopter-facing. GSD-inspired three-way diff per file; drifted `owned` prompts, drifted `shared`/`wiki-owned` emits `.gaia-merge/<path>.patch`, atomic version-marker bump.
-- Separate `create-gaia` npm package scaffolded at `../create-gaia/` — zero-dep Node CLI that downloads the release tarball from GitHub, extracts, `git init`, `npm install`. Replaces `npx create-react-router --template gaia-react/react-router` in the README quick-start (old command preserved under an "Alternative" fold).
+- Separate `create-gaia` npm package scaffolded at `../create-gaia/` — zero-dep Node CLI that downloads the release tarball from GitHub, extracts, `git init`, `npm install`. Replaces `npx create-react-router --template gaia-react/gaia` in the README quick-start (old command preserved under an "Alternative" fold).
 - CI made fork-safe: `tests.yml` + `chromatic.yml` fall back secrets to placeholders so forks pass lint/typecheck/unit. Chromatic split into a `has-chromatic-token` check job so it skips cleanly when the token is absent.
 - PR/issue templates added (`.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml`).
 - Pages created: [[Release Workflow]], [[Update Workflow]].


### PR DESCRIPTION
## Summary

Phase 1 of the rename-to-gaia plan: in-tree string updates ahead of the GitHub repo rename from \`gaia-react/react-router\` to \`gaia-react/gaia\`.

- \`package.json\` name: \`gaia-react-template\` → \`gaia-react\`
- README, CHANGELOG, Footer, hero copy, i18n eyebrows, issue templates updated to display name \`GAIA React\` and the new repo URL
- Wiki: \`entities/GAIA.md\`, \`concepts/{Update,Release} Workflow.md\`, \`log.md\` updated; package-name drift bug fixed
- \`.claude\` commands: \`gaia-update.md\`, \`gaia-release.md\`, \`gaia-init.md\` repointed at \`gaia-react/gaia\`

Out-of-scope (intentionally untouched): the npm \`react-router\` dep, \`react-router-stub.tsx\`, \`react-router.config.ts\`, \`.react-router/types/**\` paths, build artifacts, the on-disk folder name.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] pre-commit hook (lint-staged + vitest) passed
- [x] Merge AFTER Phase 2 (GitHub repo rename) so URLs in this commit resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)