### PR TITLE
fix(audit): push GAIA-Audit empty commit to upstream so CI skips

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -347,7 +347,11 @@ Then surface, as the final line of your report — pick the line that matches `s
 
 > Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer amended (un-pushed); gh pr merge is unblocked.
 
-> Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer carried on empty commit (pushed); gh pr merge is unblocked.
+> Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer carried on empty commit (pushed to upstream); gh pr merge is unblocked.
+
+> Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer carried on empty commit (push to upstream FAILED — push manually before merging or CI's audit will rerun); gh pr merge is unblocked.
+
+> Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer carried on empty commit (HEAD detached; runner pushes separately); gh pr merge is unblocked.
 
 > Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer amended onto audit-self-heal HEAD; gh pr merge is unblocked.
 

--- a/.claude/hooks/audit-stamp-trailer.sh
+++ b/.claude/hooks/audit-stamp-trailer.sh
@@ -27,6 +27,8 @@
 #        final surface line. Stamp lines:
 #          stamp: amended onto HEAD (un-pushed)
 #          stamp: amended onto audit-self-heal HEAD
+#          stamp: empty commit (pushed to upstream)
+#          stamp: empty commit (push to upstream failed)
 #          stamp: empty commit (HEAD already pushed)
 #        Decline lines (prefix "stamp: declined: "):
 #          tree dirty
@@ -175,5 +177,17 @@ fi
 git -C "$repo_root" commit --allow-empty --no-verify \
   -m "chore: code review audit passed" \
   --trailer "$trailer" >/dev/null
-emit_stamp "empty commit (HEAD already pushed)"
+
+# When on an attached tracking branch, push the empty commit so CI can read
+# the trailer and skip its own audit run. On detached HEAD (CI runner) the
+# workflow's own commit-and-push step handles propagation, so skip the push.
+if [ -n "$head_branch" ] && [ -n "${upstream:-}" ]; then
+  if git -C "$repo_root" push --quiet 2>/dev/null; then
+    emit_stamp "empty commit (pushed to upstream)"
+  else
+    emit_stamp "empty commit (push to upstream failed)"
+  fi
+else
+  emit_stamp "empty commit (HEAD already pushed)"
+fi
 exit 0

--- a/.gaia/tests/hooks/audit-stamp-trailer.bats
+++ b/.gaia/tests/hooks/audit-stamp-trailer.bats
@@ -83,7 +83,7 @@ trailer_on_head() {
   [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
 }
 
-@test "clean tree + pushed HEAD: writes empty commit carrying the trailer" {
+@test "clean tree + pushed HEAD: writes empty commit and pushes it to upstream" {
   push_head_to_upstream
 
   before_sha=$(git -C "$REPO" rev-parse HEAD)
@@ -94,7 +94,7 @@ trailer_on_head() {
   AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
 
   [ "$status" -eq 0 ]
-  [ "$output" = "stamp: empty commit (HEAD already pushed)" ]
+  [ "$output" = "stamp: empty commit (pushed to upstream)" ]
 
   after_sha=$(git -C "$REPO" rev-parse HEAD)
   after_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
@@ -108,6 +108,32 @@ trailer_on_head() {
   subject=$(git -C "$REPO" log -1 --format='%s')
   [ "$subject" = "chore: code review audit passed" ]
 
+  trailer=$(trailer_on_head)
+  [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
+
+  # The trailer commit must reach the bare upstream so CI can read it.
+  remote_sha=$(git -C "$REMOTE" rev-parse main)
+  [ "$remote_sha" = "$after_sha" ]
+}
+
+@test "clean tree + pushed HEAD + push fails: writes empty commit and reports failure" {
+  push_head_to_upstream
+
+  # Break the bare upstream so `git push` fails. Removing its objects/
+  # directory turns it into a non-repo from git's perspective; push
+  # exits non-zero, the helper catches it and emits the failure stamp.
+  rm -rf "$REMOTE"
+
+  before_sha=$(git -C "$REPO" rev-parse HEAD)
+  before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
+
+  cd "$REPO"
+  AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "stamp: empty commit (push to upstream failed)" ]
+
+  # Empty commit still landed locally; only propagation failed.
   trailer=$(trailer_on_head)
   [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
 }


### PR DESCRIPTION
## Summary

`audit-stamp-trailer.sh` previously stopped after creating the empty trailer commit, leaving it local-only. CI's audit workflow then ran a redundant audit because the PR head it saw still lacked the trailer (this is exactly what happened on PR #129 — local audit ran, marker was written, gh pr merge unblocked, but CI's audit ran fresh on origin's pre-trailer head).

The helper now pushes the empty commit when on an attached tracking branch. Detached HEAD (CI runner) still falls through to the workflow's own commit-and-push step. New stamp lines `(pushed to upstream)` and `(push to upstream failed)` distinguish the two outcomes; `(HEAD already pushed)` is preserved for detached/no-upstream cases.

## Why this matters

The "either-or" gate between local and CI audit only works if the trailer reaches origin. Without that push, every locally-audited PR pays the CI audit cost a second time.

## Test plan

- [x] bats `.gaia/tests/hooks/audit-stamp-trailer.bats` (11 tests; existing 9 plus updated pushed-HEAD test asserting `remote_sha = after_sha`, plus new push-failure test).
- [x] Local audit on this commit confirmed the GAIA-Audit trailer (carried through cherry-pick from the audited source commit; tree-sha unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)