### PR TITLE
test(distribution): layer 2 Claude-in-Docker smoke + CI workflow

### DIFF
--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -87,10 +87,14 @@ wiki/decisions/Bundle-time Scrub.md
 # `release.yml` cuts releases of the GAIA template itself (triggered by
 # `v*.*.*` tags); adopters never release GAIA. `cli-tests.yml` runs the
 # .gaia/cli/ vitest suite; adopters receive only the bundled binary, so
-# the test workflow has nothing to test on their side. Both would be
-# silent passengers at best and confusing CI failures at worst.
+# the test workflow has nothing to test on their side. `distribution.yml`
+# runs the maintainer-only `.gaia/tests/distribution/` harness against a
+# staged release tree using a Claude OAuth org secret; adopters never
+# distribute GAIA. All three would be silent passengers at best and
+# confusing CI failures at worst.
 .github/workflows/release.yml
 .github/workflows/cli-tests.yml
+.github/workflows/distribution.yml
 
 # --- 10. Maintainer-only health-audit infrastructure ---
 # `.gaia/cli/health/` holds the audit taxonomy, run state, and (post-#97)

--- a/.gaia/tests/distribution/06-claude-runs-staged.sh
+++ b/.gaia/tests/distribution/06-claude-runs-staged.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# 06-claude-runs-staged.sh
+#
+# Layer 2: validates the Claude-in-Docker plumbing for distribution tests.
+# Builds the gaia-dist-claude image, mounts a staged release tree at /work
+# read-only, and runs `claude --print` with an OAuth token from the host env.
+#
+# What this DOES test:
+#   - Docker image builds (Node + claude.ai/install.sh + correct PATH).
+#   - `claude --version` runs inside the container (binary reachable).
+#   - CLAUDE_CODE_OAUTH_TOKEN authenticates against Anthropic from the
+#     container — `claude --print` returns a real model response.
+#   - The staged tree is reachable as the container's working directory.
+#
+# What this does NOT test:
+#   - Adopter flows like /gaia-init or /setup-gaia. Those exercise interactive
+#     skills and live in follow-up scenarios; this is the harness smoke.
+#   - Token-attribution to subscription vs. API. That is the diagnostic
+#     runbook's job — see `diagnostic/claude-auth-in-docker.md` for the
+#     verified $0/run finding on Claude Max hosts.
+#
+# Skipped automatically when Docker is unavailable OR
+# CLAUDE_CODE_OAUTH_TOKEN is unset, so contributors without auth can still
+# run Layers 0 + 1 via run-all.sh.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/lib/lib.sh"
+source "$HERE/lib/docker.sh"
+
+if ! docker_available; then
+  log "docker daemon not reachable; skipping (Layer 2 requires Docker)"
+  pass "docker unavailable — Layer 2 scenario skipped"
+  exit 0
+fi
+
+if ! docker_token_available; then
+  log "CLAUDE_CODE_OAUTH_TOKEN unset; skipping (Layer 2 requires Claude auth)"
+  pass "no Claude OAuth token — Layer 2 scenario skipped"
+  exit 0
+fi
+
+STAGING="$(mktemp -d -t gaia-dist-claude-XXXXXX)"
+trap 'rm -rf "$STAGING"' EXIT
+
+"$HERE/lib/build-staging.sh" "$STAGING" \
+  || { fail "build-staging failed"; exit 1; }
+
+log "building $GAIA_DIST_IMAGE (cached after first run)"
+if ! docker_build_image; then
+  log "docker build failed; rerunning with output for diagnosis:"
+  GAIA_DIST_IMAGE="$GAIA_DIST_IMAGE" docker build -t "$GAIA_DIST_IMAGE" - <<'DOCKERFILE' || true
+FROM node:22-bullseye-slim
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"
+WORKDIR /work
+DOCKERFILE
+  fail "docker build failed"
+  exit 1
+fi
+
+# Sanity: the claude binary is on PATH and runnable inside the container.
+if ! docker_run_claude "$STAGING" --version >/dev/null 2>&1; then
+  log "claude --version failed inside container; rerunning with output:"
+  docker_run_claude "$STAGING" --version || true
+  fail "claude --version failed inside container"
+  exit 1
+fi
+
+# Auth + reachability probe. Single-word reply keeps token spend minimal;
+# `grep -i` tolerates trailing whitespace and case variation in the model's
+# reply.
+RESPONSE="$(docker_run_claude "$STAGING" --print "Reply with the single word: ok" 2>/dev/null || true)"
+if ! printf '%s' "$RESPONSE" | grep -qi 'ok'; then
+  log "claude --print did not return 'ok'; got:"
+  printf '%s\n' "$RESPONSE" >&2
+  fail "claude --print response did not contain 'ok' (auth failure or model unreachable?)"
+  exit 1
+fi
+
+pass "Layer 2 plumbing green: image builds, claude --version runs, OAuth auth succeeds against staged tree"

--- a/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
+++ b/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# 07-gaia-init-strip-branding.sh
+#
+# Adopter-flow regression: runs `gaia init strip-branding --title <T>`
+# against a writable copy of the staged release tree. The staged tree is
+# what an adopter receives via `npx create-gaia` — this scenario asserts
+# the bundled CLI binary actually executes its first user-facing step on
+# that tree.
+#
+# Why it exists: 06-claude-runs-staged.sh proves Claude can talk to
+# Anthropic from a Linux container, but does NOT prove the shipped CLI
+# works on a tree adopters receive. If release-exclude strips a file
+# strip-branding needs (e.g. .gaia/templates/README.md or
+# app/components/GaiaLogo/ or app/components/Header/index.tsx), Layers
+# 0+1+2 stay green and only this scenario fails.
+#
+# Asserts (post-conditions of strip-branding --title "Test Project"):
+#   - Exit code 0, no stdout (per the subcommand contract).
+#   - README.md exists at scaffold root and contains "Test Project"
+#     (regenerated from .gaia/templates/README.md, which ships).
+#   - app/components/GaiaLogo/ is removed (it ships in the staged tree).
+#   - app/components/Header/index.tsx no longer imports GaiaLogo.
+#
+# Layer 0.5: runs on the host or runner, no Docker. Cheap (~1s after
+# build-staging) — no pnpm install, just file-level transforms.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/lib/lib.sh"
+
+require_cmd rsync "rsync required for adopter-flow scaffold copy"
+
+STAGING="$(mktemp -d -t gaia-dist-init-stage-XXXXXX)"
+SCAFFOLD="$(mktemp -d -t gaia-dist-init-scaffold-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+
+"$HERE/lib/build-staging.sh" "$STAGING" \
+  || { fail "build-staging failed"; exit 1; }
+
+# Copy staging into a writable scaffold (strip-branding mutates files).
+rsync -a "$STAGING"/ "$SCAFFOLD"/
+
+# Pre-conditions on the staged tree. Each check is something
+# release-exclude guarantees — if any fails, release-exclude has drifted
+# and strip-branding will fail downstream.
+[ -f "$SCAFFOLD/.gaia/templates/README.md" ] \
+  || { fail "staged tree missing .gaia/templates/README.md (strip-branding template source)"; exit 1; }
+[ -d "$SCAFFOLD/app/components/GaiaLogo" ] \
+  || { fail "staged tree missing app/components/GaiaLogo/ (strip-branding deletion target)"; exit 1; }
+[ -f "$SCAFFOLD/app/components/Header/index.tsx" ] \
+  || { fail "staged tree missing app/components/Header/index.tsx (strip-branding edit target)"; exit 1; }
+if [ -f "$SCAFFOLD/README.md" ]; then
+  log "warning: README.md already in scaffold — release-exclude category 11 may have drifted"
+fi
+[ -x "$SCAFFOLD/.gaia/cli/gaia" ] \
+  || { fail "staged tree missing or non-executable .gaia/cli/gaia (bundled CLI)"; exit 1; }
+
+cd "$SCAFFOLD"
+
+# Run strip-branding. Capture stdout — the contract is "no stdout on
+# success" per the subcommand's --help.
+TITLE="Test Project"
+STDOUT="$(./.gaia/cli/gaia init strip-branding --title "$TITLE" 2>/dev/null)" || {
+  log "gaia init strip-branding exited non-zero; rerunning with stderr:"
+  ./.gaia/cli/gaia init strip-branding --title "$TITLE" || true
+  fail "gaia init strip-branding exited non-zero on staged tree"
+  exit 1
+}
+
+if [ -n "$STDOUT" ]; then
+  log "unexpected stdout from strip-branding (contract: no stdout on success):"
+  printf '%s\n' "$STDOUT" >&2
+  fail "gaia init strip-branding wrote to stdout (contract violation)"
+  exit 1
+fi
+
+# Post-condition assertions.
+[ -f "$SCAFFOLD/README.md" ] \
+  || { fail "strip-branding did not create README.md from .gaia/templates/README.md"; exit 1; }
+
+grep -q "$TITLE" "$SCAFFOLD/README.md" \
+  || { fail "strip-branding did not substitute '$TITLE' into README.md"; exit 1; }
+
+[ ! -d "$SCAFFOLD/app/components/GaiaLogo" ] \
+  || { fail "strip-branding did not remove app/components/GaiaLogo/"; exit 1; }
+
+if grep -q "GaiaLogo" "$SCAFFOLD/app/components/Header/index.tsx"; then
+  fail "strip-branding left a GaiaLogo reference in Header/index.tsx"
+  exit 1
+fi
+
+pass "gaia init strip-branding produced expected post-conditions on staged tree"

--- a/.gaia/tests/distribution/README.md
+++ b/.gaia/tests/distribution/README.md
@@ -26,6 +26,7 @@ Maintainer-only validation of the post-scrub GAIA tarball. Excluded from the rel
 ├── 04-scaffold-runs.sh          # extract + pnpm install + typecheck/lint/test/build
 ├── 05-clean-env.sh              # PATH-stripped subshell (Layer 1)
 ├── 06-claude-runs-staged.sh     # Claude-in-Docker auth + cwd smoke (Layer 2)
+├── 07-gaia-init-strip-branding.sh  # Adopter-flow regression: gaia init strip-branding
 └── diagnostic/
     └── claude-auth-in-docker.md
 ```
@@ -51,7 +52,7 @@ bash .gaia/tests/distribution/01-files-present.sh
 
 ## Layered isolation
 
-Layer 0 — host pnpm available, scenarios run with the maintainer's PATH (default). Layer 1 — PATH-stripped subshell (`05-clean-env.sh`) verifies the bootstrapper extracts cleanly with only `/usr/bin:/bin`. Layer 2 — Docker (`06-claude-runs-staged.sh`) verifies the Claude-in-container plumbing against a staged release tree.
+Layer 0 — host pnpm available, scenarios run with the maintainer's PATH (default). Layer 1 — PATH-stripped subshell (`05-clean-env.sh`) verifies the bootstrapper extracts cleanly with only `/usr/bin:/bin`. Layer 2 — Docker (`06-claude-runs-staged.sh`) verifies the Claude-in-container plumbing against a staged release tree. Adopter-flow regressions (`07-`+) run on the host or runner without Docker and exercise the bundled CLI against a writable copy of the staged tree.
 
 ### Layer 1: clean-env bootstrap (`05-clean-env.sh`)
 
@@ -68,6 +69,14 @@ Builds a `gaia-dist-claude` image (`node:22-bullseye-slim` + `claude.ai/install.
 What it covers: image build, claude binary on PATH inside the container, OAuth auth from container to Anthropic, staged tree reachable as the container's working directory. What it does NOT cover: adopter flows like `/gaia-init` or `/setup-gaia` — those exercise interactive skills and live in follow-up scenarios; this is the harness smoke that proves Layer 2 is wired.
 
 Skips automatically if Docker is unavailable OR `CLAUDE_CODE_OAUTH_TOKEN` is unset, so contributors without auth can still run Layers 0 + 1 via `run-all.sh`. Both skips report as soft PASS.
+
+### Adopter-flow regressions (`07-`+)
+
+`06-claude-runs-staged.sh` proves the harness wiring (Docker, OAuth auth, claude binary on PATH), but does NOT prove any GAIA-specific flow works in the shipped tarball. Adopter-flow scenarios fill that gap by running the bundled `.gaia/cli/gaia` binary directly against a writable copy of the staged tree.
+
+`07-gaia-init-strip-branding.sh` runs `gaia init strip-branding --title "Test Project"` and asserts the four documented post-conditions: `README.md` is regenerated from `.gaia/templates/README.md` with the title substituted, `app/components/GaiaLogo/` is removed, `app/components/Header/index.tsx` no longer references `GaiaLogo`, and the subcommand exits 0 with no stdout per its contract. Catches the failure mode where `release-exclude` accidentally strips a file the subcommand needs (template, deletion target, edit target) — Layers 0+1+2 stay green; only this scenario fails.
+
+Future adopter-flow scenarios cover the rest of `gaia init` (`configure-i18n`, `rename`, `wire-statusline`, `finalize`) and `gaia setup` subcommands.
 
 #### Local setup for maintainers
 

--- a/.gaia/tests/distribution/README.md
+++ b/.gaia/tests/distribution/README.md
@@ -91,7 +91,10 @@ The image tag defaults to `gaia-dist-claude:latest`; override via `GAIA_DIST_IMA
 
 #### CI
 
-`.github/workflows/distribution.yml` runs `run-all.sh` on `ubuntu-latest` with `CLAUDE_CODE_OAUTH_TOKEN` injected from GAIA's GitHub organization secrets. Trigger is `workflow_dispatch` only (manual, maintainer-initiated). The intended steady-state trigger is `release.published` — only the maintainer publishes releases, so contributors structurally cannot trigger Layer 2 spend. The workflow never uses `pull_request_target` (that trigger would expose the secret to fork PRs).
+Two entry points, both consuming `CLAUDE_CODE_OAUTH_TOKEN` from GAIA's GitHub organization secrets:
+
+- **Pre-publish gate inside `release.yml`.** The tag-triggered release workflow runs `bash .gaia/tests/distribution/run-all.sh` after the staging + scrub + runtime-deps phases and before the tarball is built. If any scenario fails the release halts — the tarball never builds and `gh release create` never runs, so a broken release cannot publish. This is the production gate.
+- **Manual `distribution.yml`.** `workflow_dispatch` only — used to run the harness on a feature branch (no tag) for ad-hoc verification of harness changes themselves. Never `pull_request_target` (that trigger would expose the secret to fork PRs).
 
 ## Claude auth status
 

--- a/.gaia/tests/distribution/README.md
+++ b/.gaia/tests/distribution/README.md
@@ -15,15 +15,17 @@ Maintainer-only validation of the post-scrub GAIA tarball. Excluded from the rel
 
 ```
 .gaia/tests/distribution/
-├── run-all.sh             # top-level driver
+├── run-all.sh                   # top-level driver
 ├── lib/
-│   ├── lib.sh             # pass/fail/log/require_cmd, PROJECT_ROOT
-│   └── build-staging.sh   # builds staging tarball into $1 (mktemp dir)
-├── 01-files-present.sh    # manifest/exclude/sentinel presence
-├── 02-leak-replay.sh      # re-runs scrub regexes against staged tree
-├── 03-marker-strip.sh     # asserts maintainer-only markers gone
-├── 04-scaffold-runs.sh    # extract + pnpm install + typecheck/lint/test/build
-├── 05-clean-env.sh        # PATH-stripped subshell (Layer 1)
+│   ├── lib.sh                   # pass/fail/log/require_cmd, PROJECT_ROOT
+│   ├── build-staging.sh         # builds staging tarball into $1 (mktemp dir)
+│   └── docker.sh                # Layer 2 image build + container run helpers
+├── 01-files-present.sh          # manifest/exclude/sentinel presence
+├── 02-leak-replay.sh            # re-runs scrub regexes against staged tree
+├── 03-marker-strip.sh           # asserts maintainer-only markers gone
+├── 04-scaffold-runs.sh          # extract + pnpm install + typecheck/lint/test/build
+├── 05-clean-env.sh              # PATH-stripped subshell (Layer 1)
+├── 06-claude-runs-staged.sh     # Claude-in-Docker auth + cwd smoke (Layer 2)
 └── diagnostic/
     └── claude-auth-in-docker.md
 ```
@@ -49,7 +51,7 @@ bash .gaia/tests/distribution/01-files-present.sh
 
 ## Layered isolation
 
-Layer 0 — host pnpm available, scenarios run with the maintainer's PATH (default). Layer 1 — PATH-stripped subshell (`05-clean-env.sh`) verifies the bootstrapper extracts cleanly with only `/usr/bin:/bin`. Layer 2 — Docker (deferred; tracked under `diagnostic/`).
+Layer 0 — host pnpm available, scenarios run with the maintainer's PATH (default). Layer 1 — PATH-stripped subshell (`05-clean-env.sh`) verifies the bootstrapper extracts cleanly with only `/usr/bin:/bin`. Layer 2 — Docker (`06-claude-runs-staged.sh`) verifies the Claude-in-container plumbing against a staged release tree.
 
 ### Layer 1: clean-env bootstrap (`05-clean-env.sh`)
 
@@ -57,11 +59,43 @@ Covers tarball extraction and the corepack-driven pnpm bootstrap inside a PATH-s
 
 Does not cover `/gaia-init` or `/setup-gaia` execution (no Claude in the subshell — see `diagnostic/claude-auth-in-docker.md`), full filesystem isolation (a true Docker run is the answer), or non-host operating systems. The `npm install -g pnpm` fallback path inside `create-gaia`'s `ensurePnpm()` is intentionally untested here — exercising it would mutate the host's global npm state with no clean rollback.
 
-Skips automatically if `corepack` is not on the host PATH (Node 16.13+ ships corepack, so this is rare). Skip is reported as a soft PASS so `run-all.sh` summaries stay green on hosts where the layer cannot run. Layer 2 (Docker) is deferred — see `diagnostic/claude-auth-in-docker.md` for the next-step plan.
+Skips automatically if `corepack` is not on the host PATH (Node 16.13+ ships corepack, so this is rare). Skip is reported as a soft PASS so `run-all.sh` summaries stay green on hosts where the layer cannot run.
+
+### Layer 2: Claude-in-Docker plumbing (`06-claude-runs-staged.sh`)
+
+Builds a `gaia-dist-claude` image (`node:22-bullseye-slim` + `claude.ai/install.sh`, with `/root/.local/bin` on PATH per the verified pattern in `diagnostic/claude-auth-in-docker.md`), bind-mounts the staged tree at `/work` read-only, and runs `claude --print "Reply with the single word: ok"` with `CLAUDE_CODE_OAUTH_TOKEN` passed through from the host env. The OAuth token attributes to the maintainer's Claude Max subscription, so per-run cost is $0.
+
+What it covers: image build, claude binary on PATH inside the container, OAuth auth from container to Anthropic, staged tree reachable as the container's working directory. What it does NOT cover: adopter flows like `/gaia-init` or `/setup-gaia` — those exercise interactive skills and live in follow-up scenarios; this is the harness smoke that proves Layer 2 is wired.
+
+Skips automatically if Docker is unavailable OR `CLAUDE_CODE_OAUTH_TOKEN` is unset, so contributors without auth can still run Layers 0 + 1 via `run-all.sh`. Both skips report as soft PASS.
+
+#### Local setup for maintainers
+
+```bash
+# One-time: generate a long-lived OAuth token on the host.
+claude setup-token
+
+# Export the token in the current shell. Do NOT commit it — the .gitignore
+# pattern `*.env` covers any local env file you might use.
+export CLAUDE_CODE_OAUTH_TOKEN=<paste>
+
+# Or stash in a local env file outside the repo:
+echo 'CLAUDE_CODE_OAUTH_TOKEN=<paste>' > /tmp/claude-probe.env
+chmod 600 /tmp/claude-probe.env
+set -a; . /tmp/claude-probe.env; set +a
+
+bash .gaia/tests/distribution/run-all.sh
+```
+
+The image tag defaults to `gaia-dist-claude:latest`; override via `GAIA_DIST_IMAGE` if needed. First build pulls `node:22-bullseye-slim` and runs `claude.ai/install.sh` (~30s); subsequent runs hit Docker's layer cache.
+
+#### CI
+
+`.github/workflows/distribution.yml` runs `run-all.sh` on `ubuntu-latest` with `CLAUDE_CODE_OAUTH_TOKEN` injected from GAIA's GitHub organization secrets. Trigger is `workflow_dispatch` only (manual, maintainer-initiated). The intended steady-state trigger is `release.published` — only the maintainer publishes releases, so contributors structurally cannot trigger Layer 2 spend. The workflow never uses `pull_request_target` (that trigger would expose the secret to fork PRs).
 
 ## Claude auth status
 
-**Status: not yet verified.** See `diagnostic/claude-auth-in-docker.md`.
+**Status: verified 2026-05-08** — `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` attributes to Claude Max subscription on the host generating the token. Layer 2 tests are $0 marginal per run on Max-plan hosts. Full findings in `diagnostic/claude-auth-in-docker.md` § Findings.
 
 ## See also
 

--- a/.gaia/tests/distribution/diagnostic/claude-auth-in-docker.md
+++ b/.gaia/tests/distribution/diagnostic/claude-auth-in-docker.md
@@ -26,8 +26,9 @@ What the docs do NOT settle, and what this runbook still has to verify:
   silently bill as API?~~ **Resolved 2026-05-08** (see `## Findings`):
   attributes to subscription on a Claude Max host. No API/pay-as-you-go
   billing observed for in-container calls.
-- **Token lifetime and refresh behavior.** `setup-token` says
-  "long-lived" but doesn't pin a duration. Not yet measured.
+- ~~Token lifetime and refresh behavior.~~ **Resolved 2026-05-08**:
+  `claude setup-token` issues a 1-year OAuth token. Rotation cadence,
+  failure mode on expiry, and refresh procedure documented in `## Findings`.
 
 ## Why this matters
 
@@ -220,9 +221,28 @@ on contributors with active Max subscriptions.
 
 ### Token expiry / refresh
 
-Not measured in this run — token was generated and used in a single
-session. A later run should test the same token after >24h, >7d, and
->30d to characterize lifetime; record outcomes here.
+**Lifetime: 1 year from issuance.** Tokens issued by `claude setup-token`
+expire ~365 days after generation.
+
+The CI org secret was first populated 2026-05-08, so rotation is due by
+**2027-05-08**. Failure mode after expiry: in-container `claude --print`
+calls return an auth error and Layer 2 scenarios fail with a non-zero
+exit; the pre-publish gate inside `release.yml` halts the release until
+the secret is rotated.
+
+Rotation procedure:
+
+1. On a host with an active Claude subscription, run `claude setup-token`
+   to issue a fresh token.
+2. Update GAIA's GitHub organization secret `CLAUDE_CODE_OAUTH_TOKEN`
+   (Settings → Secrets and variables → Actions → Organization secrets).
+3. Optionally run `gh workflow run distribution.yml --ref main` to
+   confirm the new token authenticates from a runner before the next
+   release.
+
+Refresh-without-replay (renewing an existing token in place) is not
+supported — `setup-token` always issues a new token; rotation means
+generating + replacing.
 
 ### Bugs found and corrected during this run
 

--- a/.gaia/tests/distribution/lib/docker.sh
+++ b/.gaia/tests/distribution/lib/docker.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Docker primitives for Layer 2 distribution scenarios.
+#
+# Sourced by Layer 2 scenarios after lib.sh:
+#   source "$HERE/lib/lib.sh"
+#   source "$HERE/lib/docker.sh"
+#
+# Convention matches lib.sh: this file does NOT enable `set -e` — the caller
+# scenario sets `set -euo pipefail` and inherits it.
+#
+# API:
+#   GAIA_DIST_IMAGE             - tag of the test image (override via env)
+#   docker_available            - 0 if `docker` runs and the daemon is reachable
+#   docker_token_available      - 0 if CLAUDE_CODE_OAUTH_TOKEN is set + non-empty
+#   docker_build_image          - builds GAIA_DIST_IMAGE; uses Docker layer cache
+#   docker_run_claude STAGING -- ARGS...
+#                                runs `claude ARGS...` inside GAIA_DIST_IMAGE
+#                                with STAGING bind-mounted at /work read-only
+#                                and CLAUDE_CODE_OAUTH_TOKEN passed through
+
+GAIA_DIST_IMAGE="${GAIA_DIST_IMAGE:-gaia-dist-claude:latest}"
+
+docker_available() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  return 0
+}
+
+docker_token_available() {
+  [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]
+}
+
+# Builds the GAIA distribution-test Claude image. The Dockerfile lives in a
+# scratch dir so the image build context stays minimal — no repo files leak
+# into the image. Pinned to the verified pattern from
+# `diagnostic/claude-auth-in-docker.md`: `claude.ai/install.sh` lands the
+# binary at `/root/.local/bin/claude`, which we put on PATH.
+docker_build_image() {
+  local dockerfile_dir
+  dockerfile_dir="$(mktemp -d -t gaia-dist-dockerfile-XXXXXX)"
+  cat > "$dockerfile_dir/Dockerfile" <<'DOCKERFILE'
+FROM node:22-bullseye-slim
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"
+WORKDIR /work
+DOCKERFILE
+  local rc=0
+  docker build -t "$GAIA_DIST_IMAGE" "$dockerfile_dir" >/dev/null 2>&1 || rc=$?
+  rm -rf "$dockerfile_dir"
+  return "$rc"
+}
+
+# `-e CLAUDE_CODE_OAUTH_TOKEN` (no `=value`) reads from the host env, so the
+# token is never on the command line where it could land in `ps` or shell
+# history. The bind mount is read-only — the Layer 2 contract is "Claude can
+# read the staged tree", not "Claude can mutate the staged tree".
+docker_run_claude() {
+  local staging="$1"; shift
+  docker run --rm \
+    -v "$staging:/work:ro" \
+    -e CLAUDE_CODE_OAUTH_TOKEN \
+    "$GAIA_DIST_IMAGE" \
+    claude "$@"
+}

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,51 @@
+name: Distribution
+
+# Runs `.gaia/tests/distribution/run-all.sh` on a GitHub runner. Layers 0 + 1
+# need only Node + pnpm; Layer 2 additionally needs Docker (pre-installed on
+# ubuntu-latest) and a Claude OAuth token (from org secrets).
+#
+# Trigger is manual (`workflow_dispatch`) until the workflow has proven itself
+# clean on `main`. The intended steady-state trigger is `release.published`
+# only — the maintainer is the only role that can publish releases, so
+# contributors structurally cannot trigger Layer 2 spend.
+#
+# IMPORTANT: never use `pull_request_target`. That trigger exposes secrets to
+# fork PRs, which would let any contributor exfiltrate
+# CLAUDE_CODE_OAUTH_TOKEN.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  distribution:
+    name: Distribution tests (Layers 0+1+2)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Verify bundled CLI binary is present
+        run: |
+          if [ ! -x .gaia/cli/gaia ]; then
+            echo "::error::.gaia/cli/gaia missing or not executable. Maintainer must commit the bundled binary." >&2
+            exit 1
+          fi
+          .gaia/cli/gaia --version || true
+
+      - name: Run distribution scenarios
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: bash .gaia/tests/distribution/run-all.sh

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -14,12 +14,6 @@ name: Distribution
 # CLAUDE_CODE_OAUTH_TOKEN.
 on:
   workflow_dispatch:
-  # TEMPORARY: pre-merge CI verification on this branch only. Remove before
-  # merging to main — the steady-state trigger is workflow_dispatch only,
-  # eventually narrowing to release.published.
-  push:
-    branches:
-      - test/distribution-layer-2
 
 permissions:
   contents: read

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -14,6 +14,11 @@ name: Distribution
 # CLAUDE_CODE_OAUTH_TOKEN.
 on:
   workflow_dispatch:
+  # TEMPORARY: pre-merge CI verification on this branch only. Remove before
+  # merging to main.
+  push:
+    branches:
+      - test/distribution-layer-2
 
 permissions:
   contents: read

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -14,6 +14,12 @@ name: Distribution
 # CLAUDE_CODE_OAUTH_TOKEN.
 on:
   workflow_dispatch:
+  # TEMPORARY: pre-merge CI verification on this branch only. Remove before
+  # merging to main — the steady-state trigger is workflow_dispatch only,
+  # eventually narrowing to release.published.
+  push:
+    branches:
+      - test/distribution-layer-2
 
 permissions:
   contents: read

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -14,11 +14,6 @@ name: Distribution
 # CLAUDE_CODE_OAUTH_TOKEN.
 on:
   workflow_dispatch:
-  # TEMPORARY: pre-merge CI verification on this branch only. Remove before
-  # merging to main.
-  push:
-    branches:
-      - test/distribution-layer-2
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,26 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           ./.gaia/cli/gaia release runtime-deps --staging "/tmp/gaia-${TAG}"
 
+      # Pre-publish distribution-test gate. Runs Layers 0+1+2 against an
+      # independently-staged tree (build-staging.sh re-runs the same
+      # ls-files + exclude + scrub + runtime-deps the steps above did).
+      # If any scenario fails the release halts before the tarball is
+      # uploaded and `gh release create` runs, so a broken release
+      # cannot publish. ~3-4 min on ubuntu-latest, $0 on Claude Max via
+      # the org OAuth token.
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Distribution test gate (Layers 0+1+2)
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: bash .gaia/tests/distribution/run-all.sh
+
       - name: Build tarball
         run: |
           TAG="${{ steps.version.outputs.tag }}"

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -129,6 +129,7 @@ Excluding the source prevents adopters from accidentally rebuilding the binary o
 
 - `.github/workflows/release.yml` — cuts releases of the GAIA template itself, triggered by `v*.*.*` tags against `.gaia/VERSION`. Adopters never release GAIA, so the workflow is at best a silent passenger and at worst a CI failure if they accidentally tag with `v*`.
 - `.github/workflows/cli-tests.yml` — runs `.gaia/cli/` typecheck and vitest. Adopters receive only the bundled binary at `.gaia/cli/gaia`, so there is nothing for the workflow to test on their side.
+- `.github/workflows/distribution.yml` — runs the `.gaia/tests/distribution/` harness on a GitHub runner. Manual trigger only (`workflow_dispatch`); the maintainer's `CLAUDE_CODE_OAUTH_TOKEN` org secret authenticates the in-container `claude` calls used by Layer 2 scenarios. Adopters never run distribution tests against their own scaffold, so the workflow is irrelevant on their side.
 
 `tests.yml` and `chromatic.yml` DO ship; both are adopter-relevant. Their `paths-filter` allowlists are written without reference to maintainer-only paths so the filter stays meaningful on an adopter clone.
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -53,12 +53,13 @@ The tag push triggers [`release.yml`](../../.github/workflows/release.yml), whic
 
 ## Tarball scrubbing
 
-`release.yml` builds the tarball in four phases:
+`release.yml` builds the tarball in five phases:
 
 1. **Stage** — drive the file set from `git ls-files` (not a raw `tar .`) and subtract `.gaia/release-exclude` patterns. `git ls-files` already ignores anything in `.gitignore` (no `.DS_Store`, `node_modules`, build output, `.idea/`); `.gaia/release-exclude` strips the tracked-but-maintainer-only content. `rsync` materializes the include list into `/tmp/gaia-vX.Y.Z/`.
 2. **Bundle-time scrub** — `gaia release scrub /tmp/gaia-vX.Y.Z` applies the transforms in `.gaia/release-scrub.yml`: marker-delimited section strips and a leak-check pass that mirrors the `wiki-style.md` audit greps. Build fails closed on any leak. See [[Bundle-time Scrub]] for rationale.
 3. **Runtime-deps verification** — `gaia release runtime-deps --staging /tmp/gaia-vX.Y.Z` walks shipped shell scripts and verifies every explicit path constant resolves to a shipped path, an adopter-owned sentinel, or a runtime-allocated location. Catches the leak class scrubbing cannot see — runtime references survive lexical strip.
-4. **Tar** — `tar -czf gaia-vX.Y.Z.tar.gz -C /tmp gaia-vX.Y.Z`. The same release-exclude list drives `gaia release manifest`, so the manifest never references files an adopter cannot have. The categories are spelled out in the next section.
+4. **Distribution test gate** — `bash .gaia/tests/distribution/run-all.sh` runs Layers 0+1+2 against an independently-staged tree (`build-staging.sh` re-runs the same `git ls-files` + scrub + runtime-deps phases above). Layer 0 confirms an adopter scaffold typechecks, lints, tests, and builds; Layer 1 confirms the bootstrap path survives in a PATH-stripped subshell; Layer 2 builds a Claude-in-Docker image and probes OAuth auth. The gate's `CLAUDE_CODE_OAUTH_TOKEN` comes from GAIA's GitHub organization secrets; per-run cost is $0 on the maintainer's Claude Max subscription. If any scenario fails the release halts — the tarball is never built and `gh release create` never runs, so a broken release cannot publish.
+5. **Tar** — `tar -czf gaia-vX.Y.Z.tar.gz -C /tmp gaia-vX.Y.Z`. The same release-exclude list drives `gaia release manifest`, so the manifest never references files an adopter cannot have. The categories are spelled out in the next section.
 
 The scrubbed `wiki/hot.md` + `wiki/log.md` contain only the release marker — none of GAIA's internal session cache.
 


### PR DESCRIPTION
## Summary

- **Layer 2 distribution scenario** (`06-claude-runs-staged.sh`) — Docker image build + OAuth auth probe against the staged release tree. Skips cleanly without Docker or `CLAUDE_CODE_OAUTH_TOKEN`.
- **Adopter-flow regression** (`07-gaia-init-strip-branding.sh`) — runs `gaia init strip-branding --title "Test Project"` against a writable copy of the staged tree and asserts the four documented post-conditions (README.md regenerated with title, GaiaLogo dir removed, GaiaLogo refs stripped from Header, exit 0 with no stdout). Catches the failure mode where `release-exclude` strips a file the subcommand needs — Layers 0+1+2 stay green and only this scenario fails.
- **`lib/docker.sh`** — image-build + container-run helpers, pinned to the verified pattern from `diagnostic/claude-auth-in-docker.md` (`/root/.local/bin` PATH).
- **Pre-publish gate inside `release.yml`** — runs `run-all.sh` after the staging/scrub/runtime-deps phases and before the tarball is built. If any scenario fails, the release halts and `gh release create` never runs. A broken release cannot publish.
- **Manual `distribution.yml`** — `workflow_dispatch` only, for ad-hoc harness verification on feature branches. Never `pull_request_target` (would expose the secret to fork PRs).
- **Token rotation** — diagnostic runbook now records the 1-year OAuth token lifetime + rotation procedure (next rotation due 2027-05-08; reminder routine `trig_01LFgJw9zuDssaMzYtfyPChF` armed for 2027-04-10).
- **Distribution boundary** — `distribution.yml` excluded via `.gaia/release-exclude` § 9; wiki Distribution Boundary § 9 lists it. Wiki Tarball-scrubbing section updated to document the five-phase build (stage → scrub → runtime-deps → distribution-gate → tar).

Cost: $0 marginal per CI run on Claude Max — see `.gaia/tests/distribution/diagnostic/claude-auth-in-docker.md` § Findings.

Future scenarios cover the rest of `gaia init` (`configure-i18n`, `rename`, `wire-statusline`, `finalize`) and `gaia setup` subcommands.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `bash -n` syntax check on all new scripts
- [x] YAML parses on `distribution.yml` and `release.yml`
- [x] Local skip-path: Docker up + token unset → all 7 scenarios PASS (06 soft-skip)
- [x] Local full pass: Docker up + token exported → all 7 scenarios PASS
- [x] CI verification: run [25522800323](https://github.com/gaia-react/gaia/actions/runs/25522800323) (Layers 0+1+2) and run [25523768514](https://github.com/gaia-react/gaia/actions/runs/25523768514) (Layers 0+1+2 + scenario 07) — both PASS on `ubuntu-latest` in ~3.5 min
- [ ] Pre-publish gate fires live at the next `v*.*.*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)