### PR TITLE
fix: support icon-only Button sizing and fix placeholder colors

### DIFF
--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -21,6 +21,14 @@ export const ICON_SIZES: Record<Size, string> = {
   xs: 'px-1.5',
 };
 
+export const ICON_ONLY_SIZES: Record<Size, string> = {
+  base: 'size-10',
+  lg: 'size-11',
+  sm: 'size-8',
+  xl: 'size-12',
+  xs: 'size-6',
+};
+
 export const ICON_POSITION: Record<'left' | 'right', string> = {
   left: '',
   right: 'flex-row-reverse',
@@ -93,6 +101,9 @@ const Button: FC<ButtonProps> = ({
 
   const innerClassName = twJoin(
     icon &&
+      !children &&
+      `flex items-center justify-center ${ICON_ONLY_SIZES[size]}`,
+    icon &&
       children &&
       `flex items-center justify-center gap-1.5 ${ICON_POSITION[iconPosition]}`
   );
@@ -105,6 +116,7 @@ const Button: FC<ButtonProps> = ({
         VARIANTS[variant],
         SIZES[size],
         icon && ICON_SIZES[size],
+        icon && !children && 'p-0',
         variant !== 'custom' && 'rounded-sm transition-colors duration-200',
         isLoading ? 'cursor-wait' : (
           'disabled:cursor-not-allowed disabled:opacity-50'

--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -100,12 +100,9 @@ const Button: FC<ButtonProps> = ({
     : null;
 
   const innerClassName = twJoin(
-    icon &&
-      !children &&
-      `flex items-center justify-center ${ICON_ONLY_SIZES[size]}`,
-    icon &&
-      children &&
-      `flex items-center justify-center gap-1.5 ${ICON_POSITION[iconPosition]}`
+    icon && 'flex items-center justify-center',
+    icon && !children && ICON_ONLY_SIZES[size],
+    icon && children && `gap-1.5 ${ICON_POSITION[iconPosition]}`
   );
 
   return (
@@ -115,7 +112,7 @@ const Button: FC<ButtonProps> = ({
         'text-center whitespace-nowrap select-none',
         VARIANTS[variant],
         SIZES[size],
-        icon && ICON_SIZES[size],
+        icon && children && ICON_SIZES[size],
         icon && !children && 'p-0',
         variant !== 'custom' && 'rounded-sm transition-colors duration-200',
         isLoading ? 'cursor-wait' : (

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -118,7 +118,7 @@
     @apply read-only:focus-visible:border-gray-400 read-only:focus-visible:ring-transparent;
     @apply dark:text-white;
     @apply read-only:text-disabled;
-    @apply placeholder:text-placeholder disabled:placeholder:text-disabled;
+    @apply placeholder:text-gray-400 disabled:placeholder:text-gray-400 dark:placeholder:text-gray-600 dark:disabled:placeholder:text-gray-600;
   }
 
   [type='checkbox'] {


### PR DESCRIPTION
## Summary

- Add `ICON_ONLY_SIZES` size map and icon-only layout logic to `Button` — when `icon` is present with no `children`, applies fixed `size-*` dimensions and `p-0` instead of padded sizing
- Fix input placeholder colors to use explicit gray values for both light/dark and disabled states

## Test plan

- [x] Render a `Button` with only an `icon` prop (no `children`) at each size — verify square fixed dimensions
- [x] Render a `Button` with both `icon` and `children` — verify existing layout unchanged
- [x] Inspect disabled input placeholders in light and dark mode — verify correct gray color

🤖 Generated with [Claude Code](https://claude.com/claude-code)