### PR TITLE
feat(gaia-init): add optional statusline install step

### DIFF
--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -129,6 +129,49 @@ GAIA bundles project-scoped skills at `.claude/skills/` (`eslint-fixes`, `playwr
 - `claude plugin marketplace add AgriciDaniel/claude-obsidian`
 - `claude plugin install claude-obsidian@claude-obsidian-marketplace`
 
+### Install the GAIA statusline (optional)
+
+The GAIA statusline shows: **project folder | git branch | active model | context window usage**.
+
+Show the user a live preview by running:
+
+```bash
+echo '{"workspace":{"current_dir":"'"$(pwd)"'"},"model":{"display_name":"Claude Opus 4.7"},"context_window":{"used_percentage":42}}' \
+  | bash .gaia/statusline/preferred-base.sh; echo
+```
+
+The Bash output renders with ANSI colors in the chat. Then `AskUserQuestion`:
+
+> Install the GAIA statusline (project | branch | model | context bar)?
+>
+> - **Globally (Recommended)** — show this statusline in every project on this machine.
+> - **Only in this project** — show only when Claude is launched in this GAIA project.
+> - **Skip** — keep Claude's default statusline.
+
+Apply the answer:
+
+- **Globally** → copy `.gaia/statusline/preferred-base.sh` to `~/.claude/preferred-base.sh`, `chmod +x ~/.claude/preferred-base.sh`, then write into `~/.claude/settings.json` (insert alphabetically, preserving existing keys):
+
+  ```json
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/preferred-base.sh"
+  }
+  ```
+
+- **Only in this project** → write into `.claude/settings.json` (insert alphabetically, preserving existing keys):
+
+  ```json
+  "statusLine": {
+    "type": "command",
+    "command": "bash .gaia/statusline/preferred-base.sh"
+  }
+  ```
+
+- **Skip** → no action.
+
+Before writing either settings file, read its current contents so you merge rather than overwrite. Use jq or manual JSON editing — never truncate the file.
+
 ## Step 10: Refresh the wiki
 
 The template ships with a wiki shaped for the upstream GAIA project. Refresh the two files that encode "where we are right now" so the new project starts with a clean context:

--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -15,9 +15,14 @@ Otherwise, ask: **"What do you want me to orchestrate?"** and wait for the respo
 Check your current model from session context.
 
 - If you are on Opus, skip to step 3.
-- If not, ask: **"You're on [model name]. Use Opus for planning? (Y/n)"** — default yes.
-  - Yes (or Enter): spawn the agent with `model: opus`.
-  - No: spawn without a model override (inherit current).
+- If not, call `AskUserQuestion` with:
+  - question: `"You're on [model name]. Use Opus for planning?"`
+  - header: `"Model"`
+  - options:
+    - `{ label: "Use Opus (Recommended)", description: "Spawn the planning agent on Opus 4.7 for higher-quality plans." }`
+    - `{ label: "Use [model name]", description: "Keep the current model." }`
+  - If user picks option 1: spawn the agent with `model: opus`.
+  - If user picks option 2: spawn without a model override (inherit current).
 
 ### 3. Spawn planning agent
 

--- a/.gaia/statusline/preferred-base.sh
+++ b/.gaia/statusline/preferred-base.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# GAIA "preferred base" statusline renderer.
+#
+# Self-contained left-side renderer: project | branch | model | context-bar.
+# Vendored so /gaia-init can offer it as either a global install or a
+# project-only base.
+#
+# Reads JSON from stdin (Claude Code convention) and prints a single line.
+# No network calls. No `set -e` — partial failure must degrade gracefully.
+
+input=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  cwd=$(printf '%s' "$input" | jq -r '.workspace.current_dir // empty' 2>/dev/null)
+  [ -z "$cwd" ] && cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+  model=$(printf '%s' "$input" | jq -r '.model.display_name // empty' 2>/dev/null | sed 's/^Claude //')
+  effort=$(printf '%s' "$input" | jq -r '.effortLevel // empty' 2>/dev/null)
+  used_pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty' 2>/dev/null)
+else
+  cwd=""
+  model=""
+  effort=""
+  used_pct=""
+fi
+[ -z "$cwd" ] && cwd="$PWD"
+
+if git -C "$cwd" rev-parse --git-dir >/dev/null 2>&1; then
+  git_root=$(git -C "$cwd" --no-optional-locks rev-parse --show-toplevel 2>/dev/null)
+  project=$(basename "$git_root")
+  branch=$(git -C "$cwd" --no-optional-locks rev-parse --abbrev-ref HEAD 2>/dev/null)
+  git_info=$(printf '\033[01;34m%s\033[00m | \033[01;32m%s\033[00m' "$project" "$branch")
+else
+  project=$(basename "$cwd")
+  git_info=$(printf '\033[01;34m%s\033[00m' "$project")
+fi
+
+if [ -n "$effort" ]; then
+  effort_cap=$(printf '%s' "$effort" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
+  model="${model} (${effort_cap})"
+fi
+
+context_bar=""
+if [ -n "$used_pct" ]; then
+  filled=$(printf '%s' "$used_pct" | awk '{printf "%d", ($1 / 10 + 0.5)}')
+  [ -z "$filled" ] && filled=0
+  [ "$filled" -gt 10 ] && filled=10
+  empty=$((10 - filled))
+  bar=""
+  for _ in $(seq 1 "$filled" 2>/dev/null); do bar="${bar}▓"; done
+  for _ in $(seq 1 "$empty" 2>/dev/null); do bar="${bar}░"; done
+  pct_int=$(printf '%.0f' "$used_pct" 2>/dev/null)
+  [ -z "$pct_int" ] && pct_int=0
+  if [ "$pct_int" -ge 80 ]; then
+    color="\033[01;31m"
+  elif [ "$pct_int" -ge 50 ]; then
+    color="\033[01;33m"
+  else
+    color="\033[01;32m"
+  fi
+  context_bar=$(printf "${color}%s\033[00m %d%%" "$bar" "$pct_int")
+fi
+
+out=""
+sep=""
+[ -n "$git_info" ] && { out="${out}${sep}${git_info}"; sep=" | "; }
+[ -n "$model" ] && { out="${out}${sep}\033[01;36m${model}\033[00m"; sep=" | "; }
+[ -n "$context_bar" ] && { out="${out}${sep}${context_bar}"; sep=" | "; }
+
+printf '%b' "${out:-Claude Code}"


### PR DESCRIPTION
## Summary

- Restores `.gaia/statusline/preferred-base.sh` (left-side renderer: project | branch | model | context bar)
- Adds optional statusline install step to `/gaia-init` with three choices: globally, project-only, or skip
- Shows a live ANSI-color preview before the user decides
- Updates docs `Statusline.tsx`: simplified copy, single preview row, 4-row legend (committed to `gaia-react/gaia-react.github.io` on main)

## Test plan

- [ ] Run `.gaia/statusline/preferred-base.sh` with sample JSON — verify ANSI output
- [ ] Review `gaia-init.md` statusline step — preview command, three options, settings merge logic
- [ ] Open docs site — Statusline section shows one row preview, no right-side copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)