### PR TITLE
wiki: sync through 9bf6ad4 + lint-report dedupe

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "09f3f1d7b1c655b66a1e1d3905c40a9e2dfafd7c",
-  "last_evaluated_at": "2026-05-08T13:29:26Z",
+  "last_evaluated_sha": "9bf6ad4b2dd6d97ac80495c4452be7495e6b857d",
+  "last_evaluated_at": "2026-05-08T14:35:01Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,10 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-08 9bf6ad4 SKIP — Serena handles hooks — audit-stamp-trailer.sh and code-review-audit.md updates
+- 2026-05-08 6c3c17d SKIP — chore(deps): version bump only
+- 2026-05-08 891f3ae WORTHY — updated forensics skill files and wiki/concepts/Forensics.md to remove studio/ references → wiki/concepts/Forensics.md
+- 2026-05-08 70a4708 SKIP — wiki: self-referential
 - 2026-05-08 09f3f1d SKIP — CI workflow guard refactor — no wiki impact
 - 2026-05-08 9e53032 SKIP — wiki: self-referential
 - 2026-05-08 a1a72e2 SKIP — CI workflow self-mod handling — no wiki impact

--- a/wiki/meta/lint-report-2026-05-08.md
+++ b/wiki/meta/lint-report-2026-05-08.md
@@ -11,21 +11,7 @@ status: developing
 
 ## #11: Wiki drift check
 
-ℹ 1 commit behind HEAD. Run `/wiki-sync` at next opportunity. Recent unsynced commits:
-
-  - cb9f7ef wiki: sync through 158c86b (23 commits, 0 worthy)
-
-## #12: Dead repo-relative paths
-
-✓ No dead repo-relative paths detected in wiki body prose.
-
-## #13: UAT/SPEC narrative-ref drift
-
-✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.
-
-## #11: Wiki drift check
-
-ℹ 1 commit behind HEAD. Run /gaia wiki sync at next opportunity.
+ℹ 1 commit behind HEAD. Run `/gaia wiki sync` at next opportunity.
 
 ## #12: Dead repo-relative paths
 


### PR DESCRIPTION
## Summary
- Wiki sync through 9bf6ad4 (audit CI fix)
- Dedupe duplicate sections in `wiki/meta/lint-report-2026-05-08.md`

## Test plan
- [x] Lint report renders cleanly (no duplicate `#11`/`#12`/`#13`)
- [x] Wiki sync state matches HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)