### PR TITLE
wiki: re-anchor state after history rewrite (158c86b → 843ffec)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "158c86b2c5af1da2292f144ecdc77af3f140257b",
+  "last_evaluated_sha": "843ffec47284f3ac4e657367a6d0bfe0c1cebb35",
   "last_evaluated_at": "2026-05-07T15:57:29Z",
   "last_consolidated_sha": "ca6cc0ad834c26a537d107a1c1ad1e3311573708",
   "last_consolidated_at": "2026-05-07T10:27:43Z"

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-08 843ffec RE_ANCHOR — re-anchored after history rewrite
 - 2026-05-08 158c86b - SKIP: docs(claude-integration): codify UAT/SPEC narrative-ref discipline (wiki-style + wiki-lint)
 - 2026-05-08 b4b9ce5 - SKIP: docs(claude-integration): audit #13 — ship check-updates, scrub SPEC IDs in extension surfaces
 - 2026-05-08 5c005da - SKIP: docs(claude-integration): close wikilink-to-excluded class across full corpus


### PR DESCRIPTION
## Summary

- `/wiki-sync` re-anchor recovery — previous `last_evaluated_sha` (`158c86b`) was on a feature branch that got squash-merged into main, leaving the recorded anchor unreachable from HEAD.
- Bumps `wiki/.state.json` `last_evaluated_sha` → `843ffec` (current HEAD).
- Prepends `RE_ANCHOR` entry to `wiki/log.md`.

## Test plan

- [x] `git merge-base --is-ancestor 158c86b HEAD` returned non-zero (confirmed re-anchor needed)
- [x] `gaia wiki state-bump` + `gaia wiki log-prepend` ran cleanly
- [x] Pre-commit hook passed (no source changes, lint-staged skipped)
- [ ] Reviewer confirms next `/wiki-sync` runs the normal evaluation pass against this anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)