### PR TITLE
chore: patch dependency updates

### DIFF
--- a/.claude/commands/update-deps.md
+++ b/.claude/commands/update-deps.md
@@ -1,6 +1,26 @@
 Autonomous superpowered Dependabot. Auto-discover all outdated packages, audit overrides, apply codebase migrations for major bumps, resolve dependency conflicts, and run the quality gate. No user prompts — just execute.
 
-## Phase 0: Override audit
+## Pre-flight: Branch check
+
+```bash
+git branch --show-current
+```
+
+If the current branch is `main` or `master`, create and switch to a new branch:
+
+```bash
+git checkout -b chore/update-deps-$(date +%Y-%m-%d-%H-%M)
+```
+
+Otherwise proceed on the current branch.
+
+## Phase 0–4: Haiku agent
+
+Spawn a **Haiku agent** (`model: "haiku"`) to run Phases 0–4. Pass it these instructions verbatim:
+
+---
+
+### Phase 0: Override audit
 
 For each key in `pnpm.overrides` (in `package.json`):
 
@@ -12,7 +32,7 @@ For each key in `pnpm.overrides` (in `package.json`):
 
 Operate on one key at a time. Always `pnpm install` after each toggle.
 
-## Phase 1: Discover outdated packages
+### Phase 1: Discover outdated packages
 
 ```bash
 pnpm outdated --json
@@ -30,7 +50,7 @@ Parse the JSON. For each entry record:
 
 If nothing is outdated after this filtering, print `All packages are up to date.` and exit.
 
-## Phase 2: Resolve companion groups
+### Phase 2: Resolve companion groups
 
 Map each outdated package into its group. **When any member of a group is outdated, include all members present in `package.json`** in the update — even ones not flagged outdated — so the group moves together.
 
@@ -56,12 +76,12 @@ Map each outdated package into its group. **When any member of a group is outdat
 
 Packages not matched form singleton groups.
 
-## Phase 3: Classify into waves
+### Phase 3: Classify into waves
 
 - **Wave A** — groups whose members all have minor or patch bumps only. Batched into one install.
 - **Wave B** — groups containing at least one major bump. Processed individually, ordered: `react-router`, `react`, `tailwindcss`, `storybook`, `vitest`, `playwright`, `eslint`, then remaining alphabetically.
 
-## Phase 4: Wave A (batch minor/patch)
+### Phase 4: Wave A (batch minor/patch)
 
 1. Build install args. For each package: if `is_pinned` use exact target, else use `^<latest>`. Example: `pnpm add foo@1.2.3 bar@^4.5.0 ...`.
 2. Run the single `pnpm add` command.
@@ -70,9 +90,44 @@ Packages not matched form singleton groups.
 5. If still failing: revert the offending packages (`pnpm add <pkg>@<previous>`) and log them as **skipped** with the reason.
 6. Run quality gate (Phase 7). If it fails, revert the entire Wave A batch.
 
+### Phase 7: Quality gate
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test --run
+pnpm pw
+pnpm build
+```
+
+### Return value
+
+Report back to the orchestrator with:
+
+- Override audit results (removed / retained)
+- Wave A results (updated packages, any skipped)
+- **Wave B groups** — list each group name and its major bump (e.g. `react-router: 6 → 7`)
+- Quality gate results
+
+---
+
 ## Phase 5: Wave B (per-group major bumps)
 
-For each Wave B group, in the order from Phase 3:
+After the Haiku agent returns, if there are no Wave B groups, skip to Phase 6.
+
+For each Wave B group, classify complexity and assign a model:
+
+**Opus** (`model: "opus"`): `react-router`, `react`, `typescript`, `storybook`, `eslint`
+
+**Sonnet** (`model: "sonnet"`): all other groups
+
+Spawn one agent per group (or sequentially if resource-constrained), passing it these instructions:
+
+---
+
+### Wave B group instructions
+
+You are upgrading the `{GROUP}` dependency group from `{FROM}` to `{TO}`.
 
 1. **Fetch migration guide** via WebFetch using the table below. If no URL applies, scan the GitHub release notes.
 2. **Install** the group:
@@ -80,7 +135,15 @@ For each Wave B group, in the order from Phase 3:
    - All others: `pnpm add <pkg1>@<latest> <pkg2>@<latest> ...` for every group member present in `package.json`.
 3. **Conflict check**: `pnpm ls 2>&1`. On peer-dep error, attempt one `pnpm.overrides` fix. If still failing, revert the group and skip with reason.
 4. **Apply breaking changes**: from the migration guide, identify code-affecting changes (renamed APIs, removed exports, config schema changes). `grep` the codebase for affected patterns and edit the matching files.
-5. **Quality gate** (Phase 7). On failure, attempt fixes inferred from the migration guide. If unfixable after a reasonable attempt, revert the entire group and log as skipped.
+5. **Quality gate**:
+   ```bash
+   pnpm typecheck
+   pnpm lint
+   pnpm test --run
+   pnpm pw
+   pnpm build
+   ```
+   On failure, attempt fixes inferred from the migration guide. If unfixable after a reasonable attempt, revert the entire group and log as skipped.
 
 Migration guide URLs:
 
@@ -97,21 +160,13 @@ Migration guide URLs:
 | msw          | `https://mswjs.io/docs/migrations`                                         |
 | vite         | `https://vite.dev/guide/migration`                                         |
 
+Report back: updated packages, breaking changes applied, any skipped reason, quality gate results.
+
+---
+
 ## Phase 6: Post-update override audit
 
-For every override that was **retained** in Phase 0, repeat the Phase 0 toggle test now that surrounding packages have moved. New versions may have resolved the original conflict.
-
-## Phase 7: Quality gate
-
-```bash
-pnpm typecheck
-pnpm lint
-pnpm test --run
-pnpm pw
-pnpm build
-```
-
-Run after Wave A completes, then once per Wave B group. Stop on first failure within a wave/group and follow the revert rules above.
+For every override that was **retained** in Phase 0, repeat the Phase 0 toggle test now that surrounding packages have moved. New versions may have resolved the original conflict. Run this as a **Haiku agent**.
 
 ## Phase 8: Final report
 

--- a/.claude/commands/update-gaia.md
+++ b/.claude/commands/update-gaia.md
@@ -7,6 +7,20 @@ Pull the latest GAIA release into this project without clobbering customizations
 
 Backups land in `.gaia-backup/<timestamp>/`. Conflict patches land in `.gaia-merge/`.
 
+## Pre-flight: Branch check
+
+```bash
+git branch --show-current
+```
+
+If the current branch is `main` or `master`, create and switch to a new branch:
+
+```bash
+git checkout -b chore/update-gaia-$(date +%Y-%m-%d-%H-%M)
+```
+
+Otherwise proceed on the current branch.
+
 ## Step 1: Read baseline version
 
 ```bash
@@ -55,7 +69,21 @@ Print the notes to the user. Then use `AskUserQuestion`:
 
 On `Abort`, exit cleanly with no filesystem changes.
 
-## Step 5: Fetch baseline and latest tarballs
+## Model selection
+
+After the user confirms, determine the model for the execution agent:
+
+- Compare `LATEST` major vs `BASELINE` major (leading integer).
+- **Major bump** → spawn an **Opus agent** (`model: "opus"`).
+- **Minor or patch bump** → spawn a **Sonnet agent** (`model: "sonnet"`).
+
+Spawn the agent for Steps 5–10, passing `BASELINE`, `LATEST`, and `LATEST_TAG` as context.
+
+---
+
+## Steps 5–10 (execution agent)
+
+### Step 5: Fetch baseline and latest tarballs
 
 Cache under `.gaia/cache/` (gitignored) so repeated runs don't redownload:
 
@@ -78,7 +106,7 @@ done
 
 If the baseline tarball is unavailable (older release, pre-manifest), stop and explain — the adopter can manually cherry-pick changes by comparing their project to the `$LATEST_DIR`.
 
-## Step 6: Load the latest manifest
+### Step 6: Load the latest manifest
 
 ```bash
 LATEST_MANIFEST="$LATEST_DIR/.gaia/manifest.json"
@@ -86,7 +114,7 @@ LATEST_MANIFEST="$LATEST_DIR/.gaia/manifest.json"
 
 Iterate keys of `.files`. For each `<path>, <class>` entry, apply the decision table below. Track counts per outcome for the summary.
 
-## Step 7: Per-file decision table
+### Step 7: Per-file decision table
 
 For every file `P` in the latest manifest:
 
@@ -119,7 +147,7 @@ Print per-file progress as you go:
 [keep]      app/utils/legacy.ts                   (upstream deleted, you customized)
 ```
 
-## Step 8: Bump `.gaia/VERSION`
+### Step 8: Bump `.gaia/VERSION`
 
 **Only** after the full walk completes without errors:
 
@@ -131,7 +159,7 @@ If the walk was aborted mid-way (user cancels, disk error), leave `.gaia/VERSION
 
 Also copy `.gaia/manifest.json` from `$LATEST_DIR/.gaia/manifest.json` into the project so the next `/update-gaia` has the right baseline.
 
-## Step 9: Summary
+### Step 9: Summary
 
 Print a table:
 
@@ -154,7 +182,7 @@ rm -f .gaia/cache/statusline-update-check.json
 
 The next statusline render fires the background refresher; the render after that reflects the post-update state.
 
-## Step 10: Next steps for the user
+### Step 10: Next steps for the user
 
 Tell the user:
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "build-storybook": "storybook build --test"
   },
   "dependencies": {
-    "@conform-to/react": "1.19.0",
-    "@conform-to/zod": "1.19.0",
+    "@conform-to/react": "1.19.1",
+    "@conform-to/zod": "1.19.1",
     "@epic-web/client-hints": "1.3.9",
     "@epic-web/invariant": "1.0.0",
     "@fortawesome/fontawesome-svg-core": "7.2.0",
@@ -52,7 +52,7 @@
     "query-string": "9.3.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",
-    "react-i18next": "17.0.4",
+    "react-i18next": "17.0.6",
     "react-router": "7.14.2",
     "react-router-dom": "7.14.2",
     "remix-i18next": "7.5.0",
@@ -104,7 +104,7 @@
     "remix-flat-routes": "0.8.5",
     "storybook": "10.3.5",
     "storybook-react-i18next": "10.1.2",
-    "stylelint": "17.9.0",
+    "stylelint": "17.9.1",
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "vite": "8.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@conform-to/react':
-        specifier: 1.19.0
-        version: 1.19.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 1.19.1
+        version: 1.19.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@conform-to/zod':
-        specifier: 1.19.0
-        version: 1.19.0(zod@4.3.6)
+        specifier: 1.19.1
+        version: 1.19.1(zod@4.3.6)
       '@epic-web/client-hints':
         specifier: 1.3.9
         version: 1.3.9
@@ -87,8 +87,8 @@ importers:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
       react-i18next:
-        specifier: 17.0.4
-        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+        specifier: 17.0.6
+        version: 17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-router:
         specifier: 7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -97,7 +97,7 @@ importers:
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       remix-i18next:
         specifier: 7.5.0
-        version: 7.5.0(i18next@26.0.8(typescript@6.0.3))(react-i18next@17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 7.5.0(i18next@26.0.8(typescript@6.0.3))(react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       remix-toast:
         specifier: 4.0.0
         version: 4.0.0(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -122,7 +122,7 @@ importers:
         version: 10.4.0
       '@gaia-react/lint':
         specifier: 1.1.0
-        version: 1.1.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(stylelint@17.9.0(typescript@6.0.3))(tailwindcss@4.2.4)(typescript@6.0.3)(vitest@4.1.5)
+        version: 1.1.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(stylelint@17.9.1(typescript@6.0.3))(tailwindcss@4.2.4)(typescript@6.0.3)(vitest@4.1.5)
       '@msw/data':
         specifier: 1.1.5
         version: 1.1.5
@@ -236,10 +236,10 @@ importers:
         version: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook-react-i18next:
         specifier: 10.1.2
-        version: 10.1.2(i18next-browser-languagedetector@8.2.1)(i18next-http-backend@3.0.6)(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react-i18next@17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 10.1.2(i18next-browser-languagedetector@8.2.1)(i18next-http-backend@3.0.6)(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       stylelint:
-        specifier: 17.9.0
-        version: 17.9.0(typescript@6.0.3)
+        specifier: 17.9.1
+        version: 17.9.1(typescript@6.0.3)
       tailwindcss:
         specifier: 4.2.4
         version: 4.2.4
@@ -405,17 +405,17 @@ packages:
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
-  '@conform-to/dom@1.19.0':
-    resolution: {integrity: sha512-2qegTdMy3ZT+SzzD8YyUWupAEhLl3X248bhrbhXdRsWjFdGSnTz12YB9j/f1MZ27A1LnmijKYiz2mgMdlblPAA==}
+  '@conform-to/dom@1.19.1':
+    resolution: {integrity: sha512-h4/T04zgASuiHMVEiXiyQA4jIW9zhpVFbp0HrWCQUDBxd8Zc1JbTarR7cuJyzkmqshC4tdm4VKIHguLp+7AYCw==}
 
-  '@conform-to/react@1.19.0':
-    resolution: {integrity: sha512-xK6+d2hHhiypLOpXIGLw9tD57N0GJFtmHBceaumS45tSV5Hr/bRiz1kioymJJrUUwV0bT+f1sTmHQZD6YJDOiw==}
+  '@conform-to/react@1.19.1':
+    resolution: {integrity: sha512-RrSfpy3B7bn1RoXCztlmQYMs113AWcvtqAluDqAx4yVbbVB+EcHWc3Ze/EXJhbtFDmljT2nMtcx/VY8f2RPGFg==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  '@conform-to/zod@1.19.0':
-    resolution: {integrity: sha512-kqwuubmJPcyDlf3gXLWjKsWhTiox4ICL/eXLFZONjnEAOHGP1sUvfhvuYwJpH0PJu82kgz9JZG5iuVOcZGsygw==}
+  '@conform-to/zod@1.19.1':
+    resolution: {integrity: sha512-S/C+Byhk87RdutjCuxhKcDf9lrmTx0V1OrtZPt5zrVG3RqcXVZz3NvLLZ7pNqdSg5DHGvuzPuotGfmPVu936ow==}
     peerDependencies:
       zod: ^3.21.0 || ^4.0.0
 
@@ -3988,8 +3988,8 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
-  react-i18next@17.0.4:
-    resolution: {integrity: sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==}
+  react-i18next@17.0.6:
+    resolution: {integrity: sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==}
     peerDependencies:
       i18next: '>= 26.0.1'
       react: '>= 16.8.0'
@@ -4474,8 +4474,8 @@ packages:
     peerDependencies:
       stylelint: ^16.18.0 || ^17.0.0
 
-  stylelint@17.9.0:
-    resolution: {integrity: sha512-xO0jeY6z1/urFL5L/BZLmB1yYlbRiRMQnYH6ArZIDWJ+SZXGssOY7XoYb1JIv/L220+EBnwwJXJS4Mt/F96SvA==}
+  stylelint@17.9.1:
+    resolution: {integrity: sha512-THTmnAPJTrg/JhkTWZlSyrO+HUYMx6ELthIHeMyD2WOKqXIJUFQv2Yxn91bvUrZdbBJaW2dUuQdPST2wcQ6C3g==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -5162,17 +5162,17 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@conform-to/dom@1.19.0': {}
+  '@conform-to/dom@1.19.1': {}
 
-  '@conform-to/react@1.19.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@conform-to/react@1.19.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@conform-to/dom': 1.19.0
+      '@conform-to/dom': 1.19.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@conform-to/zod@1.19.0(zod@4.3.6)':
+  '@conform-to/zod@1.19.1(zod@4.3.6)':
     dependencies:
-      '@conform-to/dom': 1.19.0
+      '@conform-to/dom': 1.19.1
       zod: 4.3.6
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -5393,7 +5393,7 @@ snapshots:
       '@fortawesome/fontawesome-svg-core': 7.2.0
       react: 19.2.5
 
-  '@gaia-react/lint@1.1.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(stylelint@17.9.0(typescript@6.0.3))(tailwindcss@4.2.4)(typescript@6.0.3)(vitest@4.1.5)':
+  '@gaia-react/lint@1.1.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(stylelint@17.9.1(typescript@6.0.3))(tailwindcss@4.2.4)(typescript@6.0.3)(vitest@4.1.5)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint/compat': 2.0.5(eslint@9.39.4(jiti@2.6.1))
@@ -5418,14 +5418,14 @@ snapshots:
       eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-you-dont-need-lodash-underscore: 6.14.0
       prettier-plugin-tailwindcss: 0.7.3(prettier@3.8.3)
-      stylelint-config-clean-order: 8.0.1(stylelint-order@8.1.1(stylelint@17.9.0(typescript@6.0.3)))(stylelint@17.9.0(typescript@6.0.3))
-      stylelint-config-standard: 40.0.0(stylelint@17.9.0(typescript@6.0.3))
-      stylelint-config-tailwindcss: 1.0.1(stylelint@17.9.0(typescript@6.0.3))(tailwindcss@4.2.4)
-      stylelint-order: 8.1.1(stylelint@17.9.0(typescript@6.0.3))
+      stylelint-config-clean-order: 8.0.1(stylelint-order@8.1.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-config-tailwindcss: 1.0.1(stylelint@17.9.1(typescript@6.0.3))(tailwindcss@4.2.4)
+      stylelint-order: 8.1.1(stylelint@17.9.1(typescript@6.0.3))
       typescript: 6.0.3
     optionalDependencies:
       prettier: 3.8.3
-      stylelint: 17.9.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
     transitivePeerDependencies:
       - '@eslint/css'
       - '@ianvs/prettier-plugin-sort-imports'
@@ -8744,7 +8744,7 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-i18next@17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
+  react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
@@ -8832,11 +8832,11 @@ snapshots:
       fs-extra: 11.3.4
       minimatch: 10.2.5
 
-  remix-i18next@7.5.0(i18next@26.0.8(typescript@6.0.3))(react-i18next@17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  remix-i18next@7.5.0(i18next@26.0.8(typescript@6.0.3))(react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       i18next: 26.0.8(typescript@6.0.3)
       react: 19.2.5
-      react-i18next: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      react-i18next: 17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   remix-toast@4.0.0(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
@@ -9146,12 +9146,12 @@ snapshots:
       - react
       - react-dom
 
-  storybook-react-i18next@10.1.2(i18next-browser-languagedetector@8.2.1)(i18next-http-backend@3.0.6)(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react-i18next@17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  storybook-react-i18next@10.1.2(i18next-browser-languagedetector@8.2.1)(i18next-http-backend@3.0.6)(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
       i18next: 26.0.8(typescript@6.0.3)
       i18next-browser-languagedetector: 8.2.1
       i18next-http-backend: 3.0.6
-      react-i18next: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      react-i18next: 17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook-i18n: 10.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
     transitivePeerDependencies:
@@ -9271,32 +9271,32 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stylelint-config-clean-order@8.0.1(stylelint-order@8.1.1(stylelint@17.9.0(typescript@6.0.3)))(stylelint@17.9.0(typescript@6.0.3)):
+  stylelint-config-clean-order@8.0.1(stylelint-order@8.1.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.9.0(typescript@6.0.3)
-      stylelint-order: 8.1.1(stylelint@17.9.0(typescript@6.0.3))
+      stylelint: 17.9.1(typescript@6.0.3)
+      stylelint-order: 8.1.1(stylelint@17.9.1(typescript@6.0.3))
 
-  stylelint-config-recommended@18.0.0(stylelint@17.9.0(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.9.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-config-standard@40.0.0(stylelint@17.9.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.9.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.9.0(typescript@6.0.3))
+      stylelint: 17.9.1(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.9.1(typescript@6.0.3))
 
-  stylelint-config-tailwindcss@1.0.1(stylelint@17.9.0(typescript@6.0.3))(tailwindcss@4.2.4):
+  stylelint-config-tailwindcss@1.0.1(stylelint@17.9.1(typescript@6.0.3))(tailwindcss@4.2.4):
     dependencies:
-      stylelint: 17.9.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
       tailwindcss: 4.2.4
 
-  stylelint-order@8.1.1(stylelint@17.9.0(typescript@6.0.3)):
+  stylelint-order@8.1.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
       postcss: 8.5.10
       postcss-sorting: 10.0.0(postcss@8.5.10)
-      stylelint: 17.9.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint@17.9.0(typescript@6.0.3):
+  stylelint@17.9.1(typescript@6.0.3):
     dependencies:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)


### PR DESCRIPTION
## Summary
- `@conform-to/react` 1.19.0 → 1.19.1
- `@conform-to/zod` 1.19.0 → 1.19.1
- `react-i18next` 17.0.4 → 17.0.6
- `stylelint` 17.9.0 → 17.9.1

## Test plan
- [x] typecheck passed
- [x] lint passed
- [x] unit tests passed (46 tests)
- [x] e2e tests passed (2 tests)
- [x] build passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)