### PR TITLE
chore: update issue template refs to /update-gaia

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
         - Tooling (build, test, lint, Storybook, Playwright)
         - create-gaia CLI
         - /gaia-init
-        - /gaia-update
+        - /update-gaia
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,7 +27,7 @@ body:
         - New scaffold (route, component, hook, service)
         - Existing code pattern or convention
         - Tooling or CI
-        - create-gaia / /gaia-init / /gaia-update
+        - create-gaia / /gaia-init / /update-gaia
         - Other
     validations:
       required: true


### PR DESCRIPTION
## Summary
- Update `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` to reference the renamed `/update-gaia` command (was `/gaia-update`).
- Follow-up to #42.

## Test plan
- [x] Visual check of YAML diff