### PR TITLE
fix: self-consistent /wiki-sync → /gaia-release flow

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -27,7 +27,7 @@ git -C . rev-list --count main..origin/main  # if >0, pull --ff-only
 
 ## Step 2: Verify wiki is in sync with HEAD
 
-Read `wiki/.state.json`. The `last_evaluated_sha` must equal current HEAD; otherwise the wiki is stale and the release would ship out-of-date knowledge to adopters.
+Read `wiki/.state.json`. The `last_evaluated_sha` must equal current HEAD — OR the only drift commits must be wiki-sync squash artifacts (`wiki:` prefix). Otherwise the wiki is stale and the release would ship out-of-date knowledge to adopters.
 
 ```bash
 state_sha=$(jq -r '.last_evaluated_sha' wiki/.state.json 2>/dev/null)
@@ -35,19 +35,20 @@ head_sha=$(git rev-parse HEAD)
 ```
 
 - If `wiki/.state.json` is missing or invalid JSON: STOP. Report "wiki/.state.json missing or invalid; run /wiki-sync to initialize." Maintainer must run `/wiki-sync` and re-run `/gaia-release`.
+- If `state_sha == head_sha`: report "✓ Wiki in sync with HEAD ({short_sha})." and proceed to Step 3.
 - If `state_sha != head_sha`:
-  - Compute drift: `drift=$(git rev-list --count "$state_sha..HEAD")`
-  - STOP. Report:
+  - List drift subjects: `git log "$state_sha..HEAD" --pretty=format:'%s'`
+  - **If every drift subject starts with `wiki:`** (the wiki-sync's own squash-merge artifact — the wiki content is current, only the `.state.json` pointer trails its own commit by one SHA): report "✓ Wiki content in sync; advancing state through {N} wiki-prefix commits during release." and proceed to Step 3. The release commit's amend in Step 11 will move state forward to the release SHA.
+  - **Otherwise** (drift contains substantive non-wiki commits): STOP. Compute drift count `drift=$(git rev-list --count "$state_sha..HEAD")` and report:
 
     ```
-    Wiki is {drift} commits behind HEAD. /gaia-release is blocked until the wiki is in sync.
+    Wiki is {drift} commits behind HEAD with substantive changes. /gaia-release is blocked until the wiki is in sync.
 
     Run /wiki-sync first, verify the wiki updates make sense, commit if needed, then re-run /gaia-release.
     ```
   - Maintainer runs `/wiki-sync`, reviews, then re-invokes `/gaia-release`.
-- If `state_sha == head_sha`: report "✓ Wiki in sync with HEAD ({short_sha})." and proceed to Step 3.
 
-This guard exists because the wiki is an adopter-facing knowledge layer, not just internal scaffolding. Shipping a release with stale wiki ships misleading documentation to every new `create-gaia` user.
+This guard exists because the wiki is an adopter-facing knowledge layer, not just internal scaffolding. Shipping a release with stale wiki ships misleading documentation to every new `create-gaia` user. The `wiki:`-prefix bypass exists because PR squash-merging a wiki-sync always creates a new SHA that `wiki/.state.json` cannot have known about in advance — without the bypass the gate is unsatisfiable in the standard flow (run `/wiki-sync` → merge PR → run `/gaia-release`).
 
 ## Step 3: Determine the version bump
 

--- a/.claude/commands/wiki-sync.md
+++ b/.claude/commands/wiki-sync.md
@@ -128,7 +128,7 @@ Update `wiki/.state.json`:
 }
 ```
 
-## Step 7: Commit
+## Step 7: Commit (branch-aware)
 
 Stage:
 
@@ -136,12 +136,41 @@ Stage:
 - `wiki/log.md`
 - `wiki/.state.json`
 
-Commit:
+Then check the current branch and pick the landing strategy:
+
+```bash
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+```
+
+### Case A — on `main` (or `master`)
+
+`main` is push-protected, so commit-in-place would dead-end. Branch first, commit, push, open PR, merge, return to `main`:
+
+```bash
+sync_branch="wiki/sync-$(date +%F)"
+git checkout -b "$sync_branch"
+git add wiki/
+git commit -m "wiki: sync through {short_sha} ({N_worthy} updated, {N_skipped} skipped)"
+git push -u origin "$sync_branch"
+gh pr create --title "wiki: sync through {short_sha} ({N_worthy} updated, {N_skipped} skipped)" \
+  --body "<short summary of WORTHY/SKIP decisions>"
+gh pr merge --squash --delete-branch  # release branches have no required checks; sync PRs typically pass quickly
+git checkout main
+git pull --ff-only
+```
+
+If the branch name collides (a previous incomplete sync), append `-2`, `-3`, etc. — never delete the existing branch silently.
+
+### Case B — on any other branch (feature, fix, release, worktree)
+
+The maintainer is mid-task on a non-protected branch. Commit in place — branching would fragment their working state across PRs they didn't ask for:
 
 ```bash
 git add wiki/
 git commit -m "wiki: sync through {short_sha} ({N_worthy} updated, {N_skipped} skipped)"
 ```
+
+This applies to git worktrees too: a worktree is by definition not on `main`, so commit on the worktree's branch directly.
 
 This commit is intentionally NOT prefixed `wiki: auto-commit` — it's a deliberate sync, not an auto-commit. The squash-autocommits hook will not fold it. Different audit trail.
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -36,7 +36,7 @@ How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/
 Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 
 1. Verify clean working tree + on `main`.
-2. Verify `wiki/.state.json` `last_evaluated_sha == HEAD`. If drift exists, STOP — the wiki is stale and the release would ship out-of-date adopter docs. Maintainer runs `/wiki-sync` first. See [[Wiki Sync]].
+2. Verify `wiki/.state.json` is current — either `last_evaluated_sha == HEAD`, or the only drift commits are wiki-sync squash artifacts (subjects starting with `wiki:`). Substantive non-wiki drift STOPs the release; the wiki is stale and would ship out-of-date adopter docs. Maintainer runs `/wiki-sync` first. The `wiki:`-prefix bypass exists because PR squash-merging always rewrites the SHA, so the standard flow (`/wiki-sync` → merge → `/gaia-release`) leaves the state pointer one squash-commit behind even when content is current; without the bypass the gate is unsatisfiable. See [[Wiki Sync]].
 3. Auto-determine bump by analyzing commits since last tag. `patch`/`minor` proceed automatically; `major` stops and asks.
 4. Run the [[Quality Gate]]. Stop on failure.
 5. Create `release/vX.Y.Z` branch.

--- a/wiki/concepts/Wiki Sync.md
+++ b/wiki/concepts/Wiki Sync.md
@@ -72,7 +72,7 @@ For each commit since `last_evaluated_sha`:
 2. **Second-pass on WORTHY only:** read the diff. Edit the relevant `wiki/services/`, `wiki/concepts/`, `wiki/decisions/`, `wiki/dependencies/`, etc. pages. If a commit looks worthy from its subject but turns out to be a refactor on diff inspection, demote to SKIP.
 3. **Log every decision** (worthy and skipped) to `wiki/log.md` with a one-line reason.
 4. **Advance state** to current HEAD.
-5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`.
+5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`. The landing strategy is branch-aware: on `main` (push-protected), it creates `wiki/sync-YYYY-MM-DD`, pushes, opens a PR, and squash-merges; on any other branch (feature/fix/release/worktree), it commits in place so the maintainer's working state isn't fragmented.
 
 The skip-with-reason audit trail is load-bearing: a project that always says "skipped: typo" tells you the system is running. A project with no log entries tells you the system has stopped. `wiki-lint` check #11 surfaces this drift.
 


### PR DESCRIPTION
## Summary

Two fixes that together make the `/wiki-sync` → `/gaia-release` flow work end-to-end without manual intervention.

### 1. Relax `/gaia-release` Step 2 gate

The Step 2 gate required strict equality between `wiki/.state.json` `last_evaluated_sha` and `HEAD`. In practice that gate is **unsatisfiable** in the standard flow:

1. Run `/wiki-sync` → evaluates commits → updates `wiki/.state.json` to point at current main HEAD
2. PR is squash-merged → main HEAD is now a **new** SHA the branch's `.state.json` couldn't have known about
3. Run `/gaia-release` → drift = 1 (the wiki-sync's own squash artifact) → STOP

Relax the gate: drift is allowed when every drift commit subject starts with `wiki:`. The wiki **content** is current; only the pointer trails by exactly one squash-commit. The release commit's amend in Step 11 already catches state up to the release SHA. Substantive (non-wiki) drift still STOPs.

### 2. Make `/wiki-sync` Step 7 branch-aware

`/wiki-sync` previously committed-in-place unconditionally. That dead-ends on `main` (push-protected) and fragments working state on any other branch.

New behavior:

- **On `main` (or `master`)** → create `wiki/sync-YYYY-MM-DD`, push, open PR, squash-merge.
- **On any other branch** (feature/fix/release/worktree) → commit in place. The maintainer is mid-task; don't surprise-branch them.

## Changes

- `.claude/commands/gaia-release.md` — Step 2 reflow with the `wiki:`-only bypass branch and rationale
- `.claude/commands/wiki-sync.md` — Step 7 split into Case A (on main) / Case B (anywhere else)
- `wiki/concepts/Release Workflow.md` — step 2 description updated
- `wiki/concepts/Wiki Sync.md` — what `/wiki-sync` does (step 5) updated to note branch-aware landing

## Test plan

- [ ] After this lands, run `/wiki-sync` from `main` → branches automatically, opens a wiki-sync PR
- [ ] Run `/gaia-release patch` after the wiki-sync PR merges → Step 2 reports `✓ Wiki content in sync; advancing state through 1 wiki-prefix commits during release.` and proceeds
- [ ] Substantive (non-wiki) drift still STOPs the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)