### PR TITLE
fix(ci): drop branch-prefix skip, rely on path-filter alone

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,7 +21,7 @@ jobs:
   chromatic:
     name: Run Chromatic
     needs: has-chromatic-token
-    if: needs.has-chromatic-token.outputs.present == 'true' && github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore:') && !startsWith(github.ref, 'refs/heads/wiki/') && !startsWith(github.ref, 'refs/heads/chore/') && !startsWith(github.ref, 'refs/heads/release/')
+    if: needs.has-chromatic-token.outputs.present == 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   tests:
     name: Vitest and Playwright
-    if: (github.event_name == 'pull_request') && !startsWith(github.head_ref, 'wiki/') && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'release/')
+    if: github.event_name == 'pull_request'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

The CI workflows had two mechanisms for skipping the suite on doc-only changes:

1. **Branch-prefix gate** at the job level — skipped the entire job (no runner spin-up) for `wiki/`, `chore/`, `release/` prefixes
2. **`dorny/paths-filter`** at the step level — universally gates individual steps when only `**/*.md`, `wiki/**`, or `.claude/**` files changed

The branch-prefix gate was redundant with the path-filter and created a footgun: a `fix/` (or `feat/`, etc.) branch with markdown-only changes ran the runner anyway. Surfaced when PR #66 (a markdown-only `/gaia audit` doc fix) blocked auto-merge while it waited for a runner that ultimately did no work.

This drops the prefix gate. Branch name no longer matters; files determine whether the suite runs.

**Tradeoff:** doc-only pushes from formerly-shortcut branches (`wiki/`, `chore/`, `release/`) now spin up a runner for ~30s before completing as SUCCESS. The `concurrency: cancel-in-progress` block reaps any superseded runs. Acceptable for the simpler mental model.

## Files changed

- `.github/workflows/tests.yml` — Vitest/Playwright job no longer gated on branch prefix
- `.github/workflows/chromatic.yml` — Chromatic job no longer gated on branch prefix or `chore:` commit message prefix

## Test plan

- [ ] After merge, push a markdown-only commit on a `fix/` branch — confirm job runs, all steps skip via path-filter, completes as SUCCESS in ~30-60s
- [ ] Push a markdown-only commit on a `chore/` branch — same outcome (no longer the instant SKIPPED state, but still passes fast)
- [ ] Push a code change on any branch — confirm full suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)