### PR TITLE
fix(forensics): address remaining audit suggestions from PR #114

### DIFF
--- a/.github/forensics/tests/parse-issue-body.bats
+++ b/.github/forensics/tests/parse-issue-body.bats
@@ -350,4 +350,9 @@ STUB
   run "$PARSER" "$fixture"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | jq -e . > /dev/null
+  # Bytes on either side of the stripped 0x01 must survive — guards
+  # against a regression where the strip drops more than the control
+  # byte (whole line, whole section, etc.). The control byte itself is
+  # stripped, so the symptom collapses to "beforeafter".
+  printf '%s' "$output" | jq -e '.sections.symptom == "beforeafter"' > /dev/null
 }

--- a/.github/workflows/forensics-triage.yml
+++ b/.github/workflows/forensics-triage.yml
@@ -571,6 +571,10 @@ jobs:
           # Even within scope, the diff must be a SUBSET of the
           # classifier's `proposed_paths`. Any deviation halts before the
           # gate (per task spec step 10's deviation clause).
+          # `PROPOSED_PATHS_FILE` is guaranteed populated by the upstream
+          # `scope` step; the step's `if:` gate (`scope.outputs.ok ==
+          # 'true'`) makes the missing-file branch unreachable, so no
+          # explicit `[ -f ... ]` guard is needed here.
           unexpected="${RUNNER_TEMP}/forensics/unexpected-paths.txt"
           : > "$unexpected"
           while IFS= read -r p; do


### PR DESCRIPTION
## Summary
- **P-1 (bats):** strengthens the control-byte test in `parse-issue-body.bats` to assert content survival around the stripped 0x01 byte (`.sections.symptom == "beforeafter"`), not just JSON validity.
- **P-2 (workflow):** documents the `PROPOSED_PATHS_FILE` existence-guard omission in the verify-diff step. Upstream `scope.outputs.ok == 'true'` gate makes the missing-file branch unreachable; comment over redundant `[ -f ... ]`.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `bats .github/forensics/tests/` — 158/158 pass
- [x] `actionlint .github/workflows/forensics-triage.yml` — clean

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)