### PR TITLE
fix(forensics): bootstrap-labels.sh — shorten needs-human desc, add gaia-forensics

### DIFF
--- a/.github/forensics/bootstrap-labels.sh
+++ b/.github/forensics/bootstrap-labels.sh
@@ -9,8 +9,8 @@
 #
 # Prerequisites: `gh` authenticated against the target repo with `repo` scope.
 #
-# Frozen contract: SPEC-002 phase-2 labels (5). `gaia-forensics` is owned by
-# SPEC-001 and excluded here.
+# Frozen contract: SPEC-002 phase-2 labels (5) plus the SPEC-001 trigger
+# label `gaia-forensics`.
 
 set -euo pipefail
 
@@ -44,9 +44,10 @@ done
 
 # Frozen label contract — name|color|description (per SPEC-002 task spec).
 LABELS=(
+  "gaia-forensics|5319e7|End-user bug report routed via /gaia forensics. Triggers autonomous triage."
   "gaia-triaged|0e8a16|Forensics triage workflow has processed this issue. Idempotency key — re-firing is a no-op."
   "non-issue|cccccc|Triaged: not a bug. User-config issue, missing prerequisite, or duplicate. Issue closed."
-  "needs-human|d93f0b|Triaged: real bug, but out of autofix scope OR malformed body OR ambiguous classifier verdict. Maintainer review required."
+  "needs-human|d93f0b|Triaged: out of autofix scope, malformed body, or ambiguous verdict. Maintainer review required."
   "auto-fixable|1d76db|Triaged: classifier proposed a fix in allowlisted scope. See linked draft PR."
   "gaia-bug-confirmed|b60205|Quality Gate passed on the auto-fix branch. Draft PR open and ready for human review."
 )


### PR DESCRIPTION
## Summary
- Shortens the `needs-human` label description from 122 chars to 96 chars (GitHub's hard limit is 100), unblocking the script on fresh repos where it was halting mid-run with HTTP 422.
- Adds `gaia-forensics` (color `5319e7`, description matches the manually-created label on canonical) to the `LABELS` array so fresh forks/clones get the trigger label without manual `gh label create`.
- Updates the docstring header to drop the "excluded here" note now that the label is in the contract.

## Test plan
- [x] `bash -n .github/forensics/bootstrap-labels.sh` — syntax OK
- [x] `bash bootstrap-labels.sh --dry-run --repo gaia-react/gaia` — all six labels resolve; only `needs-human` reports drift (canonical still has the long description, operator-wins as designed)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `bats .github/forensics/tests/` — 156/156 pass

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)