### PR TITLE
fix(wiki): smoke test assertions match frozen interface

### DIFF
--- a/.claude-tests/smoke/01-meaningful-change.sh
+++ b/.claude-tests/smoke/01-meaningful-change.sh
@@ -72,6 +72,11 @@ EOF
 git add app/services/Gemini.ts
 git commit --quiet -m "feat: add Gemini service for image generation"
 
+# Capture HEAD before claude runs. /wiki-sync advances state to the SHA it
+# evaluated (the pre-sync HEAD), then commits the wiki updates as a new commit
+# on top — so post-sync state == pre_claude_head, not current HEAD.
+pre_claude_head=$(git rev-parse HEAD)
+
 # Now run claude -p with /wiki-sync
 output=$(claude -p --model sonnet --permission-mode bypassPermissions \
   "Run /wiki-sync. Report what was done." 2>&1)
@@ -80,10 +85,9 @@ output=$(claude -p --model sonnet --permission-mode bypassPermissions \
 echo "$output" | grep -q "Gemini" || { echo "FAIL: Gemini not mentioned in /wiki-sync output"; exit 1; }
 [ -f wiki/services/Gemini.md ] || { echo "FAIL: wiki/services/Gemini.md not created"; exit 1; }
 
-# State should have advanced
+# State should have advanced to the SHA we wanted evaluated
 new_state=$(jq -r '.last_evaluated_sha' wiki/.state.json)
-head=$(git rev-parse HEAD)
-[ "$new_state" = "$head" ] || { echo "FAIL: state did not advance to HEAD ($new_state vs $head)"; exit 1; }
+[ "$new_state" = "$pre_claude_head" ] || { echo "FAIL: state did not advance to evaluated SHA ($new_state vs $pre_claude_head)"; exit 1; }
 
 # wiki/log.md should have an entry
 grep -q "WORTHY" wiki/log.md || { echo "FAIL: wiki/log.md missing WORTHY entry"; exit 1; }

--- a/.claude-tests/smoke/02-typo-only-skip.sh
+++ b/.claude-tests/smoke/02-typo-only-skip.sh
@@ -48,6 +48,7 @@ git add README.md
 git commit --quiet -m "fix: typo in README"
 
 before_files=$(find wiki -type f | wc -l | tr -d ' ')
+pre_claude_head=$(git rev-parse HEAD)
 
 claude -p --model sonnet --permission-mode bypassPermissions \
   "Run /wiki-sync. Report what was done." > /dev/null 2>&1
@@ -62,9 +63,8 @@ after_files=$(find wiki -type f | wc -l | tr -d ' ')
 [ -f wiki/log.md ] || { echo "FAIL: wiki/log.md not created"; exit 1; }
 grep -q "SKIP" wiki/log.md || { echo "FAIL: wiki/log.md missing SKIP entry"; exit 1; }
 
-# State should still advance
+# State should advance to the evaluated SHA (pre-sync HEAD), even on skip-only runs
 new_state=$(jq -r '.last_evaluated_sha' wiki/.state.json)
-head=$(git rev-parse HEAD)
-[ "$new_state" = "$head" ] || { echo "FAIL: state did not advance"; exit 1; }
+[ "$new_state" = "$pre_claude_head" ] || { echo "FAIL: state did not advance to evaluated SHA ($new_state vs $pre_claude_head)"; exit 1; }
 
 echo "PASS: 02-typo-only-skip"

--- a/.claude-tests/smoke/03-multi-commit-catchup.sh
+++ b/.claude-tests/smoke/03-multi-commit-catchup.sh
@@ -107,9 +107,12 @@ rm package.json.bak
 git add package.json
 git commit --quiet -m "chore(deps): bump react to 18.3.1"
 
-# Sanity: 5 commits between init_sha and HEAD
+# Sanity: 6 drifted commits — the "init state" commit + 5 feature commits.
+# init_sha was captured before "init state" was written, so drift counts both.
 drift=$(git rev-list --count "$init_sha"..HEAD)
-[ "$drift" = "5" ] || { echo "FAIL: expected 5 drifted commits, got $drift"; exit 1; }
+[ "$drift" = "6" ] || { echo "FAIL: expected 6 drifted commits, got $drift"; exit 1; }
+
+pre_claude_head=$(git rev-parse HEAD)
 
 claude -p --model sonnet --permission-mode bypassPermissions \
   "Run /wiki-sync. Report what was done." > /dev/null 2>&1
@@ -117,7 +120,8 @@ claude -p --model sonnet --permission-mode bypassPermissions \
 # Assertions
 [ -f wiki/log.md ] || { echo "FAIL: wiki/log.md not created"; exit 1; }
 
-# Log should have at least 5 entries (one per commit). Count short-SHA-looking lines.
+# Log should have at least 5 entries (one per drifted commit, minus possible
+# fold of the wiki-only "init state" commit).
 log_entries=$(grep -cE '\b[0-9a-f]{7,40}\b' wiki/log.md || true)
 [ "$log_entries" -ge 5 ] || { echo "FAIL: wiki/log.md has $log_entries entries, expected >= 5"; exit 1; }
 
@@ -128,9 +132,8 @@ worthy_pages=$(find wiki -type f -name '*.md' ! -name 'index.md' ! -name 'log.md
 # At least one SKIP entry expected (the typo)
 grep -q "SKIP" wiki/log.md || { echo "FAIL: wiki/log.md missing SKIP entry for typo commit"; exit 1; }
 
-# State should advance to HEAD
+# State should advance to the evaluated SHA (pre-sync HEAD)
 new_state=$(jq -r '.last_evaluated_sha' wiki/.state.json)
-head=$(git rev-parse HEAD)
-[ "$new_state" = "$head" ] || { echo "FAIL: state did not advance to HEAD ($new_state vs $head)"; exit 1; }
+[ "$new_state" = "$pre_claude_head" ] || { echo "FAIL: state did not advance to evaluated SHA ($new_state vs $pre_claude_head)"; exit 1; }
 
 echo "PASS: 03-multi-commit-catchup"

--- a/.claude-tests/smoke/04-non-claude-merge.sh
+++ b/.claude-tests/smoke/04-non-claude-merge.sh
@@ -42,27 +42,15 @@ git add .
 git commit --quiet -m "init"
 init_sha=$(git rev-parse HEAD)
 
-# State file matches HEAD initially (no drift)
+# State file points at init commit. Drift starts at 1 (the state-init commit
+# itself, which is wiki/.state.json-only and would be SKIP-classified). After
+# the shell commit below, drift = 2. The test's intent is "drift > 0 surfaces
+# a reminder", not a specific count.
 cat > wiki/.state.json <<EOF
 {"version":1,"last_evaluated_sha":"$init_sha","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
 git add wiki/.state.json
 git commit --quiet -m "init state"
-
-# Update state to point at this new HEAD so we begin with zero drift
-synced_sha=$(git rev-parse HEAD)
-cat > wiki/.state.json <<EOF
-{"version":1,"last_evaluated_sha":"$synced_sha","last_evaluated_at":"2026-01-01T00:00:00Z"}
-EOF
-git add wiki/.state.json
-git commit --quiet --amend --no-edit
-synced_sha=$(git rev-parse HEAD)
-# Re-write the state to the post-amend SHA so it matches HEAD
-cat > wiki/.state.json <<EOF
-{"version":1,"last_evaluated_sha":"$synced_sha","last_evaluated_at":"2026-01-01T00:00:00Z"}
-EOF
-git add wiki/.state.json
-git commit --quiet -m "sync state to HEAD"
 
 # Now make a commit via plain shell — no Claude in the loop at all
 cat > app/modules/Auth.ts <<'EOF'
@@ -74,10 +62,10 @@ EOF
 git add app/modules/Auth.ts
 git commit --quiet -m "feat: add Auth module (shell-side commit)"
 
-# Sanity: drift should be 1 now
+# Sanity: drift should be > 0 (drift hook only cares about non-zero)
 state_sha=$(jq -r '.last_evaluated_sha' wiki/.state.json)
 drift=$(git rev-list --count "$state_sha"..HEAD)
-[ "$drift" = "1" ] || { echo "FAIL: expected drift=1 after shell commit, got $drift"; exit 1; }
+[ "$drift" -ge "1" ] || { echo "FAIL: expected drift >= 1 after shell commit, got $drift"; exit 1; }
 
 # Run claude -p with a generic prompt — drift-check should fire on first prompt
 # and mention drift / wiki-sync.
@@ -91,13 +79,13 @@ if ! echo "$first_output" | grep -qiE "drift|wiki-sync|wiki state|commits ahead|
 fi
 
 # Now actually run /wiki-sync to catch up
+pre_claude_head=$(git rev-parse HEAD)
 claude -p --model sonnet --permission-mode bypassPermissions \
   "Run /wiki-sync. Report what was done." > /dev/null 2>&1
 
-# Assertions: state advanced + log entry written
+# Assertions: state advanced to the evaluated SHA + log entry written
 new_state=$(jq -r '.last_evaluated_sha' wiki/.state.json)
-head=$(git rev-parse HEAD)
-[ "$new_state" = "$head" ] || { echo "FAIL: state did not advance to HEAD after /wiki-sync ($new_state vs $head)"; exit 1; }
+[ "$new_state" = "$pre_claude_head" ] || { echo "FAIL: state did not advance to evaluated SHA after /wiki-sync ($new_state vs $pre_claude_head)"; exit 1; }
 
 [ -f wiki/log.md ] || { echo "FAIL: wiki/log.md not created"; exit 1; }
 grep -qE "Auth|auth" wiki/log.md || { echo "FAIL: wiki/log.md does not reference the Auth shell-side commit"; exit 1; }


### PR DESCRIPTION
## Summary

Follow-up to #70. The smoke suite asserted `state == HEAD` after `/wiki-sync`, but per the frozen interface §6 in the v1.0.5 design, `/wiki-sync` advances state to the SHA it *evaluated*, then commits the wiki updates as a new commit on top. So post-sync `state == pre_claude_head`, not `current HEAD`.

Verified with a debug run of scenario 01: `/wiki-sync` correctly created `wiki/services/Gemini.md`, logged WORTHY/SKIP entries, advanced state to the evaluated SHA, and made its own "wiki: sync through ..." commit on top — exactly per design.

## Fixes

- 01, 02, 03, 04: capture `pre_claude_head` before invoking `claude -p`, assert `state == pre_claude_head` instead of `state == HEAD`.
- 03: drift sanity check `5 → 6` (the `init_sha` was captured before the "init state" commit, which is itself drift).
- 04: simplified the state-init dance (no more amend chain) and relaxed drift sanity to `>= 1` — the test's intent is "drift hook fires when state != HEAD", not a specific count.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `bats .claude-tests/hooks/` 25/25 pass (regression)
- [x] `bash -n` on all 4 scripts passes
- [ ] Re-run `bash .claude-tests/smoke/run-all.sh` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)