### PR TITLE
SPEC-002: forensics triage workflow

### DIFF
--- a/.gaia/cli/health/taxonomy.md
+++ b/.gaia/cli/health/taxonomy.md
@@ -181,6 +181,20 @@ Each entry: pattern, codified detection where one exists, prior occurrences (com
 - Detection: cross-reference shipped workflow files (`tests.yml`, `chromatic.yml`) against `release-exclude` path literals
 - Prior: `tests.yml` comment scrubbed (98f7a62)
 
+### Forensics triage
+
+Forward-looking signal patterns from the autonomous triage workflow at `.github/workflows/forensics-triage.yml`. These do not fail an audit on their own — they identify when the SPEC's immutable contract is worth reopening.
+
+**Recurring `needs-human` rejections cite the same unenumerated path.** The workflow rejects auto-fix attempts on paths outside the canonical allowlist with reason-code `out-of-scope` (rendered into the `reason: \`out-of-scope\`` line in the `needs-human` comment). When a single path appears in five or more distinct out-of-scope rejections, it is a candidate for allowlist expansion — which requires a SPEC reopen.
+- Detection (signal scan; refine after first run once comment formatting is settled): `gh issue list --repo gaia-react/gaia --label needs-human --state all --search 'in:comments "reason: \`out-of-scope\`"' --json number,comments --limit 200 | jq -r '.[].comments[] | select(.body | test("reason: .out-of-scope.")) | .body' | grep -oE '\`[A-Za-z0-9._/-]+\`' | sort | uniq -c | sort -rn | awk '$1 >= 5'`
+- Threshold: any path with count ≥ 5 across distinct issues warrants discussion of allowlist expansion.
+- Codified in: `wiki/decisions/Forensics Triage Workflow.md` § Signals to revisit.
+
+**Maintainer-corrected-outcome queue exceeds learning threshold.** The classifier runs on each issue independently; over time, manual corrections (re-labels, manual closures, rejected draft PRs) accumulate as a queue of human-corrected outcomes. When the queue exceeds fifty items across all classes, a follow-up SPEC for classifier priors / batched-triage queues / supervised retraining loops becomes worthwhile.
+- Detection (proxy): `gh issue list --repo gaia-react/gaia --label gaia-triaged --state closed --json number,labels --limit 500 | jq '[.[] | select((.labels | map(.name) | contains(["non-issue"])) | not)] | length'` (count of triaged-and-closed issues that did not close as `non-issue` — a proxy for human-corrected outcomes).
+- Threshold: queue length ≥ 50 warrants a follow-up SPEC discussion.
+- Codified in: `wiki/decisions/Forensics Triage Workflow.md` § Signals to revisit.
+
 ### Tests & harnesses
 
 **Bats / smoke fixtures referencing renamed or deleted hook filenames.** `cp` lines in fixtures, embedded `settings.json` Stop hook entries, fixture filenames themselves.

--- a/.gaia/tests/forensics/fixtures/denylist-attempt.md
+++ b/.gaia/tests/forensics/fixtures/denylist-attempt.md
@@ -1,0 +1,34 @@
+---
+class: hook
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/206
+---
+
+## Symptom
+
+The session-stop hook crashes when the app router has no routes defined;
+adding a guard in the hook AND a no-op default route in the app fixes it.
+
+## Classification
+
+class: hook
+evidence: stack trace originates in `.claude/hooks/wiki-session-stop.sh` and
+in `app/routes/_index.tsx`. A complete fix would touch both files — one in
+the allowlist, one on the canonical denylist.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: false
+hook_exit: 1
+```
+
+## Reproduction context
+
+- `.claude/hooks/wiki-session-stop.sh`
+- `app/routes/_index.tsx`

--- a/.gaia/tests/forensics/fixtures/malformed-frontmatter.md
+++ b/.gaia/tests/forensics/fixtures/malformed-frontmatter.md
@@ -1,0 +1,20 @@
+## Symptom
+
+The triage workflow never fires on issues opened from the mobile app.
+
+## Classification
+
+class: other
+evidence: GitHub Actions queue shows no run for issue #204.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+issue_number: 204
+```
+
+## Reproduction context
+
+- `.github/workflows/forensics-triage.yml`

--- a/.gaia/tests/forensics/fixtures/malformed-missing-symptom.md
+++ b/.gaia/tests/forensics/fixtures/malformed-missing-symptom.md
@@ -1,0 +1,22 @@
+---
+class: hook
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Classification
+
+class: hook
+evidence: PostToolUse hook script returns exit 1 on every file edit.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+hook_exit: 1
+```
+
+## Reproduction context
+
+- `.claude/hooks/post-tool.sh`

--- a/.gaia/tests/forensics/fixtures/non-issue-config.md
+++ b/.gaia/tests/forensics/fixtures/non-issue-config.md
@@ -1,0 +1,34 @@
+---
+class: dev-server
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/203
+---
+
+## Symptom
+
+`pnpm dev` exits immediately with `Error: ENOENT: no such file or directory,
+open '.env'`.
+
+## Classification
+
+class: dev-server
+evidence: the `.env` file is required by `app/i18n.ts` per the README setup
+checklist. The reporter has not run the `cp .env.example .env` step. This is
+a missing-prerequisite, not a GAIA defect.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: false
+env_file_present: false
+```
+
+## Reproduction context
+
+- `.env.example`
+- `README.md`

--- a/.gaia/tests/forensics/fixtures/redaction-passthrough.md
+++ b/.gaia/tests/forensics/fixtures/redaction-passthrough.md
@@ -1,0 +1,36 @@
+---
+class: dev-server
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/205
+---
+
+## Symptom
+
+Dev server crashes when reading the user's API key from `<redacted>`; the
+config loader at `.gaia/cli/src/config/load.ts` then logs the resolved path
+`.gaia/cli/src/config/load.ts` before exiting non-zero.
+
+## Classification
+
+class: dev-server
+evidence: the loader rethrows on missing env; the reporter's machine has the
+env var set to `<redacted>` (phase-1 redacted), so the loader should treat it
+as present.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: false
+api_key: <redacted>
+config_path: .gaia/cli/src/config/load.ts
+```
+
+## Reproduction context
+
+- `.gaia/cli/src/config/load.ts`
+- entry derived from `<redacted>` referencing `.gaia/cli/src/config/load.ts`

--- a/.gaia/tests/forensics/fixtures/unenumerated-attempt.md
+++ b/.gaia/tests/forensics/fixtures/unenumerated-attempt.md
@@ -1,0 +1,34 @@
+---
+class: scaffold
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/207
+---
+
+## Symptom
+
+`pnpm install` fails with `ERR_PNPM_PEER_DEP_ISSUES` after a fresh clone; a
+peer-dep override in `package.json` resolves it.
+
+## Classification
+
+class: scaffold
+evidence: pnpm reports the peer-dep mismatch on a known transitive dep; the
+canonical fix lives in `package.json` under `pnpm.overrides`. `package.json`
+is in NEITHER the SPEC-002 allowlist nor the denylist, so it is denylisted by
+default per UAT-014.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: false
+install_exit: 1
+```
+
+## Reproduction context
+
+- `package.json`

--- a/.gaia/tests/forensics/fixtures/valid-init-failure.md
+++ b/.gaia/tests/forensics/fixtures/valid-init-failure.md
@@ -1,0 +1,33 @@
+---
+class: init
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/201
+---
+
+## Symptom
+
+`/gaia-init` fails halfway through with `Error: cannot read property 'replace'
+of undefined` after the project-name prompt.
+
+## Classification
+
+class: init
+evidence: stack trace points at the init skill's name-substitution step in
+`.claude/skills/gaia-init/SKILL.md`; the failure reproduces on a clean clone.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: false
+prompt_value: <redacted>
+```
+
+## Reproduction context
+
+- `.claude/skills/gaia-init/SKILL.md`
+- `.gaia/cli/templates/init/post-init.sh`

--- a/.gaia/tests/forensics/fixtures/valid-update-conflict.md
+++ b/.gaia/tests/forensics/fixtures/valid-update-conflict.md
@@ -1,0 +1,34 @@
+---
+class: update
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/202
+---
+
+## Symptom
+
+After `/update-gaia`, the app router throws `Cannot find module
+'app/routes/_session+/dashboard'` at boot.
+
+## Classification
+
+class: update
+evidence: the merge appears to have dropped a route file under `app/routes/`;
+restoring it from git history fixes boot. The fix necessarily lives inside
+`app/`, which is on the SPEC-002 canonical denylist.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v22.19.0
+pnpm_version: 10.33.0
+git_branch: main
+git_dirty: true
+missing_path: app/routes/_session+/dashboard.tsx
+```
+
+## Reproduction context
+
+- `app/routes/_session+/dashboard.tsx`
+- `app/router.ts`

--- a/.gaia/tests/forensics/integration.md
+++ b/.gaia/tests/forensics/integration.md
@@ -1,0 +1,231 @@
+# SPEC-002 forensics-triage — integration checklist (layer C)
+
+Prose checklist the maintainer runs once after merge, and again when amending SPEC-002. Each section names: the fixture body, the expected workflow outcome, and the verification command. Layer C is human-driven because GitHub Actions itself can't be cleanly mocked.
+
+## Preconditions
+
+- The triage workflow is merged to `main` at `.github/workflows/forensics-triage.yml`.
+- All six labels exist on `gaia-react/gaia`: `gaia-forensics`, `gaia-triaged`, `non-issue`, `needs-human`, `auto-fixable`, `gaia-bug-confirmed`. (Run `.github/forensics/bootstrap-labels.sh` once if missing.)
+- Repository secret `ANTHROPIC_API_KEY` is set.
+- Branch protection on `main`: required reviews >= 1, required status checks present.
+- `gh` CLI authenticated with `repo` scope on `gaia-react/gaia`.
+
+Each step uses these env vars to keep the commands copy-pasteable:
+
+```bash
+REPO=gaia-react/gaia
+FIXTURE_DIR=.gaia/tests/forensics/fixtures
+```
+
+To open a fixture as an issue:
+
+```bash
+gh issue create -R "$REPO" \
+  --title "[forensics-uat-NNN] <fixture-name>" \
+  --body-file "$FIXTURE_DIR/<fixture-name>.md" \
+  --label gaia-forensics
+```
+
+Capture the issue number returned by `gh issue create` as `ISS=...`; later steps reference it.
+
+To watch the run:
+
+```bash
+gh run list -R "$REPO" --workflow forensics-triage.yml --limit 5
+gh run watch -R "$REPO" <run-id>
+```
+
+To inspect terminal state:
+
+```bash
+gh issue view -R "$REPO" "$ISS" --json state,labels,comments
+gh pr list -R "$REPO" --head "forensics/${ISS}-*"
+```
+
+---
+
+## UAT-001 — every triaged issue receives `gaia-triaged` + classification comment
+
+- **Fixture**: `non-issue-config.md` (any conformant body works; this UAT is the lowest-common-denominator).
+- **Expected outcome**: The `gaia-triaged` label appears on the issue, and a comment names one of `non-issue` / `needs-human` / `auto-fixable` and cites the parsed `## Classification` section as evidence.
+- **Verify**:
+  ```bash
+  gh issue view -R "$REPO" "$ISS" --json labels --jq '.labels[].name' | grep -x gaia-triaged
+  gh issue view -R "$REPO" "$ISS" --json comments --jq '.comments[-1].body' | grep -E 'verdict:|reason:'
+  ```
+- **Pass criterion**: both commands exit 0.
+
+---
+
+## UAT-002 — `non-issue` verdict closes + comments + labels
+
+- **Fixture**: `non-issue-config.md`. The reporter is missing `.env`; the classifier should call this `non-issue`.
+- **Expected outcome**: Issue is CLOSED. Labels: `non-issue` AND `gaia-triaged`. The closing comment names `verdict: non-issue` with a one-line reason and a remediation pointer (e.g. "run `cp .env.example .env`").
+- **Verify**:
+  ```bash
+  gh issue view -R "$REPO" "$ISS" --json state,labels --jq '{state: .state, labels: [.labels[].name]}'
+  ```
+- **Pass criterion**: `state == "CLOSED"` and `labels` contains both `non-issue` and `gaia-triaged`.
+
+---
+
+## UAT-004 — `auto-fixable` verdict opens draft PR + labels
+
+- **Fixture**: `valid-init-failure.md`. The bug is in `.claude/skills/gaia-init/SKILL.md` (allowlisted) and `.gaia/cli/templates/init/post-init.sh` (allowlisted via `.gaia/cli/`).
+- **Expected outcome**: a branch named `forensics/<ISS>-init` exists on origin; a DRAFT PR is open against `main` linking back to the issue; the issue has labels `auto-fixable`, `gaia-bug-confirmed`, AND `gaia-triaged`. The PR body cites `## Capture` from the issue verbatim.
+- **Verify**:
+  ```bash
+  git fetch origin "forensics/${ISS}-init" && git log --oneline -1 "origin/forensics/${ISS}-init"
+  gh pr list -R "$REPO" --head "forensics/${ISS}-init" --json isDraft,title,body
+  gh issue view -R "$REPO" "$ISS" --json labels --jq '[.labels[].name] | sort'
+  ```
+- **Pass criterion**: branch exists with at least one commit; PR is `isDraft: true` and body contains a "## Capture (verbatim from issue)" section quoting fixture content; issue labels include all three of `auto-fixable`, `gaia-bug-confirmed`, `gaia-triaged`.
+
+---
+
+## UAT-005 — Quality Gate failure abandons the branch + demotes to `needs-human`
+
+This UAT is the hardest to fixture cleanly because the gate has to FAIL on the model's diff. There are two ways to provoke it:
+
+1. **Synthetic**: temporarily replace `.github/forensics/run-quality-gate.sh` on a throwaway branch with one that always exits 1, then open `valid-init-failure.md` against that branch.
+2. **Live**: open the fixture against the live workflow and trust the maintainer to read the gate result; if the gate happens to pass naturally, this UAT is exercised by inverting the assertion (no demote occurred). Re-run with synthetic-fail to actually exercise the failure path.
+
+- **Fixture**: `valid-init-failure.md` plus a synthetic `run-quality-gate.sh` returning non-zero.
+- **Expected outcome**: NO branch on origin matching `forensics/<ISS>-*`. Issue labels: `needs-human` AND `gaia-triaged`. Issue is OPEN. NO `auto-fixable` label. Comment names which gate step failed and links the workflow run.
+- **Verify**:
+  ```bash
+  git fetch origin "+refs/heads/forensics/${ISS}-*:refs/remotes/origin/forensics/${ISS}-*" 2>&1 | grep -v 'forensics/' || echo 'no remote forensics branch — pass'
+  gh issue view -R "$REPO" "$ISS" --json state,labels --jq '{state: .state, labels: [.labels[].name] | sort}'
+  gh issue view -R "$REPO" "$ISS" --json comments --jq '.comments[-1].body' | grep -E 'failed step|gate-failure'
+  ```
+- **Pass criterion**: no `forensics/<ISS>-*` ref on origin; issue is OPEN with `needs-human` + `gaia-triaged` and WITHOUT `auto-fixable`; latest comment mentions the failed step.
+
+---
+
+## UAT-006 — re-firing on an already-`gaia-triaged` issue is a no-op
+
+- **Fixture**: any previously-triaged issue (e.g. the issue from UAT-001 above).
+- **Expected outcome**: the workflow run terminates early with the `::notice::issue #N already triaged; skipping` line; no new comment, no new label, no new PR, no new branch.
+- **Reproduce**:
+  ```bash
+  # Trigger a re-fire by removing and re-adding any label.
+  gh issue edit -R "$REPO" "$ISS" --remove-label needs-human || true
+  gh issue edit -R "$REPO" "$ISS" --add-label needs-human || true
+  ```
+- **Verify**:
+  ```bash
+  gh run list -R "$REPO" --workflow forensics-triage.yml --limit 3
+  gh run view -R "$REPO" <newest-run-id> --log | grep 'already triaged'
+  # Comment count must be unchanged versus the pre-refire state.
+  gh issue view -R "$REPO" "$ISS" --json comments --jq '.comments | length'
+  ```
+- **Pass criterion**: the newest run logs `already triaged; skipping`; comment count did NOT increase across the re-fire.
+
+---
+
+## UAT-008 — every PR opened by triage is `draft: true` and never auto-merged
+
+- **Fixture**: re-use the PR opened by UAT-004 (no separate fixture needed).
+- **Expected outcome**: PR is `isDraft: true` at the moment of opening; the workflow log shows no `gh pr merge` or `gh pr ready` invocation; branch protection on `main` blocks merge without human approval.
+- **Verify**:
+  ```bash
+  gh pr view -R "$REPO" --head "forensics/${ISS}-init" --json isDraft,mergeable,reviewDecision
+  gh run view -R "$REPO" <run-id> --log | grep -E 'gh pr merge|gh pr ready' && echo 'FAIL: workflow tried to merge or ready the PR' || echo 'pass: no merge/ready calls'
+  ```
+- **Pass criterion**: `isDraft == true`; the grep returns no lines; branch protection rejects any direct push to `main`.
+
+---
+
+## UAT-010 — secrets never appear in logs / comments / PR bodies / commits
+
+- **Fixture**: any successfully-run UAT (re-use UAT-001 / UAT-002 / UAT-004).
+- **Expected outcome**: `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, and any literal secret string the workflow observed are absent from every artifact. `::add-mask::` is emitted for any secret-shaped values surfaced through the parsed body.
+- **Verify**:
+  ```bash
+  # Workflow log scan — neither the literal env-var name's value nor the masking-substitution token should leak.
+  gh run view -R "$REPO" <run-id> --log > /tmp/run.log
+  grep -E 'sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}' /tmp/run.log && echo 'FAIL: leaked secret-shaped string' || echo 'pass: no secret-shaped strings in log'
+
+  # Comment + PR-body scan — same shapes.
+  gh issue view -R "$REPO" "$ISS" --json comments --jq '.comments[].body' | grep -E 'sk-ant-|ghp_|github_pat_' && echo 'FAIL: secret in issue comments' || echo 'pass: no secrets in comments'
+  gh pr view -R "$REPO" --head "forensics/${ISS}-*" --json body --jq '.body' | grep -E 'sk-ant-|ghp_|github_pat_' && echo 'FAIL: secret in PR body' || echo 'pass: no secrets in PR body'
+  ```
+- **Pass criterion**: every grep returns no lines (each "FAIL" branch is unreached).
+
+---
+
+## UAT-011 — concurrent re-fires queue and second run early-exits
+
+- **Fixture**: a fresh issue from `non-issue-config.md` (or any conformant body).
+- **Expected outcome**: two `issues.labeled` events fired in close succession produce two scheduled runs; the second one queues until the first applies `gaia-triaged`; the second run hits the UAT-006 early-exit; no duplicate label / comment / branch / PR is created.
+- **Reproduce**:
+  ```bash
+  gh issue create -R "$REPO" --title '[forensics-uat-011] dual-fire' --body-file "$FIXTURE_DIR/non-issue-config.md" --label gaia-forensics
+  ISS=<num-from-output>
+  # Two near-simultaneous label edits — re-add an unrelated label twice.
+  gh issue edit -R "$REPO" "$ISS" --add-label gaia-forensics &
+  gh issue edit -R "$REPO" "$ISS" --add-label gaia-forensics &
+  wait
+  ```
+- **Verify**:
+  ```bash
+  gh run list -R "$REPO" --workflow forensics-triage.yml --limit 5 --json databaseId,status,conclusion,headBranch
+  # Expect two runs in the list for this issue's window: one success (the triage run), one success (the early-exit).
+  gh run view -R "$REPO" <second-run-id> --log | grep 'already triaged'
+  # Comment count is exactly one (the original verdict comment), labels include `gaia-triaged` exactly once.
+  gh issue view -R "$REPO" "$ISS" --json comments --jq '.comments | length'
+  gh issue view -R "$REPO" "$ISS" --json labels --jq '[.labels[].name] | map(select(. == "gaia-triaged")) | length'
+  ```
+- **Pass criterion**: second run logs `already triaged`; comment count is 1; `gaia-triaged` appears exactly once in the labels list.
+
+---
+
+## UAT-012 — 30-min job timeout is fail-forward (no rollback)
+
+This is the hardest UAT to fixture without artificial latency. There are two practical paths:
+
+1. **Synthetic**: temporarily lower `timeout-minutes` in `.github/workflows/forensics-triage.yml` from 30 to 1 on a throwaway branch and inject a `sleep 120` step before the handler steps. Run a fixture; the timeout fires.
+2. **Observational**: trust the timeout invariant by reading the workflow file. The workflow declares `timeout-minutes: 30` at the job level; GitHub Actions enforces it. UAT-012's invariant is that ALREADY-applied labels remain after the timeout — this is satisfied by construction because the workflow never `gh issue edit --remove-label` rolls back.
+- **Fixture**: `valid-init-failure.md` plus a synthetic 1-min-timeout branch.
+- **Expected outcome**: the run aborts at the timeout; any label that landed before the timeout REMAINS (no rollback); no PR opens; no branch is pushed; no half-applied state.
+- **Verify**:
+  ```bash
+  gh run view -R "$REPO" <run-id> --json conclusion --jq '.conclusion'   # expect: cancelled OR failure
+  gh issue view -R "$REPO" "$ISS" --json labels --jq '[.labels[].name] | sort'
+  git ls-remote --heads origin "forensics/${ISS}-*"   # expect empty
+  gh pr list -R "$REPO" --head "forensics/${ISS}-*"   # expect empty
+  ```
+- **Pass criterion**: run conclusion is `cancelled` or `failure`; labels that were applied PRE-timeout still exist; no remote branch; no PR.
+
+---
+
+## Coverage map (full SPEC-002 UAT roster)
+
+| UAT     | Layer | Where verified                                                |
+|---------|-------|---------------------------------------------------------------|
+| UAT-001 | C     | This file, "UAT-001" section above.                           |
+| UAT-002 | C     | This file, "UAT-002" section above.                           |
+| UAT-003 | A+B   | `.github/forensics/tests/handlers.bats` (handle-needs-human) + `.github/forensics/tests/parse-verdict.bats` (ambiguous verdict downgrade). |
+| UAT-004 | C     | This file, "UAT-004" section above.                           |
+| UAT-005 | C     | This file, "UAT-005" section above.                           |
+| UAT-006 | C     | This file, "UAT-006" section above.                           |
+| UAT-007 | A+B   | `.gaia/tests/forensics/unit.bats` ("UAT-007: mixed allow + deny ..."). |
+| UAT-008 | C     | This file, "UAT-008" section above.                           |
+| UAT-009 | A+B   | `.github/forensics/tests/parse-issue-body.bats` (24 tests, deterministic regex). |
+| UAT-010 | C     | This file, "UAT-010" section above.                           |
+| UAT-011 | C     | This file, "UAT-011" section above.                           |
+| UAT-012 | C     | This file, "UAT-012" section above.                           |
+| UAT-013 | A+B   | `.gaia/tests/forensics/unit.bats` (`malformed-*` fixtures) + `.github/forensics/tests/parse-issue-body.bats` (failure-mode tests). |
+| UAT-014 | A+B   | `.gaia/tests/forensics/unit.bats` ("UAT-014: unenumerated path ..."). |
+| UAT-015 | A+B   | `.gaia/tests/forensics/unit.bats` ("redaction-passthrough preserves ...") + `.github/forensics/tests/parse-issue-body.bats` (redaction tests). |
+
+## Re-running this checklist
+
+1. Open each fixture as a fresh issue via `gh issue create -R "$REPO" --label gaia-forensics --body-file <fixture>`.
+2. Walk the section that matches the fixture (UAT-001 / UAT-002 / UAT-004 / UAT-005 / UAT-006 / UAT-008 / UAT-010 / UAT-011 / UAT-012).
+3. After every section passes, close the test issues:
+   ```bash
+   gh issue list -R "$REPO" --label gaia-forensics --search '[forensics-uat' --json number --jq '.[].number' \
+     | xargs -I{} gh issue close -R "$REPO" {}
+   ```
+4. Record pass/fail per UAT in the SPEC-002 amendment PR description.

--- a/.gaia/tests/forensics/unit.bats
+++ b/.gaia/tests/forensics/unit.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# .gaia/tests/forensics/unit.bats — SPEC-002 layer B regression suite.
+#
+# This file delegates to the bats suites under `.github/forensics/tests/`
+# (parser, scope-checker, verdict-parser, handlers, quality-gate runner)
+# AND adds layer-A fixture invariants:
+#
+#   - the six `valid-*` / `non-issue-*` / `redaction-*` / `denylist-*` /
+#     `unenumerated-*` fixtures parse cleanly (`.valid == true`);
+#   - the two `malformed-*` fixtures parse to the documented error code;
+#   - the `redaction-passthrough` fixture's two redaction tokens survive
+#     the parser byte-for-byte (UAT-015);
+#   - `denylist-attempt` (UAT-007) and `unenumerated-attempt` (UAT-014)
+#     resolve to `ok:false` via `check-scope.sh`.
+#
+# UATs covered automatically by layer A+B (no GitHub round-trip):
+#   UAT-003 (handlers.bats / parse-verdict.bats), UAT-007, UAT-009,
+#   UAT-013, UAT-014, UAT-015.
+#
+# Layer C (manual checklist) covers UAT-001 / UAT-002 / UAT-004 /
+# UAT-005 / UAT-006 / UAT-008 / UAT-010 / UAT-011 / UAT-012; see
+# `.gaia/tests/forensics/integration.md`.
+
+setup() {
+  # Resolve repo root from the test file location: this file lives at
+  # `.gaia/tests/forensics/unit.bats`, so the repo root is three levels up.
+  REPO_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/../../.." && pwd )"
+  FORENSICS_DIR="$REPO_ROOT/.github/forensics"
+  FIXTURES_DIR="$REPO_ROOT/.gaia/tests/forensics/fixtures"
+  PARSER="$FORENSICS_DIR/parse-issue-body.sh"
+  SCOPE="$FORENSICS_DIR/check-scope.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Delegation: run every bats suite under `.github/forensics/tests/` so a
+# single `pnpm test:forensics` invocation runs the entire forensics
+# regression surface. Each suite emits its own ok/not ok lines; this file
+# adds a single bats test that wraps the run and checks the exit code.
+# ---------------------------------------------------------------------------
+
+@test "delegate: .github/forensics/tests/*.bats all green" {
+  run bats "$FORENSICS_DIR/tests/"
+  if [ "$status" -ne 0 ]; then
+    echo "$output"
+  fi
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Layer-A fixture invariants — `valid` group.
+# ---------------------------------------------------------------------------
+
+@test "fixture valid-init-failure parses cleanly" {
+  run "$PARSER" "$FIXTURES_DIR/valid-init-failure.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+  [[ "$output" == *'"class":"init"'* ]]
+}
+
+@test "fixture valid-update-conflict parses cleanly" {
+  run "$PARSER" "$FIXTURES_DIR/valid-update-conflict.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+  [[ "$output" == *'"class":"update"'* ]]
+}
+
+@test "fixture non-issue-config parses cleanly" {
+  run "$PARSER" "$FIXTURES_DIR/non-issue-config.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+  [[ "$output" == *'"class":"dev-server"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Layer-A fixture invariants — `malformed` group (UAT-013).
+# ---------------------------------------------------------------------------
+
+@test "fixture malformed-missing-symptom returns missing-section" {
+  run "$PARSER" "$FIXTURES_DIR/malformed-missing-symptom.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"missing-section"'* ]]
+  [[ "$output" == *'"symptom"'* ]]
+}
+
+@test "fixture malformed-frontmatter returns malformed-frontmatter" {
+  run "$PARSER" "$FIXTURES_DIR/malformed-frontmatter.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Layer-A fixture invariants — UAT-015 redaction passthrough.
+#
+# The fixture deliberately carries TWO tokens: a `<redacted>` literal AND
+# a repo-relative path (`.gaia/cli/src/config/load.ts`) derived from an
+# absolute path. Both must survive the parser byte-for-byte.
+# ---------------------------------------------------------------------------
+
+@test "fixture redaction-passthrough preserves <redacted> token verbatim" {
+  run "$PARSER" "$FIXTURES_DIR/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<redacted>'* ]]
+  [[ "$output" == *'api_key: <redacted>'* ]]
+}
+
+@test "fixture redaction-passthrough preserves repo-relative path token verbatim" {
+  run "$PARSER" "$FIXTURES_DIR/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  # Two distinct sites: capture (`config_path: ...`) and reproduction context.
+  [[ "$output" == *'config_path: .gaia/cli/src/config/load.ts'* ]]
+  [[ "$output" == *'.gaia/cli/src/config/load.ts'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Layer-A fixture invariants — UAT-007 (denylist) and UAT-014 (unenumerated).
+#
+# Both fixtures parse as VALID bodies; the boundary they exercise is the
+# scope checker that the workflow runs AFTER the classifier proposes
+# paths. We feed the proposed paths through `check-scope.sh` directly.
+# ---------------------------------------------------------------------------
+
+@test "fixture denylist-attempt parses cleanly (boundary tested via check-scope)" {
+  run "$PARSER" "$FIXTURES_DIR/denylist-attempt.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+}
+
+@test "UAT-007: mixed allow + deny path proposal denies the whole attempt" {
+  # The fixture's reproduction-context names two paths: one in the allowlist
+  # (`.claude/hooks/`), one on the canonical denylist (`app/`). Per UAT-007
+  # the WHOLE attempt is denied — `ok:false` — not just the denylisted path.
+  run "$SCOPE" .claude/hooks/wiki-session-stop.sh app/routes/_index.tsx
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"ok":false'* ]]
+  [[ "$output" == *'app/routes/_index.tsx'* ]]
+  [[ "$output" == *'"reason":"denylist"'* ]]
+  # The allowed leg still appears in `allowed[]` — the partition is informational —
+  # but `ok` is false, which is what the workflow gates on.
+  [[ "$output" == *'.claude/hooks/wiki-session-stop.sh'* ]]
+}
+
+@test "fixture unenumerated-attempt parses cleanly (boundary tested via check-scope)" {
+  run "$PARSER" "$FIXTURES_DIR/unenumerated-attempt.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+}
+
+@test "UAT-014: unenumerated path (package.json) denied as default-deny-unenumerated" {
+  run "$SCOPE" package.json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"ok":false'* ]]
+  [[ "$output" == *'"reason":"default-deny-unenumerated"'* ]]
+}

--- a/.github/forensics/README.md
+++ b/.github/forensics/README.md
@@ -1,0 +1,33 @@
+# `.github/forensics/`
+
+Supporting scripts for the SPEC-002 forensics triage workflow
+(`.github/workflows/forensics-triage.yml`). The workflow itself is on the
+canonical denylist and never self-modifies; the helpers here are pure-shell,
+unit-testable primitives the workflow shells out to.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `bootstrap-labels.sh` | Maintainer-run, idempotent. Asserts the SPEC-002 phase-2 label vocabulary on the upstream repo; creates any missing labels with frozen colors/descriptions. |
+| `check-scope.sh` | Default-deny path-policy primitive. Classifies candidate paths against the SPEC-002 allowlist/denylist. JSON to stdout. |
+| _additional helpers ship with later SPEC-002 phases (body-parser, classifier prompt, action handlers)._ |
+
+## Run-once: bootstrap labels
+
+Before the triage workflow ships, the maintainer runs:
+
+```sh
+.github/forensics/bootstrap-labels.sh --dry-run            # preview
+.github/forensics/bootstrap-labels.sh                      # apply
+```
+
+Defaults to `--repo gaia-react/gaia`. Override with `--repo <owner>/<name>`
+when bootstrapping a fork or test repo.
+
+Prerequisites: `gh` authenticated against the target repo with `repo` scope,
+`jq` on PATH.
+
+The script is operator-wins: existing labels with drifted color/description
+are reported via `::notice::` lines and left untouched. CI never invokes
+this script.

--- a/.github/forensics/apply-fix-prompt.md
+++ b/.github/forensics/apply-fix-prompt.md
@@ -1,0 +1,84 @@
+You are the GAIA forensics fix-applier for issue #{{ISSUE_NUMBER}}. The
+classifier already decided this defect is `auto-fixable` and named the
+exact paths the fix touches. Your one job: apply that fix to the working
+tree.
+
+You have file-editing tools (Edit, Read, Write). You do NOT have shell
+access, do NOT have `git` access, and do NOT push or commit. The
+workflow handles git operations after you finish; your output is the
+modified files in the working tree.
+
+## Path scope (HARD STOP — default-deny)
+
+You MUST modify ONLY files at these exact repo-relative paths:
+
+```
+{{PROPOSED_PATHS}}
+```
+
+Modifying any path outside this list is a contract violation. The
+workflow runs `git diff --name-only` after you finish; any diff outside
+the list aborts the run before the Quality Gate even runs. Do not
+"helpfully" touch adjacent files, do not "tidy up" unrelated code, do
+not edit the workflow file or any path under `.github/workflows/`.
+
+## What the classifier said
+
+Reasoning from the classifier (already posted as a comment on the
+issue):
+
+```
+{{CLASSIFIER_REASONING}}
+```
+
+## Issue context (parsed verbatim, already redacted)
+
+### Symptom
+
+```
+{{SYMPTOM}}
+```
+
+### Capture
+
+```
+{{CAPTURE}}
+```
+
+### Reproduction context
+
+```
+{{REPRO_CONTEXT}}
+```
+
+## Constraints
+
+- Make the smallest change that fixes the defect. No speculative
+  refactors, no style improvements outside the diff, no new tests
+  unless the fix demands it.
+- Match the file's existing style (indentation, quoting, header
+  comments).
+- Do NOT introduce new dependencies. Do NOT touch `package.json`,
+  `pnpm-lock.yaml`, or any lockfile (those paths are denylisted by
+  default).
+- The Quality Gate (`pnpm typecheck && pnpm lint && pnpm test --run
+  && pnpm knip`) runs on the resulting branch. Treat passing it as a
+  hard requirement; if you cannot fix the defect within scope without
+  breaking the gate, stop and emit:
+
+  ```
+  GAIA-FIX-ABORT: <one-line reason>
+  ```
+
+  on a line of its own. The workflow demotes the issue to
+  `needs-human` rather than opening a partial PR.
+- The redaction tokens in the issue body (`<redacted>`,
+  `<repo-relative-paths>`) are intentional. Do NOT attempt to
+  reconstruct masked values, and do NOT remove or alter redaction
+  tokens in any file you touch.
+
+## Output
+
+When you are done editing, write a short summary describing what you
+changed and why. The workflow uses this as the PR body alongside a
+verbatim passthrough of the issue's `## Capture` section.

--- a/.github/forensics/bootstrap-labels.sh
+++ b/.github/forensics/bootstrap-labels.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# bootstrap-labels.sh — assert SPEC-002 phase-2 label vocabulary on the upstream
+# repo. Idempotent. Operator-wins on existing labels (color/description drift is
+# logged, never overwritten). Run-once by the maintainer before the triage
+# workflow ships; not invoked by CI.
+#
+# Usage:
+#   bootstrap-labels.sh [--dry-run] [--repo gaia-react/gaia]
+#
+# Prerequisites: `gh` authenticated against the target repo with `repo` scope.
+#
+# Frozen contract: SPEC-002 phase-2 labels (5). `gaia-forensics` is owned by
+# SPEC-001 and excluded here.
+
+set -euo pipefail
+
+DRY_RUN=0
+REPO="gaia-react/gaia"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --repo)
+      REPO="${2:-}"
+      if [[ -z "$REPO" ]]; then
+        echo "error: --repo requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Frozen label contract — name|color|description (per SPEC-002 task spec).
+LABELS=(
+  "gaia-triaged|0e8a16|Forensics triage workflow has processed this issue. Idempotency key — re-firing is a no-op."
+  "non-issue|cccccc|Triaged: not a bug. User-config issue, missing prerequisite, or duplicate. Issue closed."
+  "needs-human|d93f0b|Triaged: real bug, but out of autofix scope OR malformed body OR ambiguous classifier verdict. Maintainer review required."
+  "auto-fixable|1d76db|Triaged: classifier proposed a fix in allowlisted scope. See linked draft PR."
+  "gaia-bug-confirmed|b60205|Quality Gate passed on the auto-fix branch. Draft PR open and ready for human review."
+)
+
+# Snapshot existing labels on the target repo (single API call).
+if ! existing="$(gh label list --repo "$REPO" --limit 200 --json name,color,description 2>&1)"; then
+  echo "error: gh label list failed for $REPO:" >&2
+  echo "$existing" >&2
+  exit 1
+fi
+
+created=0
+exists=0
+drift=0
+declare -a summary=()
+
+for entry in "${LABELS[@]}"; do
+  IFS='|' read -r name color description <<<"$entry"
+
+  current="$(printf '%s' "$existing" | jq -r --arg n "$name" '.[] | select(.name == $n) | "\(.color)|\(.description)"')"
+
+  if [[ -z "$current" ]]; then
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "would create: $name (color=$color)"
+    else
+      if ! gh label create "$name" --color "$color" --description "$description" --repo "$REPO" >/dev/null; then
+        echo "error: gh label create failed for $name" >&2
+        exit 1
+      fi
+      echo "created: $name"
+    fi
+    created=$((created + 1))
+    summary+=("$name|created")
+  else
+    cur_color="${current%%|*}"
+    cur_desc="${current#*|}"
+    if [[ "$cur_color" != "$color" || "$cur_desc" != "$description" ]]; then
+      echo "::notice::label '$name' exists with drifted color/description — operator wins, not overwriting"
+      drift=$((drift + 1))
+      summary+=("$name|exists (drift)")
+    else
+      summary+=("$name|exists")
+    fi
+    exists=$((exists + 1))
+  fi
+done
+
+echo
+echo "Summary (repo: $REPO):"
+printf '  %-22s %s\n' "LABEL" "STATE"
+for line in "${summary[@]}"; do
+  IFS='|' read -r name state <<<"$line"
+  printf '  %-22s %s\n' "$name" "$state"
+done
+echo
+
+if [[ $created -eq 0 ]]; then
+  if [[ $DRY_RUN -eq 1 && $exists -eq ${#LABELS[@]} ]]; then
+    echo "no-op — all labels present"
+  elif [[ $DRY_RUN -eq 0 ]]; then
+    echo "no-op — all labels present"
+  fi
+fi
+
+exit 0

--- a/.github/forensics/check-scope.sh
+++ b/.github/forensics/check-scope.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-scope.sh — SPEC-002 path-policy primitive (default-deny).
+#
+# Usage:
+#   check-scope.sh <path1> [<path2> ...]
+#
+# Verifies every candidate path against the SPEC-002 allowlist / denylist.
+# Writes a JSON report to stdout. Exit code is always 0; the consumer reads
+# the `ok` field in the JSON.
+#
+# Precedence (longest-prefix wins):
+#   1. Exact-file allowlist match (e.g. `.gaia/manifest.json`).
+#   2. Longest matching directory prefix wins. Because
+#      `.specify/extensions/gaia/templates/` (denylist) is longer than
+#      `.specify/extensions/gaia/` (allowlist), a path under templates/
+#      correctly resolves to denylist.
+#   3. No match → `default-deny-unenumerated`.
+#
+# POSIX bash only. No jq, no yq, no python.
+
+set -u
+
+# Rules are encoded as pipe-separated triples: "kind|type|pattern" where:
+#   kind = dir | file
+#   type = allow | deny
+#   pattern = directory prefix (with trailing slash) or exact file path
+#
+# Directory prefixes are intentionally written WITH the trailing slash so
+# that prefix matching cannot bleed across siblings (`.gaia/cli/` won't
+# match `.gaia/cliques/foo`).
+RULES="
+dir|allow|.gaia/cli/
+dir|allow|.claude/hooks/
+dir|allow|.claude/skills/
+dir|allow|.claude/commands/
+dir|allow|.claude/agents/
+dir|allow|.gaia/statusline/
+dir|allow|.specify/extensions/gaia/
+file|allow|.gaia/manifest.json
+dir|deny|app/
+dir|deny|wiki/
+dir|deny|studio/
+dir|deny|website/
+dir|deny|.specify/specs/
+dir|deny|.specify/memory/
+dir|deny|.gaia/local/specs/
+dir|deny|.specify/extensions/gaia/templates/
+dir|deny|.github/workflows/
+"
+
+# classify_path <path>
+# Echoes "<type>|<reason>" where:
+#   type   = allow | deny
+#   reason = "" (when allow), "denylist", "default-deny-unenumerated"
+classify_path() {
+  candidate=$1
+  best_len=0
+  best_type=""
+  best_reason="default-deny-unenumerated"
+
+  # Iterate rules; track the longest matching pattern.
+  IFS='
+'
+  for rule in $RULES; do
+    [ -z "$rule" ] && continue
+    kind=${rule%%|*}
+    rest=${rule#*|}
+    type=${rest%%|*}
+    pattern=${rest#*|}
+
+    matched=0
+    if [ "$kind" = "file" ]; then
+      if [ "$candidate" = "$pattern" ]; then
+        matched=1
+      fi
+    else
+      # Directory prefix; pattern ends in '/'.
+      case $candidate in
+        "$pattern"*) matched=1 ;;
+      esac
+    fi
+
+    if [ "$matched" = "1" ]; then
+      plen=${#pattern}
+      if [ "$plen" -gt "$best_len" ]; then
+        best_len=$plen
+        best_type=$type
+        if [ "$type" = "deny" ]; then
+          best_reason="denylist"
+        else
+          best_reason=""
+        fi
+      fi
+    fi
+  done
+  unset IFS
+
+  if [ "$best_len" -eq 0 ]; then
+    printf 'deny|default-deny-unenumerated'
+  else
+    printf '%s|%s' "$best_type" "$best_reason"
+  fi
+}
+
+# json_escape <string>
+# Escapes a string for embedding inside a JSON string literal.
+json_escape() {
+  s=$1
+  # Backslash first, then double-quote.
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+if [ "$#" -eq 0 ]; then
+  printf '{"ok":true,"allowed":[],"denied":[]}\n'
+  exit 0
+fi
+
+allowed_json=""
+denied_json=""
+ok=true
+
+for path in "$@"; do
+  result=$(classify_path "$path")
+  type=${result%%|*}
+  reason=${result#*|}
+  esc=$(json_escape "$path")
+
+  if [ "$type" = "allow" ]; then
+    if [ -z "$allowed_json" ]; then
+      allowed_json="\"$esc\""
+    else
+      allowed_json="$allowed_json,\"$esc\""
+    fi
+  else
+    ok=false
+    entry="{\"path\":\"$esc\",\"reason\":\"$reason\"}"
+    if [ -z "$denied_json" ]; then
+      denied_json="$entry"
+    else
+      denied_json="$denied_json,$entry"
+    fi
+  fi
+done
+
+printf '{"ok":%s,"allowed":[%s],"denied":[%s]}\n' "$ok" "$allowed_json" "$denied_json"
+exit 0

--- a/.github/forensics/handlers/handle-already-triaged.sh
+++ b/.github/forensics/handlers/handle-already-triaged.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# handle-already-triaged.sh — UAT-006 idempotency early-exit.
+#
+# Logs a `::notice::` line and exits 0. No comment, no label, no PR.
+# Called when the workflow finds the `gaia-triaged` label already on the
+# issue (e.g. due to UAT-011's concurrency-queued re-fire after a label
+# add/remove).
+#
+# Usage:
+#   handle-already-triaged.sh <issue-num>
+#
+# Contract: SPEC-002 UAT-006.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: handle-already-triaged.sh <issue-num>" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+issue_num="$1"
+
+printf '::notice::issue #%s already triaged; skipping\n' "$issue_num"
+
+exit 0

--- a/.github/forensics/handlers/handle-auto-fixable.sh
+++ b/.github/forensics/handlers/handle-auto-fixable.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# handle-auto-fixable.sh — UAT-004 action handler.
+#
+# Pre-conditions: the workflow has already created `<fix-branch>` from
+# `main`, applied the candidate fix, run the Quality Gate green, and
+# pushed. This handler ONLY opens the draft PR and applies labels.
+#
+# Usage:
+#   handle-auto-fixable.sh <issue-num> <class-slug> <fix-branch> <pr-body-file>
+#
+# <pr-body-file> path to a file holding the PR body. Per UAT-015 the
+# body cites `## Capture` from the issue verbatim — the workflow that
+# composes this file is responsible for the passthrough; this handler
+# never re-redacts.
+#
+# Exit code: 0 on success. 1 if `<fix-branch>` is missing on origin
+# (sanity check). gh-level failures propagate.
+#
+# Contract: SPEC-002 UAT-004 / UAT-008 (PR is draft) / UAT-015
+# (passthrough). Acceptance criterion in the task spec mandates the
+# `--draft` flag is present on `gh pr create`.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: handle-auto-fixable.sh <issue-num> <class-slug> <fix-branch> <pr-body-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 4 ] || usage
+issue_num="$1"
+class_slug="$2"
+fix_branch="$3"
+pr_body_file="$4"
+
+[ -f "$pr_body_file" ] || { echo "handle-auto-fixable.sh: pr body file not found: $pr_body_file" >&2; exit 2; }
+
+# 1. Sanity check: branch must exist on origin. Without this, gh pr create
+#    would happily try to push the local branch — but the workflow's
+#    contract says the gate-passing push has already happened. A missing
+#    remote ref means an upstream invariant is broken; fail loudly.
+if ! git ls-remote --exit-code --heads origin "$fix_branch" >/dev/null 2>&1; then
+  echo "handle-auto-fixable.sh: fix branch missing on origin: $fix_branch" >&2
+  exit 1
+fi
+
+# 2. Resolve the issue title for the PR title. We use --json to avoid
+#    fragile parsing of `gh issue view` text output.
+issue_title="$(gh issue view "$issue_num" --json title --jq '.title')"
+if [ -z "$issue_title" ]; then
+  echo "handle-auto-fixable.sh: could not resolve title for issue #$issue_num" >&2
+  exit 1
+fi
+
+pr_title="[gaia-forensics] ${issue_title} (#${issue_num})"
+
+# 3. Open the draft PR. --draft is the UAT-008 hard requirement; the
+#    handler MUST NEVER mark it ready-for-review. --body-file (never
+#    --body "$(...)") is the same shell-metacharacter discipline the
+#    issue-comment paths use; PR body content is phase-1-redacted but
+#    may still contain backticks, dollars, etc.
+pr_url="$(gh pr create \
+  --draft \
+  --base main \
+  --head "$fix_branch" \
+  --title "$pr_title" \
+  --body-file "$pr_body_file")"
+
+# 4. Apply the fix-related labels. Order: classification labels first,
+#    then `gaia-triaged` LAST so the idempotency key is the final
+#    mutation. `class_slug` is reserved for callers and used in the
+#    branch name; kept in the surface for forward-compat with any
+#    future per-class labelling without renegotiating the contract.
+gh issue edit "$issue_num" --add-label "auto-fixable"
+gh issue edit "$issue_num" --add-label "gaia-bug-confirmed"
+
+# 5. Link the PR back from the issue. Comment last (before triaged) so
+#    a re-fire under UAT-011 sees the triaged label and exits before
+#    duplicating the link.
+work_dir=$(mktemp -d 2>/dev/null) || { echo "handle-auto-fixable.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+link_file="$work_dir/link.md"
+{
+  printf 'verdict: auto-fixable (class: `%s`)\n\n' "$class_slug"
+  printf 'Draft PR opened: %s\n\n' "$pr_url"
+  printf 'Quality Gate passed on `%s`. Branch + PR are draft pending human review per branch protection on `main`.\n' "$fix_branch"
+} > "$link_file"
+
+gh issue comment "$issue_num" --body-file "$link_file"
+
+# 6. `gaia-triaged` LAST.
+gh issue edit "$issue_num" --add-label "gaia-triaged"
+
+exit 0

--- a/.github/forensics/handlers/handle-malformed-body.sh
+++ b/.github/forensics/handlers/handle-malformed-body.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# handle-malformed-body.sh — UAT-013 short-circuit handler.
+#
+# The body parser flagged the issue as `valid:false`. Without invoking
+# the LLM (UAT-013 forbids LLM fallback for parse failures), label the
+# issue `needs-human` and post a comment naming the missing/malformed
+# sections. Issue stays open. No fix attempt.
+#
+# Usage:
+#   handle-malformed-body.sh <issue-num> <parser-output-file>
+#
+# <parser-output-file> path to the captured JSON output of
+# `.github/forensics/parse-issue-body.sh`. Schema:
+#   {
+#     "valid": false,
+#     "error": "<error-code>",
+#     "missing": ["symptom", ...],
+#     "malformed": ["frontmatter", ...]
+#   }
+#
+# Exit code: 0 on success. 2 on bad usage / missing input. gh-level
+# failures propagate.
+#
+# Contract: SPEC-002 UAT-013. Idempotency key (`gaia-triaged`) is the
+# final mutation.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: handle-malformed-body.sh <issue-num> <parser-output-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+issue_num="$1"
+parser_output_file="$2"
+
+[ -f "$parser_output_file" ] || { echo "handle-malformed-body.sh: parser output file not found: $parser_output_file" >&2; exit 2; }
+
+# Extract error code + missing[] + malformed[] from the parser JSON. jq
+# is available in GitHub Actions runners and is already used by sibling
+# helpers (bootstrap-labels.sh).
+error_code="$(jq -r '.error // "unknown"' "$parser_output_file")"
+missing_csv="$(jq -r '(.missing // []) | join(", ")' "$parser_output_file")"
+malformed_csv="$(jq -r '(.malformed // []) | join(", ")' "$parser_output_file")"
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "handle-malformed-body.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+comment_file="$work_dir/comment.md"
+{
+  printf 'verdict: needs-human (malformed body — UAT-013).\n\n'
+  printf 'The forensics issue body did not match the SPEC-001 strict schema, so triage stopped before classification (no LLM fallback per UAT-013).\n\n'
+  printf 'parser error: `%s`\n\n' "$error_code"
+  if [ -n "$missing_csv" ]; then
+    printf 'missing sections: `%s`\n\n' "$missing_csv"
+  fi
+  if [ -n "$malformed_csv" ]; then
+    printf 'malformed sections: `%s`\n\n' "$malformed_csv"
+  fi
+  printf 'Required schema: `## Symptom`, `## Classification`, `## Capture`, `## Reproduction context` plus YAML frontmatter (`class`, `gaia_version`, `created`).\n'
+} > "$comment_file"
+
+# Order:
+#   1. `needs-human` (classification label).
+#   2. Comment.
+#   3. `gaia-triaged` LAST (idempotency key).
+gh issue edit "$issue_num" --add-label "needs-human"
+gh issue comment "$issue_num" --body-file "$comment_file"
+gh issue edit "$issue_num" --add-label "gaia-triaged"
+
+exit 0

--- a/.github/forensics/handlers/handle-needs-human.sh
+++ b/.github/forensics/handlers/handle-needs-human.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# handle-needs-human.sh — UAT-003 / UAT-005 / UAT-007 / UAT-014 action handler.
+#
+# Labels a forensics-triaged issue as `needs-human` and posts a comment
+# that mentions the maintainer (@stevensacks), names the reason-code, and
+# includes the classifier (or gate / scope-checker / parser) reasoning.
+# Issue stays open. The final mutation is `gaia-triaged` (idempotency key).
+#
+# Usage:
+#   handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>
+#
+# <reason-code> ∈ { out-of-scope, ambiguous-verdict, malformed-body, gate-failure }
+#
+# Exit code: 0 on success. Non-zero on bad usage, missing file, or unknown
+# reason-code. gh-level failures propagate.
+#
+# Contract: SPEC-002 UAT-003 / UAT-005 / UAT-007 / UAT-014.
+
+set -euo pipefail
+
+MAINTAINER="@stevensacks"
+
+usage() {
+  echo "usage: handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>" >&2
+  echo "  <reason-code> ∈ {out-of-scope, ambiguous-verdict, malformed-body, gate-failure}" >&2
+  exit 2
+}
+
+[ "$#" -eq 3 ] || usage
+issue_num="$1"
+reasoning_file="$2"
+reason_code="$3"
+
+[ -f "$reasoning_file" ] || { echo "handle-needs-human.sh: reasoning file not found: $reasoning_file" >&2; exit 2; }
+
+# Map reason-code → one-line UAT summary. The summary names which UAT
+# branch fired so the maintainer can locate the trigger condition fast.
+case "$reason_code" in
+  out-of-scope)
+    summary="proposed fix touches paths outside the auto-fix allowlist (UAT-007 / UAT-014)."
+    ;;
+  ambiguous-verdict)
+    summary="classifier verdict was missing or self-conflicting (UAT-003 case b)."
+    ;;
+  malformed-body)
+    summary="issue body is missing or malformed against the SPEC-001 strict schema (UAT-013)."
+    ;;
+  gate-failure)
+    summary="auto-fix branch failed the Quality Gate; branch was discarded (UAT-005)."
+    ;;
+  *)
+    echo "handle-needs-human.sh: unknown reason-code: $reason_code" >&2
+    usage
+    ;;
+esac
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "handle-needs-human.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+# Compose the comment body: maintainer mention + verdict header +
+# reason-code summary + reasoning passthrough.
+comment_file="$work_dir/comment.md"
+{
+  printf '%s — needs-human triage.\n\n' "$MAINTAINER"
+  printf 'reason: `%s`\n\n' "$reason_code"
+  printf '%s\n\n' "$summary"
+  printf -- '---\n\n'
+  cat "$reasoning_file"
+} > "$comment_file"
+
+# Order:
+#   1. Apply `needs-human` (the classification label).
+#   2. Post the comment.
+#   3. Apply `gaia-triaged` LAST (idempotency key).
+# The issue is NOT closed (UAT-003 / UAT-005 / UAT-007 / UAT-014 all
+# specify "issue stays open").
+gh issue edit "$issue_num" --add-label "needs-human"
+gh issue comment "$issue_num" --body-file "$comment_file"
+gh issue edit "$issue_num" --add-label "gaia-triaged"
+
+exit 0

--- a/.github/forensics/handlers/handle-non-issue.sh
+++ b/.github/forensics/handlers/handle-non-issue.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# handle-non-issue.sh — UAT-002 action handler.
+#
+# Closes a forensics-triaged issue, applies the `non-issue` and (last)
+# `gaia-triaged` labels, and posts the classifier reasoning as a comment
+# with a "verdict: non-issue" header.
+#
+# Usage:
+#   handle-non-issue.sh <issue-num> <reasoning-file>
+#
+# <reasoning-file> path to a file containing the classifier's reasoning;
+# always passed as a path (never inlined) because the body may contain
+# arbitrary shell metacharacters even after phase-1 redaction.
+#
+# Exit code: 0 on success or no-op idempotency. Non-zero only on a real
+# script error (bad usage, missing file, gh failure not related to
+# already-applied state).
+#
+# Contract: SPEC-002 UAT-002 / UAT-006 / UAT-015 (passthrough).
+# Idempotency: gh issue edit --add-label re-applying an existing label is
+# a no-op; gh issue close on an already-closed issue is a no-op for our
+# purposes. The final --add-label gaia-triaged is the durable idempotency
+# key the workflow's UAT-006 early-exit reads on the next fire.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: handle-non-issue.sh <issue-num> <reasoning-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+issue_num="$1"
+reasoning_file="$2"
+
+[ -f "$reasoning_file" ] || { echo "handle-non-issue.sh: reasoning file not found: $reasoning_file" >&2; exit 2; }
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "handle-non-issue.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+# Compose the comment body: header + reasoning passthrough.
+comment_file="$work_dir/comment.md"
+{
+  printf 'verdict: non-issue\n\n'
+  cat "$reasoning_file"
+} > "$comment_file"
+
+# Order:
+#   1. Apply the classification label (`non-issue`).
+#   2. Post the verdict comment via --body-file (never --body "$(...)" —
+#      reasoning may contain shell metacharacters even after redaction).
+#   3. Close the issue.
+#   4. Apply `gaia-triaged` LAST so the idempotency key is the final
+#      mutation to land. Under UAT-011's concurrency-queued re-fire, any
+#      partial completion that lands `gaia-triaged` has, by construction,
+#      already done the rest.
+gh issue edit "$issue_num" --add-label "non-issue"
+gh issue comment "$issue_num" --body-file "$comment_file"
+gh issue close "$issue_num"
+gh issue edit "$issue_num" --add-label "gaia-triaged"
+
+exit 0

--- a/.github/forensics/parse-issue-body.sh
+++ b/.github/forensics/parse-issue-body.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# parse-issue-body.sh — deterministic parser for the SPEC-001 strict
+# forensics issue body schema. Emits JSON to stdout.
+#
+# Exit code: 0 always (consumers inspect the JSON `valid` field). Exit 2
+# is reserved for genuine script errors (missing input file, bad usage).
+#
+# POSIX-tools only: awk, sed, grep, bash. No jq, no yq, no python.
+#
+# Contract: SPEC-002 (UAT-009, UAT-013, UAT-015) and the body-parser
+# task spec at
+# `.gaia/local/plans/spec-002-forensics-triage-action/task-body-parser.md`.
+
+set -u
+
+usage() {
+  echo "usage: parse-issue-body.sh <input-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+input_file="$1"
+[ -f "$input_file" ] || { echo "parse-issue-body.sh: input file not found: $input_file" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Working-area: a private temp dir holding one file per section. Avoids
+# fragile in-memory section-splitting via shell sentinels.
+# ---------------------------------------------------------------------------
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "parse-issue-body.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+# ---------------------------------------------------------------------------
+# Step 1: validate frontmatter shape and extract the required keys.
+# ---------------------------------------------------------------------------
+
+# First non-blank line (well, first line — SPEC-001 emits `---` as line 1)
+# must be the frontmatter sentinel.
+first_line=$(awk 'NR==1{print; exit}' "$input_file")
+if [ "$first_line" != "---" ]; then
+  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
+  exit 0
+fi
+
+# Closing `---` line number (must be > 1, exact match).
+fm_end=$(awk 'NR>1 && $0=="---"{print NR; exit}' "$input_file")
+if [ -z "${fm_end:-}" ]; then
+  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
+  exit 0
+fi
+
+# Frontmatter content lines (between line 2 and fm_end-1).
+awk -v end="$fm_end" 'NR>1 && NR<end' "$input_file" > "$work_dir/frontmatter.txt"
+
+fm_class=""
+fm_gaia_version=""
+fm_created=""
+fm_gh_issue_url=""
+
+# YAML-shaped key/value pairs. Accept `key: value` lines (first `: `
+# splits). Strip surrounding single or double quotes from value.
+while IFS= read -r line; do
+  case "$line" in
+    ''|'#'*) continue ;;
+  esac
+  key=$(printf '%s' "$line" | awk -F': ' '{print $1}')
+  value=$(printf '%s' "$line" | sed -n 's/^[^:]*:[[:space:]]*//p')
+  case "$value" in
+    \"*\") value=$(printf '%s' "$value" | sed -e 's/^"//' -e 's/"$//') ;;
+    \'*\') value=$(printf '%s' "$value" | sed -e "s/^'//" -e "s/'$//") ;;
+  esac
+  case "$key" in
+    class) fm_class="$value" ;;
+    gaia_version) fm_gaia_version="$value" ;;
+    created) fm_created="$value" ;;
+    gh_issue_url) fm_gh_issue_url="$value" ;;
+  esac
+done < "$work_dir/frontmatter.txt"
+
+if [ -z "$fm_class" ] || [ -z "$fm_gaia_version" ] || [ -z "$fm_created" ]; then
+  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: split the post-frontmatter body into per-section files. Detect
+# malformed `## ` headers (anything not in the canonical four).
+# ---------------------------------------------------------------------------
+
+body_start=$((fm_end + 1))
+
+# Single awk pass: route lines into per-section files; record the first
+# malformed header (if any) into a sentinel file.
+#
+# A section starts at `^## (Symptom|Classification|Capture|Reproduction context)$`
+# and ends at the next `^## ` line or EOF. Lines BEFORE the first valid
+# `## ` header are dropped (the SPEC-001 schema places the four sections
+# back-to-back; nothing precedes them). Lines under a malformed header
+# are also dropped — the malformed header itself is reported.
+awk -v start="$body_start" -v out_dir="$work_dir" '
+  function flush() {
+    if (cur != "" && out_path != "") {
+      print buf > out_path
+      close(out_path)
+    }
+    cur = ""
+    buf = ""
+    out_path = ""
+  }
+  BEGIN {
+    cur = ""
+    buf = ""
+    out_path = ""
+  }
+  NR < start { next }
+  /^## / {
+    name = substr($0, 4)
+    flush()
+    if (name == "Symptom") {
+      cur = name; out_path = out_dir "/sec-symptom.txt"
+    } else if (name == "Classification") {
+      cur = name; out_path = out_dir "/sec-classification.txt"
+    } else if (name == "Capture") {
+      cur = name; out_path = out_dir "/sec-capture.txt"
+    } else if (name == "Reproduction context") {
+      cur = name; out_path = out_dir "/sec-reproduction.txt"
+    } else {
+      # Record first malformed header (subsequent ones ignored).
+      bad_path = out_dir "/malformed-header.txt"
+      cmd = "test -f \"" bad_path "\""
+      if (system(cmd) != 0) {
+        print name > bad_path
+        close(bad_path)
+      }
+      cur = ""
+      out_path = ""
+    }
+    next
+  }
+  {
+    if (cur != "") {
+      if (buf == "") buf = $0
+      else buf = buf "\n" $0
+    }
+  }
+  END {
+    flush()
+  }
+' "$input_file"
+
+# ---------------------------------------------------------------------------
+# Step 3: failure-mode resolution. Order:
+#   1. malformed-section-header
+#   2. missing-section
+#   3. empty-section
+# ---------------------------------------------------------------------------
+
+if [ -f "$work_dir/malformed-header.txt" ]; then
+  bad_header=$(cat "$work_dir/malformed-header.txt")
+  esc_header=$(printf '%s' "$bad_header" | awk '
+    {
+      gsub(/\\/, "\\\\")
+      gsub(/"/, "\\\"")
+      gsub(/\t/, "\\t")
+      printf "%s", $0
+    }
+  ')
+  printf '{"valid":false,"error":"malformed-section-header","missing":[],"malformed":["%s"]}\n' "$esc_header"
+  exit 0
+fi
+
+have_symptom=0;        [ -f "$work_dir/sec-symptom.txt" ]        && have_symptom=1
+have_classification=0; [ -f "$work_dir/sec-classification.txt" ] && have_classification=1
+have_capture=0;        [ -f "$work_dir/sec-capture.txt" ]        && have_capture=1
+have_reproduction=0;   [ -f "$work_dir/sec-reproduction.txt" ]   && have_reproduction=1
+
+missing_list=""
+[ "$have_symptom" -eq 0 ]        && missing_list="${missing_list}\"symptom\","
+[ "$have_classification" -eq 0 ] && missing_list="${missing_list}\"classification\","
+[ "$have_capture" -eq 0 ]        && missing_list="${missing_list}\"capture\","
+[ "$have_reproduction" -eq 0 ]   && missing_list="${missing_list}\"reproduction_context\","
+missing_list=${missing_list%,}
+
+if [ -n "$missing_list" ]; then
+  printf '{"valid":false,"error":"missing-section","missing":[%s],"malformed":[]}\n' "$missing_list"
+  exit 0
+fi
+
+# Trim a single leading and a single trailing blank line per section.
+# (UAT-015 wants verbatim section *content*; the blank line that
+# typically separates a `## ` header from the first content line, and
+# the blank line that typically precedes the next `## ` header, are
+# markdown structure, not content. Stripping at most one such blank
+# line on each end keeps redaction tokens byte-identical while not
+# emitting trailing-newline noise.)
+trim_one_blank_each_end() {
+  local file="$1"
+  awk '
+    {
+      lines[NR] = $0
+    }
+    END {
+      s = 1
+      e = NR
+      if (NR >= 1 && lines[1] == "") s = 2
+      if (e >= s && lines[e] == "") e = e - 1
+      for (i = s; i <= e; i++) {
+        if (i > s) printf "\n"
+        printf "%s", lines[i]
+      }
+    }
+  ' "$file"
+}
+
+sec_symptom=$(trim_one_blank_each_end "$work_dir/sec-symptom.txt")
+sec_classification=$(trim_one_blank_each_end "$work_dir/sec-classification.txt")
+sec_capture=$(trim_one_blank_each_end "$work_dir/sec-capture.txt")
+sec_reproduction=$(trim_one_blank_each_end "$work_dir/sec-reproduction.txt")
+
+empty_list=""
+[ -z "$sec_symptom" ]        && empty_list="${empty_list}\"symptom\","
+[ -z "$sec_classification" ] && empty_list="${empty_list}\"classification\","
+[ -z "$sec_capture" ]        && empty_list="${empty_list}\"capture\","
+[ -z "$sec_reproduction" ]   && empty_list="${empty_list}\"reproduction_context\","
+empty_list=${empty_list%,}
+
+if [ -n "$empty_list" ]; then
+  printf '{"valid":false,"error":"empty-section","missing":[%s],"malformed":[]}\n' "$empty_list"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: emit success JSON. Every string value must be JSON-escaped.
+# ---------------------------------------------------------------------------
+
+# json_escape_file <path> -> stdout: escapes the file's bytes for
+# embedding inside JSON double-quotes. Handles backslash, double-quote,
+# tab, carriage return, and newline. Other control characters in the
+# 0x00–0x1f range are not expected from SPEC-001 issue bodies but if
+# present are kept as-is (the consumer is responsible for validating
+# against its own JSON parser).
+json_escape_file() {
+  awk '
+    BEGIN { first = 1 }
+    {
+      if (first == 1) { first = 0 } else { printf "\\n" }
+      n = length($0)
+      for (i = 1; i <= n; i++) {
+        c = substr($0, i, 1)
+        if (c == "\\") {
+          printf "\\\\"
+        } else if (c == "\"") {
+          printf "\\\""
+        } else if (c == "\t") {
+          printf "\\t"
+        } else if (c == "\r") {
+          printf "\\r"
+        } else {
+          printf "%s", c
+        }
+      }
+    }
+  ' "$1"
+}
+
+# Frontmatter values: never multi-line, but reuse the file-based escape
+# by writing them to disk first.
+printf '%s' "$fm_class"        > "$work_dir/fm-class.txt"
+printf '%s' "$fm_gaia_version" > "$work_dir/fm-gaia-version.txt"
+printf '%s' "$fm_created"      > "$work_dir/fm-created.txt"
+
+esc_class=$(json_escape_file "$work_dir/fm-class.txt")
+esc_gaia_version=$(json_escape_file "$work_dir/fm-gaia-version.txt")
+esc_created=$(json_escape_file "$work_dir/fm-created.txt")
+
+# Sections: write trimmed content back, then escape.
+printf '%s' "$sec_symptom"        > "$work_dir/sec-symptom-trim.txt"
+printf '%s' "$sec_classification" > "$work_dir/sec-classification-trim.txt"
+printf '%s' "$sec_capture"        > "$work_dir/sec-capture-trim.txt"
+printf '%s' "$sec_reproduction"   > "$work_dir/sec-reproduction-trim.txt"
+
+esc_symptom=$(json_escape_file "$work_dir/sec-symptom-trim.txt")
+esc_classification=$(json_escape_file "$work_dir/sec-classification-trim.txt")
+esc_capture=$(json_escape_file "$work_dir/sec-capture-trim.txt")
+esc_reproduction=$(json_escape_file "$work_dir/sec-reproduction-trim.txt")
+
+if [ -z "$fm_gh_issue_url" ]; then
+  gh_url_field='null'
+else
+  printf '%s' "$fm_gh_issue_url" > "$work_dir/fm-gh-url.txt"
+  esc_gh=$(json_escape_file "$work_dir/fm-gh-url.txt")
+  gh_url_field="\"$esc_gh\""
+fi
+
+printf '{"valid":true,"frontmatter":{"class":"%s","gaia_version":"%s","created":"%s","gh_issue_url":%s},"sections":{"symptom":"%s","classification":"%s","capture":"%s","reproduction_context":"%s"}}\n' \
+  "$esc_class" "$esc_gaia_version" "$esc_created" "$gh_url_field" \
+  "$esc_symptom" "$esc_classification" "$esc_capture" "$esc_reproduction"

--- a/.github/forensics/parse-verdict.sh
+++ b/.github/forensics/parse-verdict.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# parse-verdict.sh — extracts the classifier verdict from the
+# anthropics/claude-code-action output. Emits JSON to stdout.
+#
+# Usage:
+#   parse-verdict.sh <action-output-file>
+#
+# Output JSON shape:
+#   {
+#     "verdict": "non-issue|needs-human|auto-fixable|ambiguous",
+#     "reasoning": "<everything before the GAIA-VERDICT line>",
+#     "proposed_paths": ["path1", "path2"]
+#   }
+#
+# `ambiguous` covers UAT-003 case (b):
+#   - No `GAIA-VERDICT:` line.
+#   - Multiple `GAIA-VERDICT:` lines.
+#   - A `GAIA-VERDICT:` value outside the closed set.
+#   - `auto-fixable` without a parseable `### Proposed paths` fence.
+#
+# The verdict line MUST be the LAST non-blank line of the response;
+# anything trailing it (besides blank lines) is also ambiguous.
+#
+# POSIX bash + awk only. No jq, no python. Exit 0 always (consumers read
+# JSON); exit 2 reserved for genuine usage errors.
+
+set -u
+
+usage() {
+  echo "usage: parse-verdict.sh <action-output-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+input_file="$1"
+[ -f "$input_file" ] || { echo "parse-verdict.sh: input file not found: $input_file" >&2; exit 2; }
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "parse-verdict.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+# ---------------------------------------------------------------------------
+# Step 1: locate every `GAIA-VERDICT:` line and identify the LAST non-blank
+# line of the file. A conformant response has exactly one verdict line, and
+# that line is the last non-blank line.
+# ---------------------------------------------------------------------------
+
+# Count of GAIA-VERDICT lines (leading whitespace tolerated; the rest of the
+# line is the value, possibly with trailing whitespace).
+verdict_count=$(awk '/^[[:space:]]*GAIA-VERDICT:/ { c++ } END { print c+0 }' "$input_file")
+
+# Line number of the last non-blank line.
+last_nonblank_lineno=$(awk 'NF { last = NR } END { print last+0 }' "$input_file")
+
+# Line number of the (single) verdict line, if present.
+verdict_lineno=$(awk '/^[[:space:]]*GAIA-VERDICT:/ { print NR }' "$input_file" | tail -n 1)
+
+# ---------------------------------------------------------------------------
+# Step 2: classify the verdict.
+# ---------------------------------------------------------------------------
+
+verdict="ambiguous"
+
+if [ "$verdict_count" -eq 0 ]; then
+  verdict="ambiguous"
+elif [ "$verdict_count" -gt 1 ]; then
+  # Strict contract: exactly one verdict line. Multiple = non-conformant.
+  verdict="ambiguous"
+elif [ "$verdict_lineno" != "$last_nonblank_lineno" ]; then
+  # Verdict line exists but is not the LAST non-blank line.
+  verdict="ambiguous"
+else
+  raw=$(awk -v ln="$verdict_lineno" 'NR==ln' "$input_file")
+  # Strip leading whitespace and the `GAIA-VERDICT:` prefix.
+  value=$(printf '%s' "$raw" | sed -E 's/^[[:space:]]*GAIA-VERDICT:[[:space:]]*//' | awk '{$1=$1; print}')
+  case "$value" in
+    non-issue|needs-human|auto-fixable) verdict="$value" ;;
+    *) verdict="ambiguous" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: extract reasoning — everything before the verdict line. If no
+# verdict line was located, reasoning is the entire file (with any trailing
+# newline preserved as best-effort).
+# ---------------------------------------------------------------------------
+
+if [ "$verdict_count" -ge 1 ] && [ -n "${verdict_lineno:-}" ]; then
+  awk -v ln="$verdict_lineno" 'NR < ln' "$input_file" > "$work_dir/reasoning.txt"
+else
+  cp "$input_file" "$work_dir/reasoning.txt"
+fi
+
+# Trim a single trailing blank line (markdown structure between the
+# reasoning and the verdict line) without touching content lines.
+awk '
+  { lines[NR] = $0 }
+  END {
+    e = NR
+    if (e >= 1 && lines[e] == "") e = e - 1
+    for (i = 1; i <= e; i++) {
+      if (i > 1) printf "\n"
+      printf "%s", lines[i]
+    }
+  }
+' "$work_dir/reasoning.txt" > "$work_dir/reasoning-trim.txt"
+
+# ---------------------------------------------------------------------------
+# Step 4: extract proposed_paths from a `### Proposed paths` fenced block.
+#
+# Shape (the outer wrapper in the prompt example uses ```` to embed the
+# inner fence; we read the INNER triple-backtick block):
+#
+#   ### Proposed paths
+#
+#   ```
+#   path/one
+#   path/two
+#   ```
+#
+# Algorithm:
+#   1. Find the first `### Proposed paths` header line (case-sensitive).
+#   2. Skip blank lines and an optional opening triple-backtick fence
+#      (with optional language tag).
+#   3. Read non-blank, non-fence lines until the next fence or the next
+#      `^### ` header or EOF.
+#   4. Each accumulated line is a path (after trimming whitespace).
+# ---------------------------------------------------------------------------
+
+awk '
+  BEGIN {
+    in_block = 0
+    seen_open_fence = 0
+  }
+  # Header detection.
+  /^[[:space:]]*###[[:space:]]+Proposed paths[[:space:]]*$/ {
+    if (in_block == 0) {
+      in_block = 1
+      seen_open_fence = 0
+      next
+    }
+  }
+  # Once we are in the block, watch for the opening triple-backtick fence
+  # (possibly with a language tag).
+  in_block == 1 && seen_open_fence == 0 {
+    if ($0 ~ /^[[:space:]]*```/) {
+      seen_open_fence = 1
+      next
+    }
+    # A new `### ` header before we see the fence ends the block — the
+    # author wrote the header but never opened a fence.
+    if ($0 ~ /^[[:space:]]*###[[:space:]]+/) {
+      in_block = 0
+      next
+    }
+    # Blank lines between header and fence are fine; non-blank non-fence
+    # lines mean the author skipped the fence (laxer parsing not allowed).
+    if ($0 !~ /^[[:space:]]*$/) {
+      # Treat as malformed — abandon block.
+      in_block = 0
+    }
+    next
+  }
+  # Inside the fenced block.
+  in_block == 1 && seen_open_fence == 1 {
+    # Closing fence ends the block.
+    if ($0 ~ /^[[:space:]]*```/) {
+      in_block = 0
+      next
+    }
+    # Blank line: skip silently.
+    if ($0 ~ /^[[:space:]]*$/) { next }
+    # Trim leading and trailing whitespace.
+    line = $0
+    sub(/^[[:space:]]+/, "", line)
+    sub(/[[:space:]]+$/, "", line)
+    if (line != "") {
+      print line
+    }
+  }
+' "$input_file" > "$work_dir/paths-raw.txt"
+
+# Build the JSON array of proposed paths and remember whether any were found.
+paths_json=""
+paths_count=0
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  paths_count=$((paths_count + 1))
+  esc=$(printf '%s' "$p" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+  if [ -z "$paths_json" ]; then
+    paths_json="\"$esc\""
+  else
+    paths_json="$paths_json,\"$esc\""
+  fi
+done < "$work_dir/paths-raw.txt"
+
+# ---------------------------------------------------------------------------
+# Step 5: downgrade `auto-fixable` to `ambiguous` when no proposed paths
+# were parsed (proposing a fix without paths is malformed).
+# ---------------------------------------------------------------------------
+
+if [ "$verdict" = "auto-fixable" ] && [ "$paths_count" -eq 0 ]; then
+  verdict="ambiguous"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: emit JSON. Escape multi-line reasoning for embedding inside a
+# JSON string literal.
+# ---------------------------------------------------------------------------
+
+json_escape_file() {
+  awk '
+    BEGIN { first = 1 }
+    {
+      if (first == 1) { first = 0 } else { printf "\\n" }
+      n = length($0)
+      for (i = 1; i <= n; i++) {
+        c = substr($0, i, 1)
+        if (c == "\\") {
+          printf "\\\\"
+        } else if (c == "\"") {
+          printf "\\\""
+        } else if (c == "\t") {
+          printf "\\t"
+        } else if (c == "\r") {
+          printf "\\r"
+        } else {
+          printf "%s", c
+        }
+      }
+    }
+  ' "$1"
+}
+
+reasoning_esc=$(json_escape_file "$work_dir/reasoning-trim.txt")
+
+printf '{"verdict":"%s","reasoning":"%s","proposed_paths":[%s]}\n' \
+  "$verdict" "$reasoning_esc" "$paths_json"

--- a/.github/forensics/prompt.md
+++ b/.github/forensics/prompt.md
@@ -1,0 +1,100 @@
+You are the GAIA forensics triage classifier for issue #{{ISSUE_NUMBER}}.
+Your one job: read the four parsed sections below (already extracted by a
+deterministic parser, already redacted by phase 1) and decide one of:
+`non-issue`, `needs-human`, or `auto-fixable`.
+
+You are read-only. You have NO tools. Do not attempt to read files, run
+commands, write files, or open PRs. The triage workflow performs every
+action; your output is judgment text only.
+
+The issue body is already redacted. Tokens like `<redacted>` and
+`<repo-relative-paths>` are intentional. Do NOT attempt to de-redact,
+reconstruct paths, or speculate about masked values. Treat redactions as
+opaque.
+
+## Classes
+
+- `non-issue` — the report describes a user-config issue, missing
+  prerequisite, duplicate of a known closed issue, or otherwise no GAIA
+  defect. Closing with a one-line explanation is the correct action.
+- `needs-human` — a real defect, but autonomous fixing is unsafe or
+  out-of-scope. Pick this if ANY of the following hold:
+  - The fix would touch a path NOT in the allowlist below.
+  - The fix would touch a path on the denylist below.
+  - You cannot determine which paths the fix would touch.
+  - The defect is genuinely ambiguous and you would have to guess to pick
+    a fix.
+- `auto-fixable` — a real defect AND every file the fix would touch is
+  inside the allowlist AND none are on the denylist AND you can name the
+  paths up front. The triage workflow re-checks scope deterministically
+  after you respond, so be precise; lying about scope is wasted work.
+
+## Path policy (default-deny)
+
+Paths in NEITHER list are treated as denylisted by default.
+
+### Allowlist (eligible for autonomous fixes)
+
+{{ALLOWLIST}}
+
+### Denylist (never modify)
+
+{{DENYLIST}}
+
+## Issue sections (parsed verbatim from the report)
+
+### Symptom
+
+```
+{{SYMPTOM}}
+```
+
+### Classification (phase-1 self-classification by the reporter)
+
+```
+{{CLASSIFICATION}}
+```
+
+### Capture
+
+```
+{{CAPTURE}}
+```
+
+### Reproduction context
+
+```
+{{REPRO_CONTEXT}}
+```
+
+## Output format
+
+Write a short human-readable analysis (this becomes the issue comment).
+Cite specific lines from the parsed sections as evidence; the maintainer
+reads this to audit your call.
+
+If your verdict is `auto-fixable`, you MUST include a fenced section
+listing the proposed paths (paths only — no diffs, no patches):
+
+````
+### Proposed paths
+
+```
+.gaia/cli/path/to/file.ts
+.claude/hooks/another.sh
+```
+````
+
+End your entire response with EXACTLY ONE machine-readable verdict line.
+The verdict line must be the LAST non-blank line of the response, with
+no trailing punctuation, no surrounding quotes, no commentary on the
+same line:
+
+```
+GAIA-VERDICT: <non-issue|needs-human|auto-fixable>
+```
+
+Do not emit more than one `GAIA-VERDICT:` line. Do not emit a verdict
+value outside the closed set above. If you are unsure between two
+classes, pick `needs-human` — escalation on ambiguity is correct
+behavior, not failure.

--- a/.github/forensics/run-quality-gate.sh
+++ b/.github/forensics/run-quality-gate.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# run-quality-gate.sh — Quality Gate runner for the SPEC-002 forensics
+# triage workflow. Executes each gate step in order, halts on the first
+# failure, and writes a JSON summary the workflow YAML feeds into the
+# `handle-needs-human.sh` reason-code `gate-failure` path (UAT-005).
+#
+# Usage:
+#   run-quality-gate.sh <output-summary-file>
+#
+# Steps (in order, halt-on-first-fail):
+#   1. pnpm install --frozen-lockfile  (deps tree precondition)
+#   2. pnpm typecheck
+#   3. pnpm lint
+#   4. pnpm test --run                  (vitest only; playwright is out of
+#                                        scope for the triage gate — see
+#                                        task-quality-gate-runner.md)
+#   5. pnpm knip
+#
+# Output JSON:
+#   On failure:
+#     { "passed": false, "failed_step": "<step>",
+#       "exit_code": <int>, "log_excerpt": "<≤50 lines, ≤2000 chars>" }
+#   On pass:
+#     { "passed": true,
+#       "steps_run": ["install", "typecheck", "lint", "test", "knip"] }
+#
+# Exit code: 0 on pass, 1 on any step failure. The workflow YAML uses the
+# exit code to short-circuit; the JSON summary feeds the issue comment.
+#
+# Knip caveat:
+#   .claude/rules/knip.md says "do not run mid-task / as part of the
+#   Quality Gate — in-progress exports flag as false positives". That
+#   advice targets human/IDE Quality Gate use during active development.
+#   In the triage workflow the candidate fix is fully committed before
+#   this script runs, so knip's incomplete-export-graph failure mode
+#   does NOT apply. Knip IS in scope here and is treated identically to
+#   lint/test failures.
+#
+# Dependencies:
+#   pnpm — bootstrapped by an earlier workflow step (this script does not
+#   set up pnpm itself).
+#
+# Local maintainer use:
+#   .github/forensics/run-quality-gate.sh /tmp/qg.json
+#   …validates a candidate fix branch the same way the workflow does
+#   before manually opening a PR.
+
+set -u
+
+usage() {
+  echo "usage: run-quality-gate.sh <output-summary-file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+summary_file="$1"
+
+# Ensure parent dir exists; fail fast if the path is invalid.
+summary_parent="$(dirname "$summary_file")"
+[ -d "$summary_parent" ] || { echo "run-quality-gate.sh: parent dir does not exist: $summary_parent" >&2; exit 2; }
+
+work_dir=$(mktemp -d 2>/dev/null) || { echo "run-quality-gate.sh: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$work_dir"' EXIT
+
+# ---------------------------------------------------------------------------
+# JSON-string escaping. Pure bash; avoids the jq dependency for a runner
+# that already pulls pnpm + node into scope. Handles backslash, double
+# quote, and control bytes (newline / CR / tab → \n \r \t; other 0x00-0x1f
+# bytes → \u00XX). Trailing newlines in the input are preserved.
+# ---------------------------------------------------------------------------
+json_escape() {
+  local in="$1"
+  local out=""
+  local i ch code
+  for (( i = 0; i < ${#in}; i++ )); do
+    ch="${in:i:1}"
+    case "$ch" in
+      '\') out+='\\' ;;
+      '"') out+='\"' ;;
+      $'\n') out+='\n' ;;
+      $'\r') out+='\r' ;;
+      $'\t') out+='\t' ;;
+      *)
+        printf -v code '%d' "'$ch"
+        if [ "$code" -lt 32 ]; then
+          out+="$(printf '\\u%04x' "$code")"
+        else
+          out+="$ch"
+        fi
+        ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Run one gate step. Captures merged stderr+stdout to a per-step log.
+# On non-zero exit:
+#   - Trims the log to the last 50 lines AND ≤2000 chars (whichever is
+#     tighter — comment-fitting is the hard constraint).
+#   - Writes the failure summary JSON.
+#   - Returns 1 (caller propagates).
+# On zero exit: returns 0 silently.
+#
+# Args:
+#   $1 — step name (matches the spec's vocabulary: install/typecheck/lint/test/knip)
+#   $2..$N — command + args
+# ---------------------------------------------------------------------------
+run_step() {
+  local step="$1"
+  shift
+  local log_file="$work_dir/${step}.log"
+  local exit_code=0
+
+  echo "::group::quality-gate: ${step}"
+  # Run the command and capture its exit code DIRECTLY. Using
+  # `if "$@"; then ... fi` would clobber `$?` by the time we read it
+  # (the `else` / `fi` body itself contributes to `$?`).
+  "$@" >"$log_file" 2>&1
+  exit_code=$?
+  echo "::endgroup::"
+  if [ "$exit_code" -eq 0 ]; then
+    return 0
+  fi
+  echo "::error::quality-gate step '${step}' failed (exit ${exit_code})"
+
+  # Trim: last 50 lines, then cap at 2000 chars from the END (the tail is
+  # where the actual error message lives).
+  local excerpt
+  excerpt="$(tail -n 50 "$log_file")"
+  local max_chars=2000
+  if [ "${#excerpt}" -gt "$max_chars" ]; then
+    excerpt="${excerpt: -$max_chars}"
+  fi
+
+  local escaped
+  escaped="$(json_escape "$excerpt")"
+
+  cat >"$summary_file" <<JSON
+{
+  "passed": false,
+  "failed_step": "${step}",
+  "exit_code": ${exit_code},
+  "log_excerpt": "${escaped}"
+}
+JSON
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Steps. Halt-on-first-fail: each `run_step` returns 1 to bubble up here
+# via `|| exit 1`; we never proceed past a failure. Order matches the
+# task spec.
+# ---------------------------------------------------------------------------
+run_step install   pnpm install --frozen-lockfile || exit 1
+run_step typecheck pnpm typecheck                  || exit 1
+run_step lint      pnpm lint                       || exit 1
+run_step test      pnpm test --run                 || exit 1
+run_step knip      pnpm knip                       || exit 1
+
+# All-green summary.
+cat >"$summary_file" <<'JSON'
+{
+  "passed": true,
+  "steps_run": ["install", "typecheck", "lint", "test", "knip"]
+}
+JSON
+
+exit 0

--- a/.github/forensics/tests/check-scope.bats
+++ b/.github/forensics/tests/check-scope.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for .github/forensics/check-scope.sh
+#
+# Covers every allowlist hit, every denylist hit, the default-deny case,
+# the allowlist-subtraction edge case, and multi-path partitioning.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../check-scope.sh"
+  [ -x "$SCRIPT" ] || skip "check-scope.sh not executable"
+}
+
+# --- exit-code contract ----------------------------------------------------
+
+@test "exit code is always 0 (consumer reads ok from JSON)" {
+  run "$SCRIPT" app/foo.ts
+  [ "$status" -eq 0 ]
+  run "$SCRIPT" .gaia/cli/foo.sh
+  [ "$status" -eq 0 ]
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# --- allowlist hits --------------------------------------------------------
+
+@test "allowlist: .gaia/cli/" {
+  run "$SCRIPT" .gaia/cli/foo.sh
+  [ "$output" = '{"ok":true,"allowed":[".gaia/cli/foo.sh"],"denied":[]}' ]
+}
+
+@test "allowlist: .claude/hooks/" {
+  run "$SCRIPT" .claude/hooks/post-commit.sh
+  [ "$output" = '{"ok":true,"allowed":[".claude/hooks/post-commit.sh"],"denied":[]}' ]
+}
+
+@test "allowlist: .claude/skills/" {
+  run "$SCRIPT" .claude/skills/foo/SKILL.md
+  [ "$output" = '{"ok":true,"allowed":[".claude/skills/foo/SKILL.md"],"denied":[]}' ]
+}
+
+@test "allowlist: .claude/commands/" {
+  run "$SCRIPT" .claude/commands/gaia.md
+  [ "$output" = '{"ok":true,"allowed":[".claude/commands/gaia.md"],"denied":[]}' ]
+}
+
+@test "allowlist: .claude/agents/" {
+  run "$SCRIPT" .claude/agents/code-review-audit.md
+  [ "$output" = '{"ok":true,"allowed":[".claude/agents/code-review-audit.md"],"denied":[]}' ]
+}
+
+@test "allowlist: .gaia/statusline/" {
+  run "$SCRIPT" .gaia/statusline/render.sh
+  [ "$output" = '{"ok":true,"allowed":[".gaia/statusline/render.sh"],"denied":[]}' ]
+}
+
+@test "allowlist: .specify/extensions/gaia/ (non-templates path)" {
+  run "$SCRIPT" .specify/extensions/gaia/scripts/foo.sh
+  [ "$output" = '{"ok":true,"allowed":[".specify/extensions/gaia/scripts/foo.sh"],"denied":[]}' ]
+}
+
+@test "allowlist: .gaia/manifest.json (exact file)" {
+  run "$SCRIPT" .gaia/manifest.json
+  [ "$output" = '{"ok":true,"allowed":[".gaia/manifest.json"],"denied":[]}' ]
+}
+
+# --- denylist hits ---------------------------------------------------------
+
+@test "denylist: app/" {
+  run "$SCRIPT" app/foo.ts
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"app/foo.ts","reason":"denylist"}]}' ]
+}
+
+@test "denylist: wiki/" {
+  run "$SCRIPT" wiki/index.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"wiki/index.md","reason":"denylist"}]}' ]
+}
+
+@test "denylist: studio/" {
+  run "$SCRIPT" studio/branding/IDENTITY.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"studio/branding/IDENTITY.md","reason":"denylist"}]}' ]
+}
+
+@test "denylist: website/" {
+  run "$SCRIPT" website/src/sections/Hero.tsx
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"website/src/sections/Hero.tsx","reason":"denylist"}]}' ]
+}
+
+@test "denylist: .specify/specs/" {
+  run "$SCRIPT" .specify/specs/SPEC-002.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".specify/specs/SPEC-002.md","reason":"denylist"}]}' ]
+}
+
+@test "denylist: .specify/memory/" {
+  run "$SCRIPT" .specify/memory/foo.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".specify/memory/foo.md","reason":"denylist"}]}' ]
+}
+
+@test "denylist: .gaia/local/specs/" {
+  run "$SCRIPT" .gaia/local/specs/SPEC-002.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".gaia/local/specs/SPEC-002.md","reason":"denylist"}]}' ]
+}
+
+@test "denylist: .github/workflows/" {
+  run "$SCRIPT" .github/workflows/forensics-triage.yml
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".github/workflows/forensics-triage.yml","reason":"denylist"}]}' ]
+}
+
+# --- allowlist subtraction (UAT-007 edge case) -----------------------------
+
+@test "subtraction: .specify/extensions/gaia/templates/ overrides parent allowlist" {
+  run "$SCRIPT" .specify/extensions/gaia/templates/foo.md
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".specify/extensions/gaia/templates/foo.md","reason":"denylist"}]}' ]
+}
+
+# --- default-deny (UAT-014) ------------------------------------------------
+
+@test "default-deny: package.json" {
+  run "$SCRIPT" package.json
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"package.json","reason":"default-deny-unenumerated"}]}' ]
+}
+
+@test "default-deny: eslint.config.ts" {
+  run "$SCRIPT" eslint.config.ts
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"eslint.config.ts","reason":"default-deny-unenumerated"}]}' ]
+}
+
+@test "default-deny: .github/CODEOWNERS (unenumerated .github/ subpath)" {
+  run "$SCRIPT" .github/CODEOWNERS
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".github/CODEOWNERS","reason":"default-deny-unenumerated"}]}' ]
+}
+
+@test "default-deny: sibling of an allowlist prefix does not match" {
+  # `.gaia/cliques/` is NOT `.gaia/cli/`; trailing-slash discipline prevents
+  # bleed.
+  run "$SCRIPT" .gaia/cliques/foo.sh
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".gaia/cliques/foo.sh","reason":"default-deny-unenumerated"}]}' ]
+}
+
+@test "default-deny: bare directory name without trailing path" {
+  # Defensive: git diff names files, never bare directories. A bare
+  # ".gaia/cli" does not match the ".gaia/cli/" prefix.
+  run "$SCRIPT" .gaia/cli
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":".gaia/cli","reason":"default-deny-unenumerated"}]}' ]
+}
+
+# --- multi-path partitioning -----------------------------------------------
+
+@test "multi: all-allow → ok:true" {
+  run "$SCRIPT" .gaia/cli/foo.sh .claude/hooks/bar.sh .gaia/manifest.json
+  [ "$output" = '{"ok":true,"allowed":[".gaia/cli/foo.sh",".claude/hooks/bar.sh",".gaia/manifest.json"],"denied":[]}' ]
+}
+
+@test "multi: any-deny flips ok:false; allowed/denied partition the input" {
+  run "$SCRIPT" .gaia/cli/foo.sh app/bar.ts package.json
+  [ "$output" = '{"ok":false,"allowed":[".gaia/cli/foo.sh"],"denied":[{"path":"app/bar.ts","reason":"denylist"},{"path":"package.json","reason":"default-deny-unenumerated"}]}' ]
+}
+
+@test "multi: deny reasons are recorded per-path (mixed denylist + default-deny)" {
+  run "$SCRIPT" wiki/foo.md eslint.config.ts
+  [ "$output" = '{"ok":false,"allowed":[],"denied":[{"path":"wiki/foo.md","reason":"denylist"},{"path":"eslint.config.ts","reason":"default-deny-unenumerated"}]}' ]
+}
+
+# --- zero-input contract ---------------------------------------------------
+
+@test "no args: ok:true with empty arrays" {
+  run "$SCRIPT"
+  [ "$output" = '{"ok":true,"allowed":[],"denied":[]}' ]
+}

--- a/.github/forensics/tests/fixtures/malformed-section-header.md
+++ b/.github/forensics/tests/fixtures/malformed-section-header.md
@@ -1,0 +1,28 @@
+---
+class: scaffold
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Symptom
+
+Scaffolding fails partway.
+
+## Classification
+
+class: scaffold
+evidence: scaffold output stops mid-render.
+
+## Bogus Header
+
+This isn't one of the canonical four.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+```
+
+## Reproduction context
+
+- `.gaia/cli/`

--- a/.github/forensics/tests/fixtures/missing-frontmatter.md
+++ b/.github/forensics/tests/fixtures/missing-frontmatter.md
@@ -1,0 +1,18 @@
+## Symptom
+
+Something broke.
+
+## Classification
+
+class: other
+evidence: not enough info.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+```
+
+## Reproduction context
+
+- `.claude/hooks/post-tool.sh`

--- a/.github/forensics/tests/fixtures/missing-symptom.md
+++ b/.github/forensics/tests/fixtures/missing-symptom.md
@@ -1,0 +1,20 @@
+---
+class: hook
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Classification
+
+class: hook
+evidence: hook script returns exit 1 on every save.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+```
+
+## Reproduction context
+
+- `.claude/hooks/post-tool.sh`

--- a/.github/forensics/tests/fixtures/redaction-passthrough.md
+++ b/.github/forensics/tests/fixtures/redaction-passthrough.md
@@ -1,0 +1,28 @@
+---
+class: dev-server
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Symptom
+
+Dev server crashes when env var is `<redacted>`.
+
+## Classification
+
+class: dev-server
+evidence: stack trace points at config loader at `<repo-relative-paths>`.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+api_key: <redacted>
+config_path: <repo-relative-paths>
+git_branch: feature/<redacted>-fix
+```
+
+## Reproduction context
+
+- `<repo-relative-paths>`
+- file at `<repo-relative-paths>` referencing `<redacted>`

--- a/.github/forensics/tests/fixtures/valid.md
+++ b/.github/forensics/tests/fixtures/valid.md
@@ -1,0 +1,32 @@
+---
+class: quality-gate
+gaia_version: 1.4.2
+created: 2026-05-08
+gh_issue_url: https://github.com/gaia-react/gaia/issues/123
+---
+
+## Symptom
+
+`pnpm typecheck` reports `TS2304: Cannot find name 'foo'` after the
+0.4.0 update.
+
+## Classification
+
+class: quality-gate
+evidence: typecheck output cites the missing identifier across two
+hook files in `.claude/hooks/`.
+
+## Capture
+
+```
+gaia_version: 1.4.2
+node_version: v20.11.0
+pnpm_version: 9.0.0
+git_branch: main
+git_dirty: false
+```
+
+## Reproduction context
+
+- `.claude/hooks/wiki-session-stop.sh`
+- `.claude/hooks/post-tool.sh`

--- a/.github/forensics/tests/handlers.bats
+++ b/.github/forensics/tests/handlers.bats
@@ -1,0 +1,453 @@
+#!/usr/bin/env bats
+# Tests for `.github/forensics/handlers/*.sh`.
+#
+# Strategy: shim `gh` (and `git`, for handle-auto-fixable's ls-remote
+# sanity check) with a thin wrapper that records its full argv to
+# $GH_LOG / $GIT_LOG and exits 0. Each test asserts the recorded calls
+# match the documented contract.
+#
+# Coverage targets:
+#   UAT-002   handle-non-issue: close + label + comment, gaia-triaged last
+#   UAT-003   handle-needs-human: label + @mention + reason-code, stays open
+#   UAT-004   handle-auto-fixable: --draft PR, both fix labels, link comment
+#   UAT-005   handle-needs-human reason-code gate-failure surface
+#   UAT-006   handle-already-triaged: pure no-op, ::notice:: line
+#   UAT-007   handle-needs-human reason-code out-of-scope surface
+#   UAT-008   handle-auto-fixable never invokes gh pr ready / gh pr merge
+#   UAT-013   handle-malformed-body: parser-output → comment, no LLM
+#   UAT-014   handle-needs-human reason-code out-of-scope surface (default-deny)
+#   UAT-015   handle-auto-fixable PR body is passed via --body-file (passthrough)
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  HANDLERS="$THIS_DIR/../handlers"
+
+  # Per-test sandbox.
+  SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+  mkdir -p "$SANDBOX/bin" "$SANDBOX/captured-bodies"
+  GH_LOG="$SANDBOX/gh.log"
+  GIT_LOG="$SANDBOX/git.log"
+  CAPTURED_BODIES_DIR="$SANDBOX/captured-bodies"
+  export GH_LOG GIT_LOG CAPTURED_BODIES_DIR
+
+  # gh shim: records every invocation as one line per call AND snapshots
+  # every --body-file <path> argument's content under $CAPTURED_BODIES_DIR
+  # so tests can inspect the body even after the handler's trap cleans up
+  # its tmpdir. Special-case `gh issue view --json title --jq .title` and
+  # `gh pr create` to emit deterministic stdout.
+  cat > "$SANDBOX/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+# argv recording: one line, NUL-free shell-quoted via printf %q.
+{
+  printf 'gh'
+  for a in "$@"; do
+    printf ' %q' "$a"
+  done
+  printf '\n'
+} >> "$GH_LOG"
+
+# Snapshot --body-file content (handler's tmpdir gets cleaned via trap
+# before the test can read it).
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--body-file" ] && [ -f "$a" ]; then
+    snap="$CAPTURED_BODIES_DIR/body-$(printf '%s' "$$-$RANDOM-${#a}").md"
+    cp "$a" "$snap"
+    # Append a sidecar so tests can correlate this body to its gh call.
+    printf '%s\n' "$snap" >> "$CAPTURED_BODIES_DIR/index.txt"
+  fi
+  prev="$a"
+done
+
+# Specific stub responses needed by the handlers.
+case "$1 $2" in
+  "issue view")
+    # handle-auto-fixable: `gh issue view <num> --json title --jq .title`
+    printf 'Test issue title\n'
+    ;;
+  "pr create")
+    # handle-auto-fixable expects the URL on stdout.
+    printf 'https://github.com/gaia-react/gaia/pull/999\n'
+    ;;
+esac
+exit 0
+SHIM
+  chmod +x "$SANDBOX/bin/gh"
+
+  # git shim: only the ls-remote heads call is exercised by these tests.
+  # Default to "branch present" (exit 0). Tests that need "branch absent"
+  # set GIT_LS_REMOTE_FAIL=1.
+  cat > "$SANDBOX/bin/git" <<'SHIM'
+#!/usr/bin/env bash
+{
+  printf 'git'
+  for a in "$@"; do
+    printf ' %q' "$a"
+  done
+  printf '\n'
+} >> "$GIT_LOG"
+
+if [ "$1" = "ls-remote" ]; then
+  if [ "${GIT_LS_REMOTE_FAIL:-0}" = "1" ]; then
+    exit 2
+  fi
+  printf 'deadbeefdeadbeef\trefs/heads/dummy\n'
+  exit 0
+fi
+
+# Anything else: pass through to the real git so we don't break any
+# helper that drifts in.
+exec /usr/bin/env -u PATH PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" git "$@"
+SHIM
+  chmod +x "$SANDBOX/bin/git"
+
+  PATH="$SANDBOX/bin:$PATH"
+  export PATH
+}
+
+# Helper: count occurrences of a literal substring in $GH_LOG.
+gh_log_count() {
+  if [ ! -f "$GH_LOG" ]; then
+    printf '0'
+    return
+  fi
+  grep -cF -- "$1" "$GH_LOG" || true
+}
+
+# Helper: line-number of the first $GH_LOG line containing literal $1, or empty.
+gh_log_line_no() {
+  grep -nF -- "$1" "$GH_LOG" 2>/dev/null | head -1 | cut -d: -f1
+}
+
+# Helper: path to the first --body-file content captured by the gh shim.
+# (Order matches the gh-shim invocation order; for the suites here all
+# handlers post exactly one comment per run, so "first" == "the comment".)
+first_captured_body() {
+  head -1 "$CAPTURED_BODIES_DIR/index.txt"
+}
+
+# ---------------------------------------------------------------------------
+# handle-non-issue.sh — UAT-002
+# ---------------------------------------------------------------------------
+
+@test "non-issue: usage error with no args" {
+  run "$HANDLERS/handle-non-issue.sh"
+  [ "$status" -eq 2 ]
+}
+
+@test "non-issue: missing reasoning file exits 2" {
+  run "$HANDLERS/handle-non-issue.sh" 42 "$BATS_TEST_TMPDIR/does-not-exist"
+  [ "$status" -eq 2 ]
+}
+
+@test "non-issue: applies non-issue label" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'user mis-config; not a bug.\n' > "$reasoning"
+  run "$HANDLERS/handle-non-issue.sh" 42 "$reasoning"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count '--add-label non-issue')" -ge 1 ]
+}
+
+@test "non-issue: posts comment via --body-file (never inline)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'user mis-config; not a bug.\n' > "$reasoning"
+  run "$HANDLERS/handle-non-issue.sh" 42 "$reasoning"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh issue comment 42 --body-file')" -ge 1 ]
+  # No --body inline form anywhere (passthrough discipline).
+  [ "$(gh_log_count 'gh issue comment 42 --body ')" -eq 0 ]
+}
+
+@test "non-issue: closes the issue" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-non-issue.sh" 42 "$reasoning"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh issue close 42')" -ge 1 ]
+}
+
+@test "non-issue: gaia-triaged is the LAST mutation" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-non-issue.sh" 42 "$reasoning"
+  [ "$status" -eq 0 ]
+  triaged_line="$(gh_log_line_no '--add-label gaia-triaged')"
+  total_lines="$(wc -l < "$GH_LOG" | tr -d ' ')"
+  [ "$triaged_line" = "$total_lines" ]
+}
+
+@test "non-issue: comment body contains the verdict header and reasoning" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'sentinel-reason-line\n' > "$reasoning"
+  run "$HANDLERS/handle-non-issue.sh" 42 "$reasoning"
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'verdict: non-issue' "$body_path"
+  grep -qF 'sentinel-reason-line' "$body_path"
+}
+
+# ---------------------------------------------------------------------------
+# handle-needs-human.sh — UAT-003 / UAT-005 / UAT-007 / UAT-014
+# ---------------------------------------------------------------------------
+
+@test "needs-human: usage error with too few args" {
+  run "$HANDLERS/handle-needs-human.sh" 42
+  [ "$status" -eq 2 ]
+}
+
+@test "needs-human: rejects unknown reason-code" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" not-a-real-reason
+  [ "$status" -eq 2 ]
+}
+
+@test "needs-human: applies needs-human label" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count '--add-label needs-human')" -ge 1 ]
+}
+
+@test "needs-human: never closes the issue" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh issue close')" -eq 0 ]
+}
+
+@test "needs-human: comment mentions @stevensacks (UAT-003)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF '@stevensacks' "$body_path"
+}
+
+@test "needs-human: comment names the reason-code out-of-scope (UAT-007/UAT-014)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'out-of-scope' "$body_path"
+  grep -qF 'UAT-007' "$body_path"
+}
+
+@test "needs-human: comment names the reason-code gate-failure (UAT-005)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'gate failure detail\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" gate-failure
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'gate-failure' "$body_path"
+  grep -qF 'UAT-005' "$body_path"
+}
+
+@test "needs-human: comment names the reason-code ambiguous-verdict (UAT-003b)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'ambiguous\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" ambiguous-verdict
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'ambiguous-verdict' "$body_path"
+}
+
+@test "needs-human: gaia-triaged is the LAST mutation" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'x\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
+  [ "$status" -eq 0 ]
+  triaged_line="$(gh_log_line_no '--add-label gaia-triaged')"
+  total_lines="$(wc -l < "$GH_LOG" | tr -d ' ')"
+  [ "$triaged_line" = "$total_lines" ]
+}
+
+# ---------------------------------------------------------------------------
+# handle-auto-fixable.sh — UAT-004 / UAT-008 / UAT-015
+# ---------------------------------------------------------------------------
+
+@test "auto-fixable: usage error with too few args" {
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate
+  [ "$status" -eq 2 ]
+}
+
+@test "auto-fixable: missing pr body file exits 2" {
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$BATS_TEST_TMPDIR/nope"
+  [ "$status" -eq 2 ]
+}
+
+@test "auto-fixable: missing remote branch exits 1" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf '## Capture\nverbatim\n' > "$body"
+  GIT_LS_REMOTE_FAIL=1 run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 1 ]
+  # No gh write calls when the sanity check fails — guard against
+  # half-applied state.
+  [ "$(gh_log_count 'gh issue edit')" -eq 0 ]
+  [ "$(gh_log_count 'gh pr create')" -eq 0 ]
+}
+
+@test "auto-fixable: invokes gh pr create with --draft (UAT-008)" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf '## Capture\nverbatim\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh pr create')" -ge 1 ]
+  [ "$(gh_log_count '--draft')" -ge 1 ]
+}
+
+@test "auto-fixable: pr create uses --base main and the supplied --head" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  pr_line="$(grep -F 'gh pr create' "$GH_LOG")"
+  [[ "$pr_line" == *'--base main'* ]]
+  [[ "$pr_line" == *'--head forensics/42-quality-gate'* ]]
+}
+
+@test "auto-fixable: pr body passed via --body-file (UAT-015 passthrough)" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf '## Capture\n```\napi_key: <redacted>\n```\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  pr_line="$(grep -F 'gh pr create' "$GH_LOG")"
+  [[ "$pr_line" == *'--body-file'* ]]
+  # Inline --body must NOT appear — passthrough goes through file only.
+  [[ "$pr_line" != *'--body '* ]]
+}
+
+@test "auto-fixable: applies auto-fixable + gaia-bug-confirmed labels" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count '--add-label auto-fixable')" -ge 1 ]
+  [ "$(gh_log_count '--add-label gaia-bug-confirmed')" -ge 1 ]
+}
+
+@test "auto-fixable: posts a link-back comment via --body-file" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh issue comment 42 --body-file')" -ge 1 ]
+}
+
+@test "auto-fixable: gaia-triaged is the LAST mutation" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  triaged_line="$(gh_log_line_no '--add-label gaia-triaged')"
+  total_lines="$(wc -l < "$GH_LOG" | tr -d ' ')"
+  [ "$triaged_line" = "$total_lines" ]
+}
+
+@test "auto-fixable: never invokes gh pr merge or gh pr ready (UAT-008)" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count 'gh pr merge')" -eq 0 ]
+  [ "$(gh_log_count 'gh pr ready')" -eq 0 ]
+}
+
+@test "auto-fixable: never modifies the issue body (only labels and comments)" {
+  body="$BATS_TEST_TMPDIR/pr.md"
+  printf 'x\n' > "$body"
+  run "$HANDLERS/handle-auto-fixable.sh" 42 quality-gate forensics/42-quality-gate "$body"
+  [ "$status" -eq 0 ]
+  # `gh issue edit --body` would be a body mutation; the only --body* we
+  # tolerate on the issue is `gh issue comment --body-file`.
+  [ "$(gh_log_count 'gh issue edit 42 --body')" -eq 0 ]
+  [ "$(gh_log_count 'gh issue edit 42 --title')" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# handle-malformed-body.sh — UAT-013
+# ---------------------------------------------------------------------------
+
+@test "malformed-body: usage error with no args" {
+  run "$HANDLERS/handle-malformed-body.sh"
+  [ "$status" -eq 2 ]
+}
+
+@test "malformed-body: missing parser output exits 2" {
+  run "$HANDLERS/handle-malformed-body.sh" 42 "$BATS_TEST_TMPDIR/nope"
+  [ "$status" -eq 2 ]
+}
+
+@test "malformed-body: applies needs-human label and stays open" {
+  parser="$BATS_TEST_TMPDIR/p.json"
+  printf '{"valid":false,"error":"missing-section","missing":["symptom"],"malformed":[]}\n' > "$parser"
+  run "$HANDLERS/handle-malformed-body.sh" 42 "$parser"
+  [ "$status" -eq 0 ]
+  [ "$(gh_log_count '--add-label needs-human')" -ge 1 ]
+  [ "$(gh_log_count 'gh issue close')" -eq 0 ]
+}
+
+@test "malformed-body: comment names missing sections from parser output" {
+  parser="$BATS_TEST_TMPDIR/p.json"
+  printf '{"valid":false,"error":"missing-section","missing":["symptom","capture"],"malformed":[]}\n' > "$parser"
+  run "$HANDLERS/handle-malformed-body.sh" 42 "$parser"
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'symptom' "$body_path"
+  grep -qF 'capture' "$body_path"
+  grep -qF 'missing-section' "$body_path"
+  grep -qF 'UAT-013' "$body_path"
+}
+
+@test "malformed-body: comment names malformed sections from parser output" {
+  parser="$BATS_TEST_TMPDIR/p.json"
+  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n' > "$parser"
+  run "$HANDLERS/handle-malformed-body.sh" 42 "$parser"
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'frontmatter' "$body_path"
+  grep -qF 'malformed-frontmatter' "$body_path"
+}
+
+@test "malformed-body: gaia-triaged is the LAST mutation" {
+  parser="$BATS_TEST_TMPDIR/p.json"
+  printf '{"valid":false,"error":"missing-section","missing":["symptom"],"malformed":[]}\n' > "$parser"
+  run "$HANDLERS/handle-malformed-body.sh" 42 "$parser"
+  [ "$status" -eq 0 ]
+  triaged_line="$(gh_log_line_no '--add-label gaia-triaged')"
+  total_lines="$(wc -l < "$GH_LOG" | tr -d ' ')"
+  [ "$triaged_line" = "$total_lines" ]
+}
+
+# ---------------------------------------------------------------------------
+# handle-already-triaged.sh — UAT-006
+# ---------------------------------------------------------------------------
+
+@test "already-triaged: usage error with no args" {
+  run "$HANDLERS/handle-already-triaged.sh"
+  [ "$status" -eq 2 ]
+}
+
+@test "already-triaged: emits ::notice:: and exits 0" {
+  run "$HANDLERS/handle-already-triaged.sh" 42
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'::notice::'* ]]
+  [[ "$output" == *'#42'* ]]
+  [[ "$output" == *'already triaged'* ]]
+}
+
+@test "already-triaged: makes zero gh / git calls (no-op)" {
+  run "$HANDLERS/handle-already-triaged.sh" 42
+  [ "$status" -eq 0 ]
+  # gh and git logs may not even exist — that's the no-op contract.
+  if [ -f "$GH_LOG" ]; then
+    [ "$(wc -l < "$GH_LOG" | tr -d ' ')" = "0" ]
+  fi
+  if [ -f "$GIT_LOG" ]; then
+    [ "$(wc -l < "$GIT_LOG" | tr -d ' ')" = "0" ]
+  fi
+}

--- a/.github/forensics/tests/parse-issue-body.bats
+++ b/.github/forensics/tests/parse-issue-body.bats
@@ -1,0 +1,294 @@
+#!/usr/bin/env bats
+# Tests for `.github/forensics/parse-issue-body.sh`.
+#
+# Coverage targets the SPEC-002 UATs that touch body-parsing:
+#   UAT-009  deterministic regex extraction (no LLM)
+#   UAT-013  malformed body → needs-human signal (script returns
+#            valid=false with a precise error code)
+#   UAT-015  redaction tokens pass through verbatim
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  PARSER="$THIS_DIR/../parse-issue-body.sh"
+  FIX="$THIS_DIR/fixtures"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: a SPEC-001-conformant body parses to valid JSON with the four
+# required sections and the three required frontmatter keys.
+# ---------------------------------------------------------------------------
+
+@test "valid body returns valid:true" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+}
+
+@test "valid body extracts class from frontmatter" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"class":"quality-gate"'* ]]
+}
+
+@test "valid body extracts gaia_version from frontmatter" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"gaia_version":"1.4.2"'* ]]
+}
+
+@test "valid body extracts created from frontmatter" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"created":"2026-05-08"'* ]]
+}
+
+@test "valid body extracts optional gh_issue_url when present" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"gh_issue_url":"https://github.com/gaia-react/gaia/issues/123"'* ]]
+}
+
+@test "valid body extracts symptom section" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  # Body contains backtick-fenced inline code; ensure it survives.
+  [[ "$output" == *'pnpm typecheck'* ]]
+  [[ "$output" == *'TS2304'* ]]
+}
+
+@test "valid body extracts classification section" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'class: quality-gate'* ]]
+  [[ "$output" == *'evidence:'* ]]
+}
+
+@test "valid body extracts capture section preserving fenced block" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'node_version: v20.11.0'* ]]
+  [[ "$output" == *'pnpm_version: 9.0.0'* ]]
+}
+
+@test "valid body extracts reproduction_context section" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'.claude/hooks/wiki-session-stop.sh'* ]]
+  [[ "$output" == *'.claude/hooks/post-tool.sh'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Failure modes — UAT-013 (malformed body → needs-human without LLM).
+# Each failure emits valid:false plus a precise error code.
+# ---------------------------------------------------------------------------
+
+@test "missing symptom returns missing-section" {
+  run "$PARSER" "$FIX/missing-symptom.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"missing-section"'* ]]
+  [[ "$output" == *'"symptom"'* ]]
+}
+
+@test "missing frontmatter returns malformed-frontmatter" {
+  run "$PARSER" "$FIX/missing-frontmatter.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+}
+
+@test "malformed section header returns malformed-section-header" {
+  run "$PARSER" "$FIX/malformed-section-header.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"malformed-section-header"'* ]]
+  [[ "$output" == *'"Bogus Header"'* ]]
+}
+
+@test "frontmatter without closing delimiter returns malformed-frontmatter" {
+  body_file="$BATS_TEST_TMPDIR/no-close.md"
+  cat > "$body_file" <<'EOF'
+---
+class: hook
+gaia_version: 1.4.2
+created: 2026-05-08
+
+## Symptom
+
+Body without the closing frontmatter delimiter.
+
+## Classification
+
+class: hook
+evidence: none.
+
+## Capture
+
+```
+empty
+```
+
+## Reproduction context
+
+- `.claude/hooks/x.sh`
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+}
+
+@test "frontmatter missing required key returns malformed-frontmatter" {
+  body_file="$BATS_TEST_TMPDIR/no-class.md"
+  cat > "$body_file" <<'EOF'
+---
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Symptom
+
+x
+
+## Classification
+
+x
+
+## Capture
+
+x
+
+## Reproduction context
+
+x
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+}
+
+@test "empty section body returns empty-section" {
+  body_file="$BATS_TEST_TMPDIR/empty-symptom.md"
+  cat > "$body_file" <<'EOF'
+---
+class: hook
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+## Symptom
+
+## Classification
+
+x
+
+## Capture
+
+x
+
+## Reproduction context
+
+x
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"empty-section"'* ]]
+  [[ "$output" == *'"symptom"'* ]]
+}
+
+@test "all four sections missing reports them all" {
+  body_file="$BATS_TEST_TMPDIR/no-sections.md"
+  cat > "$body_file" <<'EOF'
+---
+class: other
+gaia_version: 1.4.2
+created: 2026-05-08
+---
+
+just freeform text, no headers at all.
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *'"error":"missing-section"'* ]]
+  [[ "$output" == *'"symptom"'* ]]
+  [[ "$output" == *'"classification"'* ]]
+  [[ "$output" == *'"capture"'* ]]
+  [[ "$output" == *'"reproduction_context"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# UAT-015 — redaction tokens pass through verbatim.
+# ---------------------------------------------------------------------------
+
+@test "redaction tokens pass through symptom verbatim" {
+  run "$PARSER" "$FIX/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<redacted>'* ]]
+}
+
+@test "redaction tokens pass through capture verbatim" {
+  run "$PARSER" "$FIX/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  # capture section contains both tokens; both must appear byte-identically.
+  [[ "$output" == *'api_key: <redacted>'* ]]
+  [[ "$output" == *'config_path: <repo-relative-paths>'* ]]
+  [[ "$output" == *'git_branch: feature/<redacted>-fix'* ]]
+}
+
+@test "redaction tokens pass through reproduction_context verbatim" {
+  run "$PARSER" "$FIX/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'- `<repo-relative-paths>`'* ]]
+  [[ "$output" == *'file at `<repo-relative-paths>` referencing `<redacted>`'* ]]
+}
+
+@test "optional gh_issue_url is null when absent from frontmatter" {
+  run "$PARSER" "$FIX/redaction-passthrough.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"gh_issue_url":null'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# CLI / script-error contract.
+# ---------------------------------------------------------------------------
+
+@test "no args prints usage and exits 2" {
+  run "$PARSER"
+  [ "$status" -eq 2 ]
+}
+
+@test "missing input file exits 2" {
+  run "$PARSER" "$BATS_TEST_TMPDIR/does-not-exist.md"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Determinism — re-running on the same input is byte-identical (UAT-009
+# in spirit: deterministic, not LLM-touched).
+# ---------------------------------------------------------------------------
+
+@test "parser output is byte-identical across two runs (determinism)" {
+  run "$PARSER" "$FIX/valid.md"
+  first="$output"
+  run "$PARSER" "$FIX/valid.md"
+  [ "$output" = "$first" ]
+}
+
+# ---------------------------------------------------------------------------
+# JSON shape sanity — make sure the success JSON contains all required
+# top-level keys.
+# ---------------------------------------------------------------------------
+
+@test "success JSON contains frontmatter and sections objects" {
+  run "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"frontmatter":{'* ]]
+  [[ "$output" == *'"sections":{'* ]]
+  [[ "$output" == *'"symptom":'* ]]
+  [[ "$output" == *'"classification":'* ]]
+  [[ "$output" == *'"capture":'* ]]
+  [[ "$output" == *'"reproduction_context":'* ]]
+}

--- a/.github/forensics/tests/parse-verdict.bats
+++ b/.github/forensics/tests/parse-verdict.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+# Tests for `.github/forensics/parse-verdict.sh`.
+#
+# Coverage maps to SPEC-002 UAT-003 case (b) — the classifier output is
+# parsed deterministically; ambiguity routes to `needs-human` without any
+# LLM fallback.
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  PARSER="$THIS_DIR/../parse-verdict.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Clean verdicts — one verdict line, last non-blank line, value in the
+# closed set.
+# ---------------------------------------------------------------------------
+
+@test "clean non-issue verdict parses to non-issue" {
+  body_file="$BATS_TEST_TMPDIR/clean-non-issue.txt"
+  cat > "$body_file" <<'EOF'
+The reporter is missing the `gh` CLI prerequisite documented in the
+README. This is a user-config issue, not a GAIA defect.
+
+GAIA-VERDICT: non-issue
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"non-issue"'* ]]
+}
+
+@test "clean needs-human verdict parses to needs-human" {
+  body_file="$BATS_TEST_TMPDIR/clean-needs-human.txt"
+  cat > "$body_file" <<'EOF'
+The fix would require touching `app/routes/`, which is on the canonical
+denylist. Escalating to the maintainer.
+
+GAIA-VERDICT: needs-human
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"needs-human"'* ]]
+}
+
+@test "clean auto-fixable with proposed paths parses to auto-fixable" {
+  body_file="$BATS_TEST_TMPDIR/clean-auto-fixable.txt"
+  cat > "$body_file" <<'EOF'
+The hook at `.claude/hooks/wiki-session-stop.sh` references a function
+that no longer exists in `.gaia/cli/wiki/sync.ts`.
+
+### Proposed paths
+
+```
+.claude/hooks/wiki-session-stop.sh
+.gaia/cli/wiki/sync.ts
+```
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"auto-fixable"'* ]]
+  [[ "$output" == *'"proposed_paths":["'.claude/hooks/wiki-session-stop.sh'","'.gaia/cli/wiki/sync.ts'"]'* ]]
+}
+
+@test "auto-fixable proposed_paths preserved in order" {
+  body_file="$BATS_TEST_TMPDIR/paths-order.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+### Proposed paths
+
+```
+zzz/last.ts
+aaa/first.ts
+mmm/middle.ts
+```
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"proposed_paths":["zzz/last.ts","aaa/first.ts","mmm/middle.ts"]'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Ambiguity — no verdict line.
+# ---------------------------------------------------------------------------
+
+@test "no GAIA-VERDICT line returns ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/no-verdict.txt"
+  cat > "$body_file" <<'EOF'
+The reporter has a misconfigured environment. They should fix it.
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+@test "empty input returns ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/empty.txt"
+  : > "$body_file"
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Ambiguity — multiple GAIA-VERDICT lines (UAT-003 case b).
+# ---------------------------------------------------------------------------
+
+@test "two conflicting verdict lines return ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/two-conflicting.txt"
+  cat > "$body_file" <<'EOF'
+First take: this is a non-issue.
+
+GAIA-VERDICT: non-issue
+
+Wait, on reflection it should be needs-human.
+
+GAIA-VERDICT: needs-human
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+@test "two duplicate verdict lines return ambiguous (strict one-line contract)" {
+  body_file="$BATS_TEST_TMPDIR/two-duplicate.txt"
+  cat > "$body_file" <<'EOF'
+GAIA-VERDICT: non-issue
+
+GAIA-VERDICT: non-issue
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Ambiguity — malformed verdict value.
+# ---------------------------------------------------------------------------
+
+@test "verdict value outside closed set returns ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/bad-value.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+GAIA-VERDICT: maybe
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+@test "verdict value with trailing punctuation returns ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/punctuation.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+GAIA-VERDICT: non-issue.
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Ambiguity — verdict line is not the last non-blank line.
+# ---------------------------------------------------------------------------
+
+@test "verdict line followed by content returns ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/trailing-content.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+GAIA-VERDICT: non-issue
+
+Note: actually I changed my mind.
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# auto-fixable contract — must include a parseable proposed-paths fence.
+# ---------------------------------------------------------------------------
+
+@test "auto-fixable verdict without proposed_paths section downgrades to ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/auto-no-paths.txt"
+  cat > "$body_file" <<'EOF'
+Looks fixable to me.
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+  [[ "$output" == *'"proposed_paths":[]'* ]]
+}
+
+@test "auto-fixable verdict with header but no fence downgrades to ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/paths-no-fence.txt"
+  cat > "$body_file" <<'EOF'
+Looks fixable.
+
+### Proposed paths
+
+.gaia/cli/foo.ts
+.claude/hooks/bar.sh
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+  [[ "$output" == *'"proposed_paths":[]'* ]]
+}
+
+@test "auto-fixable verdict with empty fence downgrades to ambiguous" {
+  body_file="$BATS_TEST_TMPDIR/paths-empty-fence.txt"
+  cat > "$body_file" <<'EOF'
+Looks fixable.
+
+### Proposed paths
+
+```
+```
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"ambiguous"'* ]]
+  [[ "$output" == *'"proposed_paths":[]'* ]]
+}
+
+@test "auto-fixable with fence using language tag still parses paths" {
+  body_file="$BATS_TEST_TMPDIR/fence-lang.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+### Proposed paths
+
+```text
+.gaia/cli/x.ts
+```
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"auto-fixable"'* ]]
+  [[ "$output" == *'"proposed_paths":[".gaia/cli/x.ts"]'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# non-issue / needs-human verdicts ignore proposed_paths existence — only
+# auto-fixable requires them.
+# ---------------------------------------------------------------------------
+
+@test "non-issue verdict does not require proposed_paths" {
+  body_file="$BATS_TEST_TMPDIR/non-issue-nopaths.txt"
+  cat > "$body_file" <<'EOF'
+Not a defect.
+
+GAIA-VERDICT: non-issue
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"non-issue"'* ]]
+  [[ "$output" == *'"proposed_paths":[]'* ]]
+}
+
+@test "needs-human verdict does not require proposed_paths" {
+  body_file="$BATS_TEST_TMPDIR/needs-human-nopaths.txt"
+  cat > "$body_file" <<'EOF'
+Out of scope.
+
+GAIA-VERDICT: needs-human
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"verdict":"needs-human"'* ]]
+  [[ "$output" == *'"proposed_paths":[]'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Reasoning extraction — everything before the verdict line, with one
+# trailing blank line trimmed.
+# ---------------------------------------------------------------------------
+
+@test "reasoning captures content before verdict line" {
+  body_file="$BATS_TEST_TMPDIR/reasoning.txt"
+  cat > "$body_file" <<'EOF'
+This is the analysis paragraph that the maintainer reads.
+
+GAIA-VERDICT: non-issue
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reasoning":"This is the analysis paragraph that the maintainer reads."'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# CLI contract.
+# ---------------------------------------------------------------------------
+
+@test "no args prints usage and exits 2" {
+  run "$PARSER"
+  [ "$status" -eq 2 ]
+}
+
+@test "missing input file exits 2" {
+  run "$PARSER" "$BATS_TEST_TMPDIR/does-not-exist.txt"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Determinism — same input twice yields byte-identical output.
+# ---------------------------------------------------------------------------
+
+@test "parser output is byte-identical across two runs" {
+  body_file="$BATS_TEST_TMPDIR/det.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+### Proposed paths
+
+```
+.gaia/cli/x.ts
+```
+
+GAIA-VERDICT: auto-fixable
+EOF
+  run "$PARSER" "$body_file"
+  first="$output"
+  run "$PARSER" "$body_file"
+  [ "$output" = "$first" ]
+}

--- a/.github/forensics/tests/run-quality-gate.bats
+++ b/.github/forensics/tests/run-quality-gate.bats
@@ -1,0 +1,275 @@
+#!/usr/bin/env bats
+# Tests for `.github/forensics/run-quality-gate.sh`.
+#
+# Strategy: shim `pnpm` with a wrapper whose per-subcommand exit code is
+# driven by env vars (PNPM_INSTALL_EXIT, PNPM_TYPECHECK_EXIT, etc). The
+# shim also prints configurable stdout/stderr so the log-excerpt path
+# can be exercised. Each test verifies the JSON summary, the exit code,
+# and the halt-on-first-failure invariant.
+#
+# Coverage targets:
+#   - Halts on the FIRST failing step (no later step runs).
+#   - JSON summary names the failed step + non-zero exit_code + excerpt.
+#   - Excerpt is ≤2000 chars and ≤50 lines.
+#   - All-green path emits the steps_run array and exits 0.
+#   - Knip is in scope (failure → demote, identical to lint/test).
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  RUNNER="$THIS_DIR/../run-quality-gate.sh"
+
+  SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+  mkdir -p "$SANDBOX/bin"
+  PNPM_LOG="$SANDBOX/pnpm.log"
+  export PNPM_LOG
+
+  # pnpm shim. Subcommand-aware: dispatches on $1 (install / typecheck /
+  # lint / test / knip). Exit code controlled per-step via env vars
+  # (default 0). Stdout content controlled via PNPM_<STEP>_STDOUT
+  # (default empty). Records every invocation to $PNPM_LOG.
+  cat > "$SANDBOX/bin/pnpm" <<'SHIM'
+#!/usr/bin/env bash
+{
+  printf 'pnpm'
+  for a in "$@"; do
+    printf ' %q' "$a"
+  done
+  printf '\n'
+} >> "$PNPM_LOG"
+
+step="$1"
+case "$step" in
+  install)   exit_var="PNPM_INSTALL_EXIT";   stdout_var="PNPM_INSTALL_STDOUT" ;;
+  typecheck) exit_var="PNPM_TYPECHECK_EXIT"; stdout_var="PNPM_TYPECHECK_STDOUT" ;;
+  lint)      exit_var="PNPM_LINT_EXIT";      stdout_var="PNPM_LINT_STDOUT" ;;
+  test)      exit_var="PNPM_TEST_EXIT";      stdout_var="PNPM_TEST_STDOUT" ;;
+  knip)      exit_var="PNPM_KNIP_EXIT";      stdout_var="PNPM_KNIP_STDOUT" ;;
+  *)         echo "shim: unknown subcommand: $step" >&2; exit 99 ;;
+esac
+
+exit_code="${!exit_var:-0}"
+stdout_content="${!stdout_var:-}"
+[ -n "$stdout_content" ] && printf '%s\n' "$stdout_content"
+exit "$exit_code"
+SHIM
+  chmod +x "$SANDBOX/bin/pnpm"
+
+  PATH="$SANDBOX/bin:$PATH"
+  export PATH
+
+  SUMMARY="$SANDBOX/summary.json"
+  export SUMMARY
+}
+
+# Helper: count pnpm-shim invocations by subcommand (matches the line
+# `pnpm <subcommand> ...`).
+pnpm_log_count() {
+  if [ ! -f "$PNPM_LOG" ]; then
+    printf '0'
+    return
+  fi
+  grep -cE "^pnpm ${1}( |$)" "$PNPM_LOG" || true
+}
+
+# ---------------------------------------------------------------------------
+# Usage / argument validation
+# ---------------------------------------------------------------------------
+
+@test "usage error with no args" {
+  run "$RUNNER"
+  [ "$status" -eq 2 ]
+}
+
+@test "usage error with too many args" {
+  run "$RUNNER" a b
+  [ "$status" -eq 2 ]
+}
+
+@test "errors when summary file's parent dir does not exist" {
+  run "$RUNNER" "$BATS_TEST_TMPDIR/no-such-dir/out.json"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# All-green path
+# ---------------------------------------------------------------------------
+
+@test "all-green: exits 0 and writes passed-true summary" {
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  [ -f "$SUMMARY" ]
+  grep -qF '"passed": true' "$SUMMARY"
+}
+
+@test "all-green: summary names every step in steps_run" {
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  grep -qF '"install"' "$SUMMARY"
+  grep -qF '"typecheck"' "$SUMMARY"
+  grep -qF '"lint"' "$SUMMARY"
+  grep -qF '"test"' "$SUMMARY"
+  grep -qF '"knip"' "$SUMMARY"
+}
+
+@test "all-green: each pnpm step is invoked exactly once, in order" {
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  [ "$(pnpm_log_count install)" = "1" ]
+  [ "$(pnpm_log_count typecheck)" = "1" ]
+  [ "$(pnpm_log_count lint)" = "1" ]
+  [ "$(pnpm_log_count test)" = "1" ]
+  [ "$(pnpm_log_count knip)" = "1" ]
+  # Order: install before typecheck before lint before test before knip.
+  install_line=$(grep -nE '^pnpm install( |$)' "$PNPM_LOG" | head -1 | cut -d: -f1)
+  typecheck_line=$(grep -nE '^pnpm typecheck( |$)' "$PNPM_LOG" | head -1 | cut -d: -f1)
+  lint_line=$(grep -nE '^pnpm lint( |$)' "$PNPM_LOG" | head -1 | cut -d: -f1)
+  test_line=$(grep -nE '^pnpm test( |$)' "$PNPM_LOG" | head -1 | cut -d: -f1)
+  knip_line=$(grep -nE '^pnpm knip( |$)' "$PNPM_LOG" | head -1 | cut -d: -f1)
+  [ "$install_line" -lt "$typecheck_line" ]
+  [ "$typecheck_line" -lt "$lint_line" ]
+  [ "$lint_line" -lt "$test_line" ]
+  [ "$test_line" -lt "$knip_line" ]
+}
+
+@test "all-green: install uses --frozen-lockfile" {
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  grep -qE '^pnpm install --frozen-lockfile' "$PNPM_LOG"
+}
+
+@test "all-green: test step uses --run (vitest non-watch)" {
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  grep -qE '^pnpm test --run' "$PNPM_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Halt-on-first-fail per step
+# ---------------------------------------------------------------------------
+
+@test "fail at install: halts immediately, no later steps run" {
+  PNPM_INSTALL_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [ "$(pnpm_log_count install)" = "1" ]
+  [ "$(pnpm_log_count typecheck)" = "0" ]
+  [ "$(pnpm_log_count lint)" = "0" ]
+  [ "$(pnpm_log_count test)" = "0" ]
+  [ "$(pnpm_log_count knip)" = "0" ]
+  grep -qF '"passed": false' "$SUMMARY"
+  grep -qF '"failed_step": "install"' "$SUMMARY"
+}
+
+@test "fail at typecheck: install ran, typecheck ran, nothing after" {
+  PNPM_TYPECHECK_EXIT=2 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [ "$(pnpm_log_count install)" = "1" ]
+  [ "$(pnpm_log_count typecheck)" = "1" ]
+  [ "$(pnpm_log_count lint)" = "0" ]
+  [ "$(pnpm_log_count test)" = "0" ]
+  [ "$(pnpm_log_count knip)" = "0" ]
+  grep -qF '"failed_step": "typecheck"' "$SUMMARY"
+  grep -qF '"exit_code": 2' "$SUMMARY"
+}
+
+@test "fail at lint: nothing after lint runs" {
+  PNPM_LINT_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [ "$(pnpm_log_count lint)" = "1" ]
+  [ "$(pnpm_log_count test)" = "0" ]
+  [ "$(pnpm_log_count knip)" = "0" ]
+  grep -qF '"failed_step": "lint"' "$SUMMARY"
+}
+
+@test "fail at test: knip never runs" {
+  PNPM_TEST_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [ "$(pnpm_log_count test)" = "1" ]
+  [ "$(pnpm_log_count knip)" = "0" ]
+  grep -qF '"failed_step": "test"' "$SUMMARY"
+}
+
+@test "fail at knip: knip failure is treated identically to lint/test" {
+  PNPM_KNIP_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [ "$(pnpm_log_count knip)" = "1" ]
+  grep -qF '"passed": false' "$SUMMARY"
+  grep -qF '"failed_step": "knip"' "$SUMMARY"
+  grep -qF '"exit_code": 1' "$SUMMARY"
+}
+
+# ---------------------------------------------------------------------------
+# Log excerpt fidelity
+# ---------------------------------------------------------------------------
+
+@test "failure summary includes a log_excerpt field" {
+  PNPM_LINT_STDOUT="error TS2304: cannot find name foo" PNPM_LINT_EXIT=1 \
+    run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  grep -qF '"log_excerpt":' "$SUMMARY"
+  grep -qF 'cannot find name foo' "$SUMMARY"
+}
+
+@test "log excerpt is bounded to <= 2000 chars" {
+  # Generate a 4000-char single-line payload; the runner should clip it.
+  big=""
+  i=0
+  while [ "$i" -lt 4000 ]; do
+    big="${big}x"
+    i=$((i + 1))
+  done
+  PNPM_TEST_STDOUT="$big" PNPM_TEST_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  # Pull just the log_excerpt string value via awk; verify length.
+  excerpt_len=$(awk 'BEGIN { RS = ""; FS = "\"log_excerpt\": \"" } NR==1 { sub(/".*/, "", $2); print length($2) }' "$SUMMARY")
+  [ "$excerpt_len" -le 2000 ]
+}
+
+@test "log excerpt is bounded to <= 50 lines" {
+  # 200 short lines; runner trims to last 50.
+  many=""
+  i=0
+  while [ "$i" -lt 200 ]; do
+    many="${many}line-${i}"$'\n'
+    i=$((i + 1))
+  done
+  PNPM_TEST_STDOUT="$many" PNPM_TEST_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  # The excerpt is JSON-escaped so each newline shows as \n; count those.
+  newline_count=$(awk 'BEGIN { RS = ""; FS = "\"log_excerpt\": \"" } NR==1 { sub(/".*/, "", $2); n = gsub(/\\n/, "&", $2); print n }' "$SUMMARY")
+  [ "$newline_count" -le 50 ]
+  # And the LAST line (line-199) must be retained — tail-50, not head-50.
+  grep -qF 'line-199' "$SUMMARY"
+  # An EARLY line dropped by the tail trim must NOT be present.
+  ! grep -qF 'line-0\\n' "$SUMMARY"
+}
+
+# ---------------------------------------------------------------------------
+# JSON shape sanity
+# ---------------------------------------------------------------------------
+
+@test "summary is parseable as JSON (jq) on pass" {
+  command -v jq >/dev/null || skip "jq not installed"
+  run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 0 ]
+  run jq -e '.passed == true' "$SUMMARY"
+  [ "$status" -eq 0 ]
+}
+
+@test "summary is parseable as JSON (jq) on fail" {
+  command -v jq >/dev/null || skip "jq not installed"
+  PNPM_LINT_STDOUT="boom" PNPM_LINT_EXIT=1 run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  run jq -e '.passed == false and .failed_step == "lint" and .exit_code == 1' "$SUMMARY"
+  [ "$status" -eq 0 ]
+}
+
+@test "summary JSON-escapes embedded quotes and backslashes" {
+  command -v jq >/dev/null || skip "jq not installed"
+  PNPM_LINT_STDOUT='msg with "quote" and \backslash' PNPM_LINT_EXIT=1 \
+    run "$RUNNER" "$SUMMARY"
+  [ "$status" -eq 1 ]
+  run jq -er '.log_excerpt' "$SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"quote"'* ]]
+  [[ "$output" == *'\backslash'* ]]
+}

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -1,0 +1,741 @@
+name: Forensics Triage
+
+# SPEC-002 phase 2: autonomous Claude Code triage for `gaia-forensics`-labeled
+# issues. Spec lives at `.gaia/local/specs/SPEC-002.md`; the per-task plan is at
+# `.gaia/local/plans/spec-002-forensics-triage-action/`.
+#
+# This file is on the canonical denylist (`.github/workflows/`). Future
+# autonomous triage runs MUST NOT modify it. Self-modifying triage is a
+# security boundary violation; the workflow's `check-scope.sh` rejects any
+# attempt to edit any path under `.github/workflows/`.
+#
+# Pinned action SHAs:
+#   anthropics/claude-code-action @ 63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 (v1.0)
+#   actions/checkout              @ 93cb6efe18208431cddfb8368fd83d5badbf9bfd (v5.0.1)
+#   actions/setup-node            @ a0853c24544627f65ddf259abe73b1d18a591444 (v5.0.0)
+#   pnpm/action-setup             @ 8912a9102ac27614460f54aedde9e1e7f9aec20d (v6.0.5)
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions: {}
+
+jobs:
+  triage:
+    name: Triage gaia-forensics issue
+    if: contains(github.event.issue.labels.*.name, 'gaia-forensics')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+      actions: read
+    concurrency:
+      group: forensics-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      FORENSICS_DIR: .github/forensics
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      # ----------------------------------------------------------------
+      # UAT-006: idempotency early-exit. If `gaia-triaged` is already on
+      # the issue, run `handle-already-triaged.sh` and skip the rest. The
+      # always-run final step (gaia-triaged-fallback) detects this via
+      # `already_triaged == 'true'` and skips its own application too.
+      # ----------------------------------------------------------------
+      - name: Idempotency check
+        id: idempotency
+        run: |
+          set -eu
+          labels="$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")')"
+          echo "labels=$labels"
+          if printf '%s' ",$labels," | grep -q ',gaia-triaged,'; then
+            echo "already_triaged=true" >> "$GITHUB_OUTPUT"
+            "$FORENSICS_DIR/handlers/handle-already-triaged.sh" "$ISSUE_NUMBER"
+          else
+            echo "already_triaged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ----------------------------------------------------------------
+      # UAT-013: deterministic body parser. If the body is malformed, run
+      # `handle-malformed-body.sh` (labels needs-human, names the missing
+      # / malformed sections, no LLM fallback) and end the meaningful
+      # work. The final fallback step still applies `gaia-triaged`.
+      # ----------------------------------------------------------------
+      - name: Write issue body to file
+        if: steps.idempotency.outputs.already_triaged != 'true'
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -eu
+          mkdir -p "${RUNNER_TEMP}/forensics"
+          # `printf '%s'` (not echo) preserves embedded backslashes / formatting
+          # exactly. Body content reaches the script via env, never argv —
+          # avoids shell-metacharacter injection.
+          printf '%s' "$ISSUE_BODY" > "${RUNNER_TEMP}/forensics/issue-body.md"
+
+      - name: Parse issue body
+        id: parse
+        if: steps.idempotency.outputs.already_triaged != 'true'
+        run: |
+          set -eu
+          parsed_file="${RUNNER_TEMP}/forensics/parsed.json"
+          "$FORENSICS_DIR/parse-issue-body.sh" "${RUNNER_TEMP}/forensics/issue-body.md" > "$parsed_file"
+          valid="$(jq -r '.valid' "$parsed_file")"
+          echo "parsed_file=$parsed_file" >> "$GITHUB_OUTPUT"
+          echo "valid=$valid" >> "$GITHUB_OUTPUT"
+
+      - name: Handle malformed body
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'false'
+        run: |
+          set -eu
+          "$FORENSICS_DIR/handlers/handle-malformed-body.sh" \
+            "$ISSUE_NUMBER" \
+            "${{ steps.parse.outputs.parsed_file }}"
+
+      # ----------------------------------------------------------------
+      # UAT-009 + UAT-010: classifier prompt. The LLM is invoked at
+      # exactly this step (judgment) and one more (fix application). All
+      # other extraction is deterministic.
+      #
+      # We render the prompt template here (placeholder substitution
+      # happens in shell, never in the model) and pass the rendered text
+      # to the action via the `prompt` input.
+      # ----------------------------------------------------------------
+      - name: Render classifier prompt
+        id: render-classifier
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true'
+        env:
+          PARSED_FILE: ${{ steps.parse.outputs.parsed_file }}
+        run: |
+          set -eu
+
+          # shellcheck disable=SC2016 # awk programs are intentionally single-quoted
+          symptom="$(jq -r '.sections.symptom' "$PARSED_FILE")"
+          classification="$(jq -r '.sections.classification' "$PARSED_FILE")"
+          capture="$(jq -r '.sections.capture' "$PARSED_FILE")"
+          repro="$(jq -r '.sections.reproduction_context' "$PARSED_FILE")"
+
+          # Defense-in-depth: mask anything that looks like a leftover
+          # secret in the parsed body. Phase 1 should have redacted these
+          # already (UAT-015 requires verbatim passthrough), but the
+          # workflow never trusts upstream. `::add-mask::` is a no-op for
+          # the redaction tokens themselves and only masks any literal
+          # secret-shaped bytes the parser might have surfaced.
+          mask_secret_shapes() {
+            printf '%s\n' "$1" | grep -oE 'sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}' | while IFS= read -r tok; do
+              [ -n "$tok" ] && echo "::add-mask::$tok"
+            done || true
+          }
+          mask_secret_shapes "$symptom"
+          mask_secret_shapes "$classification"
+          mask_secret_shapes "$capture"
+          mask_secret_shapes "$repro"
+
+          # The allowlist / denylist are markdown literals (backticks
+          # inside strings); shellcheck flags single-quoted strings that
+          # LOOK like command substitution. They're not — these are the
+          # canonical SPEC-002 path lists rendered into the classifier
+          # prompt verbatim. Disable SC2016 for this block.
+          # shellcheck disable=SC2016
+          allowlist='- `.gaia/cli/`
+          - `.claude/hooks/`
+          - `.claude/skills/`
+          - `.claude/commands/`
+          - `.claude/agents/`
+          - `.gaia/statusline/`
+          - `.specify/extensions/gaia/` (excluding `templates/`)
+          - `.gaia/manifest.json`'
+
+          # shellcheck disable=SC2016
+          denylist='- `app/`, `wiki/`, `studio/`, `website/`
+          - `.specify/specs/`, `.specify/memory/`
+          - `.gaia/local/specs/`
+          - `.specify/extensions/gaia/templates/`
+          - `.github/workflows/`'
+
+          template="$(cat "$FORENSICS_DIR/prompt.md")"
+          rendered_file="${RUNNER_TEMP}/forensics/classifier-prompt.md"
+
+          # Use awk for the substitutions: avoids the sed/`/`/`&` escaping
+          # nightmare with multi-line section content.
+          awk -v iss="$ISSUE_NUMBER" \
+              -v sym="$symptom" \
+              -v cls="$classification" \
+              -v cap="$capture" \
+              -v rep="$repro" \
+              -v al="$allowlist" \
+              -v dl="$denylist" '
+          {
+            line = $0
+            gsub(/\{\{ISSUE_NUMBER\}\}/, iss, line)
+            gsub(/\{\{SYMPTOM\}\}/, sym, line)
+            gsub(/\{\{CLASSIFICATION\}\}/, cls, line)
+            gsub(/\{\{CAPTURE\}\}/, cap, line)
+            gsub(/\{\{REPRO_CONTEXT\}\}/, rep, line)
+            gsub(/\{\{ALLOWLIST\}\}/, al, line)
+            gsub(/\{\{DENYLIST\}\}/, dl, line)
+            print line
+          }
+          ' <<< "$template" > "$rendered_file"
+
+          # Surface the rendered prompt as a step output via heredoc so
+          # the action invocation can consume it. The delimiter is a
+          # random hex string (the GitHub-recommended pattern) so it can
+          # never collide with content.
+          delim="EOF_$(openssl rand -hex 16)"
+          {
+            echo "rendered_file=$rendered_file"
+            echo "body<<$delim"
+            cat "$rendered_file"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Classify (Claude Code Action)
+        id: classify
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true'
+        uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: ${{ steps.render-classifier.outputs.body }}
+          # No tool access — judgment-only. The classifier MUST NOT
+          # touch the working tree (UAT-009).
+          claude_args: |
+            --max-turns 1
+            --disallowedTools Bash,Edit,Write,Read,WebFetch,WebSearch
+
+      - name: Extract verdict
+        id: verdict
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true'
+        env:
+          EXEC_FILE: ${{ steps.classify.outputs.execution_file }}
+        run: |
+          set -eu
+          # The action emits a JSONL execution log; the assistant's final
+          # response lives on the line where `type == "result"` (field
+          # `.result`). Extract that to a plain text file for parse-verdict.
+          verdict_text="${RUNNER_TEMP}/forensics/verdict-text.md"
+          if [ -z "${EXEC_FILE:-}" ] || [ ! -f "$EXEC_FILE" ]; then
+            echo "::error::classifier execution_file missing or unreadable: ${EXEC_FILE:-<empty>}"
+            exit 1
+          fi
+          jq -rs 'map(select(.type == "result")) | .[-1].result // empty' "$EXEC_FILE" > "$verdict_text"
+          if [ ! -s "$verdict_text" ]; then
+            echo "::warning::classifier produced no result text — treating as ambiguous"
+          fi
+
+          parsed="${RUNNER_TEMP}/forensics/verdict.json"
+          "$FORENSICS_DIR/parse-verdict.sh" "$verdict_text" > "$parsed"
+
+          verdict="$(jq -r '.verdict' "$parsed")"
+          echo "verdict=$verdict"
+
+          # Reasoning becomes the comment body for non-issue / needs-human.
+          reasoning="${RUNNER_TEMP}/forensics/reasoning.md"
+          jq -r '.reasoning' "$parsed" > "$reasoning"
+
+          {
+            echo "verdict=$verdict"
+            echo "verdict_file=$parsed"
+            echo "verdict_text=$verdict_text"
+            echo "reasoning_file=$reasoning"
+          } >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------------------------------
+      # UAT-003 case (b): ambiguous verdict → needs-human, reason-code
+      # `ambiguous-verdict`.
+      # ----------------------------------------------------------------
+      - name: Handle ambiguous verdict
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'ambiguous'
+        run: |
+          set -eu
+          "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+            "$ISSUE_NUMBER" \
+            "${{ steps.verdict.outputs.reasoning_file }}" \
+            "ambiguous-verdict"
+
+      # ----------------------------------------------------------------
+      # UAT-002: non-issue → close + comment + label.
+      # ----------------------------------------------------------------
+      - name: Handle non-issue
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'non-issue'
+        run: |
+          set -eu
+          "$FORENSICS_DIR/handlers/handle-non-issue.sh" \
+            "$ISSUE_NUMBER" \
+            "${{ steps.verdict.outputs.reasoning_file }}"
+
+      # ----------------------------------------------------------------
+      # UAT-003 case (a): needs-human verdict from the classifier.
+      # ----------------------------------------------------------------
+      - name: Handle needs-human (classifier verdict)
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'needs-human'
+        run: |
+          set -eu
+          "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+            "$ISSUE_NUMBER" \
+            "${{ steps.verdict.outputs.reasoning_file }}" \
+            "out-of-scope"
+
+      # ----------------------------------------------------------------
+      # auto-fixable path. UAT-007 / UAT-014: scope check is the FIRST
+      # gate; cross-boundary attempts fall through to needs-human before
+      # any branch is created.
+      # ----------------------------------------------------------------
+      - name: Scope check
+        id: scope
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable'
+        run: |
+          set -eu
+          paths_file="${RUNNER_TEMP}/forensics/proposed-paths.txt"
+          jq -r '.proposed_paths[]' "${{ steps.verdict.outputs.verdict_file }}" > "$paths_file"
+
+          # mapfile keeps shell-metacharacter-bearing paths intact (vs
+          # word-splitting). Empty array would have been caught by
+          # parse-verdict's downgrade-to-ambiguous rule.
+          mapfile -t paths < "$paths_file"
+          scope_json="${RUNNER_TEMP}/forensics/scope.json"
+          "$FORENSICS_DIR/check-scope.sh" "${paths[@]}" > "$scope_json"
+
+          ok="$(jq -r '.ok' "$scope_json")"
+          {
+            echo "ok=$ok"
+            echo "scope_file=$scope_json"
+            echo "paths_file=$paths_file"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Handle out-of-scope auto-fix
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'false'
+        run: |
+          set -eu
+          # Compose a reasoning file that names the offending paths so
+          # the maintainer can triage without re-reading the workflow log.
+          reason_file="${RUNNER_TEMP}/forensics/scope-reason.md"
+          # shellcheck disable=SC2016 # jq filter uses literal interpolation `\(.field)`
+          {
+            cat "${{ steps.verdict.outputs.reasoning_file }}"
+            printf '\n\n---\n\nProposed paths rejected by `check-scope.sh`:\n\n'
+            jq -r '.denied[] | "- `\(.path)` — \(.reason)"' "${{ steps.scope.outputs.scope_file }}"
+          } > "$reason_file"
+          "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+            "$ISSUE_NUMBER" \
+            "$reason_file" \
+            "out-of-scope"
+
+      # ----------------------------------------------------------------
+      # Branch creation + fix application + Quality Gate. Only fires when
+      # the verdict is `auto-fixable` AND every proposed path is in scope.
+      # ----------------------------------------------------------------
+      - name: Compute branch name
+        id: branch
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true'
+        env:
+          PARSED_FILE: ${{ steps.parse.outputs.parsed_file }}
+        run: |
+          set -eu
+          # The branch slug derives from the frontmatter `class` field
+          # (one of: init|update|wiki-sync|quality-gate|hook|scaffold|
+          # dev-server|other). That keeps branch names predictable and
+          # bounded in length, unlike using the issue title.
+          class_slug="$(jq -r '.frontmatter.class' "$PARSED_FILE" | tr 'A-Z ' 'a-z-' | tr -cd 'a-z0-9-')"
+          [ -z "$class_slug" ] && class_slug="other"
+          branch="forensics/${ISSUE_NUMBER}-${class_slug}"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+          echo "class_slug=$class_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Create fix branch from main
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true'
+        run: |
+          set -eu
+          git fetch origin main
+          git checkout -B "${{ steps.branch.outputs.name }}" origin/main
+          git config user.name 'gaia-forensics-triage[bot]'
+          git config user.email 'gaia-forensics-triage[bot]@users.noreply.github.com'
+
+      - name: Render apply-fix prompt
+        id: render-apply
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true'
+        env:
+          PARSED_FILE: ${{ steps.parse.outputs.parsed_file }}
+          VERDICT_FILE: ${{ steps.verdict.outputs.verdict_file }}
+        run: |
+          set -eu
+
+          symptom="$(jq -r '.sections.symptom' "$PARSED_FILE")"
+          capture="$(jq -r '.sections.capture' "$PARSED_FILE")"
+          repro="$(jq -r '.sections.reproduction_context' "$PARSED_FILE")"
+          reasoning="$(jq -r '.reasoning' "$VERDICT_FILE")"
+
+          # Each proposed path on its own line (the prompt fences the
+          # block; content is read-back-into-position via a single gsub).
+          paths_block="$(jq -r '.proposed_paths[]' "$VERDICT_FILE")"
+
+          template="$(cat "$FORENSICS_DIR/apply-fix-prompt.md")"
+          rendered_file="${RUNNER_TEMP}/forensics/apply-fix-prompt.md"
+
+          awk -v iss="$ISSUE_NUMBER" \
+              -v paths="$paths_block" \
+              -v reasoning="$reasoning" \
+              -v sym="$symptom" \
+              -v cap="$capture" \
+              -v rep="$repro" '
+          {
+            line = $0
+            gsub(/\{\{ISSUE_NUMBER\}\}/, iss, line)
+            gsub(/\{\{PROPOSED_PATHS\}\}/, paths, line)
+            gsub(/\{\{CLASSIFIER_REASONING\}\}/, reasoning, line)
+            gsub(/\{\{SYMPTOM\}\}/, sym, line)
+            gsub(/\{\{CAPTURE\}\}/, cap, line)
+            gsub(/\{\{REPRO_CONTEXT\}\}/, rep, line)
+            print line
+          }
+          ' <<< "$template" > "$rendered_file"
+
+          delim="EOF_$(openssl rand -hex 16)"
+          {
+            echo "body<<$delim"
+            cat "$rendered_file"
+            echo "$delim"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply fix (Claude Code Action)
+        id: apply-fix
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true'
+        uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: ${{ steps.render-apply.outputs.body }}
+          # File-edit tools only. NO Bash, NO git, NO push tools, NO web.
+          # Post-step verification asserts diffs touch only `proposed_paths`.
+          claude_args: |
+            --max-turns 30
+            --allowedTools Edit,Read,Write
+            --disallowedTools Bash,WebFetch,WebSearch
+
+      - name: Verify diff against proposed paths
+        id: verify-diff
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true'
+        run: |
+          set -eu
+
+          # set_outputs: emits one or more `key=value` pairs to
+          # $GITHUB_OUTPUT in a single block. Lets us collapse repeated
+          # write-and-exit branches without losing readability.
+          set_outputs() {
+            local kv
+            for kv in "$@"; do
+              printf '%s\n' "$kv"
+            done >> "$GITHUB_OUTPUT"
+          }
+
+          # Capture the apply-fix execution-file's last `result` line so we
+          # can detect the GAIA-FIX-ABORT escape hatch and surface the
+          # rationale to the maintainer.
+          apply_text="${RUNNER_TEMP}/forensics/apply-fix-text.md"
+          if [ -n "${{ steps.apply-fix.outputs.execution_file }}" ] \
+             && [ -f "${{ steps.apply-fix.outputs.execution_file }}" ]; then
+            jq -rs 'map(select(.type == "result")) | .[-1].result // empty' \
+              "${{ steps.apply-fix.outputs.execution_file }}" > "$apply_text"
+          else
+            : > "$apply_text"
+          fi
+          set_outputs "apply_text=$apply_text"
+
+          if grep -qE '^[[:space:]]*GAIA-FIX-ABORT:' "$apply_text"; then
+            set_outputs "diff_ok=false" "abort_reason=fix-abort"
+            exit 0
+          fi
+
+          # Stage edits so `git diff --staged` reflects everything the
+          # model touched (including new files and deletions).
+          git add -A
+          touched_file="${RUNNER_TEMP}/forensics/touched-paths.txt"
+          git diff --staged --name-only > "$touched_file"
+          set_outputs "touched_file=$touched_file"
+
+          if [ ! -s "$touched_file" ]; then
+            set_outputs "diff_ok=false" "abort_reason=empty-diff"
+            exit 0
+          fi
+
+          # Re-run check-scope on the actual touched paths. This is the
+          # post-step UAT-007 / UAT-014 backstop: even if the model lied
+          # about its proposed paths, the diff has to clear scope.
+          mapfile -t touched < "$touched_file"
+          touched_scope="${RUNNER_TEMP}/forensics/touched-scope.json"
+          "$FORENSICS_DIR/check-scope.sh" "${touched[@]}" > "$touched_scope"
+          if [ "$(jq -r '.ok' "$touched_scope")" != "true" ]; then
+            set_outputs \
+              "diff_ok=false" \
+              "abort_reason=diff-out-of-scope" \
+              "touched_scope=$touched_scope"
+            exit 0
+          fi
+
+          # Even within scope, the diff must be a SUBSET of the
+          # classifier's `proposed_paths`. Any deviation halts before the
+          # gate (per task spec step 10's deviation clause).
+          proposed_file="${{ steps.scope.outputs.paths_file }}"
+          unexpected="${RUNNER_TEMP}/forensics/unexpected-paths.txt"
+          : > "$unexpected"
+          while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            if ! grep -Fxq -- "$p" "$proposed_file"; then
+              printf '%s\n' "$p" >> "$unexpected"
+            fi
+          done < "$touched_file"
+
+          if [ -s "$unexpected" ]; then
+            set_outputs \
+              "diff_ok=false" \
+              "abort_reason=diff-not-in-proposed" \
+              "unexpected_file=$unexpected"
+            exit 0
+          fi
+
+          set_outputs "diff_ok=true"
+
+      - name: Handle apply-fix abort
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'false'
+        run: |
+          set -eu
+          reason_file="${RUNNER_TEMP}/forensics/apply-abort-reason.md"
+          # shellcheck disable=SC2016 # awk program references awk's $0
+          {
+            printf 'auto-fix abort reason: `%s`\n\n' \
+              "${{ steps.verify-diff.outputs.abort_reason }}"
+            cat "${{ steps.verdict.outputs.reasoning_file }}"
+            printf '\n\n---\n\nfix-applier final message:\n\n'
+            cat "${{ steps.verify-diff.outputs.apply_text }}" || true
+            if [ -n "${{ steps.verify-diff.outputs.unexpected_file }}" ] \
+               && [ -f "${{ steps.verify-diff.outputs.unexpected_file }}" ]; then
+              printf '\n\nDiff touched paths NOT proposed by the classifier:\n\n'
+              awk '{print "- `"$0"`"}' "${{ steps.verify-diff.outputs.unexpected_file }}"
+            fi
+          } > "$reason_file"
+          # Discard local edits before exiting — the branch was never
+          # pushed, but resetting keeps the runner's working tree clean
+          # in case any always-run step inspects it.
+          git reset --hard HEAD
+          "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+            "$ISSUE_NUMBER" \
+            "$reason_file" \
+            "out-of-scope"
+
+      # ----------------------------------------------------------------
+      # UAT-005: Quality Gate. Branch is local-only; we push only when
+      # the gate passes. `run-quality-gate.sh` is owned by the parallel
+      # task-quality-gate-runner sub-agent. CLI: `<output-summary-file>`.
+      # ----------------------------------------------------------------
+      - name: Commit fix
+        id: commit-fix
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true'
+        run: |
+          set -eu
+          # Already `git add -A`'d in verify-diff; commit on the local
+          # branch. No push yet — gate must pass first.
+          git commit -m "forensics: auto-fix attempt for #${ISSUE_NUMBER}"
+
+      - name: Run Quality Gate
+        id: quality-gate
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true'
+        continue-on-error: true
+        run: |
+          set -eu
+          summary="${RUNNER_TEMP}/forensics/gate-summary.json"
+          echo "summary_file=$summary" >> "$GITHUB_OUTPUT"
+          "$FORENSICS_DIR/run-quality-gate.sh" "$summary"
+
+      - name: Handle Quality Gate failure
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true' &&
+          steps.quality-gate.outcome == 'failure'
+        env:
+          GATE_SUMMARY_FILE: ${{ steps.quality-gate.outputs.summary_file }}
+        run: |
+          set -eu
+          # UAT-005: branch is never pushed. We're on a local-only branch;
+          # nothing to clean up on origin. Compose the comment, demote.
+          reason_file="${RUNNER_TEMP}/forensics/gate-failure-reason.md"
+          # shellcheck disable=SC2016 # jq filters are intentionally single-quoted
+          {
+            cat "${{ steps.verdict.outputs.reasoning_file }}"
+            printf '\n\n---\n\nQuality Gate failure summary:\n\n'
+            if [ -f "$GATE_SUMMARY_FILE" ]; then
+              failed_step="$(jq -r '.failed_step // "unknown"' "$GATE_SUMMARY_FILE")"
+              exit_code="$(jq -r '.exit_code // "unknown"' "$GATE_SUMMARY_FILE")"
+              printf 'failed step: `%s` (exit %s)\n\n' "$failed_step" "$exit_code"
+              printf 'log excerpt:\n\n```\n'
+              jq -r '.log_excerpt // ""' "$GATE_SUMMARY_FILE"
+              printf '\n```\n\n'
+            else
+              printf '_(gate summary file missing — see workflow run logs)_\n\n'
+            fi
+            printf 'workflow run: %s/%s/actions/runs/%s\n' \
+              "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}"
+          } > "$reason_file"
+          "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+            "$ISSUE_NUMBER" \
+            "$reason_file" \
+            "gate-failure"
+
+      # ----------------------------------------------------------------
+      # UAT-004: gate passed → push branch and open draft PR. The push
+      # step is gated on quality-gate succeeding (step's `outcome` is
+      # `success`); UAT-005 is preserved by construction.
+      # ----------------------------------------------------------------
+      - name: Push fix branch
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true' &&
+          steps.quality-gate.outcome == 'success'
+        run: |
+          set -eu
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      - name: Compose PR body
+        id: pr-body
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true' &&
+          steps.quality-gate.outcome == 'success'
+        env:
+          PARSED_FILE: ${{ steps.parse.outputs.parsed_file }}
+        run: |
+          set -eu
+          # UAT-015: `## Capture` is passed through verbatim. No
+          # re-redaction, no de-redaction, no normalization. The parsed
+          # JSON's `.sections.capture` field is the byte-for-byte content
+          # the body parser pulled from the issue (modulo the at-most-one
+          # leading/trailing blank line trim documented in
+          # parse-issue-body.sh).
+          body_file="${RUNNER_TEMP}/forensics/pr-body.md"
+          # shellcheck disable=SC2016 # markdown literals contain backticks; jq filter is single-quoted
+          {
+            printf 'Auto-fix attempt for issue #%s.\n\n' "$ISSUE_NUMBER"
+            printf 'Closes #%s\n\n' "$ISSUE_NUMBER"
+            printf -- '---\n\n'
+            printf '## Capture (verbatim from issue)\n\n'
+            jq -r '.sections.capture' "$PARSED_FILE"
+            printf '\n\n---\n\n'
+            printf '## Classifier reasoning\n\n'
+            cat "${{ steps.verdict.outputs.reasoning_file }}"
+            printf '\n\n---\n\n'
+            printf '_Draft PR. Branch protection on `main` requires human review before merge._\n'
+          } > "$body_file"
+          echo "file=$body_file" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR + finalize labels
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true' &&
+          steps.quality-gate.outcome == 'success'
+        run: |
+          set -eu
+          "$FORENSICS_DIR/handlers/handle-auto-fixable.sh" \
+            "$ISSUE_NUMBER" \
+            "${{ steps.branch.outputs.class_slug }}" \
+            "${{ steps.branch.outputs.name }}" \
+            "${{ steps.pr-body.outputs.file }}"
+
+      # ----------------------------------------------------------------
+      # UAT-012 fail-forward: if the workflow did meaningful work but
+      # bombed before any handler attached `gaia-triaged`, this final
+      # always-run step ensures the idempotency key sticks. The early-
+      # exit path (step 3) already applied the label via its handler;
+      # we suppress the fallback in that case via `already_triaged`.
+      # ----------------------------------------------------------------
+      - name: Ensure gaia-triaged is applied (fail-forward)
+        if: always() && steps.idempotency.outputs.already_triaged != 'true'
+        run: |
+          set -eu
+          gh issue edit "$ISSUE_NUMBER" --add-label gaia-triaged || true

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "vitest",
     "test:ci": "vitest --run --passWithNoTests --coverage --bail 1",
     "test:lint-staged": "vitest --run --changed --passWithNoTests --bail 1",
+    "test:forensics": "bats .gaia/tests/forensics/unit.bats",
     "pw": "pnpm exec playwright test",
     "pw-ui": "pnpm exec playwright test --ui",
     "chromatic": "pnpm exec chromatic --auto-accept-changes 'main' --storybook-build-dir 'storybook-static' --only-changed --exit-once-uploaded --exit-zero-on-changes --skip '@(renovate/**|dependabot/**)'",

--- a/wiki/decisions/Forensics Triage Workflow.md
+++ b/wiki/decisions/Forensics Triage Workflow.md
@@ -1,0 +1,168 @@
+---
+type: decision
+status: active
+priority: 1
+date: 2026-05-08
+created: 2026-05-08
+updated: 2026-05-08
+tags: [decision, ci, automation, security]
+---
+
+# Decision: Forensics Triage Workflow
+
+A GitHub Actions workflow at `.github/workflows/forensics-triage.yml` triages every `gaia-forensics`-labeled issue on the upstream repo without human action. It closes non-issues, escalates real-but-out-of-scope reports to the maintainer, and opens scope-bounded draft PRs (gated by the [[Quality Gate]] and human review on `main`) for fixable defects.
+
+The workflow is autonomous by design. The maintainer's irreducible attention surface is reviewing the candidate fix on the draft PR — never reading raw issue traffic, never running mechanical classification.
+
+## What it does
+
+Trigger: `issues.opened` and `issues.labeled` events. The job-level `if` filter exits unless the issue carries the `gaia-forensics` label, so unrelated issue traffic is free.
+
+Lifecycle:
+
+1. **Idempotency check.** If the issue already carries `gaia-triaged`, the workflow exits with no work. The fail-forward final step also suppresses re-application of the label.
+2. **Body parse.** A pure-shell parser at `.github/forensics/parse-issue-body.sh` extracts the four required sections (`## Symptom`, `## Classification`, `## Capture`, `## Reproduction context`) plus frontmatter from the strict-schema issue body. The LLM is never invoked for extraction. Missing or malformed sections route the issue to `needs-human` with a comment naming the offending section, and no classification runs.
+3. **Classify.** `anthropics/claude-code-action` runs the prompt at `.github/forensics/prompt.md` with the parsed sections rendered in. The action runs with `--max-turns 1` and tool access disabled (no `Bash`, `Read`, `Edit`, `Write`, `WebFetch`, `WebSearch`) — judgment only, no side effects on the working tree. The classifier emits a single trailing `GAIA-VERDICT: <class>` line; `parse-verdict.sh` extracts it deterministically. Missing, duplicated, or out-of-set verdict lines downgrade to `ambiguous` and route to `needs-human`.
+4. **Act on verdict.**
+   - `non-issue` — close the issue, comment with the classifier's reasoning, label `non-issue`.
+   - `needs-human` — label `needs-human`, comment with the reasoning, mention the maintainer. Issue stays open.
+   - `auto-fixable` — proceed to the fix-attempt path.
+5. **Scope check (pre-fix).** `check-scope.sh` runs over the classifier's `Proposed paths` block. Any path outside the allowlist (or on the explicit denylist) demotes the issue to `needs-human` with a comment naming the rejected paths. No branch is created.
+6. **Apply fix.** A second `claude-code-action` invocation runs the fix-application prompt with `--allowedTools Edit,Read,Write` only — no shell, no git, no network. The branch `forensics/<issue-num>-<class-slug>` is created locally from `origin/main`.
+7. **Post-fix scope check.** Even within the allowlist, the diff must be a subset of the classifier's proposed paths. Any deviation aborts before commit and demotes to `needs-human`.
+8. **Quality Gate.** `.github/forensics/run-quality-gate.sh` runs `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm test --run`, and `pnpm knip` in order, halt-on-first-fail. Gate failure abandons the branch (it was never pushed) and demotes the issue to `needs-human` with a comment naming the failed step and a log excerpt.
+9. **Open draft PR.** Gate pass pushes the branch and opens a draft PR. PR body cites the `## Capture` section verbatim. Labels `auto-fixable` and `gaia-bug-confirmed` attach to the issue.
+10. **Idempotency key.** Every triaged issue receives the `gaia-triaged` label as the final, always-run step.
+
+The workflow file at `.github/workflows/forensics-triage.yml` is on the canonical denylist below: triage runs cannot self-modify, and `check-scope.sh` rejects any attempt to edit a path under `.github/workflows/`.
+
+## Path policy
+
+Default-deny. Any path in neither list below is denylisted by default; allowlist expansion requires a SPEC reopen, not a PR-time decision.
+
+### Allowlist (eligible for autonomous fixes)
+
+| Path | Notes |
+| --- | --- |
+| `.gaia/cli/` | GAIA CLI source. |
+| `.claude/hooks/` | Shell hooks. |
+| `.claude/skills/` | Skill markdown. |
+| `.claude/commands/` | Slash command definitions. |
+| `.claude/agents/` | Sub-agent definitions. |
+| `.gaia/statusline/` | Statusline scripts. |
+| `.specify/extensions/gaia/` | GAIA spec-kit extension — excluding `templates/`. |
+| `.gaia/manifest.json` | Distribution manifest. |
+
+### Denylist (never modify)
+
+| Path | Notes |
+| --- | --- |
+| `app/` | Application source. |
+| `wiki/` | Knowledge base; human-curated. |
+| `studio/` | Private maintainer vault. |
+| `website/` | Marketing + docs site. |
+| `.specify/specs/` | spec-kit specs. |
+| `.specify/memory/` | spec-kit memory. |
+| `.gaia/local/specs/` | GAIA spec artifacts. |
+| `.specify/extensions/gaia/templates/` | Template literals; mutating these affects every adopter. |
+| `.github/workflows/` | Workflow files; covers self-modification of the triage workflow itself. |
+
+## Label vocabulary
+
+All five labels must pre-exist on the upstream repo. `bootstrap-labels.sh` asserts the inventory and creates missing entries with the canonical color and description; existing labels with drifted color or description log a notice and stay untouched (operator wins).
+
+| Label | Color | Meaning |
+| --- | --- | --- |
+| `gaia-triaged` | green (`0e8a16`) | Idempotency key. Set on every triaged issue; presence is the early-exit condition. |
+| `non-issue` | grey (`cccccc`) | Not a bug. Issue closed with explanation. |
+| `needs-human` | orange (`d93f0b`) | Real bug, but out of autofix scope OR malformed body OR ambiguous classifier verdict OR Quality Gate failure. Maintainer review required. |
+| `auto-fixable` | blue (`1d76db`) | Classifier proposed a fix in allowlisted scope. See linked draft PR. |
+| `gaia-bug-confirmed` | red (`b60205`) | Quality Gate passed on the auto-fix branch. Draft PR open and ready for human review. |
+
+The `gaia-forensics` trigger label is owned by phase 1 of the forensics arc (the `/gaia forensics` end-user bridge) and is not part of `bootstrap-labels.sh`'s inventory.
+
+## Secret hygiene
+
+The workflow handles two secrets:
+
+- `ANTHROPIC_API_KEY` — consumed only by `anthropics/claude-code-action`. Never echoed.
+- `GITHUB_TOKEN` — workflow-default token, scoped to the minimum permissions: `issues: write`, `contents: write`, `pull-requests: write`, `actions: read`.
+
+Secret-shape masking: before rendering either prompt, the workflow scans the parsed issue sections for byte patterns that look like leaked tokens (`sk-ant-…`, `ghp_…`, `github_pat_…`) and emits `::add-mask::` for each match. Phase 1 redacts the body before the issue ever opens — this is defense-in-depth against an unredacted leak slipping through.
+
+Redaction passthrough: phase-1 redaction tokens (`<redacted>`, repo-relative paths derived from absolutes) appear verbatim in every derived artifact — classifier comment, PR body, branch content. The workflow never re-redacts, de-redacts, or normalizes.
+
+Branch protection and the draft-PR contract are the autonomous-mode safety rails:
+
+- Every PR opens as `draft: true`. The workflow has no `gh pr ready` invocation.
+- The workflow has no `gh pr merge` invocation.
+- Branch protection on `main` requires at least one human review and the standard required status checks. The workflow never bypasses either.
+
+## Failure modes
+
+| Failure | Behavior |
+| --- | --- |
+| **Issue body missing or malformed.** | Parser detects the missing/malformed section without LLM fallback. Issue is labeled `needs-human`; comment names the section; no classifier runs. |
+| **Classifier verdict ambiguous** (no `GAIA-VERDICT:` line, multiple lines, value outside the closed set, or `auto-fixable` without a parseable `Proposed paths` block). | Verdict normalizes to `ambiguous`; `needs-human` handler fires with reason-code `ambiguous-verdict`. |
+| **Proposed paths cross the scope boundary.** | `check-scope.sh` rejects before any branch is created. Comment names the rejected paths; issue demoted to `needs-human` with reason-code `out-of-scope`. |
+| **Apply-fix model goes off-script** (touches paths it didn't propose, or emits the `GAIA-FIX-ABORT:` escape line). | Pre-commit verification catches the deviation. Local edits are discarded; branch is never pushed; issue demoted to `needs-human`. |
+| **Quality Gate fails.** | Branch is never pushed (no `forensics/<issue-num>-*` ref ever exists on origin). `auto-fixable` label is NOT applied. Issue is demoted to `needs-human` with a comment naming the failed step, an excerpt of the failure log, and a link to the workflow run. |
+| **Two events for the same issue fire in rapid succession.** | A `concurrency` block keyed on the issue number with `cancel-in-progress: false` queues the second run. The first run applies `gaia-triaged`; the queued run hits the early-exit and does no work. No duplicate label, comment, branch, or PR. |
+| **Job exceeds 30 minutes.** | The job-level timeout aborts cleanly. The workflow is fail-forward: any labels applied before the timeout stay (no rollback). |
+
+There is no retry loop. One fix attempt per issue; failure is terminal in autonomous mode. A maintainer can manually unstick by removing `gaia-triaged` and re-firing — that is a manual operation, outside the workflow's contract.
+
+## Amendment process
+
+The auto-fix allowlist and the canonical denylist are part of the workflow's immutable contract. Both lists live in three places that must stay synchronized:
+
+1. The path policy on this page.
+2. The classifier prompt at `.github/forensics/prompt.md` (rendered into the `{{ALLOWLIST}}` and `{{DENYLIST}}` placeholders by the workflow YAML).
+3. The deterministic check at `.github/forensics/check-scope.sh`.
+
+Amending either list requires a SPEC reopen — adding a path through a PR-only change is not an authorized path. The SPEC artifact is the source of truth; this page and the scripts are derivations.
+
+Adding a new label to the vocabulary:
+
+1. Append the entry to `bootstrap-labels.sh`'s `LABELS` array (`name|color|description`).
+2. Re-run `bootstrap-labels.sh` against the upstream repo (idempotent — re-runs are no-ops on existing labels).
+3. Update the label vocabulary table on this page.
+4. Wire any handler that needs to apply the new label.
+
+Modifying the workflow YAML or any `.github/forensics/` script is a normal PR — except those paths are themselves on the workflow's denylist, so the changes ship through human-authored PRs only, never through autonomous triage.
+
+## Operator runbook
+
+### Halt a runaway run
+
+1. Open the **Actions** tab on the upstream repo.
+2. Filter by workflow name `Forensics Triage`.
+3. Locate the in-flight run; click **Cancel workflow**.
+4. The cancelled run leaves any already-applied labels in place (fail-forward). If `gaia-triaged` was already applied, no further triage will fire on the issue. If not, removing `gaia-forensics` and re-adding it will re-trigger.
+
+### Manually re-trigger triage on an issue
+
+The workflow is idempotent on `gaia-triaged`. To force a re-run:
+
+1. On the issue: remove `gaia-triaged`. (Removing the label re-fires the workflow because of the `issues.labeled` trigger.)
+2. The next run treats the issue as untriaged and re-classifies from scratch. Any prior labels (`non-issue`, `needs-human`, etc.) stay attached unless the new run replaces them.
+
+To pre-empt a re-run, leave `gaia-triaged` attached.
+
+### Read the workflow logs without leaking secrets
+
+GitHub Actions logs apply `::add-mask::` automatically: any masked value renders as `***` in the UI and the downloadable log archive. The workflow registers masks for every observed secret-shape on the parsed issue body. Inspecting a run:
+
+1. From the Actions tab, open the run.
+2. Each `::group::` block (e.g. `quality-gate: lint`) collapses verbose output. Expand only what is relevant to the question.
+3. The `Run Quality Gate` step's `summary_file` JSON is the canonical failure record — it contains the failed step, exit code, and a trimmed log excerpt. The full per-step log lives in the runner's temp dir and only surfaces in the action log; it is never posted to comments or PR bodies.
+4. If a comment or PR body looks like it might contain a secret, treat it as a leak and rotate the secret. The workflow never intentionally writes secret-shaped values to derived artifacts; an unmasked secret in a comment is a regression.
+
+### Inspect a fix attempt without merging
+
+Draft PRs the workflow opens are normal PRs in every other respect. Check out the branch (`gh pr checkout <pr-num>`), run the [[Quality Gate]] locally, review the diff. Branch protection blocks merge until human approval; nothing the workflow does forecloses on rejecting the fix and closing the PR.
+
+## See also
+
+- [[Quality Gate]] — the gate this workflow runs on every fix-attempt branch.
+- [[Wiki Management]] — adjacent automation primitives (different surface).

--- a/wiki/decisions/Forensics Triage Workflow.md
+++ b/wiki/decisions/Forensics Triage Workflow.md
@@ -131,6 +131,20 @@ Adding a new label to the vocabulary:
 
 Modifying the workflow YAML or any `.github/forensics/` script is a normal PR — except those paths are themselves on the workflow's denylist, so the changes ship through human-authored PRs only, never through autonomous triage.
 
+## Signals to revisit
+
+The default-deny path policy and the no-cross-issue-learning posture are deliberate. Two signal patterns indicate the contract is worth revisiting.
+
+### Allowlist expansion
+
+`needs-human` comments name the rejected paths in their `reason: out-of-scope` body. When a single unenumerated path recurs across five or more distinct issues, it is a candidate for the auto-fix allowlist. Adding the path requires a SPEC reopen — not a PR-only edit — because the allowlist is part of the workflow's immutable contract.
+
+### Cross-issue learning
+
+The classifier runs on each issue independently. Manual maintainer corrections accumulate as a queue of human-corrected outcomes: re-labelled issues, manual closures, rejected draft PRs. When that queue exceeds fifty items across all classes, the data set is worth feeding back into the classifier as priors, batched-triage queues, or supervised retraining loops — work that warrants its own SPEC.
+
+Both signals are tracked by the maintainer health audit, which aggregates the reason-codes and flags threshold crossings.
+
 ## Operator runbook
 
 ### Halt a runaway run

--- a/wiki/decisions/Quality Gate.md
+++ b/wiki/decisions/Quality Gate.md
@@ -69,3 +69,5 @@ This page is the source of truth for quality gate steps. The always-loaded `.cla
 > Most projects accept warnings as "noise we'll clean up later." GAIA treats warnings as **failures**. Console warnings in tests count too. The cost of fixing one missing i18n key now is trivial; the cost of finding it in production after 200 keys silently broke is not.
 
 See [[Pre-commit Hooks]], [[PR Merge Workflow]], [[Task Orchestration]], [[Claude Hooks]] (the source-edit and Bash safeguards keep `.env`, lockfile, secrets, and destructive-git footguns out of the staged surface before the gate ever runs).
+
+The [[Forensics Triage Workflow]] runs the gate (install + typecheck + lint + test + knip) on every auto-fix branch; gate failure abandons the branch and demotes the issue to `needs-human` instead of opening a partial PR.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -95,6 +95,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Co-located Tests Folder]]
 - [[composeStory Pattern]]
 - [[Dark Mode Modernization]]
+- [[Forensics Triage Workflow]] — autonomous triage for `gaia-forensics`-labeled issues; default-deny path policy + draft-PR contract.
 - [[Quality Gate]]
 - [[pnpm]]
 - [[DragonScale Opt-Out]]


### PR DESCRIPTION
## Summary

Implements SPEC-002 (`.gaia/local/specs/SPEC-002.md`) — the autonomous GitHub Actions triage layer that classifies every `gaia-forensics`-labeled issue, closes non-issues, escalates real-but-out-of-scope reports to `needs-human`, and opens scope-bounded draft PRs (gated by Quality Gate + branch protection) for fixable defects.

## What ships

- **`.github/workflows/forensics-triage.yml`** — fires on `issues.opened|labeled` for `gaia-forensics`-labeled issues. Idempotency early-exit on `gaia-triaged`. Concurrency `forensics-<num>` with `cancel-in-progress: false`. 30-min job timeout. `::add-mask::` defense-in-depth secret hygiene.
- **`.github/forensics/`** — supporting scripts:
  - `parse-issue-body.sh` — deterministic POSIX-shell regex/awk parser for the SPEC-001 strict body schema. No LLM fallback.
  - `check-scope.sh` — default-deny path policy primitive (allowlist / canonical denylist / unenumerated → denied).
  - `bootstrap-labels.sh` — idempotent label-vocabulary bootstrap (5 phase-2 labels).
  - `prompt.md` + `parse-verdict.sh` — claude-code-action classifier prompt + deterministic verdict extractor (ambiguity → `needs-human`).
  - `apply-fix-prompt.md` — fix-application prompt with `GAIA-FIX-ABORT:` model-side opt-out routed to `needs-human` with reason `out-of-scope`.
  - `handlers/handle-{non-issue,needs-human,auto-fixable,malformed-body,already-triaged}.sh` — per-class action helpers.
  - `run-quality-gate.sh` — install + typecheck + lint + test + knip; halt on first fail; JSON summary; branch never pushed on gate fail.
- **`.gaia/tests/forensics/`** — 8 issue-body fixtures + 12 fixture-invariant bats tests + `integration.md` maintainer checklist. `pnpm test:forensics` wired into `package.json`.
- **`wiki/decisions/Forensics Triage Workflow.md`** — present-tense ADR documenting lifecycle, allowlist/denylist, label vocabulary, secret hygiene, failure modes, amendment process, signals to revisit, and operator runbook.

## Commits

1. `042a5e3` — phase 1: body parser, scope checker, label bootstrap (51 bats tests).
2. `93a2e60` — phase 2: classifier prompt + action handlers (57 bats tests).
3. `dc7cfbc` — phase 3: workflow YAML + Quality Gate runner (19 bats tests; actionlint clean).
4. `714b6eb` — phase 4: UAT fixtures + decision-page docs (12 bats tests delegating to 127 inner; `pnpm test:forensics` wired).
5. `7636686` — docs: signals-to-revisit (allowlist expansion threshold, cross-issue learning threshold; codified in the health-audit taxonomy).

## Verification

- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test --run` (vitest) — 13 files, 46 tests pass.
- [x] `pnpm test:forensics` (bats) — 12 tests pass; delegates to all 127 inner forensics bats tests.
- [x] `actionlint .github/workflows/forensics-triage.yml` clean.
- [x] Wiki-style audit greps clean for new wiki content.

## Maintainer post-merge checklist

- [ ] Run `.github/forensics/bootstrap-labels.sh` against `gaia-react/gaia` to create the 5 phase-2 labels (`gaia-triaged`, `non-issue`, `needs-human`, `auto-fixable`, `gaia-bug-confirmed`). The phase-1 `gaia-forensics` label must already exist.
- [ ] Confirm branch protection on `main`: required reviews ≥ 1, required status checks include lint + typecheck + tests.
- [ ] Confirm repository secret `ANTHROPIC_API_KEY` is set.
- [ ] Confirm `anthropics/claude-code-action` is installed via `/install-github-app`.
- [ ] Walk `.gaia/tests/forensics/integration.md` checklist for end-to-end UATs.

## Notes for review

- **`GAIA-FIX-ABORT:` escape hatch.** The fix-application prompt includes a model-side opt-out token; the workflow detects it and routes to `needs-human` with reason `out-of-scope`. Strict subset of the fail-close intent — without it, a stuck model either burns turn budget or pushes a half-applied diff.
- **Workflow file is ~741 lines** (vs SPEC's ~200–250 estimate). Driven by explicit per-step `if:` chains; GitHub Actions has no early-job-exit primitive, so each conditional gate repeats its ancestors. Distinct steps preserved for log-readability.
- **`anthropics/claude-code-action` pinned at SHA `63322d7b…`** (v1.0). If a future version renames the JSONL `type:"result"` field, verdict extraction silently empties → parser downgrades to ambiguous. Worth a smoke-test on every action SHA bump.
- **Allowlist/denylist live in three synchronized locations** — the decision page, `prompt.md`, `check-scope.sh`. A consistency-check helper would prevent silent drift; out of SPEC scope.

## Out of scope

- Phase 3 cross-issue learning (classifier priors, batched-triage queues, supervised retraining loops). Reserved as a future SPEC if triage volume produces enough data; signal threshold codified in the decision page and health-audit taxonomy.
- Allowlist expansion. Adding a path requires a SPEC reopen, not a PR-only edit; signal threshold codified.

## SPEC reference

`.gaia/local/specs/SPEC-002.md` — phase 2 of the forensics arc; consumes the strict-schema body emitted by SPEC-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
