### PR TITLE
chore: launch prep for May 12 + studio path migration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: stevensacks
+github: gaia-react

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## Checklist
 
-- [ ] Ran `/audit-code` — the quality gate is green (typecheck, lint, tests, build).
+- [ ] Quality gate is green locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`. Zero warnings.
 - [ ] Updated `CHANGELOG.md` under `## [Unreleased]` if this change is user-visible.
 - [ ] Updated or added wiki pages in `wiki/concepts`, `wiki/decisions`, or `wiki/modules` if this change affects a documented pattern.
 - [ ] Verified the change does not break the first-run `/gaia-init` flow (if touching `.claude/`, `app/components/Header`, language files, or branding paths).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at steven@gaiareact.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to GAIA React
+
+GAIA is opinionated. The conventions, rules, and hooks aren't suggestions. They're the product. Pull requests that fight the opinions will be redirected, not merged. Pull requests that sharpen them are welcome.
+
+## Before you contribute
+
+- Read the [README](./README.md). The whole thing.
+- Install with `npx create-gaia my-app` and walk through `/gaia-init` so you understand what a fresh project looks like.
+- Run the quality gate locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`. All four green, no warnings.
+- Browse the wiki under `wiki/`. That's where the project's reasoning lives.
+
+## Filing issues
+
+A good issue:
+
+- A short title that names the surface (rule, hook, skill, command, wiki page).
+- A reproduction. What you ran, what you expected, what happened.
+- GAIA version (from your project's `package.json`, or `git log -1` from a clone of `gaia-react/gaia`).
+- Node version, package manager, OS.
+
+Issues that aren't bugs:
+
+- Questions about how to use GAIA go to the docs site at [gaiareact.com](https://gaiareact.com), or open a GitHub Discussion if enabled.
+- Security issues go to steven@gaiareact.com. Do not file public issues for vulnerabilities.
+
+## Submitting pull requests
+
+1. Fork. Branch from `main`. Name the branch by intent: `fix/`, `feat/`, `chore/`, `docs/`.
+2. Commit messages follow conventional commits: `fix(scope): what`, `feat(scope): what`. Run `git log --oneline` for examples.
+3. The quality gate must pass locally before you push: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`. Zero warnings allowed. This is the project's distinguishing stance, not a starting position to negotiate.
+4. The code-review audit will run on your PR. It dispatches React Patterns, TypeScript and Architecture, and Translation specialists in parallel against your diff. It blocks the merge until findings are resolved.
+5. No `eslint-disable`, no `@ts-ignore`, no `eslint-disable-next-line`. If a rule is wrong for the case, open a separate PR to refine the rule. If the rule is right, fix the source.
+6. Update `CHANGELOG.md` under `## [Unreleased]` if your change is user-visible.
+7. PRs that lower the bar will be requested-changes back. PRs that raise it will be merged.
+
+## Working with Claude Code in this repo
+
+GAIA is itself written using GAIA conventions. If you use Claude to work on GAIA, the rules and hooks will guide you the same way they would in a downstream project. The merge audit applies to your PR regardless of who wrote the code.
+
+If Claude generates a change that fights an existing rule, the rule wins. If you disagree with the rule, open an issue first.
+
+## What we won't accept
+
+- Refactors without a stated problem.
+- Architectural changes without prior discussion.
+- Removing or weakening the strict tooling.
+- Framework swaps. The current stack is React Router 7, Tailwind, Vitest, Playwright, MSW, Conform, Zod. If you want to add support for Next.js, Astro, or TanStack Start, open an issue first. That's a roadmap conversation, not a PR.
+- Cosmetic-only changes to working code.
+
+## Code of conduct
+
+By contributing, you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you license your contributions under the [MIT License](./LICENSE), matching the project.

--- a/README.md
+++ b/README.md
@@ -8,17 +8,15 @@
 [![Node](https://img.shields.io/badge/node-%3E%3D22.19.0-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 
-**The React workflow for Claude.** GAIA makes Claude trustworthy enough to own features end to end, and disciplined enough to do it at scale.
+**Claude is raw power. GAIA is order and focus.**
 
-Every convention is enforced in code, not described in prose. Per-request token cost stays low because rules and wiki pages load on demand, not preloaded.
+The React workflow that keeps Claude-shipped code production-grade as your team scales. Every convention enforced in code. Every shortcut blocked at the source. Every merge audited before it lands.
 
 ## Who it's for
 
-- Solo developers shipping Claude-built projects
-- Product teams standardizing how Claude works across the org
-- Agencies that want a templated starting point for client work
-
-If Claude writes most of your code, GAIA is the substrate that makes it trustworthy.
+- Engineering teams whose AI output is outpacing their review process
+- Engineering leads standardizing how Claude works across the org
+- Solo developers and agencies who want production-grade defaults from day one
 
 ## Quick Start
 
@@ -66,7 +64,7 @@ Context bloat isn't just `CLAUDE.md` sprawl. Instructions get dropped into globa
 
 Every piece of GAIA's [tech stack](https://gaiareact.com/#stack) is pre-configured and wired into the Claude layer.
 
-- **1,592 lint rules** across 20+ ESLint plugins, [Prettier](https://prettier.io/), and [Stylelint](https://stylelint.io/) — including 85 Stylelint rules that catch the patterns Claude drifts into first: complexity creep, architectural shortcuts, mismatched filenames, broken CSS
+- **1,592 lint rules** across 20+ ESLint plugins, [Prettier](https://prettier.io/), and [Stylelint](https://stylelint.io/), including 85 Stylelint rules that catch the patterns Claude drifts into first: complexity creep, architectural shortcuts, mismatched filenames, broken CSS
 - **Pre-commit hooks** ([Husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged)): typecheck, lint, and test before CI
 - **Four testing layers sharing one mock layer**: [Vitest](https://vitest.dev) + [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) for unit/integration, [Playwright](https://playwright.dev/docs/intro) for E2E, [Chromatic](https://chromatic.com/) for visual regression
 - **Internationalization** via [remix-i18next](https://github.com/sergiodxa/remix-i18next) with working examples

--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,0 +1,13 @@
+# Supporters
+
+GAIA is open source. These sponsors keep the work going.
+
+[Become a supporter via GitHub Sponsors](https://github.com/sponsors/gaia-react)
+
+## Company Sponsors
+
+## Team Supporters
+
+## Personal Supporters
+
+## One-Time Supporters


### PR DESCRIPTION
## Summary

Launch-prep batch for the May 12 public release, bundled with the previously in-flight studio path migration commits on this branch.

## Launch prep (newest commit)

- README: locked positioning hook ("Claude is raw power. GAIA is order and focus."), reoriented "Who it's for" to lead with mid-market engineering teams (Tier-1 buyer per studio strategy)
- CONTRIBUTING.md (new): conventions, quality gate, code-review audit flow, what we won't accept
- CODE_OF_CONDUCT.md (new): Contributor Covenant 2.1 with steven@gaiareact.com contact
- SUPPORTERS.md (new): Company / Team / Personal / One-Time tier sections ready for first sponsors
- .github/FUNDING.yml: stevensacks → gaia-react (org has Sponsors approved via Stripe)
- .github/pull_request_template.md: drop /audit-code reference (handled solely by the code-review-audit agent now), inline quality gate commands

## Studio path migration (earlier commits on this branch)

- branding/* references updated to studio/branding/*
- branding/research/* references updated to studio/strategy/research/*

## Notes for reviewer

Markdown and config changes only. CI will verify the build.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>