### PR TITLE
test(distribution): full /gaia-init CLI-sequence regression (08) + audit fixes

### DIFF
--- a/.gaia/tests/distribution/06-claude-runs-staged.sh
+++ b/.gaia/tests/distribution/06-claude-runs-staged.sh
@@ -47,8 +47,11 @@ trap 'rm -rf "$STAGING"' EXIT
 
 log "building $GAIA_DIST_IMAGE (cached after first run)"
 if ! docker_build_image; then
+  # Re-run the build with output unsuppressed to surface which layer
+  # failed. The `fail; exit 1` below runs unconditionally — the diagnostic
+  # build's exit code is intentionally ignored (`|| :`).
   log "docker build failed; rerunning with output for diagnosis:"
-  GAIA_DIST_IMAGE="$GAIA_DIST_IMAGE" docker build -t "$GAIA_DIST_IMAGE" - <<'DOCKERFILE' || true
+  GAIA_DIST_IMAGE="$GAIA_DIST_IMAGE" docker build -t "$GAIA_DIST_IMAGE" - <<'DOCKERFILE' || :
 FROM node:22-bullseye-slim
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git \
   && rm -rf /var/lib/apt/lists/*

--- a/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
+++ b/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
@@ -60,8 +60,11 @@ fi
 # scenarios sourced or invoked from `run-all.sh` may rely on $PWD.
 TITLE="Test Project"
 STDOUT="$(cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" 2>/dev/null)" || {
+  # Re-run with stderr unsuppressed for diagnosis. The `fail; exit 1`
+  # below runs unconditionally — the diagnostic re-run's exit code is
+  # intentionally ignored (`|| :`).
   log "gaia init strip-branding exited non-zero; rerunning with stderr:"
-  ( cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" ) || true
+  ( cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" ) || :
   fail "gaia init strip-branding exited non-zero on staged tree"
   exit 1
 }

--- a/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
+++ b/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
@@ -54,14 +54,14 @@ fi
 [ -x "$SCAFFOLD/.gaia/cli/gaia" ] \
   || { fail "staged tree missing or non-executable .gaia/cli/gaia (bundled CLI)"; exit 1; }
 
-cd "$SCAFFOLD"
-
-# Run strip-branding. Capture stdout — the contract is "no stdout on
-# success" per the subcommand's --help.
+# Run strip-branding from inside $SCAFFOLD via a subshell so the CLI's
+# default `process.cwd()` resolves there. The parent scenario keeps its
+# own pwd — never `cd "$SCAFFOLD"` at scenario scope, since other
+# scenarios sourced or invoked from `run-all.sh` may rely on $PWD.
 TITLE="Test Project"
-STDOUT="$(./.gaia/cli/gaia init strip-branding --title "$TITLE" 2>/dev/null)" || {
+STDOUT="$(cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" 2>/dev/null)" || {
   log "gaia init strip-branding exited non-zero; rerunning with stderr:"
-  ./.gaia/cli/gaia init strip-branding --title "$TITLE" || true
+  ( cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" ) || true
   fail "gaia init strip-branding exited non-zero on staged tree"
   exit 1
 }

--- a/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
+++ b/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
@@ -119,8 +119,11 @@ run_step() {
   local label="$1"; shift
   local stdout
   stdout="$(cd "$SCAFFOLD" && "$GAIA" "$@" 2>/dev/null)" || {
+    # Re-run with stderr unsuppressed for diagnosis. The `fail; exit 1`
+    # below runs unconditionally — the diagnostic re-run's exit code is
+    # intentionally ignored (`|| :`).
     log "gaia $* exited non-zero; rerunning with stderr:"
-    ( cd "$SCAFFOLD" && "$GAIA" "$@" ) || true
+    ( cd "$SCAFFOLD" && "$GAIA" "$@" ) || :
     fail "gaia $* exited non-zero on staged tree (step: $label)"
     exit 1
   }
@@ -190,7 +193,7 @@ node -e "JSON.parse(require('node:fs').readFileSync('$SETTINGS','utf8'))" 2>/dev
   || { fail "wire-statusline produced invalid JSON in .claude/settings.json"; exit 1; }
 grep -q '"command": "bash .gaia/statusline/gaia-statusline.sh"' "$SETTINGS" \
   || { fail "wire-statusline did not insert canonical statusline command"; exit 1; }
-grep -q '"statusLine"' "$SETTINGS" \
+grep -q '"statusLine":' "$SETTINGS" \
   || { fail "wire-statusline did not insert statusLine key"; exit 1; }
 
 # Step 5 — finalize. Removes the interceptor hook + command file, prunes

--- a/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
+++ b/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# 08-gaia-init-cli-sequence.sh
+#
+# Adopter-flow regression: runs the full deterministic sequence behind
+# `/gaia-init` Step 3 against a writable copy of the staged release tree.
+# Extends 07's pattern (single-step regression for `strip-branding`) by
+# exercising every CLI surface the slash command dispatches to:
+#
+#   gaia init strip-branding   --title "Test Project"
+#   gaia init configure-i18n   --locales "en,es" --strip false
+#   gaia init rename           --title "Test Project" --kebab "test-project"
+#   gaia init wire-statusline  --mode project
+#   gaia init finalize
+#
+# Why it exists: 07 catches release-exclude drift on strip-branding's
+# template/deletion/edit targets. This scenario catches the same class of
+# drift on the four remaining CLI surfaces — any of them silently
+# no-ops if its target file is missing from the staged tree (existsSync
+# guards), so a missing target ships green from 07 but breaks the adopter
+# flow at the matching `/gaia-init` step.
+#
+# Asserts (post-conditions per CLI step):
+#
+#   strip-branding  README.md created at scaffold root with title; sets
+#                   the tree up for the remaining steps. Same surface as
+#                   07; no new assertions added here.
+#
+#   configure-i18n  app/languages/index.ts contains both 'en' and 'es'
+#                   imports + a LANGUAGES list with both codes;
+#                   app/i18n.ts has fallbackLng: 'en'.
+#
+#   rename          package.json "name" == "test-project"; CLAUDE.md
+#                   first H1 line == "# Test Project";
+#                   app/languages/en/common.ts has siteName: 'Test
+#                   Project'; app/languages/en/pages/_index.ts has
+#                   title/heroTitle: 'Test Project'.
+#
+#   wire-statusline .claude/settings.json contains the canonical GAIA
+#                   statusline command. --mode project so the test never
+#                   touches the host's ~/.claude/settings.json.
+#
+#   finalize        .claude/hooks/intercept-init.sh removed;
+#                   .claude/commands/gaia-init.md removed;
+#                   .claude/settings.json no longer references
+#                   intercept-init.sh.
+#
+# Layer 0.5: runs on the host or runner, no Docker, no Claude OAuth
+# token. Cheap (~few seconds after build-staging) — file-level transforms
+# only, no pnpm install.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/lib/lib.sh"
+
+require_cmd rsync "rsync required for adopter-flow scaffold copy"
+
+STAGING="$(mktemp -d -t gaia-dist-init-stage-XXXXXX)"
+SCAFFOLD="$(mktemp -d -t gaia-dist-init-scaffold-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+
+"$HERE/lib/build-staging.sh" "$STAGING" \
+  || { fail "build-staging failed"; exit 1; }
+
+# Copy staging into a writable scaffold (the CLI subcommands mutate files).
+rsync -a "$STAGING"/ "$SCAFFOLD"/
+
+# Pre-conditions on the staged tree. Each guarantees one of the CLI
+# subcommands has its target file. configure-i18n / rename / finalize all
+# use `existsSync` guards, so a missing target produces a silent no-op
+# rather than an error — the assertion would then fail downstream with a
+# confusing message. Failing pre-flight here points the maintainer at
+# release-exclude.
+[ -x "$SCAFFOLD/.gaia/cli/gaia" ] \
+  || { fail "staged tree missing or non-executable .gaia/cli/gaia (bundled CLI)"; exit 1; }
+
+# strip-branding targets (covered by 07 — re-checked here so 08 can run
+# standalone if 07 is skipped or rerun-after-edit).
+[ -f "$SCAFFOLD/.gaia/templates/README.md" ] \
+  || { fail "staged tree missing .gaia/templates/README.md (strip-branding template source)"; exit 1; }
+[ -d "$SCAFFOLD/app/components/GaiaLogo" ] \
+  || { fail "staged tree missing app/components/GaiaLogo/ (strip-branding deletion target)"; exit 1; }
+
+# configure-i18n targets.
+[ -f "$SCAFFOLD/app/languages/index.ts" ] \
+  || { fail "staged tree missing app/languages/index.ts (configure-i18n target)"; exit 1; }
+[ -f "$SCAFFOLD/app/i18n.ts" ] \
+  || { fail "staged tree missing app/i18n.ts (configure-i18n fallbackLng target)"; exit 1; }
+
+# rename targets.
+[ -f "$SCAFFOLD/package.json" ] \
+  || { fail "staged tree missing package.json (rename target)"; exit 1; }
+[ -f "$SCAFFOLD/CLAUDE.md" ] \
+  || { fail "staged tree missing CLAUDE.md (rename H1 target)"; exit 1; }
+[ -f "$SCAFFOLD/app/languages/en/common.ts" ] \
+  || { fail "staged tree missing app/languages/en/common.ts (rename siteName target)"; exit 1; }
+[ -f "$SCAFFOLD/app/languages/en/pages/_index.ts" ] \
+  || { fail "staged tree missing app/languages/en/pages/_index.ts (rename heroTitle/title target)"; exit 1; }
+
+# finalize targets — the staged tree must ship both the interceptor hook
+# script and the command file so finalize has something to delete, and
+# the settings file must contain a UserPromptExpansion entry for the
+# prune to fire.
+[ -f "$SCAFFOLD/.claude/hooks/intercept-init.sh" ] \
+  || { fail "staged tree missing .claude/hooks/intercept-init.sh (finalize deletion target)"; exit 1; }
+[ -f "$SCAFFOLD/.claude/commands/gaia-init.md" ] \
+  || { fail "staged tree missing .claude/commands/gaia-init.md (finalize deletion target)"; exit 1; }
+[ -f "$SCAFFOLD/.claude/settings.json" ] \
+  || { fail "staged tree missing .claude/settings.json (finalize prune target)"; exit 1; }
+grep -q "intercept-init.sh" "$SCAFFOLD/.claude/settings.json" \
+  || { fail "staged .claude/settings.json has no intercept-init.sh entry — finalize would no-op silently"; exit 1; }
+
+TITLE="Test Project"
+KEBAB="test-project"
+GAIA="$SCAFFOLD/.gaia/cli/gaia"
+
+# Each invocation runs from inside $SCAFFOLD via a subshell so the CLI's
+# `process.cwd()` resolves to the scaffold root without mutating the
+# parent scenario's pwd.
+run_step() {
+  local label="$1"; shift
+  local stdout
+  stdout="$(cd "$SCAFFOLD" && "$GAIA" "$@" 2>/dev/null)" || {
+    log "gaia $* exited non-zero; rerunning with stderr:"
+    ( cd "$SCAFFOLD" && "$GAIA" "$@" ) || true
+    fail "gaia $* exited non-zero on staged tree (step: $label)"
+    exit 1
+  }
+  if [ -n "$stdout" ]; then
+    log "unexpected stdout from gaia $* (contract: no stdout on success):"
+    printf '%s\n' "$stdout" >&2
+    fail "gaia $* wrote to stdout (contract violation, step: $label)"
+    exit 1
+  fi
+}
+
+# Step 1 — strip-branding. Sets up the tree for the remaining steps;
+# post-conditions are covered by 07.
+run_step "strip-branding" \
+  init strip-branding --title "$TITLE"
+
+# Step 2 — configure-i18n. --strip false keeps the i18n surface and
+# rewrites the locale list; --strip true would delete the surface
+# entirely (covered by a separate scenario in a follow-up PR).
+run_step "configure-i18n" \
+  init configure-i18n --locales "en,es" --strip false
+
+LANGUAGES_INDEX="$SCAFFOLD/app/languages/index.ts"
+grep -q "^import en from './en';" "$LANGUAGES_INDEX" \
+  || { fail "configure-i18n did not write 'en' import to app/languages/index.ts"; exit 1; }
+grep -q "^import es from './es';" "$LANGUAGES_INDEX" \
+  || { fail "configure-i18n did not write 'es' import to app/languages/index.ts"; exit 1; }
+grep -q "LANGUAGES = \['en', 'es'\]" "$LANGUAGES_INDEX" \
+  || { fail "configure-i18n did not set LANGUAGES = ['en', 'es']"; exit 1; }
+grep -q "fallbackLng: 'en'" "$SCAFFOLD/app/i18n.ts" \
+  || { fail "configure-i18n did not set fallbackLng: 'en' in app/i18n.ts"; exit 1; }
+
+# Step 3 — rename. Touches package.json, CLAUDE.md H1, and two seeded
+# language files.
+run_step "rename" \
+  init rename --title "$TITLE" --kebab "$KEBAB"
+
+# package.json "name" — JSON-aware grep avoids matching a "name" key
+# inside dependencies.
+grep -qE '^\s*"name":\s*"test-project"\s*,?\s*$' "$SCAFFOLD/package.json" \
+  || { fail "rename did not set package.json name to 'test-project'"; exit 1; }
+# First H1 of CLAUDE.md.
+first_h1="$(grep -m1 '^# ' "$SCAFFOLD/CLAUDE.md" || true)"
+[ "$first_h1" = "# $TITLE" ] \
+  || { fail "rename did not rewrite CLAUDE.md first H1 to '# $TITLE' (got: '$first_h1')"; exit 1; }
+# common.ts siteName.
+grep -qE "siteName:\s*['\"]Test Project['\"]" "$SCAFFOLD/app/languages/en/common.ts" \
+  || { fail "rename did not set siteName: 'Test Project' in en/common.ts"; exit 1; }
+# _index.ts heroTitle + title (both rewritten globally, including nested
+# meta.title — see rename.ts replaceStringPropertyAll).
+grep -qE "heroTitle:\s*['\"]Test Project['\"]" "$SCAFFOLD/app/languages/en/pages/_index.ts" \
+  || { fail "rename did not set heroTitle: 'Test Project' in en/pages/_index.ts"; exit 1; }
+grep -qE "title:\s*['\"]Test Project['\"]" "$SCAFFOLD/app/languages/en/pages/_index.ts" \
+  || { fail "rename did not set title: 'Test Project' in en/pages/_index.ts"; exit 1; }
+
+# Step 4 — wire-statusline. --mode project so the merge writes to the
+# scaffold's .claude/settings.json — never the host's ~/.claude.
+run_step "wire-statusline" \
+  init wire-statusline --mode project
+
+SETTINGS="$SCAFFOLD/.claude/settings.json"
+[ -f "$SETTINGS" ] \
+  || { fail "wire-statusline did not produce .claude/settings.json"; exit 1; }
+# JSON validity — wire-statusline does an atomic temp+rename, so a
+# parse failure here points at the merge logic, not a torn write.
+node -e "JSON.parse(require('node:fs').readFileSync('$SETTINGS','utf8'))" 2>/dev/null \
+  || { fail "wire-statusline produced invalid JSON in .claude/settings.json"; exit 1; }
+grep -q '"command": "bash .gaia/statusline/gaia-statusline.sh"' "$SETTINGS" \
+  || { fail "wire-statusline did not insert canonical statusline command"; exit 1; }
+grep -q '"statusLine"' "$SETTINGS" \
+  || { fail "wire-statusline did not insert statusLine key"; exit 1; }
+
+# Step 5 — finalize. Removes the interceptor hook + command file, prunes
+# the matching UserPromptExpansion entry from settings.json.
+run_step "finalize" \
+  init finalize
+
+[ ! -f "$SCAFFOLD/.claude/hooks/intercept-init.sh" ] \
+  || { fail "finalize did not remove .claude/hooks/intercept-init.sh"; exit 1; }
+[ ! -f "$SCAFFOLD/.claude/commands/gaia-init.md" ] \
+  || { fail "finalize did not remove .claude/commands/gaia-init.md"; exit 1; }
+if grep -q "intercept-init.sh" "$SETTINGS"; then
+  fail "finalize did not prune intercept-init.sh entry from .claude/settings.json"
+  exit 1
+fi
+# Settings JSON still parses after the prune.
+node -e "JSON.parse(require('node:fs').readFileSync('$SETTINGS','utf8'))" 2>/dev/null \
+  || { fail "finalize produced invalid JSON in .claude/settings.json"; exit 1; }
+
+pass "gaia init full sequence (strip-branding → configure-i18n → rename → wire-statusline → finalize) produced expected post-conditions on staged tree"

--- a/.gaia/tests/distribution/README.md
+++ b/.gaia/tests/distribution/README.md
@@ -27,6 +27,7 @@ Maintainer-only validation of the post-scrub GAIA tarball. Excluded from the rel
 ├── 05-clean-env.sh              # PATH-stripped subshell (Layer 1)
 ├── 06-claude-runs-staged.sh     # Claude-in-Docker auth + cwd smoke (Layer 2)
 ├── 07-gaia-init-strip-branding.sh  # Adopter-flow regression: gaia init strip-branding
+├── 08-gaia-init-cli-sequence.sh    # Adopter-flow regression: full gaia init CLI sequence
 └── diagnostic/
     └── claude-auth-in-docker.md
 ```
@@ -76,7 +77,9 @@ Skips automatically if Docker is unavailable OR `CLAUDE_CODE_OAUTH_TOKEN` is uns
 
 `07-gaia-init-strip-branding.sh` runs `gaia init strip-branding --title "Test Project"` and asserts the four documented post-conditions: `README.md` is regenerated from `.gaia/templates/README.md` with the title substituted, `app/components/GaiaLogo/` is removed, `app/components/Header/index.tsx` no longer references `GaiaLogo`, and the subcommand exits 0 with no stdout per its contract. Catches the failure mode where `release-exclude` accidentally strips a file the subcommand needs (template, deletion target, edit target) — Layers 0+1+2 stay green; only this scenario fails.
 
-Future adopter-flow scenarios cover the rest of `gaia init` (`configure-i18n`, `rename`, `wire-statusline`, `finalize`) and `gaia setup` subcommands.
+`08-gaia-init-cli-sequence.sh` runs the full deterministic sequence behind `/gaia-init` Step 3 — `strip-branding` → `configure-i18n --strip false` → `rename` → `wire-statusline --mode project` → `finalize` — and asserts each step's post-conditions on the staged tree. Catches release-exclude drift on every CLI surface the slash command dispatches to: the `existsSync` guards in `configure-i18n`/`rename`/`finalize` mean a missing target file silently no-ops rather than erroring, so this scenario is the gate that turns a no-op into a failure. `--mode project` for `wire-statusline` keeps the merge inside the scaffold's `.claude/settings.json` and never writes to the host's `~/.claude`. The `configure-i18n --strip true` path (full i18n removal via the prose `remove-i18n.md` instruction) is out of scope here — that path is orchestrated by the slash command, not the CLI alone.
+
+Future adopter-flow scenarios cover the `--strip true` removal path and the `gaia setup` subcommands.
 
 #### Local setup for maintainers
 

--- a/.gaia/tests/distribution/lib/docker.sh
+++ b/.gaia/tests/distribution/lib/docker.sh
@@ -38,7 +38,13 @@ docker_token_available() {
 docker_build_image() {
   local dockerfile_dir
   dockerfile_dir="$(mktemp -d -t gaia-dist-dockerfile-XXXXXX)"
-  cat > "$dockerfile_dir/Dockerfile" <<'DOCKERFILE'
+  # Local EXIT trap so the temp dir is cleaned even if the function is
+  # killed mid-build (SIGTERM from a CI timeout, OOM, runner preemption).
+  # Subshell scope keeps it from clobbering the calling scenario's own
+  # EXIT trap.
+  (
+    trap 'rm -rf "$dockerfile_dir"' EXIT
+    cat > "$dockerfile_dir/Dockerfile" <<'DOCKERFILE'
 FROM node:22-bullseye-slim
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl ca-certificates git \
@@ -47,10 +53,8 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /work
 DOCKERFILE
-  local rc=0
-  docker build -t "$GAIA_DIST_IMAGE" "$dockerfile_dir" >/dev/null 2>&1 || rc=$?
-  rm -rf "$dockerfile_dir"
-  return "$rc"
+    docker build -t "$GAIA_DIST_IMAGE" "$dockerfile_dir" >/dev/null 2>&1
+  )
 }
 
 # `-e CLAUDE_CODE_OAUTH_TOKEN` (no `=value`) reads from the host env, so the

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -4,10 +4,12 @@ name: Distribution
 # need only Node + pnpm; Layer 2 additionally needs Docker (pre-installed on
 # ubuntu-latest) and a Claude OAuth token (from org secrets).
 #
-# Trigger is manual (`workflow_dispatch`) until the workflow has proven itself
-# clean on `main`. The intended steady-state trigger is `release.published`
-# only — the maintainer is the only role that can publish releases, so
-# contributors structurally cannot trigger Layer 2 spend.
+# Trigger is `workflow_dispatch` only — used to run the harness on a feature
+# branch for ad-hoc verification of harness changes themselves. The
+# production gate lives inside `release.yml` (pre-publish, before tarball
+# build). No automatic trigger here on purpose: `release.published` fires
+# AFTER publish (too late to gate a release), and `pull_request` is unsafe
+# for forks.
 #
 # IMPORTANT: never use `pull_request_target`. That trigger exposes secrets to
 # fork PRs, which would let any contributor exfiltrate
@@ -26,6 +28,7 @@ jobs:
   distribution:
     name: Distribution tests (Layers 0+1+2)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Distribution test gate (Layers 0+1+2)
+        timeout-minutes: 15
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: bash .gaia/tests/distribution/run-all.sh


### PR DESCRIPTION
## Summary

- **Scenario 08** — full deterministic `/gaia-init` Step 3 CLI sequence run against the staged release tree as an adopter-flow regression. Layer 0.5 (host-side, no Docker/token, ~few seconds). Catches release-exclude drift on the four CLI surfaces 07 doesn't cover (`configure-i18n`, `rename`, `wire-statusline`, `finalize`).
- **Audit fixes from PR #100** — three blockers + two cheap nits surfaced by retroactive code-review-audit on 47cedf8 (no opportunity to run the gate before merge): `timeout-minutes: 15` on the distribution job and the release gate step, drop CWD mutation in 07, local trap inside `docker_build_image`, plus diagnostic-re-build cleanup and a stale workflow comment.

## What 08 asserts

| Step | Post-conditions |
|---|---|
| `strip-branding --title "Test Project"` | (covered by 07; runs here as setup for the rest) |
| `configure-i18n --locales "en,es" --strip false` | `app/languages/index.ts` rewritten with both imports + `LANGUAGES` list; `app/i18n.ts` `fallbackLng: 'en'` |
| `rename --title "Test Project" --kebab "test-project"` | `package.json.name`, `CLAUDE.md` first H1, `siteName` in `en/common.ts`, `heroTitle`/`title` in `en/pages/_index.ts` |
| `wire-statusline --mode project` | `.claude/settings.json` contains canonical statusline command; valid JSON; never writes to `~/.claude` |
| `finalize` | `intercept-init.sh` + `gaia-init.md` removed; `UserPromptExpansion` entry pruned; settings JSON still parses |

`configure-i18n --strip true` (full removal via the prose `remove-i18n.md` instruction) is out of scope here — earmarked for a follow-up scenario.

## Test plan

- [x] `bash .gaia/tests/distribution/08-gaia-init-cli-sequence.sh` standalone — green
- [x] `bash .gaia/tests/distribution/run-all.sh` — all 8 scenarios green (06 soft-skip, no token in shell)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] `gh workflow run distribution.yml --ref test/distribution-08-gaia-init-cli` — verify CI green on the branch
- [ ] `code-review-audit` agent on this PR's HEAD before merge (per `wiki/concepts/PR Merge Workflow.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)