### PR TITLE
chore(deps): bump zod 4.4.2 → 4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sonner": "2.0.7",
     "spark-md5": "3.0.2",
     "tailwind-merge": "3.5.0",
-    "zod": "4.4.2"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@faker-js/faker": "10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.19.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@conform-to/zod':
         specifier: 1.19.1
-        version: 1.19.1(zod@4.4.2)
+        version: 1.19.1(zod@4.4.3)
       '@epic-web/client-hints':
         specifier: 1.3.9
         version: 1.3.9
@@ -102,8 +102,8 @@ importers:
         specifier: 3.5.0
         version: 3.5.0
       zod:
-        specifier: 4.4.2
-        version: 4.4.2
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@faker-js/faker':
         specifier: 10.4.0
@@ -5199,8 +5199,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.4.2:
-    resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -5420,10 +5420,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@conform-to/zod@1.19.1(zod@4.4.2)':
+  '@conform-to/zod@1.19.1(zod@4.4.3)':
     dependencies:
       '@conform-to/dom': 1.19.1
-      zod: 4.4.2
+      zod: 4.4.3
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -7761,8 +7761,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.4.2
-      zod-validation-error: 4.0.2(zod@4.4.2)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8592,7 +8592,7 @@ snapshots:
       tinyglobby: 0.2.16
       unbash: 3.0.0
       yaml: 2.8.3
-      zod: 4.4.2
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9289,7 +9289,7 @@ snapshots:
   remix-toast@4.0.0(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
       react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      zod: 4.4.2
+      zod: 4.4.3
 
   remix-utils@9.3.1(@standard-schema/spec@1.1.0)(react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -10221,8 +10221,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.4.2):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.4.2
+      zod: 4.4.3
 
-  zod@4.4.2: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- Patch bump: `zod` 4.4.2 → 4.4.3
- No breaking changes; no companion packages required updates
- `pnpm.overrides` empty — nothing to audit

## Test plan
- [x] typecheck
- [x] lint
- [x] test (13 files, 46 tests)
- [x] build
- [ ] pw (no e2e tests configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)