### PR TITLE
fix(forensics): audit advisory follow-ups (S-1/S-2/S-3)

### DIFF
--- a/.github/forensics/parse-issue-body.sh
+++ b/.github/forensics/parse-issue-body.sh
@@ -263,13 +263,17 @@ fi
 
 # json_escape_file <path> -> stdout: escapes the file's bytes for
 # embedding inside JSON double-quotes. Handles backslash, double-quote,
-# tab, carriage return, and newline. Other control characters in the
-# 0x00–0x1f range are not expected from SPEC-001 issue bodies but if
-# present are kept as-is (the consumer is responsible for validating
-# against its own JSON parser).
+# tab, carriage return, and newline. Other control bytes in the
+# 0x01–0x1f range are stripped so the emitted JSON stays valid even on
+# pathological input (the consumer's `jq` parse remains the
+# authoritative gate; this defense keeps the internal-error path from
+# tripping on payload-shape rather than infrastructure).
 json_escape_file() {
   awk '
-    BEGIN { first = 1 }
+    BEGIN {
+      first = 1
+      for (k = 0; k < 256; k++) ord[sprintf("%c", k)] = k
+    }
     {
       if (first == 1) { first = 0 } else { printf "\\n" }
       n = length($0)
@@ -283,6 +287,10 @@ json_escape_file() {
           printf "\\t"
         } else if (c == "\r") {
           printf "\\r"
+        } else if (ord[c] < 32) {
+          # Strip remaining 0x01–0x1f control bytes; not valid in JSON
+          # strings without \uXXXX escaping, never expected from the
+          # SPEC-001 issue-body schema.
         } else {
           printf "%s", c
         }

--- a/.github/forensics/tests/parse-issue-body.bats
+++ b/.github/forensics/tests/parse-issue-body.bats
@@ -325,3 +325,29 @@ STUB
   [[ "$output" == *'"capture":'* ]]
   [[ "$output" == *'"reproduction_context":'* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Control-byte hygiene — `json_escape_file` strips raw 0x01–0x1f bytes so
+# the emitted JSON stays valid even on pathological input.
+# ---------------------------------------------------------------------------
+
+@test "embedded control bytes do not break the emitted JSON" {
+  fixture="$BATS_TEST_TMPDIR/control-bytes.md"
+  # Build a SPEC-001-shaped body whose Symptom contains a 0x01 byte.
+  # If the byte leaks through, jq rejects the output as invalid JSON.
+  ctrl="$(printf 'before\x01after')"
+  {
+    printf -- '---\n'
+    printf 'class: quality-gate\n'
+    printf 'gaia_version: 1.4.2\n'
+    printf 'created: 2026-05-08\n'
+    printf -- '---\n'
+    printf '## Symptom\n\n%s\n\n' "$ctrl"
+    printf '## Classification\n\nclass: quality-gate\n\n'
+    printf '## Capture\n\nnode_version: v20.11.0\n\n'
+    printf '## Reproduction context\n\nplaceholder\n'
+  } > "$fixture"
+  run "$PARSER" "$fixture"
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | jq -e . > /dev/null
+}

--- a/.github/forensics/tests/render-prompt.bats
+++ b/.github/forensics/tests/render-prompt.bats
@@ -251,3 +251,16 @@ Capture: x" ]
   last_byte="$(tail -c 1 "$out" | od -An -c | tr -d ' ')"
   [ "$last_byte" = "\\n" ]
 }
+
+# --- 17. Empty template ----------------------------------------------------
+# A 0-byte template trips the per-key "key not present in template" check on
+# the first supplied key, exiting 2. The behavior is correct (a template that
+# substitutes nothing is meaningless) but undocumented; pin it.
+
+@test "empty template rejects all keys with exit 2" {
+  template="$BATS_TEST_TMPDIR/empty.md"
+  : > "$template"
+  run "$SCRIPT" "$template" "FOO=bar"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not present in template"* ]]
+}

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -508,6 +508,9 @@ jobs:
           steps.parse.outputs.valid == 'true' &&
           steps.verdict.outputs.verdict == 'auto-fixable' &&
           steps.scope.outputs.ok == 'true'
+        env:
+          APPLY_FIX_EXEC_FILE: ${{ steps.apply-fix.outputs.execution_file }}
+          PROPOSED_PATHS_FILE: ${{ steps.scope.outputs.paths_file }}
         run: |
           set -eu
 
@@ -526,10 +529,9 @@ jobs:
           # rationale to the maintainer. The action emits a top-level
           # JSON array of execution events.
           apply_text="${RUNNER_TEMP}/forensics/apply-fix-text.md"
-          if [ -n "${{ steps.apply-fix.outputs.execution_file }}" ] \
-             && [ -f "${{ steps.apply-fix.outputs.execution_file }}" ]; then
+          if [ -n "$APPLY_FIX_EXEC_FILE" ] && [ -f "$APPLY_FIX_EXEC_FILE" ]; then
             jq -r '[.[] | select(.type == "result")] | .[-1].result // empty' \
-              "${{ steps.apply-fix.outputs.execution_file }}" > "$apply_text"
+              "$APPLY_FIX_EXEC_FILE" > "$apply_text"
           else
             : > "$apply_text"
           fi
@@ -569,12 +571,11 @@ jobs:
           # Even within scope, the diff must be a SUBSET of the
           # classifier's `proposed_paths`. Any deviation halts before the
           # gate (per task spec step 10's deviation clause).
-          proposed_file="${{ steps.scope.outputs.paths_file }}"
           unexpected="${RUNNER_TEMP}/forensics/unexpected-paths.txt"
           : > "$unexpected"
           while IFS= read -r p; do
             [ -z "$p" ] && continue
-            if ! grep -Fxq -- "$p" "$proposed_file"; then
+            if ! grep -Fxq -- "$p" "$PROPOSED_PATHS_FILE"; then
               printf '%s\n' "$p" >> "$unexpected"
             fi
           done < "$touched_file"


### PR DESCRIPTION
## Summary
Closes the three low-priority advisories from the pre-merge `code-review-audit` on PR #110.

- **S-1 (workflow):** hoists the four remaining inline `${{ steps.* }}` references in `forensics-triage.yml`'s `Verify diff against proposed paths` step into a step-level `env:` block (`APPLY_FIX_EXEC_FILE` ×3, `PROPOSED_PATHS_FILE` ×1), matching the existing `FIX_BRANCH` / `ABORT_REASON` pattern. Pattern-completion only — values are runner-controlled `RUNNER_TEMP` paths.
- **S-2 (bats):** adds `@test "empty template rejects all keys with exit 2"` to `render-prompt.bats`. The 0-byte template is generated via `: > "$BATS_TEST_TMPDIR/empty.md"` (no fixture file needed).
- **S-3 (parser):** extends `json_escape_file` in `parse-issue-body.sh` to strip control bytes 0x01–0x1f beyond the already-handled `\t` and `\r`. Adds a bats assertion that pipes the parser's output through `jq -e .` on a fixture containing a raw 0x01 byte to lock the JSON-validity invariant.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `bats .github/forensics/tests/` — 158/158 pass (was 156; +1 for S-2, +1 for S-3)
- [x] `actionlint .github/workflows/forensics-triage.yml` — clean
- [x] `bash -n .github/forensics/parse-issue-body.sh` — syntax OK

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)