### PR TITLE
chore: bump zod to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sonner": "2.0.7",
     "spark-md5": "3.0.2",
     "tailwind-merge": "3.5.0",
-    "zod": "4.3.6"
+    "zod": "4.4.1"
   },
   "devDependencies": {
     "@faker-js/faker": "10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.19.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@conform-to/zod':
         specifier: 1.19.1
-        version: 1.19.1(zod@4.3.6)
+        version: 1.19.1(zod@4.4.1)
       '@epic-web/client-hints':
         specifier: 1.3.9
         version: 1.3.9
@@ -114,8 +114,8 @@ importers:
         specifier: 3.5.0
         version: 3.5.0
       zod:
-        specifier: 4.3.6
-        version: 4.3.6
+        specifier: 4.4.1
+        version: 4.4.1
     devDependencies:
       '@faker-js/faker':
         specifier: 10.4.0
@@ -4952,8 +4952,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -5173,10 +5173,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@conform-to/zod@1.19.1(zod@4.3.6)':
+  '@conform-to/zod@1.19.1(zod@4.4.1)':
     dependencies:
       '@conform-to/dom': 1.19.1
-      zod: 4.3.6
+      zod: 4.4.1
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -7406,8 +7406,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.1
+      zod-validation-error: 4.0.2(zod@4.4.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8845,7 +8845,7 @@ snapshots:
   remix-toast@4.0.0(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
       react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      zod: 4.3.6
+      zod: 4.4.1
 
   remix-utils@9.3.1(@standard-schema/spec@1.1.0)(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -9769,8 +9769,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.1):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.1
 
-  zod@4.3.6: {}
+  zod@4.4.1: {}


### PR DESCRIPTION
## Summary
- Bumps `zod` 4.3.6 → 4.4.1 (patch)
- ESLint stays on 9.39.4 (capped at 9.x; latest is 10.x)
- No other outdated packages, no overrides to audit

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test --run` (46 passed)
- [x] `pnpm pw` (2 passed)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)