### PR TITLE
fix(forensics): SPEC-003 triage workflow correctness + hardening

### DIFF
--- a/.github/forensics/check-scope.sh
+++ b/.github/forensics/check-scope.sh
@@ -104,6 +104,12 @@ classify_path() {
 
 # json_escape <string>
 # Escapes a string for embedding inside a JSON string literal.
+#
+# Handles backslash and double-quote. Control bytes (U+0000..U+001F) are
+# NOT escaped here — the caller is expected to detect them via
+# find_control_byte() and reject the input with a structured error.
+# This split keeps json_escape predictable: its output is always valid
+# JSON-string content provided the input contains no control bytes.
 json_escape() {
   s=$1
   # Backslash first, then double-quote.
@@ -112,10 +118,69 @@ json_escape() {
   printf '%s' "$s"
 }
 
+# find_control_byte <string>
+# Echoes "<hex>:<position>" of the FIRST U+0000..U+001F byte found,
+# where <hex> is two lowercase hex digits and <position> is the
+# zero-indexed offset. Echoes empty string when no control byte is
+# present.
+#
+# UAT-009 (SPEC-003): JSON requires control bytes be escaped or rejected.
+# check-scope.sh's contract is path-policy enforcement; receiving a path
+# with a control byte signals upstream corruption, so we reject rather
+# than silently escape.
+find_control_byte() {
+  s=$1
+  i=0
+  while [ "$i" -lt "${#s}" ]; do
+    c=${s:$i:1}
+    # POSIX trick: leading single-quote in printf %d argument yields the
+    # ordinal of the first byte. Control bytes are single-byte in UTF-8.
+    ord=$(printf '%d' "'$c")
+    if [ "$ord" -lt 32 ]; then
+      printf '%02x:%d' "$ord" "$i"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  printf ''
+}
+
+# repr_path <string>
+# Builds a printable representation of a path that contains a control
+# byte: every non-printable byte is replaced with `?`, the result is
+# truncated to 40 chars, and a trailing ellipsis is appended when
+# truncation occurred. Used only by the control-byte rejection path.
+repr_path() {
+  s=$1
+  scrubbed=$(printf '%s' "$s" | tr -c '[:print:]' '?')
+  if [ "${#scrubbed}" -gt 40 ]; then
+    head40=$(printf '%s' "$scrubbed" | cut -c1-40)
+    printf '%s%s' "$head40" '...'
+  else
+    printf '%s' "$scrubbed"
+  fi
+}
+
 if [ "$#" -eq 0 ]; then
   printf '{"ok":true,"allowed":[],"denied":[]}\n'
   exit 0
 fi
+
+# UAT-009: short-circuit on the first control-byte-bearing path. The
+# rejection envelope replaces the normal classification result; exit 0
+# is preserved per the consumer-reads-JSON contract.
+for path in "$@"; do
+  ctrl=$(find_control_byte "$path")
+  if [ -n "$ctrl" ]; then
+    hex=${ctrl%%:*}
+    pos=${ctrl#*:}
+    repr=$(repr_path "$path")
+    repr_esc=$(json_escape "$repr")
+    printf '{"ok":false,"allowed":[],"denied":[{"path":"%s","reason":"control-byte:0x%s-at-position-%d"}]}\n' \
+      "$repr_esc" "$hex" "$pos"
+    exit 0
+  fi
+done
 
 allowed_json=""
 denied_json=""

--- a/.github/forensics/check-scope.sh
+++ b/.github/forensics/check-scope.sh
@@ -18,7 +18,7 @@
 #
 # POSIX bash only. No jq, no yq, no python.
 
-set -u
+set -uo pipefail
 
 # Rules are encoded as pipe-separated triples: "kind|type|pattern" where:
 #   kind = dir | file

--- a/.github/forensics/handlers/handle-needs-human.sh
+++ b/.github/forensics/handlers/handle-needs-human.sh
@@ -9,7 +9,7 @@
 # Usage:
 #   handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>
 #
-# <reason-code> ∈ { out-of-scope, ambiguous-verdict, malformed-body, gate-failure, internal-error }
+# <reason-code> ∈ { out-of-scope, ambiguous-verdict, malformed-body, gate-failure, deviation, internal-error }
 #
 # Exit code: 0 on success. Non-zero on bad usage, missing file, or unknown
 # reason-code. gh-level failures propagate.
@@ -22,7 +22,7 @@ MAINTAINER="@stevensacks"
 
 usage() {
   echo "usage: handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>" >&2
-  echo "  <reason-code> ∈ {out-of-scope, ambiguous-verdict, malformed-body, gate-failure, internal-error}" >&2
+  echo "  <reason-code> ∈ {out-of-scope, ambiguous-verdict, malformed-body, gate-failure, deviation, internal-error}" >&2
   exit 2
 }
 
@@ -47,6 +47,9 @@ case "$reason_code" in
     ;;
   gate-failure)
     summary="auto-fix branch failed the Quality Gate; branch was discarded (UAT-005)."
+    ;;
+  deviation)
+    summary="the auto-fix model touched in-allowlist paths that were not declared in its proposed scope; the diff deviates from the classifier's intent."
     ;;
   internal-error)
     summary="a forensics primitive emitted internal-error JSON; the workflow could not proceed deterministically."

--- a/.github/forensics/handlers/handle-needs-human.sh
+++ b/.github/forensics/handlers/handle-needs-human.sh
@@ -9,7 +9,7 @@
 # Usage:
 #   handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>
 #
-# <reason-code> ∈ { out-of-scope, ambiguous-verdict, malformed-body, gate-failure }
+# <reason-code> ∈ { out-of-scope, ambiguous-verdict, malformed-body, gate-failure, internal-error }
 #
 # Exit code: 0 on success. Non-zero on bad usage, missing file, or unknown
 # reason-code. gh-level failures propagate.
@@ -22,7 +22,7 @@ MAINTAINER="@stevensacks"
 
 usage() {
   echo "usage: handle-needs-human.sh <issue-num> <reasoning-file> <reason-code>" >&2
-  echo "  <reason-code> ∈ {out-of-scope, ambiguous-verdict, malformed-body, gate-failure}" >&2
+  echo "  <reason-code> ∈ {out-of-scope, ambiguous-verdict, malformed-body, gate-failure, internal-error}" >&2
   exit 2
 }
 
@@ -47,6 +47,9 @@ case "$reason_code" in
     ;;
   gate-failure)
     summary="auto-fix branch failed the Quality Gate; branch was discarded (UAT-005)."
+    ;;
+  internal-error)
+    summary="a forensics primitive emitted internal-error JSON; the workflow could not proceed deterministically."
     ;;
   *)
     echo "handle-needs-human.sh: unknown reason-code: $reason_code" >&2

--- a/.github/forensics/parse-issue-body.sh
+++ b/.github/forensics/parse-issue-body.sh
@@ -11,11 +11,23 @@
 # task spec at
 # `.gaia/local/plans/spec-002-forensics-triage-action/task-body-parser.md`.
 
-set -u
+set -uo pipefail
 
 usage() {
   echo "usage: parse-issue-body.sh <input-file>" >&2
   exit 2
+}
+
+# emit_internal_error <stage> <exit-code>
+# Emits the SPEC-003 internal-error JSON envelope on stdout. Used by the
+# per-awk exit-code checks: when an awk pipeline returns non-zero, the
+# consumer needs a deterministic signal distinguishing "infrastructure
+# failure" from "valid:false / verdict:ambiguous". The script's overall
+# exit code remains 0 (consumers parse JSON; exit 2 is reserved for
+# usage errors).
+emit_internal_error() {
+  printf '{"internal_error":true,"stage":"%s","exit_code":%d}\n' "$1" "$2"
+  exit 0
 }
 
 [ "$#" -eq 1 ] || usage
@@ -37,6 +49,8 @@ trap 'rm -rf "$work_dir"' EXIT
 # First non-blank line (well, first line — SPEC-001 emits `---` as line 1)
 # must be the frontmatter sentinel.
 first_line=$(awk 'NR==1{print; exit}' "$input_file")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
 if [ "$first_line" != "---" ]; then
   printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
   exit 0
@@ -44,6 +58,8 @@ fi
 
 # Closing `---` line number (must be > 1, exact match).
 fm_end=$(awk 'NR>1 && $0=="---"{print NR; exit}' "$input_file")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
 if [ -z "${fm_end:-}" ]; then
   printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
   exit 0
@@ -51,6 +67,8 @@ fi
 
 # Frontmatter content lines (between line 2 and fm_end-1).
 awk -v end="$fm_end" 'NR>1 && NR<end' "$input_file" > "$work_dir/frontmatter.txt"
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
 
 fm_class=""
 fm_gaia_version=""
@@ -147,6 +165,8 @@ awk -v start="$body_start" -v out_dir="$work_dir" '
     flush()
   }
 ' "$input_file"
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "section-split" "$awk_status"
 
 # ---------------------------------------------------------------------------
 # Step 3: failure-mode resolution. Order:
@@ -213,9 +233,17 @@ trim_one_blank_each_end() {
 }
 
 sec_symptom=$(trim_one_blank_each_end "$work_dir/sec-symptom.txt")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "section-content-extract" "$awk_status"
 sec_classification=$(trim_one_blank_each_end "$work_dir/sec-classification.txt")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "section-content-extract" "$awk_status"
 sec_capture=$(trim_one_blank_each_end "$work_dir/sec-capture.txt")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "section-content-extract" "$awk_status"
 sec_reproduction=$(trim_one_blank_each_end "$work_dir/sec-reproduction.txt")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "section-content-extract" "$awk_status"
 
 empty_list=""
 [ -z "$sec_symptom" ]        && empty_list="${empty_list}\"symptom\","

--- a/.github/forensics/parse-verdict.sh
+++ b/.github/forensics/parse-verdict.sh
@@ -24,11 +24,22 @@
 # POSIX bash + awk only. No jq, no python. Exit 0 always (consumers read
 # JSON); exit 2 reserved for genuine usage errors.
 
-set -u
+set -uo pipefail
 
 usage() {
   echo "usage: parse-verdict.sh <action-output-file>" >&2
   exit 2
+}
+
+# emit_internal_error <stage> <exit-code>
+# Emits the SPEC-003 internal-error JSON envelope on stdout. Used by the
+# per-awk exit-code checks: when an awk pipeline returns non-zero, the
+# consumer needs a deterministic signal distinguishing "infrastructure
+# failure" from "verdict:ambiguous". The script's overall exit code
+# remains 0 (consumers parse JSON; exit 2 is reserved for usage errors).
+emit_internal_error() {
+  printf '{"internal_error":true,"stage":"%s","exit_code":%d}\n' "$1" "$2"
+  exit 0
 }
 
 [ "$#" -eq 1 ] || usage
@@ -47,12 +58,19 @@ trap 'rm -rf "$work_dir"' EXIT
 # Count of GAIA-VERDICT lines (leading whitespace tolerated; the rest of the
 # line is the value, possibly with trailing whitespace).
 verdict_count=$(awk '/^[[:space:]]*GAIA-VERDICT:/ { c++ } END { print c+0 }' "$input_file")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "verdict-count" "$awk_status"
 
 # Line number of the last non-blank line.
 last_nonblank_lineno=$(awk 'NF { last = NR } END { print last+0 }' "$input_file")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "last-nonblank-locate" "$awk_status"
 
-# Line number of the (single) verdict line, if present.
+# Line number of the (single) verdict line, if present. `pipefail` is on,
+# so a non-zero awk exit propagates through the `tail` stage.
 verdict_lineno=$(awk '/^[[:space:]]*GAIA-VERDICT:/ { print NR }' "$input_file" | tail -n 1)
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "verdict-line-locate" "$awk_status"
 
 # ---------------------------------------------------------------------------
 # Step 2: classify the verdict.
@@ -178,6 +196,8 @@ awk '
     }
   }
 ' "$input_file" > "$work_dir/paths-raw.txt"
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "proposed-paths-extract" "$awk_status"
 
 # Build the JSON array of proposed paths and remember whether any were found.
 paths_json=""

--- a/.github/forensics/render-prompt.sh
+++ b/.github/forensics/render-prompt.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# render-prompt.sh — SPEC-003 prompt-template renderer.
+#
+# Usage:
+#   render-prompt.sh <template-file> <key=value>...
+#
+# Reads <template-file> from disk and substitutes each `{{KEY}}` placeholder
+# with the supplied value. Renders to stdout.
+#
+# Why this script exists: the previous inline `awk -v` rendering blocks in
+# `.github/workflows/forensics-triage.yml` had two critical bugs — POSIX
+# awk and gawk both reject `-v var=value` assignments containing literal
+# newlines (UAT-001), and `gsub(re, repl, target)` expands `&` in `repl`
+# to the matched text, corrupting any user content containing `&`
+# (UAT-002). This helper sidesteps both failures by walking the template
+# once and replacing tokens with literal-string values — no regex, no
+# `awk -v`, no replacement-string escape semantics.
+#
+# Single-pass guarantee (UAT-003): the template is walked exactly once.
+# At each cursor position we look for the LEFTMOST placeholder token; if
+# found, we emit the literal prefix and the substituted value, then
+# advance the cursor PAST the inserted value (not re-scanning it). A
+# placeholder token that appears inside a substituted value's text is
+# therefore NEVER re-substituted on a later pass.
+#
+# Bash 3.2 compatible (no associative arrays, no `mapfile`). The macOS
+# default bash is 3.2 and the existing forensics scripts run there for
+# bats locally; GitHub Actions ubuntu-latest has bash 5+.
+#
+# Exit codes:
+#   0 — success
+#   2 — bad usage (missing template, malformed key=value, key not present
+#       in template, duplicate key)
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "render-prompt.sh: usage: render-prompt.sh <template-file> <key=value>..." >&2
+  exit 2
+fi
+
+template_file="$1"
+shift
+
+if [ ! -f "$template_file" ]; then
+  echo "render-prompt.sh: template not found: $template_file" >&2
+  exit 2
+fi
+
+# Parallel arrays — bash 3.2 has no associative arrays. `keys[i]`,
+# `tokens[i]`, and `vals[i]` index together.
+keys=()
+tokens=()
+vals=()
+for arg in "$@"; do
+  case "$arg" in
+    *=*)
+      key="${arg%%=*}"
+      value="${arg#*=}"
+      if [ -z "$key" ]; then
+        echo "render-prompt.sh: malformed key=value (empty key): $arg" >&2
+        exit 2
+      fi
+      # Duplicate-key check: scan keys[] for this key.
+      for existing in ${keys[@]+"${keys[@]}"}; do
+        if [ "$existing" = "$key" ]; then
+          echo "render-prompt.sh: duplicate key $key" >&2
+          exit 2
+        fi
+      done
+      keys+=("$key")
+      tokens+=("{{${key}}}")
+      vals+=("$value")
+      ;;
+    *)
+      echo "render-prompt.sh: malformed key=value (no '='): $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Slurp the template once.
+content="$(cat "$template_file")"
+
+# Validate: every supplied key must appear at least once in the template.
+# Surfacing a typo'd key explicitly is preferable to silently emitting a
+# template with `{{FOO}}` un-substituted.
+i=0
+for key in ${keys[@]+"${keys[@]}"}; do
+  token="${tokens[$i]}"
+  case "$content" in
+    *"$token"*) ;;
+    *)
+      echo "render-prompt.sh: key $key not present in template" >&2
+      exit 2
+      ;;
+  esac
+  i=$((i + 1))
+done
+
+# Single-pass walk:
+#
+#   while content has any token:
+#     find the LEFTMOST token across all (token, value) pairs
+#     emit prefix (text before the leftmost token) verbatim
+#     emit the corresponding value verbatim
+#     advance past the value (do NOT re-scan it for tokens)
+#
+# Bash parameter-expansion idiom for "position of first occurrence of N
+# in S" is "${S%%N*}" giving the prefix; its length is the position.
+# `${#var}` works correctly for byte-length even when the content
+# contains `&`, `\`, `/`, or newlines.
+#
+# Output is built up in `result` and emitted at the end with a single
+# `printf '%s'` so there is no extra trailing newline beyond what the
+# template (or its substituted values) already contained.
+
+result=""
+
+n="${#keys[@]}"
+while :; do
+  # Find leftmost token in current `content`.
+  best_pos=-1
+  best_idx=-1
+  best_token_len=0
+  best_value=""
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    token="${tokens[$i]}"
+    case "$content" in
+      *"$token"*)
+        prefix="${content%%"$token"*}"
+        pos="${#prefix}"
+        if [ "$best_pos" -eq -1 ] || [ "$pos" -lt "$best_pos" ]; then
+          best_pos="$pos"
+          best_idx="$i"
+          best_token_len="${#token}"
+          best_value="${vals[$i]}"
+        fi
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  if [ "$best_idx" -eq -1 ]; then
+    # No more tokens. Emit the rest of the content and stop.
+    result="${result}${content}"
+    break
+  fi
+
+  # Emit prefix + value, advance content past the matched token.
+  prefix="${content:0:best_pos}"
+  result="${result}${prefix}${best_value}"
+  content="${content:best_pos + best_token_len}"
+done
+
+printf '%s' "$result"

--- a/.github/forensics/render-prompt.sh
+++ b/.github/forensics/render-prompt.sh
@@ -154,4 +154,4 @@ while :; do
   content="${content:best_pos + best_token_len}"
 done
 
-printf '%s' "$result"
+printf '%s\n' "$result"

--- a/.github/forensics/run-quality-gate.sh
+++ b/.github/forensics/run-quality-gate.sh
@@ -45,7 +45,7 @@
 #   …validates a candidate fix branch the same way the workflow does
 #   before manually opening a PR.
 
-set -u
+set -uo pipefail
 
 usage() {
   echo "usage: run-quality-gate.sh <output-summary-file>" >&2

--- a/.github/forensics/tests/check-scope.bats
+++ b/.github/forensics/tests/check-scope.bats
@@ -165,3 +165,88 @@ setup() {
   run "$SCRIPT"
   [ "$output" = '{"ok":true,"allowed":[],"denied":[]}' ]
 }
+
+# --- control-byte rejection (UAT-009) --------------------------------------
+#
+# JSON forbids unescaped U+0000..U+001F inside string literals. The script
+# rejects any path containing a control byte with a structured error
+# envelope rather than emitting malformed JSON. Filesystems forbid these
+# in path names in practice; the rejection path defends against synthetic
+# inputs (misbehaving callers, future test harnesses) and surfaces them
+# as an explicit upstream signal.
+
+@test "control-byte: tab (0x09) → reject with reason naming hex+position" {
+  path=$(printf 'app/foo\tbar.ts')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  case $output in
+    *'"ok":false'*'"reason":"control-byte:0x09-at-position-7"'*) ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: newline (0x0a) → reject with reason naming hex+position" {
+  path=$(printf 'wiki/index\nmd')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  case $output in
+    *'"ok":false'*'"reason":"control-byte:0x0a-at-position-10"'*) ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: carriage-return (0x0d) → reject" {
+  path=$(printf 'a\rb')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  case $output in
+    *'"reason":"control-byte:0x0d-at-position-1"'*) ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: U+0001 (SOH, 0x01) → reject" {
+  path=$(printf 'foo\001bar')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  case $output in
+    *'"reason":"control-byte:0x01-at-position-3"'*) ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: rejection envelope shape — ok:false, allowed:[], single denied entry" {
+  path=$(printf 'x\ty')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  # Whole envelope: allowed must be empty and denied must hold exactly the one entry.
+  case $output in
+    '{"ok":false,"allowed":[],"denied":[{"path":"x?y","reason":"control-byte:0x09-at-position-1"}]}') ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: short-circuits before classifying remaining paths" {
+  # First arg has a control byte; remaining args (allow + deny) must NOT
+  # appear in the output — the rejection envelope replaces the normal
+  # classification result.
+  bad=$(printf 'bad\tpath')
+  run "$SCRIPT" "$bad" .gaia/cli/foo.sh app/bar.ts
+  [ "$status" -eq 0 ]
+  case $output in
+    *'.gaia/cli/foo.sh'*) printf 'allowlisted path leaked: %s\n' "$output" >&2; return 1 ;;
+    *'app/bar.ts'*) printf 'denylisted path leaked: %s\n' "$output" >&2; return 1 ;;
+    *'"reason":"control-byte:0x09-at-position-3"'*) ;;
+    *) printf 'unexpected output: %s\n' "$output" >&2; return 1 ;;
+  esac
+}
+
+@test "control-byte: rejection JSON parses with jq" {
+  if ! command -v jq >/dev/null 2>&1; then
+    skip "jq not available"
+  fi
+  path=$(printf 'a\tb')
+  run "$SCRIPT" "$path"
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | jq . >/dev/null
+}

--- a/.github/forensics/tests/fixtures/render-template-basic.md
+++ b/.github/forensics/tests/fixtures/render-template-basic.md
@@ -1,0 +1,8 @@
+Issue #{{ISSUE_NUMBER}} classifier prompt.
+
+Symptom: {{SYMPTOM}}
+Classification: {{CLASSIFICATION}}
+Capture: {{CAPTURE}}
+Reproduction context: {{REPRO_CONTEXT}}
+Allowlist: {{ALLOWLIST}}
+Denylist: {{DENYLIST}}

--- a/.github/forensics/tests/fixtures/render-template-multiline.md
+++ b/.github/forensics/tests/fixtures/render-template-multiline.md
@@ -1,0 +1,9 @@
+Issue #{{ISSUE_NUMBER}}
+
+## Capture
+
+```
+{{CAPTURE}}
+```
+
+## End

--- a/.github/forensics/tests/fixtures/render-template-placeholder-collision.md
+++ b/.github/forensics/tests/fixtures/render-template-placeholder-collision.md
@@ -1,0 +1,2 @@
+Symptom: {{SYMPTOM}}
+Capture: {{CAPTURE}}

--- a/.github/forensics/tests/fixtures/render-template-special-chars.md
+++ b/.github/forensics/tests/fixtures/render-template-special-chars.md
@@ -1,0 +1,2 @@
+Symptom: {{SYMPTOM}}
+Capture: {{CAPTURE}}

--- a/.github/forensics/tests/handlers.bats
+++ b/.github/forensics/tests/handlers.bats
@@ -256,6 +256,17 @@ first_captured_body() {
   grep -qF 'ambiguous-verdict' "$body_path"
 }
 
+@test "needs-human: comment names the reason-code deviation (UAT-010)" {
+  reasoning="$BATS_TEST_TMPDIR/r.md"
+  printf 'deviation detail\n' > "$reasoning"
+  run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" deviation
+  [ "$status" -eq 0 ]
+  body_path="$(first_captured_body)"
+  grep -qF 'reason: `deviation`' "$body_path"
+  grep -qF 'in-allowlist paths' "$body_path"
+  grep -qF 'deviates from the classifier' "$body_path"
+}
+
 @test "needs-human: gaia-triaged is the LAST mutation" {
   reasoning="$BATS_TEST_TMPDIR/r.md"
   printf 'x\n' > "$reasoning"

--- a/.github/forensics/tests/parse-issue-body.bats
+++ b/.github/forensics/tests/parse-issue-body.bats
@@ -278,6 +278,39 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# SPEC-003 UAT-006 — pipefail + internal-error JSON envelope. When awk
+# fails, the script must NOT fall through to a default valid:false; it
+# must emit `{"internal_error":true,...}` so the workflow can distinguish
+# infrastructure failure from a malformed body.
+# ---------------------------------------------------------------------------
+
+@test "pipefail preamble is declared" {
+  grep -qE '^set -uo pipefail' "$PARSER"
+}
+
+@test "awk failure emits internal-error JSON envelope (not valid:false)" {
+  # Shadow `awk` with a stub that always exits non-zero. The script is
+  # invoked via `env PATH=...` so it picks up the stub before the system
+  # awk. Exit-code check on the FIRST awk call (frontmatter-extract)
+  # fires immediately.
+  fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/awk" <<'STUB'
+#!/usr/bin/env bash
+exit 7
+STUB
+  chmod +x "$fake_bin/awk"
+
+  run env PATH="$fake_bin:$PATH" "$PARSER" "$FIX/valid.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"internal_error":true'* ]]
+  [[ "$output" == *'"stage":"frontmatter-extract"'* ]]
+  [[ "$output" == *'"exit_code":7'* ]]
+  # Critical: the failure path does NOT pretend to be a malformed body.
+  [[ "$output" != *'"valid":false'* ]]
+}
+
+# ---------------------------------------------------------------------------
 # JSON shape sanity — make sure the success JSON contains all required
 # top-level keys.
 # ---------------------------------------------------------------------------

--- a/.github/forensics/tests/parse-verdict.bats
+++ b/.github/forensics/tests/parse-verdict.bats
@@ -320,6 +320,44 @@ EOF
 # Determinism — same input twice yields byte-identical output.
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# SPEC-003 UAT-006 — pipefail + internal-error JSON envelope. When awk
+# fails, the script must NOT fall through to a default verdict:ambiguous;
+# it must emit `{"internal_error":true,...}` so the workflow can
+# distinguish infrastructure failure from a non-conformant classifier
+# response.
+# ---------------------------------------------------------------------------
+
+@test "pipefail preamble is declared" {
+  grep -qE '^set -uo pipefail' "$PARSER"
+}
+
+@test "awk failure emits internal-error JSON envelope (not verdict:ambiguous)" {
+  body_file="$BATS_TEST_TMPDIR/internal-error-input.txt"
+  cat > "$body_file" <<'EOF'
+Reasoning.
+
+GAIA-VERDICT: non-issue
+EOF
+
+  # Shadow `awk` with a stub that always exits non-zero. Exit-code check
+  # on the first awk call (verdict-count) fires immediately.
+  fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/awk" <<'STUB'
+#!/usr/bin/env bash
+exit 9
+STUB
+  chmod +x "$fake_bin/awk"
+
+  run env PATH="$fake_bin:$PATH" "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"internal_error":true'* ]]
+  [[ "$output" == *'"exit_code":9'* ]]
+  # Critical: the failure path does NOT pretend to be an ambiguous verdict.
+  [[ "$output" != *'"verdict":"ambiguous"'* ]]
+}
+
 @test "parser output is byte-identical across two runs" {
   body_file="$BATS_TEST_TMPDIR/det.txt"
   cat > "$body_file" <<'EOF'

--- a/.github/forensics/tests/render-prompt.bats
+++ b/.github/forensics/tests/render-prompt.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# Tests for `.github/forensics/render-prompt.sh`.
+#
+# SPEC-003 UAT-001 / UAT-002 / UAT-003 / UAT-004. The shipped workflow's
+# inline `awk -v` rendering blocks failed on multi-line section content,
+# corrupted `&` characters via `gsub` replacement-string semantics, and
+# could not be exercised by bats. This suite covers the structural fix:
+# every render edge-case the shipped renderer would have mishandled, plus
+# the contract's exit-code surface (missing template, malformed args,
+# unknown keys, duplicate keys, empty values, values containing `=`).
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  SCRIPT="$THIS_DIR/../render-prompt.sh"
+  FIXTURES="$THIS_DIR/fixtures"
+  [ -x "$SCRIPT" ] || skip "render-prompt.sh not executable"
+}
+
+# --- 1. Basic substitution -------------------------------------------------
+
+@test "basic: single placeholder substitutes" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=hello" \
+    "CAPTURE=world"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: hello
+Capture: world" ]
+}
+
+# --- 2. Multi-line value (UAT-001) -----------------------------------------
+
+@test "multi-line value preserves all lines verbatim" {
+  multi=$'line1\nline2\nline3'
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=x" \
+    "CAPTURE=$multi"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: x
+Capture: line1
+line2
+line3" ]
+}
+
+# --- 3. Multi-line value with fenced code block (UAT-001) ------------------
+
+@test "multi-line value containing a fenced code block round-trips" {
+  fenced=$'```bash\nset -e\necho hi\n```'
+  run "$SCRIPT" "$FIXTURES/render-template-multiline.md" \
+    "ISSUE_NUMBER=42" \
+    "CAPTURE=$fenced"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'Issue #42
+
+## Capture
+
+```
+```bash
+set -e
+echo hi
+```
+```
+
+## End' ]
+}
+
+# --- 4. Ampersand in value (UAT-002) ---------------------------------------
+
+@test "ampersand in value passes through literally (no & replacement-string expansion)" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=install fails & dev-server hangs" \
+    "CAPTURE=x"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: install fails & dev-server hangs
+Capture: x" ]
+}
+
+# --- 5. Backslash in value (UAT-002) ---------------------------------------
+
+@test "backslashes in value pass through literally" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=x" \
+    'CAPTURE=C:\path\to\file'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'Symptom: x
+Capture: C:\path\to\file' ]
+}
+
+# --- 6. Forward slash in value (defensive) ---------------------------------
+
+@test "forward slashes in value pass through literally" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=x" \
+    "CAPTURE=/path/to/file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: x
+Capture: /path/to/file" ]
+}
+
+# --- 7. Placeholder token in value (UAT-003) -------------------------------
+
+@test "placeholder token inside a value is NOT re-substituted by a later pass" {
+  # CAPTURE substitutes first (lexical order in args is preserved by the
+  # script). Its value contains the literal string `{{SYMPTOM}}`. SYMPTOM's
+  # subsequent pass MUST NOT re-substitute that string — single-pass-per-
+  # placeholder guarantee.
+  run "$SCRIPT" "$FIXTURES/render-template-placeholder-collision.md" \
+    "CAPTURE=user wrote {{SYMPTOM}} in their capture" \
+    "SYMPTOM=actual-symptom"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: actual-symptom
+Capture: user wrote {{SYMPTOM}} in their capture" ]
+}
+
+# --- 8. Multiple placeholders, mixed values --------------------------------
+
+@test "all seven classifier tokens substitute with no cross-contamination" {
+  run "$SCRIPT" "$FIXTURES/render-template-basic.md" \
+    "ISSUE_NUMBER=999" \
+    "SYMPTOM=sym-val" \
+    "CLASSIFICATION=cls-val" \
+    "CAPTURE=cap-val" \
+    "REPRO_CONTEXT=rep-val" \
+    "ALLOWLIST=al-val" \
+    "DENYLIST=dl-val"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Issue #999 classifier prompt.
+
+Symptom: sym-val
+Classification: cls-val
+Capture: cap-val
+Reproduction context: rep-val
+Allowlist: al-val
+Denylist: dl-val" ]
+}
+
+# --- 9. Missing template file ---------------------------------------------
+
+@test "missing template file: exit 2 with stderr message" {
+  run "$SCRIPT" "/nonexistent/template.md" "FOO=bar"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"template not found"* ]]
+}
+
+# --- 10. Malformed key=value arg ------------------------------------------
+
+@test "malformed key=value (no '='): exit 2" {
+  run "$SCRIPT" "$FIXTURES/render-template-basic.md" "FOO"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"malformed key=value"* ]]
+}
+
+# --- 11. Key not in template ----------------------------------------------
+
+@test "key not present in template: exit 2 with key name" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=x" \
+    "CAPTURE=y" \
+    "BOGUS=z"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"BOGUS"* ]]
+  [[ "$output" == *"not present in template"* ]]
+}
+
+# --- 12. Duplicate key arg -------------------------------------------------
+
+@test "duplicate key: exit 2 with key name" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=a" \
+    "SYMPTOM=b" \
+    "CAPTURE=c"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"duplicate key"* ]]
+  [[ "$output" == *"SYMPTOM"* ]]
+}
+
+# --- 13. Empty value -------------------------------------------------------
+
+@test "empty value substitutes to empty string" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=" \
+    "CAPTURE=x"
+  [ "$status" -eq 0 ]
+  # Template has `Symptom: {{SYMPTOM}}` — empty value collapses the
+  # placeholder but the literal space before it stays. The expected
+  # string has a trailing space after `Symptom:`.
+  expected="Symptom: "$'\n'"Capture: x"
+  [ "$output" = "$expected" ]
+}
+
+# --- 14. Value containing `=` ---------------------------------------------
+
+@test "value containing '=' splits on first '=' only" {
+  run "$SCRIPT" "$FIXTURES/render-template-special-chars.md" \
+    "SYMPTOM=a=b=c" \
+    "CAPTURE=x"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Symptom: a=b=c
+Capture: x" ]
+}
+
+# --- 15. Idempotency / determinism ----------------------------------------
+
+@test "two consecutive runs with identical inputs produce byte-identical output" {
+  out1="$BATS_TEST_TMPDIR/out1"
+  out2="$BATS_TEST_TMPDIR/out2"
+  multi=$'line1\nline2 with & ampersand\nline3 with \\ backslash'
+  "$SCRIPT" "$FIXTURES/render-template-basic.md" \
+    "ISSUE_NUMBER=42" \
+    "SYMPTOM=s" \
+    "CLASSIFICATION=c" \
+    "CAPTURE=$multi" \
+    "REPRO_CONTEXT=r" \
+    "ALLOWLIST=a" \
+    "DENYLIST=d" > "$out1"
+  "$SCRIPT" "$FIXTURES/render-template-basic.md" \
+    "ISSUE_NUMBER=42" \
+    "SYMPTOM=s" \
+    "CLASSIFICATION=c" \
+    "CAPTURE=$multi" \
+    "REPRO_CONTEXT=r" \
+    "ALLOWLIST=a" \
+    "DENYLIST=d" > "$out2"
+  cmp "$out1" "$out2"
+}

--- a/.github/forensics/tests/render-prompt.bats
+++ b/.github/forensics/tests/render-prompt.bats
@@ -222,3 +222,32 @@ Capture: x" ]
     "DENYLIST=d" > "$out2"
   cmp "$out1" "$out2"
 }
+
+# --- 16. Newline termination ----------------------------------------------
+# Workflow YAML pipes the rendered output into a $GITHUB_OUTPUT heredoc; if
+# the last byte is not a newline, the closing delimiter ends up appended to
+# the last content line and the heredoc parser rejects it
+# ("Matching delimiter not found"). Lock the invariant.
+
+@test "rendered output ends with a newline byte" {
+  out="$BATS_TEST_TMPDIR/out"
+  "$SCRIPT" "$FIXTURES/render-template-basic.md" \
+    "ISSUE_NUMBER=42" \
+    "SYMPTOM=s" \
+    "CLASSIFICATION=c" \
+    "CAPTURE=cap" \
+    "REPRO_CONTEXT=r" \
+    "ALLOWLIST=a" \
+    "DENYLIST=d" > "$out"
+  last_byte="$(tail -c 1 "$out" | od -An -c | tr -d ' ')"
+  [ "$last_byte" = "\\n" ]
+}
+
+@test "rendered output ends with a newline even when template has no trailing newline" {
+  template="$BATS_TEST_TMPDIR/no-trailing.md"
+  printf '%s' "Issue {{ISSUE_NUMBER}}" > "$template"
+  out="$BATS_TEST_TMPDIR/out"
+  "$SCRIPT" "$template" "ISSUE_NUMBER=42" > "$out"
+  last_byte="$(tail -c 1 "$out" | od -An -c | tr -d ' ')"
+  [ "$last_byte" = "\\n" ]
+}

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -242,15 +242,16 @@ jobs:
           EXEC_FILE: ${{ steps.classify.outputs.execution_file }}
         run: |
           set -eu
-          # The action emits a JSONL execution log; the assistant's final
-          # response lives on the line where `type == "result"` (field
-          # `.result`). Extract that to a plain text file for parse-verdict.
+          # The action emits a top-level JSON array of execution events;
+          # the assistant's final response lives on the entry where
+          # `type == "result"` (field `.result`). Extract that to a plain
+          # text file for parse-verdict.
           verdict_text="${RUNNER_TEMP}/forensics/verdict-text.md"
           if [ -z "${EXEC_FILE:-}" ] || [ ! -f "$EXEC_FILE" ]; then
             echo "::error::classifier execution_file missing or unreadable: ${EXEC_FILE:-<empty>}"
             exit 1
           fi
-          jq -rs 'map(select(.type == "result")) | .[-1].result // empty' "$EXEC_FILE" > "$verdict_text"
+          jq -r '[.[] | select(.type == "result")] | .[-1].result // empty' "$EXEC_FILE" > "$verdict_text"
           if [ ! -s "$verdict_text" ]; then
             echo "::warning::classifier produced no result text — treating as ambiguous"
           fi
@@ -502,13 +503,14 @@ jobs:
             done >> "$GITHUB_OUTPUT"
           }
 
-          # Capture the apply-fix execution-file's last `result` line so we
+          # Capture the apply-fix execution-file's last `result` entry so we
           # can detect the GAIA-FIX-ABORT escape hatch and surface the
-          # rationale to the maintainer.
+          # rationale to the maintainer. The action emits a top-level
+          # JSON array of execution events.
           apply_text="${RUNNER_TEMP}/forensics/apply-fix-text.md"
           if [ -n "${{ steps.apply-fix.outputs.execution_file }}" ] \
              && [ -f "${{ steps.apply-fix.outputs.execution_file }}" ]; then
-            jq -rs 'map(select(.type == "result")) | .[-1].result // empty' \
+            jq -r '[.[] | select(.type == "result")] | .[-1].result // empty' \
               "${{ steps.apply-fix.outputs.execution_file }}" > "$apply_text"
           else
             : > "$apply_text"

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -233,6 +233,11 @@ jobs:
         if: |
           steps.idempotency.outputs.already_triaged != 'true' &&
           steps.parse.outputs.valid == 'true'
+        # Continue on failure: max-turns / SDK / API errors must not strand
+        # the issue in a "triaged but no verdict" half-state. The verdict
+        # extractor downstream treats an empty result as ambiguous and
+        # routes to needs-human via the standard fallback.
+        continue-on-error: true
         uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -482,6 +487,12 @@ jobs:
           steps.parse.outputs.valid == 'true' &&
           steps.verdict.outputs.verdict == 'auto-fixable' &&
           steps.scope.outputs.ok == 'true'
+        # Continue on failure: max-turns / SDK / API errors must not strand
+        # the issue. The Verify-diff step already routes empty-diff and
+        # GAIA-FIX-ABORT to handle-needs-human.sh; an action exit-non-zero
+        # demotes cleanly through the same path instead of short-circuiting
+        # the rest of the workflow.
+        continue-on-error: true
         uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -32,6 +32,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      id-token: write
     concurrency:
       group: forensics-${{ github.event.issue.number }}
       cancel-in-progress: false

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -499,8 +499,11 @@ jobs:
           prompt: ${{ steps.render-apply.outputs.body }}
           # File-edit tools only. NO Bash, NO git, NO push tools, NO web.
           # Post-step verification asserts diffs touch only `proposed_paths`.
+          # max-turns bumped to 60 after Phase 4a UAT-004 surfaced 30 was
+          # too tight on a moderate-complexity fixture; the fix-abort and
+          # quality-gate backstops contain runaway behavior.
           claude_args: |
-            --max-turns 30
+            --max-turns 60
             --allowedTools Edit,Write
             --disallowedTools Bash,WebFetch,WebSearch
 

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -158,7 +158,7 @@ jobs:
           # the redaction tokens themselves and only masks any literal
           # secret-shaped bytes the parser might have surfaced.
           mask_secret_shapes() {
-            printf '%s\n' "$1" | grep -oE 'sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}' | while IFS= read -r tok; do
+            printf '%s\n' "$1" | grep -oE 'sk-ant-[A-Za-z0-9_-]{20,}|gh[psuor]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}' | while IFS= read -r tok; do
               [ -n "$tok" ] && echo "::add-mask::$tok"
             done || true
           }
@@ -575,13 +575,14 @@ jobs:
           steps.verdict.outputs.verdict == 'auto-fixable' &&
           steps.scope.outputs.ok == 'true' &&
           steps.verify-diff.outputs.diff_ok == 'false'
+        env:
+          ABORT_REASON: ${{ steps.verify-diff.outputs.abort_reason }}
         run: |
           set -eu
           reason_file="${RUNNER_TEMP}/forensics/apply-abort-reason.md"
           # shellcheck disable=SC2016 # awk program references awk's $0
           {
-            printf 'auto-fix abort reason: `%s`\n\n' \
-              "${{ steps.verify-diff.outputs.abort_reason }}"
+            printf 'auto-fix abort reason: `%s`\n\n' "$ABORT_REASON"
             cat "${{ steps.verdict.outputs.reasoning_file }}"
             printf '\n\n---\n\nfix-applier final message:\n\n'
             cat "${{ steps.verify-diff.outputs.apply_text }}" || true
@@ -595,10 +596,18 @@ jobs:
           # pushed, but resetting keeps the runner's working tree clean
           # in case any always-run step inspects it.
           git reset --hard HEAD
+          # UAT-010: `diff-not-in-proposed` is a deviation (the model
+          # touched in-allowlist paths it did not declare upfront), not a
+          # scope violation. Other abort reasons remain `out-of-scope`.
+          if [ "$ABORT_REASON" = "diff-not-in-proposed" ]; then
+            reason_code="deviation"
+          else
+            reason_code="out-of-scope"
+          fi
           "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
             "$ISSUE_NUMBER" \
             "$reason_file" \
-            "out-of-scope"
+            "$reason_code"
 
       # ----------------------------------------------------------------
       # UAT-005: Quality Gate. Branch is local-only; we push only when

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -53,7 +53,17 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
-          cache: 'pnpm'
+          # No cache: setup-node@v5's post-step tries to save the pnpm
+          # store at end-of-job regardless of whether the path actually
+          # ran `pnpm install`. On non-apply-fix paths (classifier-only,
+          # idempotency early-exit, non-issue, ambiguous) the store is
+          # never populated, the post-step's path-validation fails, and
+          # the job conclusion flips to `failure` — generating a notification
+          # to maintainer inboxes for every non-apply-fix run. Apply-fix
+          # is the only path that needs pnpm, and runs `pnpm install`
+          # explicitly inside `run-quality-gate.sh`; the trade-off is a
+          # 30-60s slower install per auto-fix run for clean notifications
+          # across the majority of runs.
 
       # ----------------------------------------------------------------
       # UAT-006: idempotency early-exit. If `gaia-triaged` is already on

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -98,6 +98,20 @@ jobs:
           set -eu
           parsed_file="${RUNNER_TEMP}/forensics/parsed.json"
           "$FORENSICS_DIR/parse-issue-body.sh" "${RUNNER_TEMP}/forensics/issue-body.md" > "$parsed_file"
+
+          # SPEC-003 UAT-006: parse-issue-body.sh emits an internal-error
+          # JSON envelope when one of its awk pipelines fails. Distinct
+          # from valid:false; route to needs-human with reason-code
+          # `internal-error` rather than letting the workflow fall
+          # through to malformed-body handling.
+          if [ "$(jq -r '.internal_error // false' "$parsed_file")" = "true" ]; then
+            reason_file="${RUNNER_TEMP}/forensics/internal-error-reason.md"
+            jq -r '"forensics primitive `parse-issue-body.sh` failed at stage `\(.stage)` (exit \(.exit_code))"' "$parsed_file" > "$reason_file"
+            "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+              "$ISSUE_NUMBER" "$reason_file" "internal-error"
+            exit 0
+          fi
+
           valid="$(jq -r '.valid' "$parsed_file")"
           echo "parsed_file=$parsed_file" >> "$GITHUB_OUTPUT"
           echo "valid=$valid" >> "$GITHUB_OUTPUT"
@@ -243,6 +257,21 @@ jobs:
           parsed="${RUNNER_TEMP}/forensics/verdict.json"
           "$FORENSICS_DIR/parse-verdict.sh" "$verdict_text" > "$parsed"
 
+          # SPEC-003 UAT-006: parse-verdict.sh emits an internal-error
+          # JSON envelope when one of its awk pipelines fails. Route to
+          # needs-human with reason-code `internal-error` before the
+          # ambiguous-verdict dispatch (the two are deliberately
+          # distinct: `ambiguous` is a parsed-but-non-conformant
+          # classifier response; `internal-error` is the parser itself
+          # failing).
+          if [ "$(jq -r '.internal_error // false' "$parsed")" = "true" ]; then
+            reason_file="${RUNNER_TEMP}/forensics/internal-error-reason.md"
+            jq -r '"forensics primitive `parse-verdict.sh` failed at stage `\(.stage)` (exit \(.exit_code))"' "$parsed" > "$reason_file"
+            "$FORENSICS_DIR/handlers/handle-needs-human.sh" \
+              "$ISSUE_NUMBER" "$reason_file" "internal-error"
+            exit 0
+          fi
+
           verdict="$(jq -r '.verdict' "$parsed")"
           echo "verdict=$verdict"
 
@@ -385,10 +414,12 @@ jobs:
           steps.parse.outputs.valid == 'true' &&
           steps.verdict.outputs.verdict == 'auto-fixable' &&
           steps.scope.outputs.ok == 'true'
+        env:
+          FIX_BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -eu
           git fetch origin main
-          git checkout -B "${{ steps.branch.outputs.name }}" origin/main
+          git checkout -B "$FIX_BRANCH" origin/main
           git config user.name 'gaia-forensics-triage[bot]'
           git config user.email 'gaia-forensics-triage[bot]@users.noreply.github.com'
 
@@ -447,7 +478,7 @@ jobs:
           # Post-step verification asserts diffs touch only `proposed_paths`.
           claude_args: |
             --max-turns 30
-            --allowedTools Edit,Read,Write
+            --allowedTools Edit,Write
             --disallowedTools Bash,WebFetch,WebSearch
 
       - name: Verify diff against proposed paths
@@ -653,9 +684,11 @@ jobs:
           steps.scope.outputs.ok == 'true' &&
           steps.verify-diff.outputs.diff_ok == 'true' &&
           steps.quality-gate.outcome == 'success'
+        env:
+          FIX_BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -eu
-          git push origin "${{ steps.branch.outputs.name }}"
+          git push origin "$FIX_BRANCH"
 
       - name: Compose PR body
         id: pr-body
@@ -700,13 +733,17 @@ jobs:
           steps.scope.outputs.ok == 'true' &&
           steps.verify-diff.outputs.diff_ok == 'true' &&
           steps.quality-gate.outcome == 'success'
+        env:
+          FIX_BRANCH: ${{ steps.branch.outputs.name }}
+          FIX_CLASS_SLUG: ${{ steps.branch.outputs.class_slug }}
+          PR_BODY_FILE: ${{ steps.pr-body.outputs.file }}
         run: |
           set -eu
           "$FORENSICS_DIR/handlers/handle-auto-fixable.sh" \
             "$ISSUE_NUMBER" \
-            "${{ steps.branch.outputs.class_slug }}" \
-            "${{ steps.branch.outputs.name }}" \
-            "${{ steps.pr-body.outputs.file }}"
+            "$FIX_CLASS_SLUG" \
+            "$FIX_BRANCH" \
+            "$PR_BODY_FILE"
 
       # ----------------------------------------------------------------
       # UAT-012 fail-forward: if the workflow did meaningful work but

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -46,24 +46,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version-file: '.node-version'
-          # No cache: setup-node@v5's post-step tries to save the pnpm
-          # store at end-of-job regardless of whether the path actually
-          # ran `pnpm install`. On non-apply-fix paths (classifier-only,
-          # idempotency early-exit, non-issue, ambiguous) the store is
-          # never populated, the post-step's path-validation fails, and
-          # the job conclusion flips to `failure` — generating a notification
-          # to maintainer inboxes for every non-apply-fix run. Apply-fix
-          # is the only path that needs pnpm, and runs `pnpm install`
-          # explicitly inside `run-quality-gate.sh`; the trade-off is a
-          # 30-60s slower install per auto-fix run for clean notifications
-          # across the majority of runs.
+      # Setup pnpm + Setup Node are gated to the apply-fix path (see
+      # before `Run Quality Gate` further down). Running them
+      # unconditionally at the top of the job triggers a `Post Setup
+      # Node` cache-cleanup post-step at end-of-job for every non-
+      # apply-fix path; even with `cache:` unset, setup-node@v5's
+      # post-step still validates the lockfile path and emits
+      # `Path Validation Error`, which flips the job conclusion to
+      # `failure` and notifies the maintainer for benign runs (non-
+      # issue, ambiguous, classifier-only, idempotency early-exit).
+      # The `claude-code-action` invocations provision their own Node
+      # runtimes, so the only consumer of this repo's Node + pnpm is
+      # `run-quality-gate.sh` on the apply-fix path.
 
       # ----------------------------------------------------------------
       # UAT-006: idempotency early-exit. If `gaia-triaged` is already on
@@ -654,6 +648,30 @@ jobs:
           # Already `git add -A`'d in verify-diff; commit on the local
           # branch. No push yet — gate must pass first.
           git commit -m "forensics: auto-fix attempt for #${ISSUE_NUMBER}"
+
+      # Apply-fix-only Node + pnpm provisioning. Gated to the same
+      # condition set as `Run Quality Gate` so non-apply-fix paths
+      # never trigger setup-node@v5's `Post Setup Node` cleanup
+      # post-step at end-of-job.
+      - name: Setup pnpm
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true'
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+
+      - name: Setup Node
+        if: |
+          steps.idempotency.outputs.already_triaged != 'true' &&
+          steps.parse.outputs.valid == 'true' &&
+          steps.verdict.outputs.verdict == 'auto-fixable' &&
+          steps.scope.outputs.ok == 'true' &&
+          steps.verify-diff.outputs.diff_ok == 'true'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version-file: '.node-version'
 
       - name: Run Quality Gate
         id: quality-gate

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -224,7 +224,7 @@ jobs:
           steps.parse.outputs.valid == 'true'
         uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.render-classifier.outputs.body }}
           # No tool access — judgment-only. The classifier MUST NOT
           # touch the working tree (UAT-009).
@@ -472,7 +472,7 @@ jobs:
           steps.scope.outputs.ok == 'true'
         uses: anthropics/claude-code-action@63322d7b2bc79e7b621b89f41b53ceb8e5a5d314 # v1.0
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.render-apply.outputs.body }}
           # File-edit tools only. NO Bash, NO git, NO push tools, NO web.
           # Post-step verification asserts diffs touch only `proposed_paths`.

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -175,30 +175,21 @@ jobs:
           - `.specify/extensions/gaia/templates/`
           - `.github/workflows/`'
 
-          template="$(cat "$FORENSICS_DIR/prompt.md")"
           rendered_file="${RUNNER_TEMP}/forensics/classifier-prompt.md"
 
-          # Use awk for the substitutions: avoids the sed/`/`/`&` escaping
-          # nightmare with multi-line section content.
-          awk -v iss="$ISSUE_NUMBER" \
-              -v sym="$symptom" \
-              -v cls="$classification" \
-              -v cap="$capture" \
-              -v rep="$repro" \
-              -v al="$allowlist" \
-              -v dl="$denylist" '
-          {
-            line = $0
-            gsub(/\{\{ISSUE_NUMBER\}\}/, iss, line)
-            gsub(/\{\{SYMPTOM\}\}/, sym, line)
-            gsub(/\{\{CLASSIFICATION\}\}/, cls, line)
-            gsub(/\{\{CAPTURE\}\}/, cap, line)
-            gsub(/\{\{REPRO_CONTEXT\}\}/, rep, line)
-            gsub(/\{\{ALLOWLIST\}\}/, al, line)
-            gsub(/\{\{DENYLIST\}\}/, dl, line)
-            print line
-          }
-          ' <<< "$template" > "$rendered_file"
+          # Render via the standalone helper (SPEC-003 UAT-004). Bash
+          # parameter-expansion-based substitution sidesteps both the
+          # multi-line `awk -v` rejection and the `gsub` `&`-replacement
+          # corruption that the previous inline awk shipped with.
+          "$FORENSICS_DIR/render-prompt.sh" "$FORENSICS_DIR/prompt.md" \
+            "ISSUE_NUMBER=$ISSUE_NUMBER" \
+            "SYMPTOM=$symptom" \
+            "CLASSIFICATION=$classification" \
+            "CAPTURE=$capture" \
+            "REPRO_CONTEXT=$repro" \
+            "ALLOWLIST=$allowlist" \
+            "DENYLIST=$denylist" \
+            > "$rendered_file"
 
           # Surface the rendered prompt as a step output via heredoc so
           # the action invocation can consume it. The delimiter is a
@@ -423,26 +414,16 @@ jobs:
           # block; content is read-back-into-position via a single gsub).
           paths_block="$(jq -r '.proposed_paths[]' "$VERDICT_FILE")"
 
-          template="$(cat "$FORENSICS_DIR/apply-fix-prompt.md")"
           rendered_file="${RUNNER_TEMP}/forensics/apply-fix-prompt.md"
 
-          awk -v iss="$ISSUE_NUMBER" \
-              -v paths="$paths_block" \
-              -v reasoning="$reasoning" \
-              -v sym="$symptom" \
-              -v cap="$capture" \
-              -v rep="$repro" '
-          {
-            line = $0
-            gsub(/\{\{ISSUE_NUMBER\}\}/, iss, line)
-            gsub(/\{\{PROPOSED_PATHS\}\}/, paths, line)
-            gsub(/\{\{CLASSIFIER_REASONING\}\}/, reasoning, line)
-            gsub(/\{\{SYMPTOM\}\}/, sym, line)
-            gsub(/\{\{CAPTURE\}\}/, cap, line)
-            gsub(/\{\{REPRO_CONTEXT\}\}/, rep, line)
-            print line
-          }
-          ' <<< "$template" > "$rendered_file"
+          "$FORENSICS_DIR/render-prompt.sh" "$FORENSICS_DIR/apply-fix-prompt.md" \
+            "ISSUE_NUMBER=$ISSUE_NUMBER" \
+            "PROPOSED_PATHS=$paths_block" \
+            "CLASSIFIER_REASONING=$reasoning" \
+            "SYMPTOM=$symptom" \
+            "CAPTURE=$capture" \
+            "REPRO_CONTEXT=$repro" \
+            > "$rendered_file"
 
           delim="EOF_$(openssl rand -hex 16)"
           {


### PR DESCRIPTION
## Summary

Fix-PR for SPEC-003 forensics-triage-fixes. The forensics-triage workflow shipped under SPEC-002 (PR #104, squash 3226a58) was inoperative on every real-world issue: two awk-rendering bugs in the workflow YAML routed every multi-line issue body to `needs-human` via ambiguous-verdict fallthrough. A post-merge `code-review-audit` surfaced 9 findings — 2 critical, 3 important, 4 lower.

This PR closes all 9 findings plus the two non-bypassable gates: end-to-end re-verification of the SPEC-002 integration UAT suite (UAT-011) and pre-merge `code-review-audit-clean` (UAT-012).

Plus eight Phase 4a-driven workflow fixes surfaced by the empirical UAT-011 dispatches — every one was either a pre-existing SPEC-002 carryover defect (id-token, jq shape) or required for the workflow to be operable end-to-end (auth swap, render newline, continue-on-error, max-turns, Setup pnpm/Node relocation). All bundled here because each is necessary for correctness; without UAT-011's empirical exercise they would have shipped to canonical unfixed.

## Source SPEC

`.gaia/local/specs/SPEC-003.md` (immutable). SPEC-002 unchanged.

## Phase plan

- **Phase 1** — render-prompt extraction: extract inline awk template-rendering out of `.github/workflows/forensics-triage.yml` into `.github/forensics/render-prompt.sh` with `tests/render-prompt.bats` coverage. Single-pass cursor walk; bash 3.2 compatible. Closes UAT-001 / UAT-002 / UAT-003 / UAT-004.
- **Phase 2** — security/robustness: scope `--allowedTools` (drop `Read`; `Edit,Write` only); add `pipefail` + structured internal-error JSON to parsing primitives; move branch-name interpolation into step-level env vars. Closes UAT-005 / UAT-006 / UAT-007.
- **Phase 3** — cleanup: extend `mask_secret_shapes` token-prefix coverage; harden `check-scope.sh json_escape` against control bytes (early reject with `control-byte:0xXX-at-position-N` envelope); add `deviation` reason-code for `diff-not-in-proposed`. Closes UAT-008 / UAT-009 / UAT-010.
- **Phase 4** — verification + merge gate (sequential): UAT-011 integration-suite re-run against fork `stevensacks/gaia`; UAT-012 pre-merge `code-review-audit` (non-bypassable).

## UAT-011 — integration-suite re-run

Test path: fork `stevensacks/gaia` against branch `spec-003-forensics-fixes` HEAD. Eight UAT-011 dispatches surfaced and resolved every blocker. Full evidence at `.gaia/local/plans/spec-003-forensics-triage-fixes/integration-evidence.md`.

**Layer-C UATs runnable without synthetic-branch setup:** 5/6 PASS (UAT-001, UAT-002, UAT-006, UAT-010, UAT-011 + SPEC-003 multi-line/`&`/`\`/`{{TOKEN}}` regression fixture all green). UAT-013 (malformed) and UAT-014 (out-of-scope) also PASS.

**SPEC-003 source-fix empirical verification (every one green against the fork):**
- Multi-line `## Capture` renders verbatim through render-prompt + classifier prompt (issue #10, run 25541401625).
- `&` and `\` pass through unmodified; literal `{{TOKEN}}` not re-substituted (single-pass cursor walk).
- `pipefail` + internal-error envelope on awk pipelines verified across 12+ runs.
- Auth swap, id-token permission, jq verdict-extract shape, trailing-newline guarantee — all green on every relevant run.
- `continue-on-error` + `--max-turns 60` — verified via dispatch v8 (run 25542456762): apply-fix completed in 42 turns, demoted cleanly to `needs-human` on a fixture-vs-fork-state mismatch with no half-state.
- Setup pnpm/Node relocation — gating logic deterministic; bats + static analysis sufficient (the Post Setup Node step doesn't exist on non-apply-fix paths so it can't fail).

**UAT-004's happy-path PR creation** is fixture-bound to a tree state that doesn't exist on the fork (`.claude/skills/gaia-init/SKILL.md` and `.gaia/cli/templates/init/post-init.sh` are 404 on the fork). The model emitted a clean `GAIA-FIX-ABORT` and the workflow demoted to `needs-human` with full diagnostic. Once SPEC-003 merges to canonical, the workflow runs against canonical's tree where the fixture's proposed paths resolve normally and the auto-fixable happy path becomes naturally exercisable post-merge. The workflow-source surface that UAT-004 is supposed to verify (continue-on-error + max-turns + abort handler routing) is empirically verified.

## UAT-012 — pre-merge code-review-audit

Code-review-audit ran against `cd38e6a` (HEAD of `spec-003-forensics-fixes`). Sixteen files / ~864 lines reviewed across `.github/forensics/**` and `.github/workflows/forensics-triage.yml`. **Zero critical findings. Zero important findings.** Three suggestions, all pre-existing or advisory:

- **S-1** (low) — Three `${{ steps.apply-fix.outputs.execution_file }}` and one `${{ steps.scope.outputs.paths_file }}` remain inline in `verify-diff` run: block. Pre-existing (not introduced by this PR); runner-internal paths so no injection vector. Pattern-completion follow-up.
- **S-2** (low) — `render-prompt.sh` could add a bats assertion for empty-template behavior; documentation gap, no runtime risk.
- **S-3** (low) — `parse-issue-body.sh json_escape_file` keeps raw 0x01–0x1f bytes for non-`/`-leading inputs; pre-existing, downstream `internal-error` path already covers blast radius gracefully.

Security boundary confirmed sound: shell-injection resistance, scope double-gate, action SHA pinning, and workflow gate parity for the relocated Setup pnpm/Node block all pass. Bash 3.2 compatibility verified (no `declare -A`, no `mapfile`, no `printf -v`). Full audit result at `.gaia/local/plans/spec-003-forensics-triage-fixes/audit-result.md`.

## Quality gate

`pnpm typecheck && pnpm lint` green every phase; `bats .github/forensics/tests/` 156/156 after phases 1, 3, and the Setup-relocation commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
