### PR TITLE
Update Agentic Design audit path to studio/

### DIFF
--- a/wiki/concepts/Agentic Design.md
+++ b/wiki/concepts/Agentic Design.md
@@ -118,7 +118,7 @@ A handful of patterns from the canonical taxonomy are deliberately absent in GAI
 - **Vector RAG**: wiki retrieval is symbolic (paths, grep, `wiki/index.md`, backlinks), not embedding-based. Closer to "structured-markdown retrieval-on-demand" than canonical RAG.
 - **Code-Then-Execute**: a Claude Code runtime capability, not a GAIA convention.
 
-The full pattern-by-pattern grading (12 Strong, 13 Partial, 1 Inferential, 3 Absent), with evidence per pattern and an honest discussion of overclaims to retire, lives in [`branding/research/AGENTIC_DESIGN.md`](../../../branding/research/AGENTIC_DESIGN.md). That report is the source of truth for these claims.
+The full pattern-by-pattern grading (12 Strong, 13 Partial, 1 Inferential, 3 Absent), with evidence per pattern and an honest discussion of overclaims to retire, lives in [`studio/strategy/research/AGENTIC_DESIGN.md`](../../../studio/strategy/research/AGENTIC_DESIGN.md). That report is the source of truth for these claims.
 
 ## Why structural matters
 
@@ -139,4 +139,4 @@ The result is a system where Claude's autonomy is bounded, its quality is enforc
 - [[GAIA Audit]]
 - [[PR Merge Workflow]]
 - [Source taxonomy: 29 agentic design patterns](https://zeljkoavramovic.github.io/agentic-design-patterns/)
-- Internal audit: [`branding/research/AGENTIC_DESIGN.md`](../../../branding/research/AGENTIC_DESIGN.md)
+- Internal audit: [`studio/strategy/research/AGENTIC_DESIGN.md`](../../../studio/strategy/research/AGENTIC_DESIGN.md)


### PR DESCRIPTION
## Summary

- Update path reference: `branding/research/AGENTIC_DESIGN.md` → `studio/strategy/research/AGENTIC_DESIGN.md`

The `branding/research/` content moved into a private `studio/` vault as part of a broader workspace reorganization. Mechanical path update; no analytical content changed.

## Test plan

- [x] `wiki/concepts/Agentic Design.md` renders correctly with the updated link
- [x] Path resolves: `~/Development/gaia-react/studio/strategy/research/AGENTIC_DESIGN.md` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)