### PR TITLE
fix(hooks-tests): relocate audit-stamp bats + repair latent path bug in 4 existing bats

### DIFF
--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -25,7 +25,6 @@
     ".claude/hooks/intercept-init.sh": "owned",
     ".claude/hooks/pr-merge-audit-check.sh": "owned",
     ".claude/hooks/telemetry-task-postuse.sh": "owned",
-    ".claude/hooks/tests/audit-stamp-trailer.bats": "owned",
     ".claude/hooks/wiki-commit-nudge.sh": "owned",
     ".claude/hooks/wiki-drift-check.sh": "owned",
     ".claude/hooks/wiki-session-start.sh": "owned",

--- a/.gaia/tests/hooks/audit-stamp-trailer.bats
+++ b/.gaia/tests/hooks/audit-stamp-trailer.bats
@@ -22,7 +22,7 @@
 #   - HEAD sha movement (amend or empty commit moves it; decline does not)
 
 setup() {
-  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/.." && pwd)/audit-stamp-trailer.sh
+  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/audit-stamp-trailer.sh
   REPO=$(mktemp -d -t audit-stamp-test-XXXXXX)
   REMOTE=$(mktemp -d -t audit-stamp-remote-XXXXXX)
 

--- a/.gaia/tests/hooks/commit-nudge.bats
+++ b/.gaia/tests/hooks/commit-nudge.bats
@@ -2,7 +2,7 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
-  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../.claude/hooks" && pwd)/wiki-commit-nudge.sh
+  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/wiki-commit-nudge.sh
 }
 
 teardown() {

--- a/.gaia/tests/hooks/drift-check.bats
+++ b/.gaia/tests/hooks/drift-check.bats
@@ -2,7 +2,7 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
-  HOOK="$BATS_TEST_DIRNAME/../../.claude/hooks/wiki-drift-check.sh"
+  HOOK="$BATS_TEST_DIRNAME/../../../.claude/hooks/wiki-drift-check.sh"
   # Hook is invoked relative to its own repo. Resolve to absolute.
   HOOK_ABS=$(cd "$(dirname "$HOOK")" && pwd)/$(basename "$HOOK")
 }

--- a/.gaia/tests/hooks/session-stop.bats
+++ b/.gaia/tests/hooks/session-stop.bats
@@ -2,7 +2,7 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
-  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../.claude/hooks" && pwd)/wiki-session-stop.sh
+  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/wiki-session-stop.sh
 }
 
 teardown() {

--- a/.gaia/tests/hooks/squash-autocommits.bats
+++ b/.gaia/tests/hooks/squash-autocommits.bats
@@ -7,7 +7,7 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
-  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../.claude/hooks" && pwd)/wiki-squash-autocommits.sh
+  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/wiki-squash-autocommits.sh
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

Follow-on to PR #117. Two changes:

1. **Relocate** `.claude/hooks/tests/audit-stamp-trailer.bats` → `.gaia/tests/hooks/audit-stamp-trailer.bats` to match the project's hooks-bats convention (alongside `commit-nudge`, `drift-check`, `session-stop`, `squash-autocommits`).

2. **Repair latent path bug** in the four pre-existing hook bats files: their \`setup()\` resolves \`HOOK_ABS\` via \`\$BATS_TEST_DIRNAME/../../.claude/hooks\`, but \`\$BATS_TEST_DIRNAME\` is \`.gaia/tests/hooks/\` — two \`..\` lands at \`.gaia/.claude/hooks\` (which doesn't exist). All four suites have been failing at \`setup()\` with \`No such file or directory\`. The fix is mechanical: change two dots to three. No bats file is wired into CI today, which is why this drift went unnoticed.

After the fix all five hook bats suites pass: 35 tests total.

## Findings worth flagging

- The entire \`.gaia/tests/\` tree (forensics, smoke, distribution, hooks) is unmanifested in \`.gaia/manifest.json\`. Adding a single \`.gaia/tests/hooks/audit-stamp-trailer.bats\` entry inconsistently would obscure the gap, so this PR drops the obsolete \`.claude/hooks/tests/...\` entry and adds nothing new under \`.gaia/tests/\`. The manifest gap deserves its own pass — either bulk-manifest the tree (~30 entries, mostly \`owned\`) or document the intentional exclusion.
- No CI surface runs the hook bats today (only \`pnpm test:forensics\` is wired). Worth adding a \`pnpm test:hooks\` script + a CI job once the suites are clean (now that they actually pass), but that's out of scope for this fix.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green
- [x] All 5 hook bats suites pass: 10 + 8 + 7 + 6 + 4 = 35 tests
- [x] Manifest JSON valid (\`jq -e '.'\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)