### PR TITLE
fix(ci): surface code-review-audit aborts as red checks

### DIFF
--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -257,9 +257,15 @@ jobs:
             --body "code-review-audit skipped: GAIA-Audit trailer matches version $MATCHED_VERSION tree $short_tree"
 
       - name: Status — audit aborted (budget exhausted)
-        # `continue-on-error: true` forces conclusion=success even on
-        # failure or step-level timeout (cancelled), so the only reliable
-        # signal that the audit did not run cleanly is `outcome != success`.
+        # `continue-on-error: true` on the audit step keeps the workflow
+        # alive after the audit fails (max-turns hit, SDK error, transient
+        # API failure) so this terminal step can post the truthful comment.
+        # `outcome != 'success'` is the only reliable signal that the audit
+        # did not run cleanly (the audit step's `conclusion` is forced to
+        # success by `continue-on-error`). After commenting, `exit 1`
+        # surfaces the abort as a red check on the PR — without it, the
+        # green-check-plus-aborted-comment combo silently hides real audit
+        # failures from PR authors.
         if: |
           steps.gate.outputs.gated == 'false' &&
           steps.source-changes.outputs.has_source == 'true' &&
@@ -269,6 +275,7 @@ jobs:
           set -eu
           gh pr comment "$PR_NUMBER" \
             --body "code-review-audit aborted: budget exhausted or agent error (see workflow run logs)"
+          exit 1
 
       - name: Status — audit complete
         if: |


### PR DESCRIPTION
## Summary

The `Run code-review-audit (claude-code-action)` step has `continue-on-error: true`, which forces its conclusion to `success` regardless of what actually happened. Net effect: a real abort (max-turns, SDK error, transient API failure) showed as a **green check plus a truthful "aborted" PR comment** that authors could easily miss.

PR #122's CI audit demonstrated this exactly — the workflow showed pass (1m58s), but the actual audit aborted; only the PR comment surfaced the truth.

## Fix

Add `exit 1` at the end of the `Status — audit aborted (budget exhausted)` terminal step. The comment still posts first (diagnostic preserved), then the step fails — job conclusion becomes failure, required check turns red, branch protection blocks merge until the audit either succeeds on retry or the abort is investigated.

## Trade-off

Transient SDK / API errors now block PR merges (until a re-run or a new commit retriggers CI). This is the deliberate choice — silently letting potentially-unaudited code merge is worse than asking authors to re-run on a flake.

The audit step's `continue-on-error: true` is preserved — it's still load-bearing for keeping the workflow alive long enough for the status-comment step to post.

## Other terminal status steps unchanged

- `Status — skipped (gate label missing)` — intentional skip, stays green
- `Status — skipped (no source changes)` — intentional skip, stays green
- `Status — skipped (trailer matches)` — intentional skip, stays green
- `Status — audit complete` — clean run, stays green

Only the abort path turns red.

## Test plan

- [ ] CI: this PR touches `.github/workflows/` (in audit-relevant scope per PR #122) → audit should run; if it succeeds, check is green; if it aborts, check is now red (the new behavior under test)
- [ ] If CI audit aborts on this PR specifically, that itself validates the fix — re-run to land

🤖 Generated with [Claude Code](https://claude.com/claude-code)