### PR TITLE
wiki: sync through f23915a (2 updated, 1 skipped)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "last_evaluated_sha": "6686f26305338b14990079383e236fe4af300b34",
-  "last_evaluated_at": "2026-05-03T14:02:14Z"
+  "last_evaluated_sha": "f23915aa0a6d7e48e57c1c7965e0519a94f25b1c",
+  "last_evaluated_at": "2026-05-03T17:13:59Z"
 }

--- a/wiki/concepts/Claude Skills.md
+++ b/wiki/concepts/Claude Skills.md
@@ -59,11 +59,12 @@ A prior design used a `SessionStart` `<system-reminder>` hook. It was dropped be
 
 GAIA's `.claude/` surface places each kind of guidance in the layer that loads it most efficiently. Use this matrix when adding new guidance:
 
-| Layer                     | Loads when…                                            | Use for                                                                            |
-| ------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
-| Hook (`.claude/hooks/`)   | Tool call matches a registered event                   | Mechanical enforcement (block / advise) on a specific tool shape — no judgment     |
-| Rule (`.claude/rules/`)   | Matching `paths:` glob in scope (or always when empty) | File-path-bound conventions: project-wide style, route layout, accessibility, i18n |
-| Skill (`.claude/skills/`) | `description:` matches user intent / context           | Cross-file reasoning patterns: refactor playbooks, error-fix recipes, TDD loop     |
+| Layer                                 | Loads when…                                            | Use for                                                                            |
+| ------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Hook (`.claude/hooks/`)               | Tool call matches a registered event                   | Mechanical enforcement (block / advise) on a specific tool shape — no judgment     |
+| Rule (`.claude/rules/`)               | Matching `paths:` glob in scope (or always when empty) | File-path-bound conventions: project-wide style, route layout, accessibility, i18n |
+| Skill (`.claude/skills/`)             | `description:` matches user intent / context           | Cross-file reasoning patterns: refactor playbooks, error-fix recipes, TDD loop     |
+| Instruction (`.claude/instructions/`) | Dispatched by a command/skill at runtime               | Parameterized one-shot runbooks (add a locale, strip i18n, etc.); self-deleting    |
 
 Heuristic when migrating:
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## 2026-05-04 | /wiki-sync 6686f26..f23915a
+
+- 2026-05-04 f23915a - WORTHY: statusline replaces SessionStart hook for /update-deps and /update-gaia indicators → wiki/concepts/Claude Hooks.md, wiki/concepts/Claude Skills.md, wiki/modules/Claude Integration.md (already updated in-commit)
+- 2026-05-04 fd27c0a - WORTHY: language-aware /gaia-init + new .claude/instructions/ folder → wiki/concepts/Claude Skills.md (decision matrix), wiki/modules/Claude Integration.md (folder list)
+- 2026-05-04 5203732 - SKIP: wiki: prefix (backfill commit, advances state itself)
+
 ## 2026-05-03 | Backfill /wiki-sync from v1.0.0
 
 - 2026-05-03 6686f26 - SKIP: smoke test fix, no behavior change

--- a/wiki/modules/Claude Integration.md
+++ b/wiki/modules/Claude Integration.md
@@ -14,7 +14,7 @@ GAIA ships with [Claude Code](https://claude.ai/) support out of the box. Everyt
 
 ## Layout
 
-`.claude/` contains `settings.json` (hooks, env, plugins), `settings.local.json` (gitignored personal overrides), `agents/`, `agent-memory/` (gitignored, ephemeral; **not** a source of truth — durable knowledge belongs in the wiki), `audit/` (gitignored hook output, e.g. `wiki-evaluator-{sha}.log`), `commands/`, `hooks/`, `rules/`, and `skills/`.
+`.claude/` contains `settings.json` (hooks, env, plugins), `settings.local.json` (gitignored personal overrides), `agents/`, `agent-memory/` (gitignored, ephemeral; **not** a source of truth — durable knowledge belongs in the wiki), `audit/` (gitignored hook output, e.g. `wiki-evaluator-{sha}.log`), `commands/`, `hooks/`, `instructions/` (parameterized one-shot runbooks dispatched by commands like `/gaia-init`; self-deleting after use), `rules/`, and `skills/`.
 
 ## Commands (slash)
 


### PR DESCRIPTION
## Summary

Pre-release wiki sync. Range: \`6686f26..f23915a\` (3 commits).

- **WORTHY** \`f23915a\` — statusline restore. Wiki edits landed in-commit; no follow-up needed.
- **WORTHY** \`fd27c0a\` — language-aware /gaia-init. Adds \`.claude/instructions/\` as a new template file class. Documented in:
  - \`wiki/concepts/Claude Skills.md\` — new row in the decision matrix
  - \`wiki/modules/Claude Integration.md\` — added to the \`.claude/\` folder list
- **SKIP** \`5203732\` — wiki: backfill (advances state itself).

State advanced to \`f23915a\`. Unblocks \`/gaia-release\`.

## Test plan

- [x] \`wiki/.state.json\` \`last_evaluated_sha\` matches current HEAD before merge
- [x] No new orphan pages
- [x] Decision-matrix table renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)