### PR TITLE
wiki: sync through 647b850 (1 updated, 1 skipped)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "last_evaluated_sha": "f23915aa0a6d7e48e57c1c7965e0519a94f25b1c",
-  "last_evaluated_at": "2026-05-03T17:13:59Z"
+  "last_evaluated_sha": "647b8508df24067ff99e4280b507aef6f7a85c86",
+  "last_evaluated_at": "2026-05-03T17:30:09Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,10 @@
 # Log
 
+## 2026-05-04 | /wiki-sync f23915a..647b850
+
+- 2026-05-04 647b850 - WORTHY: relax /gaia-release Step 2 gate to allow wiki-prefix-only drift + make /wiki-sync Step 7 branch-aware → wiki/concepts/Release Workflow.md, wiki/concepts/Wiki Sync.md (already updated in-commit)
+- 2026-05-04 1d51882 - SKIP: wiki: prefix (previous wiki-sync squash artifact)
+
 ## 2026-05-04 | /wiki-sync 6686f26..f23915a
 
 - 2026-05-04 f23915a - WORTHY: statusline replaces SessionStart hook for /update-deps and /update-gaia indicators → wiki/concepts/Claude Hooks.md, wiki/concepts/Claude Skills.md, wiki/modules/Claude Integration.md (already updated in-commit)


### PR DESCRIPTION
## Summary

Pre-release wiki sync. Range \`f23915a..647b850\` (2 commits).

- **WORTHY** \`647b850\` — fix: self-consistent /wiki-sync → /gaia-release flow. Wiki content already updated in-commit (\`Release Workflow.md\`, \`Wiki Sync.md\`).
- **SKIP** \`1d51882\` — wiki: prefix (previous wiki-sync squash artifact).

State advanced to \`647b850\`. The \`/gaia-release\` Step 2 gate (relaxed in #76) will accept the wiki-prefix-only drift this PR produces, unblocking v1.0.5.

## Test plan

- [x] State pointer matches HEAD before merge
- [x] No new wiki orphans
- [ ] Post-merge: \`/gaia-release patch\` reports \`✓ Wiki content in sync; advancing state through 1 wiki-prefix commits during release.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)