### PR TITLE
docs: pin install command to npx create-gaia@latest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
       description: |
         Minimal steps to reproduce. Even better — a link to a public repo that reproduces it.
       placeholder: |
-        1. Scaffold via `npx create-gaia my-app`
+        1. Scaffold via `npx create-gaia@latest my-app`
         2. Run `/gaia-init` in Claude Code
         3. …
     validations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ GAIA v1.0.0 is the inaugural public release of the GAIA React workflow — a Cla
 - **i18n.** `remix-i18next` middleware, English + Japanese language scaffolding, `LanguageSelect` component, Storybook locale switcher.
 - **Dark mode.** Cookie-as-truth + `@epic-web/client-hints` + optimistic `useFetchers()` UI.
 - **Quality gate.** Mandatory pre-commit pipeline: simplify, localization check, typecheck, lint, unit tests, E2E tests, dev smoke test, build. Zero warnings tolerated.
-- **Release tooling.** Tag-triggered `release.yml` builds a scrubbed tarball; `create-gaia` bootstrapper consumes it via `npx create-gaia my-app`.
+- **Release tooling.** Tag-triggered `release.yml` builds a scrubbed tarball; `create-gaia` bootstrapper consumes it via `npx create-gaia@latest my-app`.
 
 [Unreleased]: https://github.com/gaia-react/gaia/compare/v1.0.4...HEAD
 [1.0.4]: https://github.com/gaia-react/gaia/releases/tag/v1.0.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ GAIA is opinionated. The conventions, rules, and hooks aren't suggestions. They'
 ## Before you contribute
 
 - Read the [README](./README.md). The whole thing.
-- Install with `npx create-gaia my-app` and walk through `/gaia-init` so you understand what a fresh project looks like.
+- Install with `npx create-gaia@latest my-app` and walk through `/gaia-init` so you understand what a fresh project looks like.
 - Run the quality gate locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`. All four green, no warnings.
 - Browse the wiki under `wiki/`. That's where the project's reasoning lives.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The React workflow that keeps Claude-shipped code production-grade as your team 
 Make sure you have [Node.js](https://nodejs.org/en/) >= 22.19.0 installed, preferably via [nvm](https://github.com/nvm-sh/nvm).
 
 ```bash
-npx create-gaia my-app
+npx create-gaia@latest my-app
 ```
 
 One simple command. GAIA takes care of the rest.

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -66,7 +66,7 @@ Adopters who download the v1.0.0 tarball get 348 files, ~550 KB. The scrubbed `w
 
 ## create-gaia bootstrapper
 
-Separate repo, separate npm package (`create-gaia`). Zero runtime deps. When an adopter runs `npx create-gaia my-app`:
+Separate repo, separate npm package (`create-gaia`). Zero runtime deps. When an adopter runs `npx create-gaia@latest my-app`:
 
 1. Resolves the target version (flag, or latest GitHub release).
 2. Downloads the release tarball from `github.com/gaia-react/gaia/releases/download/vX.Y.Z/gaia-vX.Y.Z.tar.gz`.


### PR DESCRIPTION
Avoids stale-cached scaffolds when users have an older create-gaia binary in their npx cache. Updates README, CONTRIBUTING, bug report template, CHANGELOG entry, and Release Workflow wiki page.

## Summary

<!-- What does this change, and why? One or two sentences. -->

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature / skill / command (minor)
- [ ] Breaking change (major)
- [ ] Documentation / wiki only
- [ ] Dependency bump

## Checklist

- [ ] Quality gate is green locally: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`. Zero warnings.
- [ ] Updated `CHANGELOG.md` under `## [Unreleased]` if this change is user-visible.
- [ ] Updated or added wiki pages in `wiki/concepts`, `wiki/decisions`, or `wiki/modules` if this change affects a documented pattern.
- [ ] Verified the change does not break the first-run `/gaia-init` flow (if touching `.claude/`, `app/components/Header`, language files, or branding paths).

## Notes for reviewer

<!-- Anything reviewers should pay attention to, edge cases, follow-ups, etc. -->
