### PR TITLE
wiki: re-anchor state at 74c4491

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "91a0dafdf784552e5d8f549f2fdda4edb6a3284e",
+  "last_evaluated_sha": "74c44913cbc48398e75cb8b3b74025f3d8c6077a",
   "last_evaluated_at": "2026-05-08T12:09:57Z",
   "last_consolidated_sha": "ca6cc0ad834c26a537d107a1c1ad1e3311573708",
   "last_consolidated_at": "2026-05-07T10:27:43Z"

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-08 74c4491 RE_ANCHOR — re-anchored after history rewrite
 - 2026-05-08 91a0daf WORTHY — renamed /wiki-{sync,consolidate,lint} → /gaia wiki <sub>; updated 7 wiki pages in-commit
 - 2026-05-08 66b757c SKIP — wiki: self-referential
 - 2026-05-08 f649523 SKIP — Serena handles instruction-file inventory — /gaia spec auto + plan isolation in .claude/skills/


### PR DESCRIPTION
## Summary

- Re-anchor `wiki/.state.json` from `91a0daf` → `74c4491` after history rewrite on `main`.
- Append re-anchor entry to `wiki/log.md`.

## Why

`/gaia wiki sync` detected the lagging state SHA was no longer in main's history (rewrite from PRs #121–#123). Standard re-anchor recovery path per `references/wiki/sync.md` Step 1.

## Test plan

- [x] `wiki/.state.json` updated to current HEAD
- [x] `wiki/log.md` carries re-anchor entry
- [x] No content changes; subsequent normal sync runs evaluate forward from this anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)