### PR TITLE
fix(audit-followups): CI source-changes gate, knip binaries, instruction-file paths

### DIFF
--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -6,11 +6,11 @@ Dispatched by the `/gaia wiki` router (`references/wiki.md` → "Lint"). Runs in
 
 GAIA-local wrapper around the upstream `claude-obsidian:wiki-lint` skill. Runs the upstream lint flow first, then appends GAIA-specific checks **#11: Wiki drift check**, **#12: Dead repo-relative paths**, and **#13: UAT/SPEC narrative-ref drift** to the report.
 
-Do **not** modify the upstream skill (`~/.claude/plugins/marketplaces/claude-obsidian-marketplace/skills/wiki-lint/SKILL.md`) — it is read-only territory. Extensions live here.
+Do **not** modify the upstream `claude-obsidian:wiki-lint` skill — it ships from a marketplace plugin and is read-only territory. Extensions live here.
 
 ## Step 1: Run upstream wiki-lint
 
-Invoke the `claude-obsidian:wiki-lint` skill following its documented pattern (see `~/.claude/plugins/marketplaces/claude-obsidian-marketplace/skills/wiki-lint/SKILL.md`). The upstream skill writes the report to:
+Invoke the `claude-obsidian:wiki-lint` skill following its documented pattern. The runtime resolves the plugin and dispatches the upstream playbook; do not attempt to read the plugin's SKILL.md from a hardcoded path. The upstream skill writes the report to:
 
 ```
 wiki/meta/lint-report-YYYY-MM-DD.md

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -2,11 +2,13 @@ name: Code Review Audit
 
 # Pre-merge gate that runs the `code-review-audit` agent
 # (.claude/agents/code-review-audit.md) against the PR diff. Skipped when
-# the PR HEAD already carries a matching `GAIA-Audit:` commit trailer
-# (locally-stamped audit). Adopter-tunable knobs live at
-# .gaia/audit-ci.yml; the frozen contracts (trailer format, skip logic,
-# check name) live at .gaia/local/plans/code-review-audit-ci/trailer-format.md
-# and that plan's README.
+# (a) the PR HEAD already carries a matching `GAIA-Audit:` commit trailer
+# (locally-stamped audit), or (b) the PR diff contains no audit-relevant
+# files (wiki, instruction files, and other prose-only surfaces are out
+# of scope). Adopter-tunable knobs live at .gaia/audit-ci.yml; the frozen
+# contracts (trailer format, skip logic, check name) live at
+# .gaia/local/plans/code-review-audit-ci/trailer-format.md and that plan's
+# README.
 #
 # Required-check semantics under classic branch protection: the job MUST
 # reach a terminal "set check status" step on every code path. A skipped
@@ -81,20 +83,47 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check for source-code changes
+        id: source-changes
+        if: steps.gate.outputs.gated == 'false'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          # Audit-relevant scope: TS/TSX/CSS code under app/, the CLI
+          # source under .gaia/cli/src/, tests, .storybook configs,
+          # GitHub workflow files, and root-level build/lint/test/
+          # typecheck configs. PRs that only touch wiki/, .claude/,
+          # .specify/, prose docs, or .gaia/ metadata are skipped here —
+          # the agent has no rules that would meaningfully apply.
+          changed=$(git diff --name-only "${BASE_SHA}..${HEAD_SHA}")
+          dir_pattern='^(app|test|\.storybook|\.gaia/cli/src|\.github/workflows)/'
+          file_pattern='^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$|^tsconfig[^/]*\.json$|^[^/]*\.config\.(ts|mts|mjs|cjs|js)$'
+          if printf '%s\n' "$changed" | grep -qE "${dir_pattern}|${file_pattern}"; then
+            echo "has_source=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_source=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check audit trailer
         id: trailer
-        if: steps.gate.outputs.gated == 'false'
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true'
         run: bash .github/audit/check-trailer.sh >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false'
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
@@ -104,6 +133,7 @@ jobs:
       - name: Install dependencies
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false'
         run: pnpm install --frozen-lockfile
 
@@ -111,6 +141,7 @@ jobs:
         id: timeout
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false'
         env:
           BUDGET_SECONDS: ${{ steps.config.outputs.budget_seconds }}
@@ -132,6 +163,7 @@ jobs:
         id: audit
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false'
         # Continue on failure: max-turns / SDK / API errors must not strand
         # the PR check in a half-state. The status-summary terminal steps
@@ -161,6 +193,7 @@ jobs:
         id: push-fixes
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false' &&
           steps.config.outputs.push_fixes == 'true' &&
           steps.audit.outcome == 'success'
@@ -200,9 +233,19 @@ jobs:
           gh pr comment "$PR_NUMBER" \
             --body "code-review-audit skipped: gate_label '$GATE_LABEL' not present on PR"
 
+      - name: Status — skipped (no source changes)
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'false'
+        run: |
+          set -eu
+          gh pr comment "$PR_NUMBER" \
+            --body "code-review-audit skipped: no audit-relevant files changed in this PR"
+
       - name: Status — skipped (trailer matches)
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'true'
         env:
           MATCHED_VERSION: ${{ steps.trailer.outputs.matched_version }}
@@ -219,6 +262,7 @@ jobs:
         # signal that the audit did not run cleanly is `outcome != success`.
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false' &&
           steps.audit.outcome != 'success'
         run: |
@@ -229,6 +273,7 @@ jobs:
       - name: Status — audit complete
         if: |
           steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
           steps.trailer.outputs.skip == 'false' &&
           steps.audit.outcome == 'success'
         env:

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -11,6 +11,7 @@ export default {
     'app/utils/**/*.ts',
     'test/**/*.{ts,tsx}',
   ],
+  ignoreBinaries: ['bats'],
   ignoreDependencies: [
     '@epic-web/invariant',
     '@msw/data',


### PR DESCRIPTION
## Summary

Three follow-ups from the local `code-review-audit` run on PR #121:

1. **CI source-changes gate** for `code-review-audit` — workflow ran on every PR regardless of diff scope (wiki-only, instruction-file-only, etc.). New step-level skip mirrors the existing `gate_label` / `trailer.skip` patterns so the required check still reaches a clean conclusion on every path.
2. **Knip `bats` advisory** — added `ignoreBinaries: ['bats']` to `knip.config.ts`. The audit suggested `ignoreDependencies`, but knip categorizes `bats` under "Unlisted binaries" — `ignoreBinaries` is the correct field.
3. **`~/.claude/...` absolute paths** in `.claude/skills/gaia/references/wiki/lint.md` — violated `.claude/rules/instruction-files.md`. The runtime resolves the upstream `claude-obsidian:wiki-lint` skill by name; the paths were descriptive, not load-bearing.

## Audit-relevant scope (CI gate)

The new gate considers a PR audit-relevant when its diff touches:

- **Directories**: `app/`, `test/`, `.storybook/`, `.gaia/cli/src/`, `.github/workflows/`
- **Root files**: `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `tsconfig*.json`, `*.config.{ts,mts,mjs,cjs,js}`

Anything else (wiki, `.claude/`, `.specify/`, `.gaia/` metadata, prose docs) skips the audit and emits a comment: `code-review-audit skipped: no audit-relevant files changed in this PR`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm knip` clean (no "Unlisted binaries" entry for `bats`)
- [ ] CI: this PR itself touches `.github/workflows/` and `knip.config.ts` → audit should run (gate passes through, no skip)
- [ ] Future wiki-only or `.claude/`-only PRs: audit should skip with the new `Status — skipped (no source changes)` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)