### PR TITLE
chore(ci): bump actions/checkout and actions/setup-node v4 → v5

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # Doc-only pushes report this required check green without running Chromatic.
@@ -41,7 +41,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - if: steps.filter.outputs.code == 'true'
         name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout at tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       SESSION_SECRET: ${{ secrets.SESSION_SECRET || 'ci-placeholder-session-secret-not-real' }}
       SITE_URL: ${{ secrets.SITE_URL || 'http://localhost:3000' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # Detect non-doc changes. Doc-only PRs report this required check green
@@ -42,7 +42,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - if: steps.filter.outputs.code == 'true'
         name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

Bump first-party GitHub Actions to v5 ahead of Node 20 deprecation in June 2026. Deprecation warning surfaced on the `create-gaia` publish workflow last run.

## Files changed

- `.github/workflows/tests.yml` (checkout, setup-node)
- `.github/workflows/release.yml` (checkout)
- `.github/workflows/chromatic.yml` (checkout, setup-node)

## Scope

First-party actions only (`actions/checkout`, `actions/setup-node`). Third-party actions (chromaui/action, dorny/paths-filter, pnpm/action-setup, etc.) intentionally left at current pins.

## Audit skip

Skipping code-review-audit subagent. Config-only YAML edit, no React/TS code for the specialists to evaluate.

## Test plan

- [x] CI runs green on this branch