### PR TITLE
wiki: backfill v1.0.0..v1.0.5 (3 updated, 17 skipped)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "last_evaluated_sha": "baa58d964bdc5290e449d1728fcd631ee7133b94",
-  "last_evaluated_at": "2026-04-30T19:28:58Z"
+  "last_evaluated_sha": "6686f26305338b14990079383e236fe4af300b34",
+  "last_evaluated_at": "2026-05-03T14:02:14Z"
 }

--- a/wiki/components/Form YearMonthDay.md
+++ b/wiki/components/Form YearMonthDay.md
@@ -31,7 +31,10 @@ Three [[Form Select]]s (year, month, day) feeding one hidden `<input type="hidde
 
 When the user changes year or month, `getSafeValue` computes the new ISO string, clamping the day to the last valid day of the new month. Prevents 2024-02-29 from rolling over to 2023-02-29.
 
-## > [!warning] Conform integration — two non-obvious gotchas
+## Conform integration — two non-obvious gotchas
+
+> [!warning]
+> The two pitfalls below are non-obvious. Skip them and submission breaks silently.
 
 ### 1. Block native `input` events from bubbling to Conform
 

--- a/wiki/concepts/Claude Hooks.md
+++ b/wiki/concepts/Claude Hooks.md
@@ -2,13 +2,13 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-01
+updated: 2026-05-03
 tags: [concept, claude, hooks]
 ---
 
 # Claude Hooks
 
-Bash scripts that run on Claude Code tool calls. Configured in `.claude/settings.json` under `hooks.PreToolUse` (and other event types). The `Bash` matcher supports per-hook `if:` patterns so a single matcher block can fan out to command-specific hooks.
+Bash scripts that run on Claude Code tool calls. Configured in `.claude/settings.json` under `hooks.PreToolUse` (and other event types). Hook scripts filter by command content internally — they do not use per-hook `if:` patterns. (Claude Code's `if:` field requires `ToolUseContext` which isn't always available, surfacing as `"ToolUseContext is required for prompt hooks"` errors. Removed in v1.0.3.)
 
 Exit code semantics:
 
@@ -38,22 +38,29 @@ Hooks are grouped by the safeguard they enforce, not by event type.
 
 ### Bash safeguards (Bash)
 
-- **`block-bare-test.sh`** (`if: Bash(pnpm *)` and `if: Bash(npm *)`) — denies bare `pnpm test` / `npm test` (and `run test` variants); they start vitest watch mode. Requires `--run` for a one-shot pass. See [[Test Runner]].
-- **`block-main-destructive-git.sh`** (`if: Bash(git *)`) — denies (1) `git commit` while HEAD is `main`/`master`, (2) force-push to `main`/`master`, and (3) plain `git push` originating from `main`/`master` (PR-only flow — closes the "forgot to switch branches" footgun). Authoritative rule: [[Git Workflow]].
-- **`block-rm-rf.sh`** (`if: Bash(rm *)`) — denies catastrophic `rm -rf` patterns: `--no-preserve-root`, absolute paths, `~` / `$HOME`, `.`, unscoped `*`, `.git`, `node_modules`. Allows scoped scratch paths (`.claude/plans/*`, `.claude/audit/*`, `.gaia/cache/*`, `dist/*`, `build/*`).
+Each script reads `tool_input.command` from stdin and filters by content — there is no `if:` annotation on the hook entry.
+
+- **`block-bare-test.sh`** — denies bare `pnpm test` / `npm test` (and `run test` variants); they start vitest watch mode. Requires `--run` for a one-shot pass. See [[Test Runner]].
+- **`block-main-destructive-git.sh`** — denies (1) `git commit` while HEAD is `main`/`master`, (2) force-push to `main`/`master`, and (3) plain `git push` originating from `main`/`master` (PR-only flow — closes the "forgot to switch branches" footgun). Handles `git -C <path>` invocations correctly. Authoritative rule: [[Git Workflow]].
+- **`block-rm-rf.sh`** — denies catastrophic `rm -rf` patterns: `--no-preserve-root`, absolute paths, `~` / `$HOME`, `.`, unscoped `*`, `.git`, `node_modules`. Allows scoped scratch paths (`.claude/plans/*`, `.claude/audit/*`, `.gaia/cache/*`, `dist/*`, `build/*`).
 
 ### Advisory (Bash)
 
-- **`pr-merge-audit-check.sh`** (`if: Bash(gh pr merge:*)`) — reminds to spawn `code-review-audit`, fix issues, and push fixes before merging. See [[PR Merge Workflow]].
+- **`pr-merge-audit-check.sh`** — reminds to spawn `code-review-audit`, fix issues, and push fixes before merging. See [[PR Merge Workflow]].
 
 ### Wiki coherence (multiple events)
 
-- **`wiki-session-start.sh`** (SessionStart) / **`wiki-session-stop.sh`** (Stop) / **`wiki-squash-autocommits.sh`** (Stop) — wiki coherence and `hot.md` refresh. See [[Claude Integration Conventions]] § Wiki vendor relationship for the full pair.
-- **`wiki-update-evaluator.sh`** (PostToolUse, `if: Bash(git commit:*)`) — autonomous post-commit wiki evaluator. Captures the new HEAD sha, backgrounds a `claude -p --model sonnet --permission-mode bypassPermissions` sub-agent that reads the diff against `wiki/index.md` and either edits the relevant pages + appends to `wiki/log.md` (subject `wiki: evaluator update for <sha>`) or exits with `NO_UPDATE_NEEDED`. The sub-agent commits independently; subsequent wiki commits get folded by `wiki-squash-autocommits.sh` into the standard wiki-branch PR flow on main. Logs to `.claude/audit/wiki-evaluator-{sha}.log` (gitignored). Skips merge / amend / wiki auto-commit subjects to avoid loops; never blocks the user's commit (always exits 0).
+The wiki sync system is convergent: the user's already-paid-for Claude session does the work via `/wiki-sync`. Hooks only keep Claude *informed* — they never spawn `claude -p` sub-processes. See [[Wiki Sync]] for the full design.
+
+- **`wiki-session-start.sh`** (SessionStart) / **`wiki-session-stop.sh`** (Stop) — wiki coherence and `hot.md` refresh. See [[Claude Integration Conventions]] § Wiki vendor relationship for the full pair.
+- **`wiki-drift-check.sh`** (UserPromptSubmit) — first prompt of each session, compares `wiki/.state.json`'s `last_evaluated_sha` to HEAD; if drifted, injects a `[wiki state]` reminder. Once-per-session via `.claude/wiki-drift-checked` marker.
+- **`wiki-commit-nudge.sh`** (PostToolUse, Bash) — fires after `git commit` invocations. Injects a `[wiki nudge]` line with the short SHA, subject, file count, and current drift count. Skips merge / amend / `wiki:` subjects to avoid loops. Never spawns sub-processes.
+- **`wiki-stop-safety-net.sh`** (Stop) — at session end, if the session committed but `wiki/.state.json` did not advance, injects `[wiki end-of-session]` reminder. Once-per-session via `.claude/wiki-safety-checked` marker.
+- **`wiki-squash-autocommits.sh`** (Stop) — folds adjacent `wiki: auto-commit` subjects into a single PR-branch commit. The reset-on-PR-failure path is gated so a failed `gh pr create` / `gh pr merge` no longer silently discards working-tree changes (the silent-loss bug fixed in v1.0.5).
 
 ### Other events
 
-- **`intercept-init.sh`** (UserPromptSubmit) — blocks the built-in `/init` and auto-invokes `/gaia-init`.
+- **`intercept-init.sh`** (UserPromptExpansion, matcher `init`) — emits `additionalContext` that overrides the built-in `/init` expansion and tells the model to invoke `/gaia-init` via the Skill tool. Does not block the turn — earlier `UserPromptSubmit + exit-2` design blocked the model from running at all.
 - **`gaia-session-update-prompt.sh`** (SessionStart, `startup|resume`) — reads `.gaia/cache/update-check.json` and emits a `<system-reminder>` asking the user whether to run the `update-deps` skill (when outdated packages are detected) or the `update-gaia` skill (when a newer GAIA release is available). Sequences `deps` before `gaia` — only one prompt per session; if the deps prompt is snoozed, the hook falls through to gaia. Snoozes each kind for 6h after emit via `.gaia/cache/update-prompt-state.json`. Background-fires `.gaia/scripts/check-updates.sh` (TTL 6h) when the cache is stale. Silent on missing cache or missing `jq`. Never blocks. See [[Claude Skills]] § SessionStart update prompt.
 
 ## Adding hooks

--- a/wiki/concepts/GAIA Audit.md
+++ b/wiki/concepts/GAIA Audit.md
@@ -3,7 +3,7 @@ type: concept
 title: GAIA Audit
 status: active
 created: 2026-04-20
-updated: 2026-05-01
+updated: 2026-05-03
 tags: [concept, claude, skill, knowledge, hygiene]
 ---
 
@@ -19,12 +19,14 @@ tags: [concept, claude, skill, knowledge, hygiene]
 
 ## Two-stage execution
 
-| Stage | Model  | Mode                  | Output                                                      |
-| ----- | ------ | --------------------- | ----------------------------------------------------------- |
-| 1     | Sonnet | `/gaia audit`         | Research report at `.claude/audit/KNOWLEDGE-{timestamp}.md` |
-| 2     | Sonnet | `/gaia audit --apply` | Applies unchecked actions mechanically                      |
+`/gaia audit` is the intent to apply. The default chains both stages — Stage 1 produces a report, Stage 2 executes it. The two-stage split is for technical reasons (different reasoning loads, drift-check between stages), not as a user-confirmation gate.
 
-Stage 1 proposes actions — `delete`, `delete-entry`, `promote`, `shrink`, `merge`, `fix-link` — each with verbatim `expect` snippets and sha256 drift signals. Stage 2 reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Both stages run on Sonnet — drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model.
+| Invocation            | Stages                  | When to use                                                |
+| --------------------- | ----------------------- | ---------------------------------------------------------- |
+| `/gaia audit`         | Stage 1 → Stage 2       | Default. Research, then apply, in sequence                 |
+| `/gaia audit --apply` | Stage 2 only            | Retry against the most recent existing report (after drift fix or interrupted apply) |
+
+Stage 1 (Sonnet) proposes actions — `delete`, `delete-entry`, `promote`, `shrink`, `merge`, `fix-link` — each with verbatim `expect` snippets and sha256 drift signals, written to `.claude/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model.
 
 ## What it catches
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Release Workflow
 status: active
 created: 2026-04-22
-updated: 2026-05-01
+updated: 2026-05-03
 tags: [release, claude, maintainer, versioning]
 ---
 
@@ -33,20 +33,21 @@ How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/
 
 ## Cutting a release
 
-Run `/gaia-release` on a clean `main`. The command is a 12-step orchestrator:
+Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 
 1. Verify clean working tree + on `main`.
-2. Auto-determine bump by analyzing commits since last tag. `patch`/`minor` proceed automatically; `major` stops and asks.
-3. Run the [[Quality Gate]]. Stop on failure.
-4. Create `release/vX.Y.Z` branch.
-5. Bump `package.json` + `.gaia/VERSION`.
-6. Auto-draft CHANGELOG from `git log` since last release; present for approval; graduate to `## [vX.Y.Z] — YYYY-MM-DD` and seed a new empty `## [Unreleased]`.
-7. Overwrite `wiki/hot.md` with release-baseline content (so adopters clone a fresh slate).
-8. Overwrite `wiki/log.md` with a single release-milestone entry (dev history lives in git).
-9. Regenerate `.gaia/manifest.json` via the classifier script.
-10. Commit: `chore(release): vX.Y.Z`.
-11. Push branch, open PR, print PR URL.
-12. Schedule a background agent that polls for the PR to merge, then tags the merge commit and pushes automatically. The maintainer only needs to merge the PR — everything else is hands-off.
+2. Verify `wiki/.state.json` `last_evaluated_sha == HEAD`. If drift exists, STOP — the wiki is stale and the release would ship out-of-date adopter docs. Maintainer runs `/wiki-sync` first. See [[Wiki Sync]].
+3. Auto-determine bump by analyzing commits since last tag. `patch`/`minor` proceed automatically; `major` stops and asks.
+4. Run the [[Quality Gate]]. Stop on failure.
+5. Create `release/vX.Y.Z` branch.
+6. Bump `package.json` + `.gaia/VERSION`.
+7. Auto-draft CHANGELOG from `git log` since last release; present for approval; graduate to `## [vX.Y.Z] — YYYY-MM-DD` and seed a new empty `## [Unreleased]`.
+8. Overwrite `wiki/hot.md` with release-baseline content (so adopters clone a fresh slate).
+9. Overwrite `wiki/log.md` with a single release-milestone entry (dev history lives in git).
+10. Regenerate `.gaia/manifest.json` via the classifier script.
+11. Commit on the release branch: `chore(release): vX.Y.Z`. The pre-commit dance updates `wiki/.state.json`'s `last_evaluated_sha` to the new commit's own SHA via amend, so adopters' state files match their release commit on first scaffold.
+12. Push branch, open PR via `gh`, merge inline via `gh pr merge --merge`. Release branches have no required checks, so the merge is immediate.
+13. Pull `main`, tag the merge commit (`v<NEW_VERSION>`), push the tag.
 
 The tag push triggers [`release.yml`](../../.github/workflows/release.yml), which produces the scrubbed tarball.
 
@@ -81,4 +82,5 @@ The CLI is deliberately thin — heavy lifting (i18n, branding strip, plugin ins
 
 - [[Update Workflow]] — how adopters pull later releases into an initialized project without clobbering drift.
 - [[Quality Gate]] — must pass before `/gaia-release` will let you tag.
+- [[Wiki Sync]] — drift gate at Step 2; release is blocked until `wiki/.state.json` matches HEAD.
 - [[Git Workflow]] — destructive-on-main hook that `/gaia-release` coexists with (the final push is gated behind explicit user confirmation).

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -127,6 +127,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 
 - [[README]] — vault schema, mode declaration, conventions
 - [[dashboard]]
+- [[lint-report-2026-05-03]]
 - [[lint-report-2026-05-01]]
 - [[lint-report-2026-04-27]]
 - [[lint-report-2026-04-26]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,32 @@
 # Log
 
+## 2026-05-03 | Backfill /wiki-sync from v1.0.0
+
+- 2026-05-03 6686f26 - SKIP: smoke test fix, no behavior change
+- 2026-05-03 80c9be7 - SKIP: v1.0.5 wiki sync system — concept page filed in-commit (wiki/concepts/Wiki Sync.md)
+- 2026-05-03 c6e054e - SKIP: docs-only npx pin
+- 2026-05-03 3cc024d - SKIP: CI action major bumps (no behavior change)
+- 2026-05-03 78f70fe - SKIP: CI workflow tweak, drop branch-prefix skip
+- 2026-05-03 4d671aa - WORTHY: /gaia audit chains research+apply by default → wiki/concepts/GAIA Audit.md
+- 2026-05-03 7f07c45 - SKIP: README section rename
+- 2026-05-03 be2eba0 - SKIP: repo-root governance (CONTRIBUTING, CoC, FUNDING) — not wiki-page material
+- 2026-05-02 c0f07b6 - SKIP: wiki self-edit (Agentic Design audit path)
+- 2026-05-01 fb7cec3 - SKIP: v1.0.4 release commit
+- 2026-05-01 ae5b037 - SKIP: delete RELEASE_NOTES.md
+- 2026-05-01 0307c3d - SKIP: wiki hygiene sweep already applied inline
+- 2026-05-01 a752348 - SKIP: internal hook fix (git -C path handling)
+- 2026-05-01 1ad5b8e - WORTHY: gaia-release merge+tag inline → wiki/concepts/Release Workflow.md
+- 2026-05-01 2b3d2ba - SKIP: v1.0.3 release commit
+- 2026-05-01 c408936 - WORTHY: dropped per-hook `if:` conditionals → wiki/concepts/Claude Hooks.md
+- 2026-05-01 b80d227 - SKIP: README quick-start tweak
+- 2026-05-01 4d76745 - SKIP: README polish
+- 2026-05-01 5c1564b - WORTHY: gaia-release auto-bump + auto-changelog + post-merge tag → wiki/concepts/Release Workflow.md
+- 2026-05-01 c29083b - SKIP: v1.0.2 release commit (CI tweak bundled, ephemeral)
+- 2026-05-01 b3a24c0 - WORTHY: PR-based release flow (main is protected) → wiki/concepts/Release Workflow.md
+- 2026-05-01 cf52705 - SKIP: v1.0.1 release commit
+- 2026-05-01 76b0a2c - WORTHY: /init redirect via UserPromptExpansion (not UserPromptSubmit) → wiki/concepts/Claude Hooks.md
+- 2026-05-01 f9c05a5 - SKIP: v1.0.0 release commit
+
 ## [v1.0.4] 2026-05-01 | Released
 
 See CHANGELOG.md for details.

--- a/wiki/meta/lint-report-2026-05-03.md
+++ b/wiki/meta/lint-report-2026-05-03.md
@@ -1,0 +1,83 @@
+---
+type: meta
+title: "Lint Report 2026-05-03"
+created: 2026-05-03
+updated: 2026-05-03
+tags: [meta, lint]
+status: developing
+---
+
+# Lint Report: 2026-05-03
+
+Run after `/wiki-sync` backfill from v1.0.0 baseline through v1.0.5 + smoke fix (range `baa58d9..6686f26`, 23 non-merge commits, 6 worthy + 17 skipped). Three concept pages updated by sync: `Claude Hooks.md`, `Release Workflow.md`, `GAIA Audit.md`.
+
+## Summary
+
+- Pages scanned: 86 (excluding meta + this report)
+- Issues found: 4
+- Auto-fixed: 0
+- Needs review: 4
+
+## Orphan Pages
+
+None. Every concept, decision, dependency, component, flow, module, and entity page has at least one inbound wikilink.
+
+## Dead Links
+
+No active dead links. Historical references to removed pages (`Audit-Knowledge Command`, `Pickup Command`, `Handoff Command`, `FontAwesome`, `[[CLAUDE]]`) live only inside archival lint reports under `wiki/meta/lint-report-*.md` — these are append-only records, not navigational links.
+
+False positives surfaced and dismissed:
+
+- `[[Form Select\|Select]]` and `[[Form YearMonthDay\|YearMonthDay]]` in `Form Field.md` and `Form Select.md` — valid Obsidian table-cell pipe escapes. Targets exist.
+- `[[modules/Claude Integration|...]]` in `Claude Skills.md` and `Claude Integration Conventions.md` — valid path-prefixed wikilinks. Target `wiki/modules/Claude Integration.md` exists.
+- `[[Note Name]]` in `wiki/README.md:39` — documentation prose explaining wikilink format, not a link.
+
+## Frontmatter Gaps
+
+- **`wiki/hot.md`**: missing `status`, `created`, `tags`.
+- **`wiki/log.md`**: missing the frontmatter block entirely.
+
+> [!note] Recurring regression
+> Both files were correctly populated by the 2026-05-01 audit hygiene sweep (commit 0307c3d). They get reset every release: `/gaia-release` Steps 8–9 overwrite both files with release-baseline content that lacks the canonical fields. Tracked separately — fix lives in `.claude/commands/gaia-release.md`, not in this lint pass.
+
+## Empty Sections
+
+- **`wiki/components/Form YearMonthDay.md:34`**: heading `## > [!warning] Conform integration — two non-obvious gotchas` has a stray `>` prefix in the heading text. Likely an `H2` + adjacent callout that got merged on edit. Should be either:
+  ```markdown
+  ## Conform integration — two non-obvious gotchas
+
+  > [!warning]
+  > ...
+  ```
+  or just a top-level callout with no `## `.
+
+(Other matches from the empty-section scan were false positives — H2 parents whose content is delegated to H3 children, e.g. `## The 12 patterns GAIA implements` in `Agentic Design.md`. Legitimate structural pattern.)
+
+## Stale Index Entries
+
+None. All 86 entries in `wiki/index.md` resolve to existing pages.
+
+## Cross-Reference Gaps
+
+Not exhaustively audited this pass. Targeted spot-check: `Wiki Sync.md` correctly cross-links `[[Quality Gate]]`, `[[GAIA Plan]]`, `[[Release Workflow]]`, `[[Claude Hooks]]` — all four resolve.
+
+## Stale Claims
+
+None surfaced. The three pages updated by `/wiki-sync` (`Claude Hooks.md`, `Release Workflow.md`, `GAIA Audit.md`) are now consistent with code at HEAD; the remaining 83 pages are unchanged from prior lint runs and reflect their last verified state.
+
+## Address Validation
+
+Skipped — DragonScale not enabled (`scripts/allocate-address.sh` not present).
+
+## Semantic Tiling
+
+Skipped — `scripts/tiling-check.py` not present.
+
+## State
+
+`wiki/.state.json` `last_evaluated_sha` = `6686f26305338b14990079383e236fe4af300b34` (matches HEAD on `main` at the time of the upstream `/wiki-sync` run). HEAD at lint time is 1 commit ahead — the in-flight `wiki: sync through 6686f26` commit on `wiki/backfill-v1.0.5` itself. State will catch up after PR #72 merges.
+
+## Action items
+
+1. Decide whether to fix the malformed `## > [!warning]` heading in `Form YearMonthDay.md:34` — single-page edit.
+2. Patch `/gaia-release` Steps 8–9 to preserve `hot.md` and `log.md` frontmatter on release scrub. Recurring root-cause; should be a separate PR (touches `.claude/commands/gaia-release.md`).


### PR DESCRIPTION
## Summary

First production run of `/wiki-sync`. Backfills the wiki from v1.0.0 baseline (`baa58d9`) to current HEAD (`6686f26`). 23 commits evaluated.

## Pages updated

- **wiki/concepts/Claude Hooks.md** — drop the `if:` pattern claim (Claude Code bug surfaced in c4089367, fix shipped in v1.0.3). Document the new convergent wiki sync system (drift-check, commit-nudge, stop-safety-net) replacing the deleted Path B evaluator. Update `intercept-init.sh` from `UserPromptSubmit` to `UserPromptExpansion`.
- **wiki/concepts/Release Workflow.md** — 12 → 13 steps. Adds Step 2 (wiki sync drift gate). Step 12 is now "push branch, open PR, merge inline" instead of "schedule a background agent." Tag is created on the merge commit on `main` (Step 13).
- **wiki/concepts/GAIA Audit.md** — `/gaia audit` chains research → apply by default. `/gaia audit --apply` becomes the retry escape hatch for re-running an existing report after drift fix.

## Worthy commits (6)

| SHA       | Subject                                                                          | Page                          |
|-----------|----------------------------------------------------------------------------------|-------------------------------|
| 76b0a2c   | fix(gaia-init): redirect /init via UserPromptExpansion                           | Claude Hooks                  |
| b3a24c0   | docs(gaia-release): document the actual PR-based release flow                    | Release Workflow              |
| 5c1564b   | chore(gaia-release): automate bump detection, changelog drafting, post-merge tag | Release Workflow              |
| c408936   | fix: remove if conditionals from PreToolUse/PostToolUse hooks                    | Claude Hooks                  |
| 1ad5b8e   | chore(gaia-release): merge and tag inline, drop background agent                 | Release Workflow              |
| 4d671aa   | fix: chain /gaia audit research and apply by default                             | GAIA Audit                    |

## Skipped (17)

5 release commits, 4 README polish commits, 2 CI tweaks, 2 wiki self-edits, 1 internal hook fix, 1 RELEASE_NOTES delete, 1 repo-root governance bundle, 1 wiki-sync system commit (concept page filed in-commit), 1 smoke-test fix.

## State

`wiki/.state.json` advanced from `baa58d9` to `6686f26`.

## Test plan

- [x] All 4 pages still pass markdown rendering
- [x] Wikilinks resolve (`[[Wiki Sync]]`, `[[GAIA Audit]]`, `[[Release Workflow]]`)
- [x] No system-affecting code changes — pure docs
- [x] `pnpm typecheck` + `pnpm lint` (no source touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)