### PR TITLE
chore: harden PR merge gate + opt-in /gaia spec issue mirror

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -304,14 +304,17 @@ After producing the report, decide whether to write the marker:
 
 Knip / react-doctor advisories and Suggestions never block the marker — they are advisory-by-design.
 
-When the marker is warranted, write it with:
+When the marker is warranted, write it with the snippet below. The `[ ! -f "$marker" ]` guard makes the write idempotent — re-running the audit on the same HEAD never overwrites an existing marker:
 
 ```bash
 HEAD_SHA="$(git rev-parse HEAD)"
 mkdir -p .gaia/local/audit
-printf '{"sha":"%s","audited_at":"%s"}\n' \
-  "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  > ".gaia/local/audit/${HEAD_SHA}.ok"
+marker=".gaia/local/audit/${HEAD_SHA}.ok"
+if [ ! -f "$marker" ]; then
+  printf '{"sha":"%s","audited_at":"%s"}\n' \
+    "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    > "$marker"
+fi
 ```
 
 Then surface, as the final line of your report:
@@ -322,7 +325,7 @@ If you do not write the marker, surface this instead:
 
 > Audit marker NOT written. Address findings, commit, and re-invoke this agent on the new HEAD before merging.
 
-Never write a marker for a SHA other than current `HEAD`. Never overwrite an existing marker — `[ -f "$marker" ]` already short-circuits the hook.
+Never write a marker for a SHA other than current `HEAD`. The agent-side guard above prevents accidental overwrite; the hook-side `[ -f "$marker" ]` check is what unblocks `gh pr merge` once the marker exists.
 
 ## Durable knowledge
 

--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -291,6 +291,39 @@ If no violations are found for a rule, don't mention it. If no violations are fo
 - Prioritize ruthlessly — 5 important issues beats 50 trivial ones
 - Work within the project's existing patterns when suggesting fixes; don't introduce new dependencies
 
+## Audit marker (gate handshake)
+
+`.claude/hooks/pr-merge-audit-check.sh` blocks `gh pr merge` until a marker file at `.gaia/local/audit/<HEAD-sha>.ok` exists. The marker proves the audit ran against the exact commit being merged. **You** are responsible for writing the marker — only when the audit is genuinely clean.
+
+After producing the report, decide whether to write the marker:
+
+- **Write the marker** when both:
+  1. The Critical Issues section is empty.
+  2. The Important Issues section is empty, OR every item is already fixed in the working tree (verify by re-reading the relevant file; do not trust prior chat claims).
+- **Do NOT write the marker** when any Critical Issue exists or any Important Issue remains unaddressed in the working tree. The operator must address findings, commit, and re-invoke this agent on the new HEAD; the next clean run writes the marker.
+
+Knip / react-doctor advisories and Suggestions never block the marker — they are advisory-by-design.
+
+When the marker is warranted, write it with:
+
+```bash
+HEAD_SHA="$(git rev-parse HEAD)"
+mkdir -p .gaia/local/audit
+printf '{"sha":"%s","audited_at":"%s"}\n' \
+  "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  > ".gaia/local/audit/${HEAD_SHA}.ok"
+```
+
+Then surface, as the final line of your report:
+
+> Audit marker written for HEAD `<short-sha>`; gh pr merge is unblocked.
+
+If you do not write the marker, surface this instead:
+
+> Audit marker NOT written. Address findings, commit, and re-invoke this agent on the new HEAD before merging.
+
+Never write a marker for a SHA other than current `HEAD`. Never overwrite an existing marker — `[ -f "$marker" ]` already short-circuits the hook.
+
 ## Durable knowledge
 
 Before starting a review, consult `wiki/concepts/Code Review Audit Agent.md` and any cross-linked pages for established patterns, past architectural decisions, and known anti-patterns. Pull only what is relevant for the current review — don't preload the entire wiki.

--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -16,6 +16,8 @@
 #
 # See wiki/concepts/PR Merge Workflow.md for the full contract.
 
+# -e is intentionally omitted: we must not abort before writing the deny JSON.
+# All error-prone commands are individually guarded (|| true, 2>/dev/null).
 set -uo pipefail
 
 input=$(cat)
@@ -25,18 +27,24 @@ command -v jq >/dev/null 2>&1 || exit 0
 tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null)
 [ "$tool_name" = "Bash" ] || exit 0
 
-command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+# Note: avoid naming this `command` — it would shadow bash's `command` builtin
+# and make any later `command -v ...` calls in this script silently misbehave.
+cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
 # Match `gh pr merge` only when it appears as an actual shell invocation —
 # either at the very start of the command (after optional whitespace) or
-# immediately after a shell separator (&&, ;, ||, |). This avoids false
-# positives on heredoc body text and quoted strings (e.g. commit messages
-# that reference the command in prose). Use bash =~ for whole-string regex
-# semantics; grep operates line-by-line and would match heredoc body lines.
-if [[ "$command" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
-  : # match
-elif [[ "$command" =~ (\&\&|\;|\|\||\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
-  : # match after a shell separator
+# immediately after a shell separator (&&, ;, ||, |, newline). This avoids
+# false positives on heredoc body text and quoted strings (e.g. commit
+# messages that reference the command in prose). Use bash =~ for whole-string
+# regex semantics; grep operates line-by-line and would match heredoc body
+# lines. The newline alternative covers multi-statement scripts where each
+# command is on its own line.
+sep_re=$'(\\&\\&|;|\\|\\||\\||\n)[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+start_re='^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+if [[ "$cmd" =~ $start_re ]]; then
+  : # match at command start
+elif [[ "$cmd" =~ $sep_re ]]; then
+  : # match after a shell separator (incl. newline)
 else
   exit 0
 fi
@@ -71,6 +79,8 @@ the merge.
 
 See wiki/concepts/PR Merge Workflow.md for the full contract."
 
+# --arg safely escapes $reason; never interpolate dynamic values directly into
+# the JSON template string.
 jq -n --arg r "$reason" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",

--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
-# PreToolUse advisory: before `gh pr merge`, remind Claude (and the user)
-# that PR Merge Workflow requires a clean code-review-audit pass with all
-# findings addressed. Non-blocking — exit 0 always.
+# PreToolUse Bash hook: BLOCK `gh pr merge` until a code-review-audit marker
+# exists for the current HEAD SHA at .gaia/local/audit/<sha>.ok.
 #
-# Emits both:
-#   - structured `additionalContext` JSON via hookSpecificOutput, so Claude
-#     reliably surfaces the reminder even on terminals where stderr is hidden
-#   - a stderr line as a fallback for environments that ignore the JSON
+# The marker is the load-bearing handshake between the audit agent and this
+# hook. Its presence proves the audit ran against the exact commit being
+# merged and that the agent saw no Critical Issues and no unresolved Important
+# Issues. The agent writes it at the end of a clean review (see
+# .claude/agents/code-review-audit.md, "Audit marker (gate handshake)").
+#
+# Without a marker, the hook denies the gh pr merge call. To unblock:
+#   1. Spawn the code-review-audit agent on the current branch.
+#   2. Address any findings; commit and push.
+#   3. Re-spawn the agent on the new HEAD; let it write the marker.
+#   4. Retry gh pr merge.
 #
 # See wiki/concepts/PR Merge Workflow.md for the full contract.
 
@@ -21,20 +27,56 @@ tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null)
 
 command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
-# Match `gh pr merge` (any spacing, any flags)
-if ! echo "$command" | grep -qE '(^|[^[:alnum:]_-])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+# Match `gh pr merge` only when it appears as an actual shell invocation —
+# either at the very start of the command (after optional whitespace) or
+# immediately after a shell separator (&&, ;, ||, |). This avoids false
+# positives on heredoc body text and quoted strings (e.g. commit messages
+# that reference the command in prose). Use bash =~ for whole-string regex
+# semantics; grep operates line-by-line and would match heredoc body lines.
+if [[ "$command" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
+  : # match
+elif [[ "$command" =~ (\&\&|\;|\|\||\|)[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$) ]]; then
+  : # match after a shell separator
+else
   exit 0
 fi
 
-reminder="PR Merge gate: before merging, ensure code-review-audit ran clean on the latest commit and any findings were addressed and pushed. See wiki/concepts/PR Merge Workflow.md."
+# Resolve HEAD SHA. If we cannot (no git, detached state we can't read),
+# fall back to permissive: this hook only enforces in repos where git answers.
+sha=$(git rev-parse HEAD 2>/dev/null || true)
+if [ -z "$sha" ]; then
+  exit 0
+fi
 
-jq -n --arg ctx "$reminder" '{
+marker=".gaia/local/audit/${sha}.ok"
+if [ -f "$marker" ]; then
+  exit 0
+fi
+
+reason="PR merge gate: no code-review-audit marker for HEAD ${sha:0:12}.
+
+Expected: ${marker}
+
+To unblock:
+  1. Spawn the code-review-audit agent on the current branch.
+  2. Address any Critical/Important findings; commit and push.
+  3. Re-spawn the agent on the new HEAD; the agent writes the marker
+     when it confirms the working tree is clean.
+  4. Retry gh pr merge.
+
+LOCAL-SYNC FAILURE NOTE: if a previous gh pr merge exited with
+'fatal: main is already used by worktree at <path>', the GitHub-side merge
+already succeeded. Verify with: gh pr view <N> --json state — do NOT retry
+the merge.
+
+See wiki/concepts/PR Merge Workflow.md for the full contract."
+
+jq -n --arg r "$reason" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
-    additionalContext: $ctx
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
   }
 }'
-
-echo "$reminder" >&2
 
 exit 0

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -180,7 +180,7 @@ If `$ARGUMENTS` (the args after `spec`) is non-empty, use it as the feature desc
 
 Otherwise, ask: **"What do you want to spec?"** and wait for the response before continuing. This is open-ended — use a plain prompt, not `AskUserQuestion`.
 
-After capturing the description, prompt for the GitHub-issue preference via `AskUserQuestion`:
+After capturing the description — **on both the `$ARGUMENTS` fast-path and the interactive-prompt path** — ask the GitHub-issue preference via `AskUserQuestion`. The question fires regardless of how the description was sourced; users invoking `/gaia spec "..."` should expect this single prompt before discovery proper begins.
 
 - question: `"Mirror this SPEC to a GitHub issue on save?"`
 - header: `"GH issue"`
@@ -188,7 +188,7 @@ After capturing the description, prompt for the GitHub-issue preference via `Ask
   - `{ label: "No, skip GitHub issue (Recommended)", description: "Default. SPEC stays local under .gaia/local/specs/. Choose this for solo work or when the implementing PR will track the work directly." }`
   - `{ label: "Yes, create a GitHub issue", description: "After save, mirror the SPEC body to a new issue on the project's GitHub repo and stamp gh_issue_url into frontmatter. The implementing PR should then include 'Closes #<N>' in its body so the issue auto-closes on merge." }`
 
-Persist the answer as `gh_mirror_optin: <bool>` in working memory for this session. Used at step 10 (gate the mirror invocation) and step 12 (PR-body closure wiring). On resume, the default reverts to `false` — the user re-invokes /gaia spec from a fresh shell with intent.
+Persist the answer as `gh_mirror_optin: <bool>` in working memory for this session. Used at step 10 (gate the mirror invocation) and step 12 (PR-body closure wiring). On resume (step 2), if the loaded draft has no `gh_issue_url` in frontmatter, re-ask this question as part of the resume setup — the resumed session needs the same opt-in signal that the fresh session would have. If `gh_issue_url` is already present, a prior session already mirrored; treat opt-in as implicitly true and do not re-ask.
 
 ### 2. Resume-vs-start-new prompt (pre-flight)
 
@@ -224,6 +224,7 @@ Honor the user's choice. Never silently overwrite, never silently start new.
   - If gate-1 cache exists AND no pending clarifications → resume at step 7 (gate 2).
   - Step 3 (initial draft) is always skipped on resume.
   - Never re-snapshot the gate-1 cache; its purpose is immutable drift detection.
+  - **GH-mirror opt-in on resume.** Inspect the loaded draft's frontmatter. If `gh_issue_url` is set, treat `gh_mirror_optin = true` (a prior session already mirrored). Otherwise, ask the GH-mirror `AskUserQuestion` from step 1 once now — `gh_mirror_optin` does not persist across resumes and silently defaulting it to `false` would lose the user's earlier intent.
 - **Start new:** continue with a fresh allocation (Step 3 onward). The in-progress SPEC remains untouched. Append `spec_started` telemetry with `resumed: false`, then initialize the session-shape cache per the operational primitive once the new `spec_id` is known (step 3).
 - **Discard SPEC-NNN draft cache:** confirm via a follow-up `AskUserQuestion` (`"Delete the draft cache for SPEC-NNN? (The canonical artifact remains.)"` with options `Yes, delete` / `Cancel`). On confirm, `rm -f "$DRAFT_PATH" .gaia/local/cache/spec-session-${SPEC_ID}.json`, then continue with a fresh allocation. Note: the canonical SPEC artifact is untouched; the allocator will continue to flag SPEC-NNN as in-progress until the artifact itself is renamed or relabeled (out of scope for this step).
 

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -180,6 +180,16 @@ If `$ARGUMENTS` (the args after `spec`) is non-empty, use it as the feature desc
 
 Otherwise, ask: **"What do you want to spec?"** and wait for the response before continuing. This is open-ended — use a plain prompt, not `AskUserQuestion`.
 
+After capturing the description, prompt for the GitHub-issue preference via `AskUserQuestion`:
+
+- question: `"Mirror this SPEC to a GitHub issue on save?"`
+- header: `"GH issue"`
+- options:
+  - `{ label: "No, skip GitHub issue (Recommended)", description: "Default. SPEC stays local under .gaia/local/specs/. Choose this for solo work or when the implementing PR will track the work directly." }`
+  - `{ label: "Yes, create a GitHub issue", description: "After save, mirror the SPEC body to a new issue on the project's GitHub repo and stamp gh_issue_url into frontmatter. The implementing PR should then include 'Closes #<N>' in its body so the issue auto-closes on merge." }`
+
+Persist the answer as `gh_mirror_optin: <bool>` in working memory for this session. Used at step 10 (gate the mirror invocation) and step 12 (PR-body closure wiring). On resume, the default reverts to `false` — the user re-invokes /gaia spec from a fresh shell with intent.
+
 ### 2. Resume-vs-start-new prompt (pre-flight)
 
 Run `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"`. If the output is a `SPEC-NNN` id (not `none`), an in-progress SPEC already exists.
@@ -495,7 +505,9 @@ Reset `lint_cycle = 0` on user choice. Step-back-to-gate-2 returns to step 7 wit
 
 ### 10. Optional GH Issue mirror
 
-After save, run:
+If `gh_mirror_optin` (captured at step 1) is `false`, **skip this step entirely**. No mirror invocation, no telemetry write — the user opted out at the top of the session.
+
+If `gh_mirror_optin` is `true`, run:
 
 ```bash
 bash .specify/extensions/gaia/lib/gh-mirror.sh "$PWD" "<spec-id>" ".gaia/local/specs/<spec-id>.md"
@@ -575,3 +587,31 @@ Print a single summary block after the loop exits:
 >   …
 >
 > Discover later with: `ls .gaia/local/plans/ | grep ^spec-nnn-`
+
+If the saved SPEC carries a `gh_issue_url` frontmatter field (i.e. step 10 mirrored successfully), append one line to the summary:
+
+> Implementing PR body should include `Closes #<N>` (extracted from `gh_issue_url`) so merge auto-closes the upstream issue.
+
+### 12. PR-body closure wiring (only when mirrored)
+
+This step is documentation, not action — but it is load-bearing for issue lifecycle.
+
+When the SPEC has a `gh_issue_url` set (step 10 mirrored), every PR opened in service of this SPEC's implementation must reference the issue with GitHub's [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) in the PR body. Use `Closes #<N>` where `<N>` is the integer at the tail of `gh_issue_url`.
+
+Concrete shape for the PR body:
+
+```markdown
+## Summary
+<brief description of changes>
+
+## Test plan
+<bulleted checklist>
+
+Closes #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Multi-PR SPECs (where `/gaia plan` produced multiple plan slices) should reference the same issue from each PR — GitHub closes the issue on the merge of the first PR that contains the keyword. The remaining PRs' references are inert but harmless and signal the lineage.
+
+If the SPEC has no `gh_issue_url` (step 10 was skipped), this step is a no-op.

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,13 +2,13 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-04-21
+updated: 2026-05-08
 tags: [concept, ci, review]
 ---
 
 # PR Merge Workflow
 
-Mandatory before any `gh pr merge`. Machine-enforced by `.claude/hooks/pr-merge-audit-check.sh` — the hook blocks `gh pr merge` calls that have not been preceded by a `code-review-audit` run on the current branch.
+Mandatory before any `gh pr merge`. Machine-enforced by `.claude/hooks/pr-merge-audit-check.sh`, which denies `gh pr merge` calls when no `code-review-audit` marker exists for the current HEAD SHA.
 
 ## Four-step protocol
 
@@ -25,23 +25,35 @@ Task(
 
 ### 2. Fix all issues
 
-- Fix every issue the audit identifies (security, performance, code quality).
+- Fix every Critical Issue and every Important Issue the audit identifies.
 - Re-run linting and type checking after fixes.
-- If fixes are non-trivial, re-run the audit to confirm resolution.
+- Stage, commit, and push the fixes — HEAD must move so the next audit runs against the fixed tree.
+- Re-spawn the audit agent on the new HEAD until it reports clean.
 
-### 3. Commit fixes
+### 3. Marker handshake
 
-- Stage and commit all fixes before merging.
-- Push the commit to the remote branch so the PR includes the fixes.
+The audit agent writes `.gaia/local/audit/<HEAD-sha>.ok` only on a clean pass (no Critical Issues, every Important Issue addressed in the working tree). The hook gates `gh pr merge` on the presence of that marker for the exact commit being merged. Knip / react-doctor advisories and Suggestions never block marker emission.
+
+If the agent declines to write the marker, the report names what remains unaddressed; resolve those, commit, push, re-spawn.
 
 ### 4. Merge
 
-- Only after steps 1-3 are complete and clean, proceed with the merge.
+Once the marker exists for HEAD, run `gh pr merge`. The hook short-circuits to allow the call.
+
+## Local-sync failure mode
+
+When `gh pr merge` exits with `fatal: 'main' is already used by worktree at <path>`, **the GitHub-side merge has already succeeded**. The local checkout step is what failed, not the merge itself. Confirm with:
+
+```
+gh pr view <N> --json state
+```
+
+If `state == "MERGED"`, do NOT retry the merge. Treat it as merged, run any post-merge steps (wiki-sync, spec-close, etc.), and resolve the local worktree conflict separately. Retrying compounds the problem and can produce a duplicate squash on a non-existent branch.
 
 ## No exceptions
 
-- Never skip the audit, even for "small" PRs.
-- Never merge with known issues from the audit.
-- If the user explicitly requests skipping the audit, confirm once before proceeding.
+- Never skip the audit, even for "small" PRs. The hook denies the merge.
+- Never hand-write a marker file to bypass the gate. The agent owns marker emission.
+- If a doc-only PR genuinely does not warrant an audit, run the agent anyway — it will report no findings and write the marker quickly.
 
 See [[Code Review Audit Agent]], [[Quality Gate]], [[Git Workflow]].


### PR DESCRIPTION
## Summary

Post-ship cleanup for SPEC-001. Three interlocked changes that close gaps surfaced when SPEC-001 (`/gaia forensics`) shipped on main without a clean audit pass.

- **Merge gate now actually blocks.** `pr-merge-audit-check.sh` used to exit 0 always (advisory text only). It now requires `.gaia/local/audit/<HEAD-sha>.ok` and denies the merge call when absent. The marker is written by the `code-review-audit` agent on a clean pass — agent file gains a new "Audit marker (gate handshake)" section. The hook's match is also tightened to anchor on shell-syntax boundaries so heredoc body text and quoted prose no longer false-positive.
- **Local-sync failure mode documented.** The deny reason and the wiki workflow doc both call out: when the merge command exits with `fatal: 'main' is already used by worktree at <path>`, the GitHub-side merge already succeeded. Verify with `gh pr view <N> --json state` and do not retry.
- **/gaia spec GitHub issue mirror is now opt-in.** Step 1 prompts via `AskUserQuestion` with default "skip"; the answer gates the step-10 `gh-mirror.sh` invocation. New step 12 documents that PRs implementing a mirrored SPEC must include `Closes #<N>` so the upstream issue auto-closes on merge.

## Files

- `.claude/hooks/pr-merge-audit-check.sh` — block on missing marker; surface unblock instructions and local-sync note in deny reason; tighten command match
- `.claude/agents/code-review-audit.md` — new "Audit marker (gate handshake)" section (writes marker on clean pass; refuses on findings)
- `.claude/skills/gaia/references/spec.md` — step 1 prompts for issue-mirror opt-in (default: no); step 10 gates on the answer; new step 12 documents `Closes #<N>` PR-body wiring
- `wiki/concepts/PR Merge Workflow.md` — rewrite to reflect blocking semantics; add local-sync failure mode

## Test plan

- [x] Verify hook denies `gh pr merge` when no marker exists for HEAD (validated during this session — first commit attempt was correctly blocked, then unblocked once the regex was tightened to ignore heredoc body text)
- [x] Verify hook does NOT trigger on commits whose message references `gh pr merge` in prose (validated; first false-positive commit failed, post-fix succeeded)
- [ ] Run `code-review-audit` on this branch; confirm marker is written at `.gaia/local/audit/<HEAD-sha>.ok` on clean pass
- [ ] Confirm `gh pr merge` succeeds locally once marker is present
- [ ] Smoke /gaia spec: verify step-1 question fires, default "no" skips step 10, "yes" runs gh-mirror

## Closes / refs

Closes #103 (already closed in this session via `gh issue close`; reference here for lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)