### PR TITLE
chore(ci): add self_modified guard to trailer-matches step

### DIFF
--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -277,6 +277,7 @@ jobs:
         if: |
           steps.gate.outputs.gated == 'false' &&
           steps.source-changes.outputs.has_source == 'true' &&
+          steps.workflow-self-mod.outputs.self_modified == 'false' &&
           steps.trailer.outputs.skip == 'true'
         env:
           MATCHED_VERSION: ${{ steps.trailer.outputs.matched_version }}


### PR DESCRIPTION
## Summary

One-line follow-up to #125. Adds `steps.workflow-self-mod.outputs.self_modified == 'false'` to the `Status — skipped (trailer matches)` terminal so it matches the gating pattern used by every other post-`workflow-self-mod` step.

## Why

Functionally inert — when `self_modified == 'true'` the trailer step never runs, so its empty `skip` output never equals `'true'`. But the missing guard was a silent assumption flagged by the code-review-audit on #125. Explicit guard removes the implicit reasoning step for future readers.

## Test plan

- [x] No behavior change; pure consistency fix
- [x] PR self-skips its own audit (workflow self-modification path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)