### PR TITLE
fix(forensics): address pre-merge audit findings (post #105)

### DIFF
--- a/.claude/skills/gaia/SKILL.md
+++ b/.claude/skills/gaia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gaia
-description: GAIA workflow router. Dispatches to the four user-invoked GAIA workflows - plan (task orchestration), handoff (session handoff doc), pickup (resume from handoff), audit (knowledge audit), forensics (bug report bridge). Trigger on `/gaia <subcommand>` or natural-language asks like "kick off a plan", "write a handoff", "pick up where we left off", "audit the knowledge stores".
+description: GAIA workflow router. Dispatches to the five user-invoked GAIA workflows - plan (task orchestration), handoff (session handoff doc), pickup (resume from handoff), audit (knowledge audit), forensics (bug report bridge). Trigger on `/gaia <subcommand>` or natural-language asks like "kick off a plan", "write a handoff", "pick up where we left off", "audit the knowledge stores".
 ---
 
 # GAIA Router

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -352,6 +352,7 @@
     "wiki/concepts/Coding Guidelines.md": "wiki-owned",
     "wiki/concepts/Component Testing.md": "wiki-owned",
     "wiki/concepts/ESLint Fixes.md": "wiki-owned",
+    "wiki/concepts/Forensics.md": "wiki-owned",
     "wiki/concepts/GAIA Audit.md": "wiki-owned",
     "wiki/concepts/GAIA Handoff.md": "wiki-owned",
     "wiki/concepts/GAIA Philosophy.md": "wiki-owned",

--- a/.gaia/tests/forensics/07-gh-not-installed.bats
+++ b/.gaia/tests/forensics/07-gh-not-installed.bats
@@ -38,17 +38,20 @@ no_gh_surrogate() {
 
 setup() {
   WORKDIR="$(mktemp -d)"
-  # Build a PATH that has no gh binary
+  # Build a PATH that has no gh binary. CLEAN_BIN is the ONLY entry —
+  # /usr/bin and /bin are deliberately excluded because GitHub Actions
+  # ubuntu-latest ships gh at /usr/bin/gh, which would defeat the test.
   CLEAN_BIN="$(mktemp -d)"
-  # Populate with only the bare minimum for the test
-  for cmd in bash printf mkdir command; do
+  # Populate with the binaries the surrogate needs. printf/command are bash
+  # builtins; mkdir is the only external command exercised in the surrogate.
+  for cmd in bash mkdir; do
     local real
     real="$(command -v "$cmd" 2>/dev/null || true)"
     if [[ -n "$real" ]]; then
       ln -sf "$real" "$CLEAN_BIN/$cmd" 2>/dev/null || true
     fi
   done
-  NO_GH_PATH="$CLEAN_BIN:/usr/bin:/bin"
+  NO_GH_PATH="$CLEAN_BIN"
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

Three findings from the pre-merge `code-review-audit` of #105 landed after the squash merge had already completed. This PR fixes them:

- **Manifest gap (merge-blocker on `/update-gaia` flow):** register `wiki/concepts/Forensics.md` as `wiki-owned`. Without the entry, the new concept page is invisible to the manifest-driven adopter sync.
- **Frontmatter mismatch:** `.claude/skills/gaia/SKILL.md` description said "four user-invoked GAIA workflows" but enumerated five. Corrected to "five".
- **CI portability defect in `07-gh-not-installed.bats`:** `NO_GH_PATH` included `/usr/bin`, where GitHub Actions ubuntu-latest pre-installs `gh` — `command -v gh` would have found it and the gh-absent assertions would have failed. PATH is now `$CLEAN_BIN` only, with `bash` and `mkdir` symlinked.

## Test plan

- [x] `pnpm typecheck && pnpm lint` green
- [x] `bash .gaia/tests/forensics/run-all.sh` green (97/97 bats tests pass)
- [x] `07-gh-not-installed.bats` passes locally (CI-side `/usr/bin/gh` defeat is now structurally prevented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)