### PR TITLE
docs: integrate Serena MCP and document knip dead code detection

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -27,7 +27,7 @@ When constructing each specialist subagent's prompt below, append the full conte
 Work happens in two layers, dispatched in parallel:
 
 - **Main agent (you)** — cross-cutting concerns: security reasoning, architectural fit, performance at the module/data-flow level, accessibility, edge cases, maintainability. Do this yourself.
-- **Specialist subagents** — line-level rule compliance against the project's skills/rules files. Spawned in parallel from a single tool call, alongside `react-doctor`.
+- **Specialist subagents** — line-level rule compliance against the project's skills/rules files. Spawned in parallel from a single tool call, alongside `react-doctor` and `pnpm knip --reporter json`.
 
 Don't duplicate work: if a subagent is going to check every `useEffect` against the react-code skill, you don't need to do that line by line too. Focus your own review on the issues only a full-context reviewer can catch.
 
@@ -134,11 +134,11 @@ Include only when there are specific, concrete patterns worth reinforcing. Skip 
 5. **Be specific** — never say "this could be improved" without saying exactly how and why
 6. **Be proportionate** — don't nitpick formatting when there are security holes; focus energy on what matters most
 7. **Respect existing patterns** — if the codebase has an established way of doing something, don't suggest alternatives unless there's a concrete benefit
-8. **Dispatch in parallel** — once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor` from a single tool-call message so they run concurrently with your own review
+8. **Dispatch in parallel** — once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor` and `pnpm knip --reporter json` from a single tool-call message so they run concurrently with your own review
 
-## Rules-Based Audit (Specialist Subagents + react-doctor)
+## Rules-Based Audit (Specialist Subagents + react-doctor + knip)
 
-Rule-based line-level checks are done by specialist subagents in parallel with `react-doctor`. This runs concurrently with your own cross-cutting review.
+Rule-based line-level checks are done by specialist subagents in parallel with `react-doctor` and `pnpm knip --reporter json`. This runs concurrently with your own cross-cutting review.
 
 ### How to run
 
@@ -151,7 +151,18 @@ Rule-based line-level checks are done by specialist subagents in parallel with `
 3. **Dispatch in parallel, in one tool-call message**:
    - 1 × `Agent` call per surviving subagent (foreground — results merge on return)
    - 1 × `Bash` call for `npx -y react-doctor@latest . --verbose --diff` (also foreground, runs alongside)
+   - 1 × `Bash` call for `pnpm knip --reporter json` (also foreground, runs alongside) — pre-merge is post-task by design, so the noise concern from `.claude/rules/knip.md` doesn't apply here
 4. **Merge findings** into your report under Critical/Important/Suggestions. Deduplicate against your own findings, keeping the more detailed version. Many react-doctor barrel-import and multiple-useState warnings are false positives in this codebase — cross-reference against project conventions before including them.
+
+### Knip findings
+
+Parse the JSON output from `pnpm knip --reporter json` (an `issues[]` array keyed by file with `files`, `dependencies`, `devDependencies`, `unlisted`, `binaries`, `unresolved`, `exports`, `types`, `enumMembers`, `duplicates`). For each finding, classify into one of the three buckets from `.claude/rules/knip.md`:
+
+1. **Real dead code** — unused file/export/type with no remaining callers. Recommend deletion.
+2. **Library API exposed for downstream use** — intentionally exported even though this repo doesn't consume it (common for `app/components/`, `app/hooks/`, `app/utils/`, `app/services/`, `app/types/` — see template-aware config). Recommend adding to `entry` globs in `knip.config.ts`.
+3. **Implicit dependency** — package used via config plugin, CSS, or runtime resolution that knip can't trace. Recommend adding to `ignoreDependencies` in `knip.config.ts`.
+
+Knip findings are **advisory, not blocking** — like react-doctor's. Surface them in the audit summary with the recommended bucket and action so the user can decide. Do not auto-delete or auto-edit `knip.config.ts` during the review.
 
 ### Subagent 1: React Patterns & Accessibility Audit
 

--- a/.claude/rules/knip.md
+++ b/.claude/rules/knip.md
@@ -2,16 +2,20 @@
 
 `pnpm knip` reports unused files, exports, types, and dependencies. Configured at `knip.config.ts`.
 
-## When to suggest running
+## When it runs automatically
 
-Suggest `pnpm knip` after:
+Knip runs automatically pre-merge inside the `code-review-audit` agent (`.claude/agents/code-review-audit.md`), in the same parallel batch as `react-doctor`. Pre-merge is post-task by design — work is finished, audit fires, then merge — so the noise concern below does not apply at that point.
+
+## When to suggest running manually
+
+Outside the pre-merge audit, suggest `pnpm knip` after:
 
 - A refactor that removes or restructures modules
 - Deleting a feature, route, page, or component
 - Removing or replacing a dependency
 - Before opening a release-candidate PR
 
-Do **not** run knip mid-task or as part of the Quality Gate — in-progress work routinely flags exports that haven't been wired up yet, and the noise drowns the signal.
+Do **not** run knip mid-task or as part of the Quality Gate (pre-commit) — in-progress work routinely flags exports that haven't been wired up yet, and the noise drowns the signal. The pre-merge auto-run inside `code-review-audit` is the only automated invocation; everything else is manual or suggestion-driven.
 
 ## Acting on output
 

--- a/wiki/concepts/Code Review Audit Agent.md
+++ b/wiki/concepts/Code Review Audit Agent.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-04-30
+updated: 2026-05-05
 tags: [concept, claude, agent, review]
 ---
 
@@ -12,7 +12,9 @@ Defined in `.claude/agents/code-review-audit.md`. Sonnet-class subagent for comp
 
 Full spec: `.claude/agents/code-review-audit.md`.
 
-Reviews security, performance, code smells, architecture, robustness, and maintainability. Output is tiered: Critical (must fix) → Important (should fix) → Suggestions → What's done well. After its own pass, spawns three specialist subagents in parallel (React Patterns & Accessibility, TypeScript & Architecture, Translation) plus `react-doctor` in a single tool call. Each subagent is gated on file scope so it doesn't spawn when there's nothing to review (e.g. no `.tsx` → skip Subagent 1).
+Reviews security, performance, code smells, architecture, robustness, and maintainability. Output is tiered: Critical (must fix) → Important (should fix) → Suggestions → What's done well. After its own pass, spawns three specialist subagents in parallel (React Patterns & Accessibility, TypeScript & Architecture, Translation) plus `react-doctor` and `pnpm knip --reporter json` in a single tool call. Each subagent is gated on file scope so it doesn't spawn when there's nothing to review (e.g. no `.tsx` → skip Subagent 1).
+
+Knip runs pre-merge here (post-task by design) and its findings are bucketed advisory: real dead code, intentional library export (update `entry` globs), or implicit dependency (update `ignoreDependencies`). See [[knip]].
 
 ## Durable knowledge
 

--- a/wiki/dependencies/knip.md
+++ b/wiki/dependencies/knip.md
@@ -5,7 +5,7 @@ package: knip
 version: ^6.11.0
 role: dead-code-detection
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 tags: [dependency, quality]
 ---
 
@@ -16,8 +16,9 @@ Reports unused files, exports, types, and dependencies across the codebase. Devt
 ## Conventions
 
 - Config: `knip.config.ts` (repo root)
-- Run: `pnpm knip`
-- Not part of the [[Quality Gate]] — in-progress work routinely flags exports that haven't been wired up yet, which drowns the signal.
+- Run: `pnpm knip` (manual) or `pnpm knip --reporter json` (machine-readable, used by the audit agent)
+- Runs automatically pre-merge inside the [[Code Review Audit Agent]] (alongside `react-doctor`) — pre-merge is post-task by design, so the in-progress noise concern doesn't apply.
+- Not part of the [[Quality Gate]] (pre-commit) — in-progress work routinely flags exports that haven't been wired up yet, which drowns the signal.
 
 ## Template-aware config
 


### PR DESCRIPTION
Update code-review-audit agent and wiki documentation to reflect Serena MCP integration and knip configuration for automated dead code detection in the pre-merge audit.