### PR TITLE
docs(gaia-release): document the actual PR-based release flow

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -1,21 +1,28 @@
 ---
 name: gaia-release
-description: Cut a new GAIA release — bump version, graduate CHANGELOG, regenerate manifest, commit, tag, push. Maintainer-only.
+description: Cut a new GAIA release — bump version, graduate CHANGELOG, regenerate manifest, open release PR, then tag on merge. Maintainer-only.
 ---
 
-Cut a new GAIA release. Verifies the tree is clean, bumps the version, graduates `## [Unreleased]` in `CHANGELOG.md`, scrubs the adopter-facing wiki files, regenerates `.gaia/manifest.json`, commits, tags, and pushes. This command is **maintainer-only** — it is stripped from distributed tarballs by `.gaia/release-exclude` so adopters never see it.
+Cut a new GAIA release. Verifies the tree is clean, bumps the version, graduates `## [Unreleased]` in `CHANGELOG.md`, scrubs the adopter-facing wiki files, regenerates `.gaia/manifest.json`, commits to a `release/v<NEW_VERSION>` branch, opens a PR, and — after the maintainer merges — tags the merge commit on `main` and pushes the tag. This command is **maintainer-only** — it is stripped from distributed tarballs by `.gaia/release-exclude` so adopters never see it.
 
 Unlike `/gaia-init`, this command does **not** self-delete. It runs every release.
 
-## Step 1: Verify clean tree and release branch
+> [!important] `main` is protected
+> Direct pushes to `main` are blocked. The release commit lands on a `release/v<NEW_VERSION>` branch, goes through a PR, and the tag is created on the merge commit *after* it lands on `main`. Do not tag locally before the PR merges — the tag must point at the merge commit, not the pre-merge release commit.
 
-- Current branch must be `main` (or an explicit release branch). If not, stop and report.
+## Step 1: Verify clean tree, on `main`
+
+- Current branch must be `main`. If not, stop and report (the command creates the release branch itself in Step 4).
 - `git status` must show a clean working tree. If there are uncommitted changes, stop and report.
+- Local `main` must be up to date with `origin/main`. If behind, `git pull --ff-only` first.
 - Working directory is the repo root.
 
 ```bash
 git -C . rev-parse --abbrev-ref HEAD
 git -C . status --porcelain
+git -C . fetch origin main
+git -C . rev-list --count origin/main..main  # must be 0
+git -C . rev-list --count main..origin/main  # if >0, pull --ff-only
 ```
 
 ## Step 2: Ask the user which bump
@@ -31,22 +38,32 @@ Compute the new version from `.gaia/VERSION` + the bump. Persist it as `NEW_VERS
 
 Run the quality gate per `wiki/decisions/Quality Gate.md`. It must pass before continuing. If anything fails, stop and report — the maintainer fixes, recommits, then re-runs `/gaia-release`.
 
-## Step 4: Bump version files
+## Step 4: Switch to the release branch
+
+Create and switch to `release/v<NEW_VERSION>` from `main`. All subsequent edits and the release commit land here, not on `main`.
+
+```bash
+git -C . checkout -b "release/v<NEW_VERSION>"
+```
+
+If the branch already exists (e.g. a previous attempt aborted mid-flow), stop and ask the maintainer whether to delete it and retry, or resume.
+
+## Step 5: Bump version files
 
 - Update `package.json` `"version"` to `NEW_VERSION`.
 - Update `.gaia/VERSION` to `NEW_VERSION` (single line).
 
-## Step 5: Graduate CHANGELOG
+## Step 6: Graduate CHANGELOG
 
 In `CHANGELOG.md`:
 
-1. Find the `## [Unreleased]` heading.
+1. Find the `## [Unreleased]` heading. If absent (e.g. immediately after a release that didn't seed it), draft the new release entry directly without aborting.
 2. If the section below it is empty (no Added/Changed/Fixed bullets), stop and ask the maintainer to write release notes first.
 3. Replace `## [Unreleased]` with `## [NEW_VERSION] — YYYY-MM-DD` (today's ISO date).
 4. Insert a fresh `## [Unreleased]` section (empty) above the newly-dated section.
 5. Update the comparison link footer at the bottom of the file — add a line like `[NEW_VERSION]: https://github.com/gaia-react/gaia/releases/tag/vNEW_VERSION` and update the `[Unreleased]` link to compare from the new tag.
 
-## Step 6: Scrub `wiki/hot.md`
+## Step 7: Scrub `wiki/hot.md`
 
 Overwrite `wiki/hot.md` entirely with:
 
@@ -68,7 +85,7 @@ updated: <TODAY_ISO>
 - None.
 ```
 
-## Step 7: Scrub `wiki/log.md`
+## Step 8: Scrub `wiki/log.md`
 
 Overwrite `wiki/log.md` entirely with:
 
@@ -82,7 +99,7 @@ See CHANGELOG.md for details.
 
 (The full development history remains in `git log`; adopters do not need it in the wiki.)
 
-## Step 8: Regenerate `.gaia/manifest.json`
+## Step 9: Regenerate `.gaia/manifest.json`
 
 Walk the tree and emit a manifest mapping each GAIA-shipped file to a class. Adopter-owned files (`wiki/hot.md`, `wiki/log.md`, anything not listed) are implicit — absent from the manifest entirely.
 
@@ -136,7 +153,7 @@ node .gaia/scripts/generate-manifest.mjs > .gaia/manifest.json.tmp && \
 
 (If `.gaia/scripts/generate-manifest.mjs` has not been authored yet, do so now — see Step 8's classification rules. The script is tiny: walk `git ls-files`, subtract `.gaia/release-exclude` matches and sentinel paths, classify each remaining path by the rules above, emit sorted JSON.)
 
-## Step 9: Commit
+## Step 10: Commit on the release branch
 
 Stage everything changed (package.json, .gaia/VERSION, .gaia/manifest.json, CHANGELOG.md, wiki/hot.md, wiki/log.md) and commit:
 
@@ -147,23 +164,55 @@ git -C . commit -m "chore(release): v<NEW_VERSION>"
 
 If a pre-commit hook fails, stop and report — fix the issue and create a **new** commit; do not `--amend`.
 
-## Step 10: Tag
+**Do not tag yet.** The tag must point at the merge commit on `main`, which doesn't exist until after the PR merges. Tagging the local pre-merge commit and then pushing leads to a tag that doesn't match `main`'s history.
+
+## Step 11: Push the release branch and open the PR
 
 ```bash
-git -C . tag -a "v<NEW_VERSION>" -m "Release v<NEW_VERSION>"
+git -C . push -u origin "release/v<NEW_VERSION>"
+```
+
+Then open the PR with `gh pr create` against `main`:
+
+```bash
+gh pr create --base main --head "release/v<NEW_VERSION>" \
+  --title "chore: release v<NEW_VERSION>" \
+  --body "<release summary — link the CHANGELOG entry, list highlights, include the quality-gate checklist>"
+```
+
+Print the PR URL.
+
+## Step 12: STOP and wait for the maintainer to merge
+
+The release commit cannot land on `main` without a PR review/merge. Stop here, surface the PR URL, and wait for the maintainer to confirm the merge before continuing.
+
+When the maintainer says it's merged, proceed to Step 13.
+
+## Step 13: Tag the merge commit and push
+
+After the maintainer merges the PR:
+
+```bash
+git -C . checkout main
+git -C . pull --ff-only origin main
+git -C . log --oneline -1   # confirm the merge commit is at HEAD
+```
+
+Capture the merge commit SHA. Then create the annotated tag on that commit and confirm with the maintainer before pushing.
+
+```bash
+MERGE_SHA=$(git -C . rev-parse HEAD)
+git -C . tag -a "v<NEW_VERSION>" "$MERGE_SHA" -m "Release v<NEW_VERSION>"
 ```
 
 Use `-s` instead of `-a` if the maintainer has gpg/ssh signing configured.
 
-## Step 11: Confirm and push
-
-**Ask the maintainer explicitly** before pushing. Show exactly what will be pushed:
+**Ask the maintainer explicitly** before pushing the tag. Show exactly what will be pushed:
 
 ```
 About to push:
-  commit: chore(release): v<NEW_VERSION>
-  tag:    v<NEW_VERSION>
-  to:     origin/main
+  tag: v<NEW_VERSION> → <short SHA> (chore(release): v<NEW_VERSION> (#<PR>))
+  to:  origin
 
 Proceed? (y/n)
 ```
@@ -171,16 +220,26 @@ Proceed? (y/n)
 On `y`:
 
 ```bash
-git -C . push origin main
 git -C . push origin "v<NEW_VERSION>"
 ```
 
 The tag push triggers `.github/workflows/release.yml`, which builds the scrubbed tarball and creates the GitHub Release.
 
-## Step 12: Report
+## Step 14: Report
 
 Print:
 
-- Tag name and short SHA of the release commit.
+- Tag name and short SHA of the merge commit.
 - Expected GitHub Release URL: `https://github.com/gaia-react/gaia/releases/tag/v<NEW_VERSION>` — workflow takes ~1 minute.
 - Reminder: if publishing `create-gaia` as well, bump its pinned default version to `v<NEW_VERSION>` and publish.
+
+## Recovery: I tagged on the wrong commit
+
+If you (or a previous attempt) tagged the local pre-merge commit instead of the merge commit:
+
+```bash
+git -C . tag -d "v<NEW_VERSION>"           # delete locally
+git -C . push origin :"v<NEW_VERSION>"     # only if already pushed (otherwise skip)
+```
+
+Then re-tag from Step 13 against the actual merge commit.


### PR DESCRIPTION
## Summary

`main` is protected — direct pushes are blocked. The previous `/gaia-release` flow had the command commit, tag, and push to `main` directly, which fails. The v1.0.1 release had to abort mid-flow, move the commit to a release branch, delete the local tag, open a PR, and re-tag the merge commit after the PR landed.

This PR encodes that real flow as the canonical sequence so future releases run cleanly:

- **Step 4** (new) — create `release/v<NEW_VERSION>` branch before any edits.
- **Step 10** — commit on the release branch; explicitly do **not** tag yet.
- **Step 11** — push the branch and open the PR via `gh pr create`.
- **Step 12** (new) — STOP and wait for the maintainer to merge.
- **Step 13** — checkout `main`, pull, tag the merge commit, push the tag.
- **Recovery** section — what to do if you tagged the wrong commit (we hit this on v1.0.1).

The doc is in `.gaia/release-exclude`, so adopters don't ship this file — no CHANGELOG entry needed.

## Test plan

- [x] Step numbering is sequential (1-14)
- [x] Next release will follow the new flow — verifies it end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)