### PR TITLE
wiki: sync through 09f3f1d

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "74c44913cbc48398e75cb8b3b74025f3d8c6077a",
-  "last_evaluated_at": "2026-05-08T12:09:57Z",
+  "last_evaluated_sha": "09f3f1d7b1c655b66a1e1d3905c40a9e2dfafd7c",
+  "last_evaluated_at": "2026-05-08T13:29:26Z",
   "last_consolidated_sha": "ca6cc0ad834c26a537d107a1c1ad1e3311573708",
   "last_consolidated_at": "2026-05-07T10:27:43Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-08 09f3f1d SKIP — CI workflow guard refactor — no wiki impact
+- 2026-05-08 9e53032 SKIP — wiki: self-referential
+- 2026-05-08 a1a72e2 SKIP — CI workflow self-mod handling — no wiki impact
 - 2026-05-08 74c4491 RE_ANCHOR — re-anchored after history rewrite
 - 2026-05-08 91a0daf WORTHY — renamed /wiki-{sync,consolidate,lint} → /gaia wiki <sub>; updated 7 wiki pages in-commit
 - 2026-05-08 66b757c SKIP — wiki: self-referential


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 09f3f1d.