### PR TITLE
wiki: sync through 320335e (1 updated, 3 skipped)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "f54f7301ecd2cac7f49b2472459b859b31555f64",
-  "last_evaluated_at": "2026-05-06T09:56:06Z",
+  "last_evaluated_sha": "320335eadfe265efef3426dac8c0834a80da2b06",
+  "last_evaluated_at": "2026-05-07T00:00:00Z",
   "last_consolidated_sha": "f54f7301ecd2cac7f49b2472459b859b31555f64"
 }

--- a/wiki/concepts/Telemetry.md
+++ b/wiki/concepts/Telemetry.md
@@ -1,0 +1,89 @@
+---
+type: concept
+title: Telemetry
+status: active
+created: 2026-05-07
+updated: 2026-05-07
+tags: [concept, gaia-cli, telemetry, mentorship]
+---
+
+# Telemetry
+
+GAIA's telemetry system (SPEC-001) captures structured events across the dev workflow to power mentorship feedback and aggregated analytics. It ships as the `gaia-cli/` workspace — a standalone Node.js CLI (`bin/gaia`) invoked by hooks and slash-command emits.
+
+## Three-stream architecture
+
+Events flow into one of three independent streams:
+
+| Stream | Location | Permissions | Purpose |
+|---|---|---|---|
+| **Mentorship** | `~/.claude/projects/<slug>/gaia/telemetry/mentorship/events-*.jsonl` | `700/600` | Full identity; in-session adaptation. Off-project, machine-local. |
+| **Cloud projection** | `.gaia/local/telemetry/cloud/` | `755/644` | Strict whitelist + denylist sweep. No user paths, text, or identity. |
+| **Analytics** | `.gaia/local/telemetry/analytics/` | `755/644` | Daily aggregate reports; auto-attested (audit-attest.ts throws on drift). |
+
+Mentorship data stays off-project. Cloud + analytics live in `.gaia/local/telemetry/` (gitignored). Claude must not display raw mentorship event files — see `.claude/rules/mentorship-display.md`. The displayable aggregate is `profile.md`.
+
+## gaia-cli workspace
+
+`gaia-cli/` is a pnpm workspace at the repo root. Entry: `bin/gaia` (bash shim → `gaia-cli/src/index.ts`). Subcommand router uses an object map (no switch; project's `no-switch` rule).
+
+Top-level subcommands:
+- `telemetry emit <event_type> [--field value …]` — universal emit; writes to mentorship + cloud streams based on config
+- `telemetry compute-profile` — regenerates `profile.md` from mentorship events via three pattern detectors
+- `mentorship enable|disable|purge|status` — opt-in lifecycle; state machine in `src/mentorship/config.ts`
+- `mentorship analytics enable|disable|dry-run` — analytics stream opt-in
+- `_internal-fetch-coaching` — reads `profile.md`, writes `.gaia/cache/coaching-active.txt` if active adaptations match; consumed by `/gaia spec` at session start
+
+## Universal envelope
+
+Every emit writes a `UniversalEnvelope` (Zod schema in `src/schemas/envelope.ts`): `event_id` (content-derived ULID), `event_type`, `install_id`, `project_id`, `timestamp`, plus event-specific payload fields. Cloud projection applies a strict field whitelist and a denylist sweep that exits 12 on drift — any new field that reaches the cloud without explicit allow is a build break.
+
+## Storage paths
+
+`src/storage/paths.ts` resolves `StorageRoots` from repo root + home dir:
+
+- `cloudDir` = `.gaia/local/telemetry/cloud/` (mode 755)
+- `analyticsDir` = `.gaia/local/telemetry/analytics/` (mode 755)
+- `mentorshipDir` = `~/.claude/projects/<slug>/gaia/telemetry/mentorship/` (mode 700)
+- `profilePath` = `~/.claude/projects/<slug>/gaia/profile.md`
+- `installIdPath` = `~/.claude/projects/<slug>/gaia/install-id.txt`
+- `projectIdPath` = `.gaia/local/.project-id`
+
+`<slug>` = repo root path with `/` replaced by `-`.
+
+## Mentorship opt-in
+
+`gaia-init` Step 10 presents a verbatim privacy explainer and a three-option `AskUserQuestion`. Opt-in state lives in `~/.claude/projects/<slug>/gaia/telemetry/mentorship/config.json`. Mentorship is disabled by default; emits that target the mentorship stream short-circuit when `enabled === false`.
+
+## Profile computation
+
+`gaia telemetry compute-profile` runs three pattern detectors over mentorship events:
+
+- **articulation-gap** — detects spec sessions where clarify-loop question counts spike
+- **knowledge-gap** — detects recurring research-agent dispatch on the same topic cluster
+- **intent-clarity-gap** — detects gate-2 revision cycles
+
+Detectors are wired-but-inert at v1.0.0: production behavior requires N ≥ 10 events above threshold. Strength + fade helpers use `FLAKE_DOWNWEIGHT=0.25` to discount single-occurrence spikes. Output: `profile.md` with `DO-NOT-EDIT` header and atomic write.
+
+## Emit wiring
+
+| Hook / skill | Event emitted |
+|---|---|
+| `PostToolUse Task` hook (`telemetry-task-postuse.sh`) | `engineer_return`, `code_review_audit_finding` (trailer-parsed; stub in v1) |
+| `/gaia spec` Gate 2 | `time_to_resolved_spec` |
+| `/gaia spec` abandoned-exit | `time_to_resolved_spec` (abandoned) |
+| `/gaia plan` revision detection | `plan_revised` |
+| `spec-close` Step 5 | chains `compute-profile` after pacing append |
+
+Statusline shows a compass segment when mentorship is enabled (wired in `.gaia/statusline/gaia-statusline.sh`). Session-start clears `.gaia/cache/coaching-active.txt` so stale injections never persist.
+
+## Release-gate harness
+
+`.claude-tests/smoke/telemetry-v1/run.sh` — 6 tests, 28 deterministic assertions: envelope correctness + idempotency, cloud-projection drift exit 12, file modes, compute-profile idempotency + DO-NOT-EDIT header, analytics audit attestation, mentorship-disabled short-circuit.
+
+## Pairs with
+
+- [[GAIA Spec]] — emits time_to_resolved_spec; receives coaching injection via `_internal-fetch-coaching`
+- [[GAIA Plan]] — emits plan_revised on slug collision
+- [[Claude Hooks]] — PostToolUse Task hook backstops engineer-return and code-review-audit events
+- [[Release Workflow]] — mentorship dirs + project identity excluded from adopter bundle via `.gaia/release-exclude`

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -3,7 +3,7 @@ type: meta
 title: Index
 status: active
 created: 2026-04-20
-updated: 2026-05-06
+updated: 2026-05-07
 tags: [meta]
 ---
 
@@ -123,6 +123,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[GAIA Audit]] — `/gaia audit`: two-stage knowledge-store hygiene sweep.
 - [[Wiki Sync]] — `/wiki-sync` + drift hooks: keep the wiki convergent with code without spawned sub-Claudes.
 - [[Wiki Consolidate]] — `/wiki-consolidate`: cross-SPEC redundancy and contradiction audit; surfaces supersession candidates, reversed decisions, near-collision slugs, and subject-orphans.
+- [[Telemetry]] — SPEC-001 three-stream telemetry (mentorship, cloud projection, analytics), `gaia-cli/` workspace, `bin/gaia` CLI, profile computation, adaptation injection.
 - [[Serena Integration]] — Serena handles live code; the wiki handles institutional memory.
 - [[Chromatic Opt-Out]]
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -3,7 +3,7 @@ type: meta
 title: Log
 status: active
 created: 2026-05-04
-updated: 2026-05-06
+updated: 2026-05-07
 tags: [meta, log]
 ---
 
@@ -11,6 +11,10 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-07 320335e - WORTHY: SPEC-001 telemetry v1 — gaia-cli/ workspace, three-stream architecture, mentorship opt-in, profile detection, adaptation injection → wiki/concepts/Telemetry.md (new), wiki/index.md
+- 2026-05-07 b27f060 - SKIP: README-only update (no architectural decision)
+- 2026-05-07 5ddfe48 - SKIP: wiki already updated in-commit (wiki/dependencies/Husky.md updated for lint-staged v17 + .lintstagedrc.json rename in the same commit); react-router + other bumps are version-only
+- 2026-05-07 dab5338 - SKIP: wiki sync + lint fixes already landed in-commit (squash PR included wiki: sync through f54f730 and wiki: lint fixes sub-commits)
 - 2026-05-06 f54f730 - WORTHY: /wiki-consolidate command + consolidation gate in /wiki-sync + state schema change → wiki/concepts/Wiki Consolidate.md (new), wiki/concepts/Wiki Sync.md, wiki/index.md
 - 2026-05-06 7dd6e44 - SKIP: /gaia plan + /gaia spec skill refactor (implementation details in skill refs; user-facing wiki surface unchanged)
 - 2026-05-06 7a2c8fb - SKIP: wiki pages updated in-commit (gaia state path .claude/ → .gaia/local/; all wiki edits landed in the commit)


### PR DESCRIPTION
SPEC-001 telemetry v1 commit (320335e) is WORTHY — new gaia-cli workspace, three-stream telemetry, mentorship, profile detection. Created wiki/concepts/Telemetry.md. Updated wiki/index.md. Other 3 commits skipped: dab5338 (wiki already in-commit), 5ddfe48 (wiki updated in-commit for lint-staged v17), b27f060 (README-only).