### PR TITLE
fix(distribution): split release CLI into maintainer-only binary

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -3,9 +3,9 @@ name: gaia-release
 description: Cut a new GAIA release — bump version, graduate CHANGELOG, regenerate manifest, open release PR, then tag on merge. Maintainer-only.
 ---
 
-Cut a new GAIA release. Thin orchestrator over the `gaia release` CLI namespace, which owns every deterministic step (preflight checks, semver bump, CHANGELOG graduation, wiki scrub, manifest regen, commit + tag dance). This command sequences the CLI subcommands and surfaces user-facing prompts where human judgment is required.
+Cut a new GAIA release. Thin orchestrator over the `gaia-maintainer release` CLI namespace, which owns every deterministic step (preflight checks, semver bump, CHANGELOG graduation, wiki scrub, manifest regen, commit + tag dance). This command sequences the CLI subcommands and surfaces user-facing prompts where human judgment is required.
 
-This command is **maintainer-only** — it is stripped from distributed tarballs by `.gaia/release-exclude` so adopters never see it. Unlike `/gaia-init`, it does not self-delete; it runs every release.
+This command is **maintainer-only** — both this slash command and the `gaia-maintainer` binary are stripped from distributed tarballs by `.gaia/release-exclude` so adopters never see them. The adopter `gaia` binary has no `release` namespace at all; only `gaia-maintainer` does. Unlike `/gaia-init`, this command does not self-delete; it runs every release.
 
 > [!important] `main` is protected
 > Direct pushes to `main` are blocked. The release commit lands on a `release/v<NEW_VERSION>` branch, goes through a PR, and the tag is created on the merge commit _after_ it lands on `main`. Release branches have no required checks, so the PR is merged immediately by this command — no manual merge step needed.
@@ -17,7 +17,7 @@ The CLI surface is the source of truth. The classification rules for `.gaia/mani
 ### 1. Preflight
 
 ```bash
-gaia release preflight
+gaia-maintainer release preflight
 ```
 
 Verifies: on `main`, clean working tree, `wiki/.state.json` matches HEAD (per the `gaia wiki state --json` `commits_ahead === 0` contract). Exits non-zero with an explanation on any failure. STOP and report; the maintainer fixes (commit, push, run `/gaia wiki sync`) and re-runs `/gaia-release`.
@@ -25,7 +25,7 @@ Verifies: on `main`, clean working tree, `wiki/.state.json` matches HEAD (per th
 ### 2. Determine the bump
 
 ```bash
-gaia release bump            # propose only
+gaia-maintainer release bump            # propose only
 ```
 
 Prints `vCURRENT -> vNEXT (bump)` from a conventional-commit scan since the last tag. Highest severity wins; `BREAKING CHANGE` body lines or `!:` suffixes register as major.
@@ -35,7 +35,7 @@ If the proposal is **major**, present the breaking commits and ask the maintaine
 If **minor** or **patch** (or major-with-confirmation), apply:
 
 ```bash
-gaia release bump --auto     # writes package.json + .gaia/VERSION
+gaia-maintainer release bump --auto     # writes package.json + .gaia/VERSION
 ```
 
 `--auto` refuses major bumps without explicit confirmation; if the maintainer confirmed, proceed (the CLI surfaces the refusal as exit 1 — capture the proposed version and write package.json + `.gaia/VERSION` directly, or extend the runbook with a `--allow-major` flag if it becomes routine).
@@ -55,13 +55,13 @@ If the branch already exists (a previous attempt aborted), STOP and ask the main
 ### 5. Graduate the CHANGELOG
 
 ```bash
-gaia release changelog --draft   # render to stdout for human review
+gaia-maintainer release changelog --draft   # render to stdout for human review
 ```
 
 Present the draft to the maintainer. On approval (or "looks good"), apply:
 
 ```bash
-gaia release changelog            # graduate Unreleased → vX.Y.Z
+gaia-maintainer release changelog            # graduate Unreleased → vX.Y.Z
 ```
 
 The graduation is idempotent — re-running with the same version is a no-op.
@@ -69,7 +69,7 @@ The graduation is idempotent — re-running with the same version is a no-op.
 ### 6. Scrub adopter-facing wiki state
 
 ```bash
-gaia release scrub-wiki
+gaia-maintainer release scrub-wiki
 ```
 
 Overwrites `wiki/hot.md` and `wiki/log.md` with release-clean content (full frontmatter required by `/gaia wiki lint`).
@@ -77,18 +77,26 @@ Overwrites `wiki/hot.md` and `wiki/log.md` with release-clean content (full fron
 ### 7. Regenerate the manifest
 
 ```bash
-gaia release manifest
+gaia-maintainer release manifest
 ```
 
 Writes `.gaia/manifest.json`, sorted alphabetically. Walks `git ls-files`, subtracts `.gaia/release-exclude` patterns and adopter-owned sentinels, classifies the remainder as `owned` / `shared` / `wiki-owned`. Adopters use this manifest in `/update-gaia` to decide which files to overwrite, three-way merge, or leave alone.
 
+### 7b. Rebuild the bundled CLIs
+
+```bash
+pnpm --filter @gaia-react/cli bundle
+```
+
+Rebuilds both `.gaia/cli/gaia` (adopter binary) and `.gaia/cli/gaia-maintainer` (maintainer binary, excluded from the tarball). Skip only when no `.gaia/cli/src/` files changed since the last release; when in doubt, rebuild — the script is fast and idempotent. The release tarball ships the committed `gaia` binary as-is, so a stale bundle ships a stale CLI.
+
 ### 8. Commit on the release branch
 
 ```bash
-gaia release commit-and-tag --commit
+gaia-maintainer release commit-and-tag --commit
 ```
 
-Stages `package.json`, `.gaia/VERSION`, `.gaia/manifest.json`, `CHANGELOG.md`, `wiki/hot.md`, `wiki/log.md` (and `wiki/.state.json` after the amend). Commits as `chore(release): vX.Y.Z`, captures the new SHA, updates `wiki/.state.json` to point at it, then amends the commit so the tree contains a self-referential state file. Adopters who scaffold via `create-gaia` get a state file that says "wiki is in sync at this release."
+Stages `package.json`, `.gaia/VERSION`, `.gaia/manifest.json`, `CHANGELOG.md`, `wiki/hot.md`, `wiki/log.md` (and `wiki/.state.json` after the amend). The maintainer adds `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer` manually if Step 7b rebuilt them. Commits as `chore(release): vX.Y.Z`, captures the new SHA, updates `wiki/.state.json` to point at it, then amends the commit so the tree contains a self-referential state file. Adopters who scaffold via `create-gaia` get a state file that says "wiki is in sync at this release."
 
 If the pre-commit hook fails, STOP and report — fix the issue and create a **new** commit; do not `--amend`.
 
@@ -109,7 +117,7 @@ sleep 5
 git checkout main
 git pull --ff-only origin main
 git log -1 --oneline    # verify this is the merge commit
-gaia release commit-and-tag --tag
+gaia-maintainer release commit-and-tag --tag
 ```
 
 Push the tag, which kicks the GitHub Release workflow (`release.yml`) to build the scrubbed tarball.
@@ -119,5 +127,5 @@ Push the tag, which kicks the GitHub Release workflow (`release.yml`) to build t
 ```bash
 git tag -d "v<NEW_VERSION>"           # delete locally
 git push origin :"v<NEW_VERSION>"     # only if already pushed
-gaia release commit-and-tag --tag      # re-tag from the actual merge commit
+gaia-maintainer release commit-and-tag --tag      # re-tag from the actual merge commit
 ```

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -724,10 +724,10 @@ function jsonStringifyReplacer(_, value) {
   return value;
 }
 function cached(getter) {
-  const set2 = false;
+  const set3 = false;
   return {
     get value() {
-      if (!set2) {
+      if (!set3) {
         const value = getter();
         Object.defineProperty(this, "value", { value });
         return value;
@@ -794,13 +794,13 @@ function mergeDefs(...defs) {
   }
   return Object.defineProperties({}, mergedDescriptors);
 }
-function cloneDef(schema) {
-  return mergeDefs(schema._zod.def);
+function cloneDef(schema2) {
+  return mergeDefs(schema2._zod.def);
 }
-function getElementAtPath(obj, path35) {
-  if (!path35)
+function getElementAtPath(obj, path42) {
+  if (!path42)
     return obj;
-  return path35.reduce((acc, key) => acc?.[key], obj);
+  return path42.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -815,14 +815,14 @@ function promiseAllObject(promisesObj) {
 }
 function randomString(length = 10) {
   const chars = "abcdefghijklmnopqrstuvwxyz";
-  let str = "";
+  let str2 = "";
   for (let i = 0; i < length; i++) {
-    str += chars[Math.floor(Math.random() * chars.length)];
+    str2 += chars[Math.floor(Math.random() * chars.length)];
   }
-  return str;
+  return str2;
 }
-function esc(str) {
-  return JSON.stringify(str);
+function esc(str2) {
+  return JSON.stringify(str2);
 }
 function slugify(input) {
   return input.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/[\s_-]+/g, "-").replace(/^-+|-+$/g, "");
@@ -936,8 +936,8 @@ var primitiveTypes = /* @__PURE__ */ new Set([
   "symbol",
   "undefined"
 ]);
-function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function escapeRegex(str2) {
+  return str2.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function clone(inst, def, params) {
   const cl = new inst._zod.constr(def ?? inst._zod.def);
@@ -1017,14 +1017,14 @@ var BIGINT_FORMAT_RANGES = {
   int64: [/* @__PURE__ */ BigInt("-9223372036854775808"), /* @__PURE__ */ BigInt("9223372036854775807")],
   uint64: [/* @__PURE__ */ BigInt(0), /* @__PURE__ */ BigInt("18446744073709551615")]
 };
-function pick(schema, mask) {
-  const currDef = schema._zod.def;
+function pick(schema2, mask) {
+  const currDef = schema2._zod.def;
   const checks = currDef.checks;
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
     throw new Error(".pick() cannot be used on object schemas containing refinements");
   }
-  const def = mergeDefs(schema._zod.def, {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
       const newShape = {};
       for (const key in mask) {
@@ -1040,18 +1040,18 @@ function pick(schema, mask) {
     },
     checks: []
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
-function omit(schema, mask) {
-  const currDef = schema._zod.def;
+function omit(schema2, mask) {
+  const currDef = schema2._zod.def;
   const checks = currDef.checks;
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
     throw new Error(".omit() cannot be used on object schemas containing refinements");
   }
-  const def = mergeDefs(schema._zod.def, {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
-      const newShape = { ...schema._zod.def.shape };
+      const newShape = { ...schema2._zod.def.shape };
       for (const key in mask) {
         if (!(key in currDef.shape)) {
           throw new Error(`Unrecognized key: "${key}"`);
@@ -1065,43 +1065,43 @@ function omit(schema, mask) {
     },
     checks: []
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
-function extend(schema, shape) {
+function extend(schema2, shape) {
   if (!isPlainObject(shape)) {
     throw new Error("Invalid input to extend: expected a plain object");
   }
-  const checks = schema._zod.def.checks;
+  const checks = schema2._zod.def.checks;
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
-    const existingShape = schema._zod.def.shape;
+    const existingShape = schema2._zod.def.shape;
     for (const key in shape) {
       if (Object.getOwnPropertyDescriptor(existingShape, key) !== void 0) {
         throw new Error("Cannot overwrite keys on object schemas containing refinements. Use `.safeExtend()` instead.");
       }
     }
   }
-  const def = mergeDefs(schema._zod.def, {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
-      const _shape = { ...schema._zod.def.shape, ...shape };
+      const _shape = { ...schema2._zod.def.shape, ...shape };
       assignProp(this, "shape", _shape);
       return _shape;
     }
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
-function safeExtend(schema, shape) {
+function safeExtend(schema2, shape) {
   if (!isPlainObject(shape)) {
     throw new Error("Invalid input to safeExtend: expected a plain object");
   }
-  const def = mergeDefs(schema._zod.def, {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
-      const _shape = { ...schema._zod.def.shape, ...shape };
+      const _shape = { ...schema2._zod.def.shape, ...shape };
       assignProp(this, "shape", _shape);
       return _shape;
     }
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
 function merge(a, b) {
   if (a._zod.def.checks?.length) {
@@ -1120,16 +1120,16 @@ function merge(a, b) {
   });
   return clone(a, def);
 }
-function partial(Class2, schema, mask) {
-  const currDef = schema._zod.def;
+function partial(Class2, schema2, mask) {
+  const currDef = schema2._zod.def;
   const checks = currDef.checks;
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
     throw new Error(".partial() cannot be used on object schemas containing refinements");
   }
-  const def = mergeDefs(schema._zod.def, {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
-      const oldShape = schema._zod.def.shape;
+      const oldShape = schema2._zod.def.shape;
       const shape = { ...oldShape };
       if (mask) {
         for (const key in mask) {
@@ -1156,12 +1156,12 @@ function partial(Class2, schema, mask) {
     },
     checks: []
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
-function required(Class2, schema, mask) {
-  const def = mergeDefs(schema._zod.def, {
+function required(Class2, schema2, mask) {
+  const def = mergeDefs(schema2._zod.def, {
     get shape() {
-      const oldShape = schema._zod.def.shape;
+      const oldShape = schema2._zod.def.shape;
       const shape = { ...oldShape };
       if (mask) {
         for (const key in mask) {
@@ -1187,7 +1187,7 @@ function required(Class2, schema, mask) {
       return shape;
     }
   });
-  return clone(schema, def);
+  return clone(schema2, def);
 }
 function aborted(x, startIndex = 0) {
   if (x.aborted === true)
@@ -1209,11 +1209,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path35, issues) {
+function prefixIssues(path42, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path35);
+    iss.path.unshift(path42);
     return iss;
   });
 }
@@ -1360,16 +1360,16 @@ function flattenError(error51, mapper = (issue2) => issue2.message) {
 }
 function formatError(error51, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error52, path35 = []) => {
+  const processError = (error52, path42 = []) => {
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path35, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path42, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path35, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path42, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path35, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path42, ...issue2.path]);
       } else {
-        const fullpath = [...path35, ...issue2.path];
+        const fullpath = [...path42, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -1396,17 +1396,17 @@ function formatError(error51, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error51, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error52, path35 = []) => {
+  const processError = (error52, path42 = []) => {
     var _a3, _b;
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path35, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path42, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path35, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path42, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path35, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path42, ...issue2.path]);
       } else {
-        const fullpath = [...path35, ...issue2.path];
+        const fullpath = [...path42, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -1438,8 +1438,8 @@ function treeifyError(error51, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path35 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path35) {
+  const path42 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path42) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -1466,9 +1466,9 @@ function prettifyError(error51) {
 }
 
 // node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/parse.js
-var _parse = (_Err) => (schema, value, _ctx, _params) => {
+var _parse = (_Err) => (schema2, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
-  const result = schema._zod.run({ value, issues: [] }, ctx);
+  const result = schema2._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError();
   }
@@ -1480,9 +1480,9 @@ var _parse = (_Err) => (schema, value, _ctx, _params) => {
   return result.value;
 };
 var parse = /* @__PURE__ */ _parse($ZodRealError);
-var _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
+var _parseAsync = (_Err) => async (schema2, value, _ctx, params) => {
   const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
-  let result = schema._zod.run({ value, issues: [] }, ctx);
+  let result = schema2._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
   if (result.issues.length) {
@@ -1493,9 +1493,9 @@ var _parseAsync = (_Err) => async (schema, value, _ctx, params) => {
   return result.value;
 };
 var parseAsync = /* @__PURE__ */ _parseAsync($ZodRealError);
-var _safeParse = (_Err) => (schema, value, _ctx) => {
+var _safeParse = (_Err) => (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
-  const result = schema._zod.run({ value, issues: [] }, ctx);
+  const result = schema2._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new $ZodAsyncError();
   }
@@ -1505,9 +1505,9 @@ var _safeParse = (_Err) => (schema, value, _ctx) => {
   } : { success: true, data: result.value };
 };
 var safeParse = /* @__PURE__ */ _safeParse($ZodRealError);
-var _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
+var _safeParseAsync = (_Err) => async (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, async: true } : { async: true };
-  let result = schema._zod.run({ value, issues: [] }, ctx);
+  let result = schema2._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise)
     result = await result;
   return result.issues.length ? {
@@ -1516,40 +1516,40 @@ var _safeParseAsync = (_Err) => async (schema, value, _ctx) => {
   } : { success: true, data: result.value };
 };
 var safeParseAsync = /* @__PURE__ */ _safeParseAsync($ZodRealError);
-var _encode = (_Err) => (schema, value, _ctx) => {
+var _encode = (_Err) => (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _parse(_Err)(schema, value, ctx);
+  return _parse(_Err)(schema2, value, ctx);
 };
 var encode = /* @__PURE__ */ _encode($ZodRealError);
-var _decode = (_Err) => (schema, value, _ctx) => {
-  return _parse(_Err)(schema, value, _ctx);
+var _decode = (_Err) => (schema2, value, _ctx) => {
+  return _parse(_Err)(schema2, value, _ctx);
 };
 var decode = /* @__PURE__ */ _decode($ZodRealError);
-var _encodeAsync = (_Err) => async (schema, value, _ctx) => {
+var _encodeAsync = (_Err) => async (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _parseAsync(_Err)(schema, value, ctx);
+  return _parseAsync(_Err)(schema2, value, ctx);
 };
 var encodeAsync = /* @__PURE__ */ _encodeAsync($ZodRealError);
-var _decodeAsync = (_Err) => async (schema, value, _ctx) => {
-  return _parseAsync(_Err)(schema, value, _ctx);
+var _decodeAsync = (_Err) => async (schema2, value, _ctx) => {
+  return _parseAsync(_Err)(schema2, value, _ctx);
 };
 var decodeAsync = /* @__PURE__ */ _decodeAsync($ZodRealError);
-var _safeEncode = (_Err) => (schema, value, _ctx) => {
+var _safeEncode = (_Err) => (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _safeParse(_Err)(schema, value, ctx);
+  return _safeParse(_Err)(schema2, value, ctx);
 };
 var safeEncode = /* @__PURE__ */ _safeEncode($ZodRealError);
-var _safeDecode = (_Err) => (schema, value, _ctx) => {
-  return _safeParse(_Err)(schema, value, _ctx);
+var _safeDecode = (_Err) => (schema2, value, _ctx) => {
+  return _safeParse(_Err)(schema2, value, _ctx);
 };
 var safeDecode = /* @__PURE__ */ _safeDecode($ZodRealError);
-var _safeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
+var _safeEncodeAsync = (_Err) => async (schema2, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" } : { direction: "backward" };
-  return _safeParseAsync(_Err)(schema, value, ctx);
+  return _safeParseAsync(_Err)(schema2, value, ctx);
 };
 var safeEncodeAsync = /* @__PURE__ */ _safeEncodeAsync($ZodRealError);
-var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
-  return _safeParseAsync(_Err)(schema, value, _ctx);
+var _safeDecodeAsync = (_Err) => async (schema2, value, _ctx) => {
+  return _safeParseAsync(_Err)(schema2, value, _ctx);
 };
 var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
 
@@ -3069,13 +3069,13 @@ var $ZodObject = /* @__PURE__ */ $constructor("$ZodObject", (inst, def) => {
     }
     return propValues;
   });
-  const isObject3 = isObject;
+  const isObject4 = isObject;
   const catchall = def.catchall;
   let value;
   inst._zod.parse = (payload, ctx) => {
     value ?? (value = _normalized.value);
     const input = payload.value;
-    if (!isObject3(input)) {
+    if (!isObject4(input)) {
       payload.issues.push({
         expected: "object",
         code: "invalid_type",
@@ -3125,9 +3125,9 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
     for (const key of normalized.keys) {
       const id = ids[key];
       const k = esc(key);
-      const schema = shape[key];
-      const isOptionalIn = schema?._zod?.optin === "optional";
-      const isOptionalOut = schema?._zod?.optout === "optional";
+      const schema2 = shape[key];
+      const isOptionalIn = schema2?._zod?.optin === "optional";
+      const isOptionalOut = schema2?._zod?.optout === "optional";
       doc.write(`const ${id} = ${parseStr(key)};`);
       if (isOptionalIn && isOptionalOut) {
         doc.write(`
@@ -3202,7 +3202,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
     return (payload, ctx) => fn(shape, payload, ctx);
   };
   let fastpass;
-  const isObject3 = isObject;
+  const isObject4 = isObject;
   const jit = !globalConfig.jitless;
   const allowsEval2 = allowsEval;
   const fastEnabled = jit && allowsEval2.value;
@@ -3211,7 +3211,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
   inst._zod.parse = (payload, ctx) => {
     value ?? (value = _normalized.value);
     const input = payload.value;
-    if (!isObject3(input)) {
+    if (!isObject4(input)) {
       payload.issues.push({
         expected: "object",
         code: "invalid_type",
@@ -3371,19 +3371,19 @@ var $ZodDiscriminatedUnion = /* @__PURE__ */ $constructor("$ZodDiscriminatedUnio
   });
   const disc = cached(() => {
     const opts = def.options;
-    const map2 = /* @__PURE__ */ new Map();
+    const map3 = /* @__PURE__ */ new Map();
     for (const o of opts) {
       const values = o._zod.propValues?.[def.discriminator];
       if (!values || values.size === 0)
         throw new Error(`Invalid discriminated union option at index "${def.options.indexOf(o)}"`);
       for (const v of values) {
-        if (map2.has(v)) {
+        if (map3.has(v)) {
           throw new Error(`Duplicate discriminator value "${String(v)}"`);
         }
-        map2.set(v, o);
+        map3.set(v, o);
       }
     }
-    return map2;
+    return map3;
   });
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -10360,11 +10360,11 @@ var $ZodRegistry = class {
     this._map = /* @__PURE__ */ new WeakMap();
     this._idmap = /* @__PURE__ */ new Map();
   }
-  add(schema, ..._meta) {
+  add(schema2, ..._meta) {
     const meta3 = _meta[0];
-    this._map.set(schema, meta3);
+    this._map.set(schema2, meta3);
     if (meta3 && typeof meta3 === "object" && "id" in meta3) {
-      this._idmap.set(meta3.id, schema);
+      this._idmap.set(meta3.id, schema2);
     }
     return this;
   }
@@ -10373,26 +10373,26 @@ var $ZodRegistry = class {
     this._idmap = /* @__PURE__ */ new Map();
     return this;
   }
-  remove(schema) {
-    const meta3 = this._map.get(schema);
+  remove(schema2) {
+    const meta3 = this._map.get(schema2);
     if (meta3 && typeof meta3 === "object" && "id" in meta3) {
       this._idmap.delete(meta3.id);
     }
-    this._map.delete(schema);
+    this._map.delete(schema2);
     return this;
   }
-  get(schema) {
-    const p = schema._zod.parent;
+  get(schema2) {
+    const p = schema2._zod.parent;
     if (p) {
       const pm = { ...this.get(p) ?? {} };
       delete pm.id;
-      const f = { ...pm, ...this._map.get(schema) };
+      const f = { ...pm, ...this._map.get(schema2) };
       return Object.keys(f).length ? f : void 0;
     }
-    return this._map.get(schema);
+    return this._map.get(schema2);
   }
-  has(schema) {
-    return this._map.has(schema);
+  has(schema2) {
+    return this._map.has(schema2);
   }
 };
 function registry() {
@@ -11045,11 +11045,11 @@ function _endsWith(suffix, params) {
   });
 }
 // @__NO_SIDE_EFFECTS__
-function _property(property, schema, params) {
+function _property(property, schema2, params) {
   return new $ZodCheckProperty({
     check: "property",
     property,
-    schema,
+    schema: schema2,
     ...normalizeParams(params)
   });
 }
@@ -11297,23 +11297,23 @@ function _promise(Class2, innerType) {
 function _custom(Class2, fn, _params) {
   const norm = normalizeParams(_params);
   norm.abort ?? (norm.abort = true);
-  const schema = new Class2({
+  const schema2 = new Class2({
     type: "custom",
     check: "custom",
     fn,
     ...norm
   });
-  return schema;
+  return schema2;
 }
 // @__NO_SIDE_EFFECTS__
 function _refine(Class2, fn, _params) {
-  const schema = new Class2({
+  const schema2 = new Class2({
     type: "custom",
     check: "custom",
     fn,
     ...normalizeParams(_params)
   });
-  return schema;
+  return schema2;
 }
 // @__NO_SIDE_EFFECTS__
 function _superRefine(fn, params) {
@@ -11462,40 +11462,40 @@ function initializeContext(params) {
     external: params?.external ?? void 0
   };
 }
-function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
+function process2(schema2, ctx, _params = { path: [], schemaPath: [] }) {
   var _a3;
-  const def = schema._zod.def;
-  const seen = ctx.seen.get(schema);
+  const def = schema2._zod.def;
+  const seen = ctx.seen.get(schema2);
   if (seen) {
     seen.count++;
-    const isCycle = _params.schemaPath.includes(schema);
+    const isCycle = _params.schemaPath.includes(schema2);
     if (isCycle) {
       seen.cycle = _params.path;
     }
     return seen.schema;
   }
   const result = { schema: {}, count: 1, cycle: void 0, path: _params.path };
-  ctx.seen.set(schema, result);
-  const overrideSchema = schema._zod.toJSONSchema?.();
+  ctx.seen.set(schema2, result);
+  const overrideSchema = schema2._zod.toJSONSchema?.();
   if (overrideSchema) {
     result.schema = overrideSchema;
   } else {
     const params = {
       ..._params,
-      schemaPath: [..._params.schemaPath, schema],
+      schemaPath: [..._params.schemaPath, schema2],
       path: _params.path
     };
-    if (schema._zod.processJSONSchema) {
-      schema._zod.processJSONSchema(ctx, result.schema, params);
+    if (schema2._zod.processJSONSchema) {
+      schema2._zod.processJSONSchema(ctx, result.schema, params);
     } else {
       const _json = result.schema;
       const processor = ctx.processors[def.type];
       if (!processor) {
         throw new Error(`[toJSONSchema]: Non-representable type encountered: ${def.type}`);
       }
-      processor(schema, ctx, _json, params);
+      processor(schema2, ctx, _json, params);
     }
-    const parent = schema._zod.parent;
+    const parent = schema2._zod.parent;
     if (parent) {
       if (!result.ref)
         result.ref = parent;
@@ -11503,21 +11503,21 @@ function process2(schema, ctx, _params = { path: [], schemaPath: [] }) {
       ctx.seen.get(parent).isParent = true;
     }
   }
-  const meta3 = ctx.metadataRegistry.get(schema);
+  const meta3 = ctx.metadataRegistry.get(schema2);
   if (meta3)
     Object.assign(result.schema, meta3);
-  if (ctx.io === "input" && isTransforming(schema)) {
+  if (ctx.io === "input" && isTransforming(schema2)) {
     delete result.schema.examples;
     delete result.schema.default;
   }
   if (ctx.io === "input" && "_prefault" in result.schema)
     (_a3 = result.schema).default ?? (_a3.default = result.schema._prefault);
   delete result.schema._prefault;
-  const _result = ctx.seen.get(schema);
+  const _result = ctx.seen.get(schema2);
   return _result.schema;
 }
-function extractDefs(ctx, schema) {
-  const root = ctx.seen.get(schema);
+function extractDefs(ctx, schema2) {
+  const root = ctx.seen.get(schema2);
   if (!root)
     throw new Error("Unprocessed schema. This is a bug in Zod.");
   const idToSchema = /* @__PURE__ */ new Map();
@@ -11560,11 +11560,11 @@ function extractDefs(ctx, schema) {
     seen.def = { ...seen.schema };
     if (defId)
       seen.defId = defId;
-    const schema2 = seen.schema;
-    for (const key in schema2) {
-      delete schema2[key];
+    const schema3 = seen.schema;
+    for (const key in schema3) {
+      delete schema3[key];
     }
-    schema2.$ref = ref;
+    schema3.$ref = ref;
   };
   if (ctx.cycles === "throw") {
     for (const entry of ctx.seen.entries()) {
@@ -11578,13 +11578,13 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
   }
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
-    if (schema === entry[0]) {
+    if (schema2 === entry[0]) {
       extractToDef(entry);
       continue;
     }
     if (ctx.external) {
       const ext = ctx.external.registry.get(entry[0])?.id;
-      if (schema !== entry[0] && ext) {
+      if (schema2 !== entry[0] && ext) {
         extractToDef(entry);
         continue;
       }
@@ -11606,16 +11606,16 @@ Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.
     }
   }
 }
-function finalize(ctx, schema) {
-  const root = ctx.seen.get(schema);
+function finalize(ctx, schema2) {
+  const root = ctx.seen.get(schema2);
   if (!root)
     throw new Error("Unprocessed schema. This is a bug in Zod.");
   const flattenRef = (zodSchema) => {
     const seen = ctx.seen.get(zodSchema);
     if (seen.ref === null)
       return;
-    const schema2 = seen.def ?? seen.schema;
-    const _cached = { ...schema2 };
+    const schema3 = seen.def ?? seen.schema;
+    const _cached = { ...schema3 };
     const ref = seen.ref;
     seen.ref = null;
     if (ref) {
@@ -11623,28 +11623,28 @@ function finalize(ctx, schema) {
       const refSeen = ctx.seen.get(ref);
       const refSchema = refSeen.schema;
       if (refSchema.$ref && (ctx.target === "draft-07" || ctx.target === "draft-04" || ctx.target === "openapi-3.0")) {
-        schema2.allOf = schema2.allOf ?? [];
-        schema2.allOf.push(refSchema);
+        schema3.allOf = schema3.allOf ?? [];
+        schema3.allOf.push(refSchema);
       } else {
-        Object.assign(schema2, refSchema);
+        Object.assign(schema3, refSchema);
       }
-      Object.assign(schema2, _cached);
+      Object.assign(schema3, _cached);
       const isParentRef = zodSchema._zod.parent === ref;
       if (isParentRef) {
-        for (const key in schema2) {
+        for (const key in schema3) {
           if (key === "$ref" || key === "allOf")
             continue;
           if (!(key in _cached)) {
-            delete schema2[key];
+            delete schema3[key];
           }
         }
       }
       if (refSchema.$ref && refSeen.def) {
-        for (const key in schema2) {
+        for (const key in schema3) {
           if (key === "$ref" || key === "allOf")
             continue;
-          if (key in refSeen.def && JSON.stringify(schema2[key]) === JSON.stringify(refSeen.def[key])) {
-            delete schema2[key];
+          if (key in refSeen.def && JSON.stringify(schema3[key]) === JSON.stringify(refSeen.def[key])) {
+            delete schema3[key];
           }
         }
       }
@@ -11654,13 +11654,13 @@ function finalize(ctx, schema) {
       flattenRef(parent);
       const parentSeen = ctx.seen.get(parent);
       if (parentSeen?.schema.$ref) {
-        schema2.$ref = parentSeen.schema.$ref;
+        schema3.$ref = parentSeen.schema.$ref;
         if (parentSeen.def) {
-          for (const key in schema2) {
+          for (const key in schema3) {
             if (key === "$ref" || key === "allOf")
               continue;
-            if (key in parentSeen.def && JSON.stringify(schema2[key]) === JSON.stringify(parentSeen.def[key])) {
-              delete schema2[key];
+            if (key in parentSeen.def && JSON.stringify(schema3[key]) === JSON.stringify(parentSeen.def[key])) {
+              delete schema3[key];
             }
           }
         }
@@ -11668,7 +11668,7 @@ function finalize(ctx, schema) {
     }
     ctx.override({
       zodSchema,
-      jsonSchema: schema2,
+      jsonSchema: schema3,
       path: seen.path ?? []
     });
   };
@@ -11686,13 +11686,13 @@ function finalize(ctx, schema) {
   } else {
   }
   if (ctx.external?.uri) {
-    const id = ctx.external.registry.get(schema)?.id;
+    const id = ctx.external.registry.get(schema2)?.id;
     if (!id)
       throw new Error("Schema is missing an `id` property");
     result.$id = ctx.external.uri(id);
   }
   Object.assign(result, root.def ?? root.schema);
-  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
+  const rootMetaId = ctx.metadataRegistry.get(schema2)?.id;
   if (rootMetaId !== void 0 && result.id === rootMetaId)
     delete result.id;
   const defs = ctx.external?.defs ?? {};
@@ -11718,10 +11718,10 @@ function finalize(ctx, schema) {
     const finalized = JSON.parse(JSON.stringify(result));
     Object.defineProperty(finalized, "~standard", {
       value: {
-        ...schema["~standard"],
+        ...schema2["~standard"],
         jsonSchema: {
-          input: createStandardJSONSchemaMethod(schema, "input", ctx.processors),
-          output: createStandardJSONSchemaMethod(schema, "output", ctx.processors)
+          input: createStandardJSONSchemaMethod(schema2, "input", ctx.processors),
+          output: createStandardJSONSchemaMethod(schema2, "output", ctx.processors)
         }
       },
       enumerable: false,
@@ -11785,18 +11785,18 @@ function isTransforming(_schema, _ctx) {
   }
   return false;
 }
-var createToJSONSchemaMethod = (schema, processors = {}) => (params) => {
+var createToJSONSchemaMethod = (schema2, processors = {}) => (params) => {
   const ctx = initializeContext({ ...params, processors });
-  process2(schema, ctx);
-  extractDefs(ctx, schema);
-  return finalize(ctx, schema);
+  process2(schema2, ctx);
+  extractDefs(ctx, schema2);
+  return finalize(ctx, schema2);
 };
-var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) => {
+var createStandardJSONSchemaMethod = (schema2, io, processors = {}) => (params) => {
   const { libraryOptions, target } = params ?? {};
   const ctx = initializeContext({ ...libraryOptions ?? {}, target, io, processors });
-  process2(schema, ctx);
-  extractDefs(ctx, schema);
-  return finalize(ctx, schema);
+  process2(schema2, ctx);
+  extractDefs(ctx, schema2);
+  return finalize(ctx, schema2);
 };
 
 // node_modules/.pnpm/zod@4.4.3/node_modules/zod/v4/core/json-schema-processors.js
@@ -11808,30 +11808,30 @@ var formatMap = {
   regex: ""
   // do not set
 };
-var stringProcessor = (schema, ctx, _json, _params) => {
-  const json2 = _json;
-  json2.type = "string";
-  const { minimum, maximum, format, patterns, contentEncoding } = schema._zod.bag;
+var stringProcessor = (schema2, ctx, _json, _params) => {
+  const json3 = _json;
+  json3.type = "string";
+  const { minimum, maximum, format, patterns, contentEncoding } = schema2._zod.bag;
   if (typeof minimum === "number")
-    json2.minLength = minimum;
+    json3.minLength = minimum;
   if (typeof maximum === "number")
-    json2.maxLength = maximum;
+    json3.maxLength = maximum;
   if (format) {
-    json2.format = formatMap[format] ?? format;
-    if (json2.format === "")
-      delete json2.format;
+    json3.format = formatMap[format] ?? format;
+    if (json3.format === "")
+      delete json3.format;
     if (format === "time") {
-      delete json2.format;
+      delete json3.format;
     }
   }
   if (contentEncoding)
-    json2.contentEncoding = contentEncoding;
+    json3.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {
     const regexes = [...patterns];
     if (regexes.length === 1)
-      json2.pattern = regexes[0].source;
+      json3.pattern = regexes[0].source;
     else if (regexes.length > 1) {
-      json2.allOf = [
+      json3.allOf = [
         ...regexes.map((regex) => ({
           ...ctx.target === "draft-07" || ctx.target === "draft-04" || ctx.target === "openapi-3.0" ? { type: "string" } : {},
           pattern: regex.source
@@ -11840,41 +11840,41 @@ var stringProcessor = (schema, ctx, _json, _params) => {
     }
   }
 };
-var numberProcessor = (schema, ctx, _json, _params) => {
-  const json2 = _json;
-  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = schema._zod.bag;
+var numberProcessor = (schema2, ctx, _json, _params) => {
+  const json3 = _json;
+  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = schema2._zod.bag;
   if (typeof format === "string" && format.includes("int"))
-    json2.type = "integer";
+    json3.type = "integer";
   else
-    json2.type = "number";
+    json3.type = "number";
   const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
   const exMax = typeof exclusiveMaximum === "number" && exclusiveMaximum <= (maximum ?? Number.POSITIVE_INFINITY);
   const legacy = ctx.target === "draft-04" || ctx.target === "openapi-3.0";
   if (exMin) {
     if (legacy) {
-      json2.minimum = exclusiveMinimum;
-      json2.exclusiveMinimum = true;
+      json3.minimum = exclusiveMinimum;
+      json3.exclusiveMinimum = true;
     } else {
-      json2.exclusiveMinimum = exclusiveMinimum;
+      json3.exclusiveMinimum = exclusiveMinimum;
     }
   } else if (typeof minimum === "number") {
-    json2.minimum = minimum;
+    json3.minimum = minimum;
   }
   if (exMax) {
     if (legacy) {
-      json2.maximum = exclusiveMaximum;
-      json2.exclusiveMaximum = true;
+      json3.maximum = exclusiveMaximum;
+      json3.exclusiveMaximum = true;
     } else {
-      json2.exclusiveMaximum = exclusiveMaximum;
+      json3.exclusiveMaximum = exclusiveMaximum;
     }
   } else if (typeof maximum === "number") {
-    json2.maximum = maximum;
+    json3.maximum = maximum;
   }
   if (typeof multipleOf === "number")
-    json2.multipleOf = multipleOf;
+    json3.multipleOf = multipleOf;
 };
-var booleanProcessor = (_schema, _ctx, json2, _params) => {
-  json2.type = "boolean";
+var booleanProcessor = (_schema, _ctx, json3, _params) => {
+  json3.type = "boolean";
 };
 var bigintProcessor = (_schema, ctx, _json, _params) => {
   if (ctx.unrepresentable === "throw") {
@@ -11886,13 +11886,13 @@ var symbolProcessor = (_schema, ctx, _json, _params) => {
     throw new Error("Symbols cannot be represented in JSON Schema");
   }
 };
-var nullProcessor = (_schema, ctx, json2, _params) => {
+var nullProcessor = (_schema, ctx, json3, _params) => {
   if (ctx.target === "openapi-3.0") {
-    json2.type = "string";
-    json2.nullable = true;
-    json2.enum = [null];
+    json3.type = "string";
+    json3.nullable = true;
+    json3.enum = [null];
   } else {
-    json2.type = "null";
+    json3.type = "null";
   }
 };
 var undefinedProcessor = (_schema, ctx, _json, _params) => {
@@ -11905,8 +11905,8 @@ var voidProcessor = (_schema, ctx, _json, _params) => {
     throw new Error("Void cannot be represented in JSON Schema");
   }
 };
-var neverProcessor = (_schema, _ctx, json2, _params) => {
-  json2.not = {};
+var neverProcessor = (_schema, _ctx, json3, _params) => {
+  json3.not = {};
 };
 var anyProcessor = (_schema, _ctx, _json, _params) => {
 };
@@ -11917,17 +11917,17 @@ var dateProcessor = (_schema, ctx, _json, _params) => {
     throw new Error("Date cannot be represented in JSON Schema");
   }
 };
-var enumProcessor = (schema, _ctx, json2, _params) => {
-  const def = schema._zod.def;
+var enumProcessor = (schema2, _ctx, json3, _params) => {
+  const def = schema2._zod.def;
   const values = getEnumValues(def.entries);
   if (values.every((v) => typeof v === "number"))
-    json2.type = "number";
+    json3.type = "number";
   if (values.every((v) => typeof v === "string"))
-    json2.type = "string";
-  json2.enum = values;
+    json3.type = "string";
+  json3.enum = values;
 };
-var literalProcessor = (schema, ctx, json2, _params) => {
-  const def = schema._zod.def;
+var literalProcessor = (schema2, ctx, json3, _params) => {
+  const def = schema2._zod.def;
   const vals = [];
   for (const val of def.values) {
     if (val === void 0) {
@@ -11948,22 +11948,22 @@ var literalProcessor = (schema, ctx, json2, _params) => {
   if (vals.length === 0) {
   } else if (vals.length === 1) {
     const val = vals[0];
-    json2.type = val === null ? "null" : typeof val;
+    json3.type = val === null ? "null" : typeof val;
     if (ctx.target === "draft-04" || ctx.target === "openapi-3.0") {
-      json2.enum = [val];
+      json3.enum = [val];
     } else {
-      json2.const = val;
+      json3.const = val;
     }
   } else {
     if (vals.every((v) => typeof v === "number"))
-      json2.type = "number";
+      json3.type = "number";
     if (vals.every((v) => typeof v === "string"))
-      json2.type = "string";
+      json3.type = "string";
     if (vals.every((v) => typeof v === "boolean"))
-      json2.type = "boolean";
+      json3.type = "boolean";
     if (vals.every((v) => v === null))
-      json2.type = "null";
-    json2.enum = vals;
+      json3.type = "null";
+    json3.enum = vals;
   }
 };
 var nanProcessor = (_schema, ctx, _json, _params) => {
@@ -11971,22 +11971,22 @@ var nanProcessor = (_schema, ctx, _json, _params) => {
     throw new Error("NaN cannot be represented in JSON Schema");
   }
 };
-var templateLiteralProcessor = (schema, _ctx, json2, _params) => {
-  const _json = json2;
-  const pattern = schema._zod.pattern;
+var templateLiteralProcessor = (schema2, _ctx, json3, _params) => {
+  const _json = json3;
+  const pattern = schema2._zod.pattern;
   if (!pattern)
     throw new Error("Pattern not found in template literal");
   _json.type = "string";
   _json.pattern = pattern.source;
 };
-var fileProcessor = (schema, _ctx, json2, _params) => {
-  const _json = json2;
+var fileProcessor = (schema2, _ctx, json3, _params) => {
+  const _json = json3;
   const file2 = {
     type: "string",
     format: "binary",
     contentEncoding: "binary"
   };
-  const { minimum, maximum, mime } = schema._zod.bag;
+  const { minimum, maximum, mime } = schema2._zod.bag;
   if (minimum !== void 0)
     file2.minLength = minimum;
   if (maximum !== void 0)
@@ -12003,8 +12003,8 @@ var fileProcessor = (schema, _ctx, json2, _params) => {
     Object.assign(_json, file2);
   }
 };
-var successProcessor = (_schema, _ctx, json2, _params) => {
-  json2.type = "boolean";
+var successProcessor = (_schema, _ctx, json3, _params) => {
+  json3.type = "boolean";
 };
 var customProcessor = (_schema, ctx, _json, _params) => {
   if (ctx.unrepresentable === "throw") {
@@ -12031,28 +12031,28 @@ var setProcessor = (_schema, ctx, _json, _params) => {
     throw new Error("Set cannot be represented in JSON Schema");
   }
 };
-var arrayProcessor = (schema, ctx, _json, params) => {
-  const json2 = _json;
-  const def = schema._zod.def;
-  const { minimum, maximum } = schema._zod.bag;
+var arrayProcessor = (schema2, ctx, _json, params) => {
+  const json3 = _json;
+  const def = schema2._zod.def;
+  const { minimum, maximum } = schema2._zod.bag;
   if (typeof minimum === "number")
-    json2.minItems = minimum;
+    json3.minItems = minimum;
   if (typeof maximum === "number")
-    json2.maxItems = maximum;
-  json2.type = "array";
-  json2.items = process2(def.element, ctx, {
+    json3.maxItems = maximum;
+  json3.type = "array";
+  json3.items = process2(def.element, ctx, {
     ...params,
     path: [...params.path, "items"]
   });
 };
-var objectProcessor = (schema, ctx, _json, params) => {
-  const json2 = _json;
-  const def = schema._zod.def;
-  json2.type = "object";
-  json2.properties = {};
+var objectProcessor = (schema2, ctx, _json, params) => {
+  const json3 = _json;
+  const def = schema2._zod.def;
+  json3.type = "object";
+  json3.properties = {};
   const shape = def.shape;
   for (const key in shape) {
-    json2.properties[key] = process2(shape[key], ctx, {
+    json3.properties[key] = process2(shape[key], ctx, {
       ...params,
       path: [...params.path, "properties", key]
     });
@@ -12067,35 +12067,35 @@ var objectProcessor = (schema, ctx, _json, params) => {
     }
   }));
   if (requiredKeys.size > 0) {
-    json2.required = Array.from(requiredKeys);
+    json3.required = Array.from(requiredKeys);
   }
   if (def.catchall?._zod.def.type === "never") {
-    json2.additionalProperties = false;
+    json3.additionalProperties = false;
   } else if (!def.catchall) {
     if (ctx.io === "output")
-      json2.additionalProperties = false;
+      json3.additionalProperties = false;
   } else if (def.catchall) {
-    json2.additionalProperties = process2(def.catchall, ctx, {
+    json3.additionalProperties = process2(def.catchall, ctx, {
       ...params,
       path: [...params.path, "additionalProperties"]
     });
   }
 };
-var unionProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var unionProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   const isExclusive = def.inclusive === false;
   const options = def.options.map((x, i) => process2(x, ctx, {
     ...params,
     path: [...params.path, isExclusive ? "oneOf" : "anyOf", i]
   }));
   if (isExclusive) {
-    json2.oneOf = options;
+    json3.oneOf = options;
   } else {
-    json2.anyOf = options;
+    json3.anyOf = options;
   }
 };
-var intersectionProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var intersectionProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   const a = process2(def.left, ctx, {
     ...params,
     path: [...params.path, "allOf", 0]
@@ -12109,12 +12109,12 @@ var intersectionProcessor = (schema, ctx, json2, params) => {
     ...isSimpleIntersection(a) ? a.allOf : [a],
     ...isSimpleIntersection(b) ? b.allOf : [b]
   ];
-  json2.allOf = allOf;
+  json3.allOf = allOf;
 };
-var tupleProcessor = (schema, ctx, _json, params) => {
-  const json2 = _json;
-  const def = schema._zod.def;
-  json2.type = "array";
+var tupleProcessor = (schema2, ctx, _json, params) => {
+  const json3 = _json;
+  const def = schema2._zod.def;
+  json3.type = "array";
   const prefixPath = ctx.target === "draft-2020-12" ? "prefixItems" : "items";
   const restPath = ctx.target === "draft-2020-12" ? "items" : ctx.target === "openapi-3.0" ? "items" : "additionalItems";
   const prefixItems = def.items.map((x, i) => process2(x, ctx, {
@@ -12126,37 +12126,37 @@ var tupleProcessor = (schema, ctx, _json, params) => {
     path: [...params.path, restPath, ...ctx.target === "openapi-3.0" ? [def.items.length] : []]
   }) : null;
   if (ctx.target === "draft-2020-12") {
-    json2.prefixItems = prefixItems;
+    json3.prefixItems = prefixItems;
     if (rest) {
-      json2.items = rest;
+      json3.items = rest;
     }
   } else if (ctx.target === "openapi-3.0") {
-    json2.items = {
+    json3.items = {
       anyOf: prefixItems
     };
     if (rest) {
-      json2.items.anyOf.push(rest);
+      json3.items.anyOf.push(rest);
     }
-    json2.minItems = prefixItems.length;
+    json3.minItems = prefixItems.length;
     if (!rest) {
-      json2.maxItems = prefixItems.length;
+      json3.maxItems = prefixItems.length;
     }
   } else {
-    json2.items = prefixItems;
+    json3.items = prefixItems;
     if (rest) {
-      json2.additionalItems = rest;
+      json3.additionalItems = rest;
     }
   }
-  const { minimum, maximum } = schema._zod.bag;
+  const { minimum, maximum } = schema2._zod.bag;
   if (typeof minimum === "number")
-    json2.minItems = minimum;
+    json3.minItems = minimum;
   if (typeof maximum === "number")
-    json2.maxItems = maximum;
+    json3.maxItems = maximum;
 };
-var recordProcessor = (schema, ctx, _json, params) => {
-  const json2 = _json;
-  const def = schema._zod.def;
-  json2.type = "object";
+var recordProcessor = (schema2, ctx, _json, params) => {
+  const json3 = _json;
+  const def = schema2._zod.def;
+  json3.type = "object";
   const keyType = def.keyType;
   const keyBag = keyType._zod.bag;
   const patterns = keyBag?.patterns;
@@ -12165,18 +12165,18 @@ var recordProcessor = (schema, ctx, _json, params) => {
       ...params,
       path: [...params.path, "patternProperties", "*"]
     });
-    json2.patternProperties = {};
+    json3.patternProperties = {};
     for (const pattern of patterns) {
-      json2.patternProperties[pattern.source] = valueSchema;
+      json3.patternProperties[pattern.source] = valueSchema;
     }
   } else {
     if (ctx.target === "draft-07" || ctx.target === "draft-2020-12") {
-      json2.propertyNames = process2(def.keyType, ctx, {
+      json3.propertyNames = process2(def.keyType, ctx, {
         ...params,
         path: [...params.path, "propertyNames"]
       });
     }
-    json2.additionalProperties = process2(def.valueType, ctx, {
+    json3.additionalProperties = process2(def.valueType, ctx, {
       ...params,
       path: [...params.path, "additionalProperties"]
     });
@@ -12185,46 +12185,46 @@ var recordProcessor = (schema, ctx, _json, params) => {
   if (keyValues) {
     const validKeyValues = [...keyValues].filter((v) => typeof v === "string" || typeof v === "number");
     if (validKeyValues.length > 0) {
-      json2.required = validKeyValues;
+      json3.required = validKeyValues;
     }
   }
 };
-var nullableProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var nullableProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   const inner = process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   if (ctx.target === "openapi-3.0") {
     seen.ref = def.innerType;
-    json2.nullable = true;
+    json3.nullable = true;
   } else {
-    json2.anyOf = [inner, { type: "null" }];
+    json3.anyOf = [inner, { type: "null" }];
   }
 };
-var nonoptionalProcessor = (schema, ctx, _json, params) => {
-  const def = schema._zod.def;
+var nonoptionalProcessor = (schema2, ctx, _json, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
 };
-var defaultProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var defaultProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
-  json2.default = JSON.parse(JSON.stringify(def.defaultValue));
+  json3.default = JSON.parse(JSON.stringify(def.defaultValue));
 };
-var prefaultProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var prefaultProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
   if (ctx.io === "input")
-    json2._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+    json3._prefault = JSON.parse(JSON.stringify(def.defaultValue));
 };
-var catchProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var catchProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
   let catchValue;
   try {
@@ -12232,39 +12232,39 @@ var catchProcessor = (schema, ctx, json2, params) => {
   } catch {
     throw new Error("Dynamic catch values are not supported in JSON Schema");
   }
-  json2.default = catchValue;
+  json3.default = catchValue;
 };
-var pipeProcessor = (schema, ctx, _json, params) => {
-  const def = schema._zod.def;
+var pipeProcessor = (schema2, ctx, _json, params) => {
+  const def = schema2._zod.def;
   const inIsTransform = def.in._zod.traits.has("$ZodTransform");
   const innerType = ctx.io === "input" ? inIsTransform ? def.out : def.in : def.out;
   process2(innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = innerType;
 };
-var readonlyProcessor = (schema, ctx, json2, params) => {
-  const def = schema._zod.def;
+var readonlyProcessor = (schema2, ctx, json3, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
-  json2.readOnly = true;
+  json3.readOnly = true;
 };
-var promiseProcessor = (schema, ctx, _json, params) => {
-  const def = schema._zod.def;
+var promiseProcessor = (schema2, ctx, _json, params) => {
+  const def = schema2._zod.def;
   process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
-  seen.ref = def.innerType;
-};
-var optionalProcessor = (schema, ctx, _json, params) => {
-  const def = schema._zod.def;
-  process2(def.innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = def.innerType;
 };
-var lazyProcessor = (schema, ctx, _json, params) => {
-  const innerType = schema._zod.innerType;
+var optionalProcessor = (schema2, ctx, _json, params) => {
+  const def = schema2._zod.def;
+  process2(def.innerType, ctx, params);
+  const seen = ctx.seen.get(schema2);
+  seen.ref = def.innerType;
+};
+var lazyProcessor = (schema2, ctx, _json, params) => {
+  const innerType = schema2._zod.innerType;
   process2(innerType, ctx, params);
-  const seen = ctx.seen.get(schema);
+  const seen = ctx.seen.get(schema2);
   seen.ref = innerType;
 };
 var allProcessors = {
@@ -12314,8 +12314,8 @@ function toJSONSchema(input, params) {
     const ctx2 = initializeContext({ ...params, processors: allProcessors });
     const defs = {};
     for (const entry of registry2._idmap.entries()) {
-      const [_, schema] = entry;
-      process2(schema, ctx2);
+      const [_, schema2] = entry;
+      process2(schema2, ctx2);
     }
     const schemas = {};
     const external = {
@@ -12325,9 +12325,9 @@ function toJSONSchema(input, params) {
     };
     ctx2.external = external;
     for (const entry of registry2._idmap.entries()) {
-      const [key, schema] = entry;
-      extractDefs(ctx2, schema);
-      schemas[key] = finalize(ctx2, schema);
+      const [key, schema2] = entry;
+      extractDefs(ctx2, schema2);
+      schemas[key] = finalize(ctx2, schema2);
     }
     if (Object.keys(defs).length > 0) {
       const defsSegment = ctx2.target === "draft-2020-12" ? "$defs" : "definitions";
@@ -12395,14 +12395,14 @@ var JSONSchemaGenerator = class {
    * Process a schema to prepare it for JSON Schema generation.
    * This must be called before emit().
    */
-  process(schema, _params = { path: [], schemaPath: [] }) {
-    return process2(schema, this.ctx, _params);
+  process(schema2, _params = { path: [], schemaPath: [] }) {
+    return process2(schema2, this.ctx, _params);
   }
   /**
    * Emit the final JSON Schema after processing.
    * Must call process() first.
    */
-  emit(schema, _params) {
+  emit(schema2, _params) {
     if (_params) {
       if (_params.cycles)
         this.ctx.cycles = _params.cycles;
@@ -12411,8 +12411,8 @@ var JSONSchemaGenerator = class {
       if (_params.external)
         this.ctx.external = _params.external;
     }
-    extractDefs(this.ctx, schema);
-    const result = finalize(this.ctx, schema);
+    extractDefs(this.ctx, schema2);
+    const result = finalize(this.ctx, schema2);
     const { "~standard": _, ...plainResult } = result;
     return plainResult;
   }
@@ -12891,7 +12891,7 @@ var ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
 var _ZodString = /* @__PURE__ */ $constructor("_ZodString", (inst, def) => {
   $ZodString.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => stringProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => stringProcessor(inst, ctx, json3, params);
   const bag = inst._zod.bag;
   inst.format = bag.format ?? null;
   inst.minLength = bag.minimum ?? null;
@@ -13162,7 +13162,7 @@ function hash(alg, params) {
 var ZodNumber = /* @__PURE__ */ $constructor("ZodNumber", (inst, def) => {
   $ZodNumber.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => numberProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => numberProcessor(inst, ctx, json3, params);
   _installLazyMethods(inst, "ZodNumber", {
     gt(value, params) {
       return this.check(_gt(value, params));
@@ -13242,7 +13242,7 @@ function uint32(params) {
 var ZodBoolean = /* @__PURE__ */ $constructor("ZodBoolean", (inst, def) => {
   $ZodBoolean.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => booleanProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => booleanProcessor(inst, ctx, json3, params);
 });
 function boolean2(params) {
   return _boolean(ZodBoolean, params);
@@ -13250,7 +13250,7 @@ function boolean2(params) {
 var ZodBigInt = /* @__PURE__ */ $constructor("ZodBigInt", (inst, def) => {
   $ZodBigInt.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => bigintProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => bigintProcessor(inst, ctx, json3, params);
   inst.gte = (value, params) => inst.check(_gte(value, params));
   inst.min = (value, params) => inst.check(_gte(value, params));
   inst.gt = (value, params) => inst.check(_gt(value, params));
@@ -13285,7 +13285,7 @@ function uint64(params) {
 var ZodSymbol = /* @__PURE__ */ $constructor("ZodSymbol", (inst, def) => {
   $ZodSymbol.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => symbolProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => symbolProcessor(inst, ctx, json3, params);
 });
 function symbol(params) {
   return _symbol(ZodSymbol, params);
@@ -13293,7 +13293,7 @@ function symbol(params) {
 var ZodUndefined = /* @__PURE__ */ $constructor("ZodUndefined", (inst, def) => {
   $ZodUndefined.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => undefinedProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => undefinedProcessor(inst, ctx, json3, params);
 });
 function _undefined3(params) {
   return _undefined2(ZodUndefined, params);
@@ -13301,7 +13301,7 @@ function _undefined3(params) {
 var ZodNull = /* @__PURE__ */ $constructor("ZodNull", (inst, def) => {
   $ZodNull.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => nullProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => nullProcessor(inst, ctx, json3, params);
 });
 function _null3(params) {
   return _null2(ZodNull, params);
@@ -13309,7 +13309,7 @@ function _null3(params) {
 var ZodAny = /* @__PURE__ */ $constructor("ZodAny", (inst, def) => {
   $ZodAny.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => anyProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => anyProcessor(inst, ctx, json3, params);
 });
 function any() {
   return _any(ZodAny);
@@ -13317,7 +13317,7 @@ function any() {
 var ZodUnknown = /* @__PURE__ */ $constructor("ZodUnknown", (inst, def) => {
   $ZodUnknown.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => unknownProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => unknownProcessor(inst, ctx, json3, params);
 });
 function unknown() {
   return _unknown(ZodUnknown);
@@ -13325,7 +13325,7 @@ function unknown() {
 var ZodNever = /* @__PURE__ */ $constructor("ZodNever", (inst, def) => {
   $ZodNever.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => neverProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => neverProcessor(inst, ctx, json3, params);
 });
 function never(params) {
   return _never(ZodNever, params);
@@ -13333,7 +13333,7 @@ function never(params) {
 var ZodVoid = /* @__PURE__ */ $constructor("ZodVoid", (inst, def) => {
   $ZodVoid.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => voidProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => voidProcessor(inst, ctx, json3, params);
 });
 function _void2(params) {
   return _void(ZodVoid, params);
@@ -13341,7 +13341,7 @@ function _void2(params) {
 var ZodDate = /* @__PURE__ */ $constructor("ZodDate", (inst, def) => {
   $ZodDate.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => dateProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => dateProcessor(inst, ctx, json3, params);
   inst.min = (value, params) => inst.check(_gte(value, params));
   inst.max = (value, params) => inst.check(_lte(value, params));
   const c = inst._zod.bag;
@@ -13354,7 +13354,7 @@ function date3(params) {
 var ZodArray = /* @__PURE__ */ $constructor("ZodArray", (inst, def) => {
   $ZodArray.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => arrayProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => arrayProcessor(inst, ctx, json3, params);
   inst.element = def.element;
   _installLazyMethods(inst, "ZodArray", {
     min(n, params) {
@@ -13377,14 +13377,14 @@ var ZodArray = /* @__PURE__ */ $constructor("ZodArray", (inst, def) => {
 function array(element, params) {
   return _array(ZodArray, element, params);
 }
-function keyof(schema) {
-  const shape = schema._zod.def.shape;
+function keyof(schema2) {
+  const shape = schema2._zod.def.shape;
   return _enum2(Object.keys(shape));
 }
 var ZodObject = /* @__PURE__ */ $constructor("ZodObject", (inst, def) => {
   $ZodObjectJIT.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => objectProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => objectProcessor(inst, ctx, json3, params);
   util_exports.defineLazy(inst, "shape", () => {
     return def.shape;
   });
@@ -13457,7 +13457,7 @@ function looseObject(shape, params) {
 var ZodUnion = /* @__PURE__ */ $constructor("ZodUnion", (inst, def) => {
   $ZodUnion.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => unionProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => unionProcessor(inst, ctx, json3, params);
   inst.options = def.options;
 });
 function union(options, params) {
@@ -13470,7 +13470,7 @@ function union(options, params) {
 var ZodXor = /* @__PURE__ */ $constructor("ZodXor", (inst, def) => {
   ZodUnion.init(inst, def);
   $ZodXor.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => unionProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => unionProcessor(inst, ctx, json3, params);
   inst.options = def.options;
 });
 function xor(options, params) {
@@ -13496,7 +13496,7 @@ function discriminatedUnion(discriminator, options, params) {
 var ZodIntersection = /* @__PURE__ */ $constructor("ZodIntersection", (inst, def) => {
   $ZodIntersection.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => intersectionProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => intersectionProcessor(inst, ctx, json3, params);
 });
 function intersection(left, right) {
   return new ZodIntersection({
@@ -13508,7 +13508,7 @@ function intersection(left, right) {
 var ZodTuple = /* @__PURE__ */ $constructor("ZodTuple", (inst, def) => {
   $ZodTuple.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => tupleProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => tupleProcessor(inst, ctx, json3, params);
   inst.rest = (rest) => inst.clone({
     ...inst._zod.def,
     rest
@@ -13528,7 +13528,7 @@ function tuple(items, _paramsOrRest, _params) {
 var ZodRecord = /* @__PURE__ */ $constructor("ZodRecord", (inst, def) => {
   $ZodRecord.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => recordProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => recordProcessor(inst, ctx, json3, params);
   inst.keyType = def.keyType;
   inst.valueType = def.valueType;
 });
@@ -13570,7 +13570,7 @@ function looseRecord(keyType, valueType, params) {
 var ZodMap = /* @__PURE__ */ $constructor("ZodMap", (inst, def) => {
   $ZodMap.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => mapProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => mapProcessor(inst, ctx, json3, params);
   inst.keyType = def.keyType;
   inst.valueType = def.valueType;
   inst.min = (...args) => inst.check(_minSize(...args));
@@ -13589,7 +13589,7 @@ function map(keyType, valueType, params) {
 var ZodSet = /* @__PURE__ */ $constructor("ZodSet", (inst, def) => {
   $ZodSet.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => setProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => setProcessor(inst, ctx, json3, params);
   inst.min = (...args) => inst.check(_minSize(...args));
   inst.nonempty = (params) => inst.check(_minSize(1, params));
   inst.max = (...args) => inst.check(_maxSize(...args));
@@ -13605,7 +13605,7 @@ function set(valueType, params) {
 var ZodEnum = /* @__PURE__ */ $constructor("ZodEnum", (inst, def) => {
   $ZodEnum.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => enumProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => enumProcessor(inst, ctx, json3, params);
   inst.enum = def.entries;
   inst.options = Object.values(def.entries);
   const keys = new Set(Object.keys(def.entries));
@@ -13658,7 +13658,7 @@ function nativeEnum(entries, params) {
 var ZodLiteral = /* @__PURE__ */ $constructor("ZodLiteral", (inst, def) => {
   $ZodLiteral.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => literalProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => literalProcessor(inst, ctx, json3, params);
   inst.values = new Set(def.values);
   Object.defineProperty(inst, "value", {
     get() {
@@ -13679,7 +13679,7 @@ function literal(value, params) {
 var ZodFile = /* @__PURE__ */ $constructor("ZodFile", (inst, def) => {
   $ZodFile.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => fileProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => fileProcessor(inst, ctx, json3, params);
   inst.min = (size, params) => inst.check(_minSize(size, params));
   inst.max = (size, params) => inst.check(_maxSize(size, params));
   inst.mime = (types, params) => inst.check(_mime(Array.isArray(types) ? types : [types], params));
@@ -13690,7 +13690,7 @@ function file(params) {
 var ZodTransform = /* @__PURE__ */ $constructor("ZodTransform", (inst, def) => {
   $ZodTransform.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => transformProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => transformProcessor(inst, ctx, json3, params);
   inst._zod.parse = (payload, _ctx) => {
     if (_ctx.direction === "backward") {
       throw new $ZodEncodeError(inst.constructor.name);
@@ -13730,7 +13730,7 @@ function transform(fn) {
 var ZodOptional = /* @__PURE__ */ $constructor("ZodOptional", (inst, def) => {
   $ZodOptional.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => optionalProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => optionalProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function optional(innerType) {
@@ -13742,7 +13742,7 @@ function optional(innerType) {
 var ZodExactOptional = /* @__PURE__ */ $constructor("ZodExactOptional", (inst, def) => {
   $ZodExactOptional.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => optionalProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => optionalProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function exactOptional(innerType) {
@@ -13754,7 +13754,7 @@ function exactOptional(innerType) {
 var ZodNullable = /* @__PURE__ */ $constructor("ZodNullable", (inst, def) => {
   $ZodNullable.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => nullableProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => nullableProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function nullable(innerType) {
@@ -13769,7 +13769,7 @@ function nullish2(innerType) {
 var ZodDefault = /* @__PURE__ */ $constructor("ZodDefault", (inst, def) => {
   $ZodDefault.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => defaultProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => defaultProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
   inst.removeDefault = inst.unwrap;
 });
@@ -13785,7 +13785,7 @@ function _default2(innerType, defaultValue) {
 var ZodPrefault = /* @__PURE__ */ $constructor("ZodPrefault", (inst, def) => {
   $ZodPrefault.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => prefaultProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => prefaultProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function prefault(innerType, defaultValue) {
@@ -13800,7 +13800,7 @@ function prefault(innerType, defaultValue) {
 var ZodNonOptional = /* @__PURE__ */ $constructor("ZodNonOptional", (inst, def) => {
   $ZodNonOptional.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => nonoptionalProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => nonoptionalProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function nonoptional(innerType, params) {
@@ -13813,7 +13813,7 @@ function nonoptional(innerType, params) {
 var ZodSuccess = /* @__PURE__ */ $constructor("ZodSuccess", (inst, def) => {
   $ZodSuccess.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => successProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => successProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function success(innerType) {
@@ -13825,7 +13825,7 @@ function success(innerType) {
 var ZodCatch = /* @__PURE__ */ $constructor("ZodCatch", (inst, def) => {
   $ZodCatch.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => catchProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => catchProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
   inst.removeCatch = inst.unwrap;
 });
@@ -13839,7 +13839,7 @@ function _catch2(innerType, catchValue) {
 var ZodNaN = /* @__PURE__ */ $constructor("ZodNaN", (inst, def) => {
   $ZodNaN.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => nanProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => nanProcessor(inst, ctx, json3, params);
 });
 function nan(params) {
   return _nan(ZodNaN, params);
@@ -13847,7 +13847,7 @@ function nan(params) {
 var ZodPipe = /* @__PURE__ */ $constructor("ZodPipe", (inst, def) => {
   $ZodPipe.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => pipeProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => pipeProcessor(inst, ctx, json3, params);
   inst.in = def.in;
   inst.out = def.out;
 });
@@ -13889,7 +13889,7 @@ var ZodPreprocess = /* @__PURE__ */ $constructor("ZodPreprocess", (inst, def) =>
 var ZodReadonly = /* @__PURE__ */ $constructor("ZodReadonly", (inst, def) => {
   $ZodReadonly.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => readonlyProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => readonlyProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function readonly(innerType) {
@@ -13901,7 +13901,7 @@ function readonly(innerType) {
 var ZodTemplateLiteral = /* @__PURE__ */ $constructor("ZodTemplateLiteral", (inst, def) => {
   $ZodTemplateLiteral.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => templateLiteralProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => templateLiteralProcessor(inst, ctx, json3, params);
 });
 function templateLiteral(parts, params) {
   return new ZodTemplateLiteral({
@@ -13913,7 +13913,7 @@ function templateLiteral(parts, params) {
 var ZodLazy = /* @__PURE__ */ $constructor("ZodLazy", (inst, def) => {
   $ZodLazy.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => lazyProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => lazyProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.getter();
 });
 function lazy(getter) {
@@ -13925,7 +13925,7 @@ function lazy(getter) {
 var ZodPromise = /* @__PURE__ */ $constructor("ZodPromise", (inst, def) => {
   $ZodPromise.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => promiseProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => promiseProcessor(inst, ctx, json3, params);
   inst.unwrap = () => inst._zod.def.innerType;
 });
 function promise(innerType) {
@@ -13937,7 +13937,7 @@ function promise(innerType) {
 var ZodFunction = /* @__PURE__ */ $constructor("ZodFunction", (inst, def) => {
   $ZodFunction.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => functionProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => functionProcessor(inst, ctx, json3, params);
 });
 function _function(params) {
   return new ZodFunction({
@@ -13949,7 +13949,7 @@ function _function(params) {
 var ZodCustom = /* @__PURE__ */ $constructor("ZodCustom", (inst, def) => {
   $ZodCustom.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json2, params) => customProcessor(inst, ctx, json2, params);
+  inst._zod.processJSONSchema = (ctx, json3, params) => customProcessor(inst, ctx, json3, params);
 });
 function check(fn) {
   const ch = new $ZodCheck({
@@ -14003,11 +14003,11 @@ function json(params) {
   });
   return jsonSchema;
 }
-function preprocess(fn, schema) {
+function preprocess(fn, schema2) {
   return new ZodPreprocess({
     type: "pipe",
     in: transform(fn),
-    out: schema
+    out: schema2
   });
 }
 
@@ -14025,9 +14025,9 @@ var ZodIssueCode = {
   invalid_value: "invalid_value",
   custom: "custom"
 };
-function setErrorMap(map2) {
+function setErrorMap(map3) {
   config({
-    customError: map2
+    customError: map3
   });
 }
 function getErrorMap() {
@@ -14114,8 +14114,8 @@ var RECOGNIZED_KEYS = /* @__PURE__ */ new Set([
   "nullable",
   "readOnly"
 ]);
-function detectVersion(schema, defaultTarget) {
-  const $schema = schema.$schema;
+function detectVersion(schema2, defaultTarget) {
+  const $schema = schema2.$schema;
   if ($schema === "https://json-schema.org/draft/2020-12/schema") {
     return "draft-2020-12";
   }
@@ -14131,13 +14131,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path35 = ref.slice(1).split("/").filter(Boolean);
-  if (path35.length === 0) {
+  const path42 = ref.slice(1).split("/").filter(Boolean);
+  if (path42.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path35[0] === defsKey) {
-    const key = path35[1];
+  if (path42[0] === defsKey) {
+    const key = path42[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -14145,27 +14145,27 @@ function resolveRef(ref, ctx) {
   }
   throw new Error(`Reference not found: ${ref}`);
 }
-function convertBaseSchema(schema, ctx) {
-  if (schema.not !== void 0) {
-    if (typeof schema.not === "object" && Object.keys(schema.not).length === 0) {
+function convertBaseSchema(schema2, ctx) {
+  if (schema2.not !== void 0) {
+    if (typeof schema2.not === "object" && Object.keys(schema2.not).length === 0) {
       return z.never();
     }
     throw new Error("not is not supported in Zod (except { not: {} } for never)");
   }
-  if (schema.unevaluatedItems !== void 0) {
+  if (schema2.unevaluatedItems !== void 0) {
     throw new Error("unevaluatedItems is not supported");
   }
-  if (schema.unevaluatedProperties !== void 0) {
+  if (schema2.unevaluatedProperties !== void 0) {
     throw new Error("unevaluatedProperties is not supported");
   }
-  if (schema.if !== void 0 || schema.then !== void 0 || schema.else !== void 0) {
+  if (schema2.if !== void 0 || schema2.then !== void 0 || schema2.else !== void 0) {
     throw new Error("Conditional schemas (if/then/else) are not supported");
   }
-  if (schema.dependentSchemas !== void 0 || schema.dependentRequired !== void 0) {
+  if (schema2.dependentSchemas !== void 0 || schema2.dependentRequired !== void 0) {
     throw new Error("dependentSchemas and dependentRequired are not supported");
   }
-  if (schema.$ref) {
-    const refPath = schema.$ref;
+  if (schema2.$ref) {
+    const refPath = schema2.$ref;
     if (ctx.refs.has(refPath)) {
       return ctx.refs.get(refPath);
     }
@@ -14184,9 +14184,9 @@ function convertBaseSchema(schema, ctx) {
     ctx.processing.delete(refPath);
     return zodSchema2;
   }
-  if (schema.enum !== void 0) {
-    const enumValues = schema.enum;
-    if (ctx.version === "openapi-3.0" && schema.nullable === true && enumValues.length === 1 && enumValues[0] === null) {
+  if (schema2.enum !== void 0) {
+    const enumValues = schema2.enum;
+    if (ctx.version === "openapi-3.0" && schema2.nullable === true && enumValues.length === 1 && enumValues[0] === null) {
       return z.null();
     }
     if (enumValues.length === 0) {
@@ -14204,13 +14204,13 @@ function convertBaseSchema(schema, ctx) {
     }
     return z.union([literalSchemas[0], literalSchemas[1], ...literalSchemas.slice(2)]);
   }
-  if (schema.const !== void 0) {
-    return z.literal(schema.const);
+  if (schema2.const !== void 0) {
+    return z.literal(schema2.const);
   }
-  const type = schema.type;
-  if (Array.isArray(type)) {
-    const typeSchemas = type.map((t) => {
-      const typeSchema = { ...schema, type: t };
+  const type2 = schema2.type;
+  if (Array.isArray(type2)) {
+    const typeSchemas = type2.map((t) => {
+      const typeSchema = { ...schema2, type: t };
       return convertBaseSchema(typeSchema, ctx);
     });
     if (typeSchemas.length === 0) {
@@ -14221,15 +14221,15 @@ function convertBaseSchema(schema, ctx) {
     }
     return z.union(typeSchemas);
   }
-  if (!type) {
+  if (!type2) {
     return z.any();
   }
   let zodSchema;
-  switch (type) {
+  switch (type2) {
     case "string": {
       let stringSchema = z.string();
-      if (schema.format) {
-        const format = schema.format;
+      if (schema2.format) {
+        const format = schema2.format;
         if (format === "email") {
           stringSchema = stringSchema.check(z.email());
         } else if (format === "uri" || format === "uri-reference") {
@@ -14278,39 +14278,39 @@ function convertBaseSchema(schema, ctx) {
           stringSchema = stringSchema.check(z.ksuid());
         }
       }
-      if (typeof schema.minLength === "number") {
-        stringSchema = stringSchema.min(schema.minLength);
+      if (typeof schema2.minLength === "number") {
+        stringSchema = stringSchema.min(schema2.minLength);
       }
-      if (typeof schema.maxLength === "number") {
-        stringSchema = stringSchema.max(schema.maxLength);
+      if (typeof schema2.maxLength === "number") {
+        stringSchema = stringSchema.max(schema2.maxLength);
       }
-      if (schema.pattern) {
-        stringSchema = stringSchema.regex(new RegExp(schema.pattern));
+      if (schema2.pattern) {
+        stringSchema = stringSchema.regex(new RegExp(schema2.pattern));
       }
       zodSchema = stringSchema;
       break;
     }
     case "number":
     case "integer": {
-      let numberSchema = type === "integer" ? z.number().int() : z.number();
-      if (typeof schema.minimum === "number") {
-        numberSchema = numberSchema.min(schema.minimum);
+      let numberSchema = type2 === "integer" ? z.number().int() : z.number();
+      if (typeof schema2.minimum === "number") {
+        numberSchema = numberSchema.min(schema2.minimum);
       }
-      if (typeof schema.maximum === "number") {
-        numberSchema = numberSchema.max(schema.maximum);
+      if (typeof schema2.maximum === "number") {
+        numberSchema = numberSchema.max(schema2.maximum);
       }
-      if (typeof schema.exclusiveMinimum === "number") {
-        numberSchema = numberSchema.gt(schema.exclusiveMinimum);
-      } else if (schema.exclusiveMinimum === true && typeof schema.minimum === "number") {
-        numberSchema = numberSchema.gt(schema.minimum);
+      if (typeof schema2.exclusiveMinimum === "number") {
+        numberSchema = numberSchema.gt(schema2.exclusiveMinimum);
+      } else if (schema2.exclusiveMinimum === true && typeof schema2.minimum === "number") {
+        numberSchema = numberSchema.gt(schema2.minimum);
       }
-      if (typeof schema.exclusiveMaximum === "number") {
-        numberSchema = numberSchema.lt(schema.exclusiveMaximum);
-      } else if (schema.exclusiveMaximum === true && typeof schema.maximum === "number") {
-        numberSchema = numberSchema.lt(schema.maximum);
+      if (typeof schema2.exclusiveMaximum === "number") {
+        numberSchema = numberSchema.lt(schema2.exclusiveMaximum);
+      } else if (schema2.exclusiveMaximum === true && typeof schema2.maximum === "number") {
+        numberSchema = numberSchema.lt(schema2.maximum);
       }
-      if (typeof schema.multipleOf === "number") {
-        numberSchema = numberSchema.multipleOf(schema.multipleOf);
+      if (typeof schema2.multipleOf === "number") {
+        numberSchema = numberSchema.multipleOf(schema2.multipleOf);
       }
       zodSchema = numberSchema;
       break;
@@ -14325,15 +14325,15 @@ function convertBaseSchema(schema, ctx) {
     }
     case "object": {
       const shape = {};
-      const properties = schema.properties || {};
-      const requiredSet = new Set(schema.required || []);
+      const properties = schema2.properties || {};
+      const requiredSet = new Set(schema2.required || []);
       for (const [key, propSchema] of Object.entries(properties)) {
         const propZodSchema = convertSchema(propSchema, ctx);
         shape[key] = requiredSet.has(key) ? propZodSchema : propZodSchema.optional();
       }
-      if (schema.propertyNames) {
-        const keySchema = convertSchema(schema.propertyNames, ctx);
-        const valueSchema = schema.additionalProperties && typeof schema.additionalProperties === "object" ? convertSchema(schema.additionalProperties, ctx) : z.any();
+      if (schema2.propertyNames) {
+        const keySchema = convertSchema(schema2.propertyNames, ctx);
+        const valueSchema = schema2.additionalProperties && typeof schema2.additionalProperties === "object" ? convertSchema(schema2.additionalProperties, ctx) : z.any();
         if (Object.keys(shape).length === 0) {
           zodSchema = z.record(keySchema, valueSchema);
           break;
@@ -14343,8 +14343,8 @@ function convertBaseSchema(schema, ctx) {
         zodSchema = z.intersection(objectSchema2, recordSchema);
         break;
       }
-      if (schema.patternProperties) {
-        const patternProps = schema.patternProperties;
+      if (schema2.patternProperties) {
+        const patternProps = schema2.patternProperties;
         const patternKeys = Object.keys(patternProps);
         const looseRecords = [];
         for (const pattern of patternKeys) {
@@ -14371,18 +14371,18 @@ function convertBaseSchema(schema, ctx) {
         break;
       }
       const objectSchema = z.object(shape);
-      if (schema.additionalProperties === false) {
+      if (schema2.additionalProperties === false) {
         zodSchema = objectSchema.strict();
-      } else if (typeof schema.additionalProperties === "object") {
-        zodSchema = objectSchema.catchall(convertSchema(schema.additionalProperties, ctx));
+      } else if (typeof schema2.additionalProperties === "object") {
+        zodSchema = objectSchema.catchall(convertSchema(schema2.additionalProperties, ctx));
       } else {
         zodSchema = objectSchema.passthrough();
       }
       break;
     }
     case "array": {
-      const prefixItems = schema.prefixItems;
-      const items = schema.items;
+      const prefixItems = schema2.prefixItems;
+      const items = schema2.items;
       if (prefixItems && Array.isArray(prefixItems)) {
         const tupleItems = prefixItems.map((item) => convertSchema(item, ctx));
         const rest = items && typeof items === "object" && !Array.isArray(items) ? convertSchema(items, ctx) : void 0;
@@ -14391,34 +14391,34 @@ function convertBaseSchema(schema, ctx) {
         } else {
           zodSchema = z.tuple(tupleItems);
         }
-        if (typeof schema.minItems === "number") {
-          zodSchema = zodSchema.check(z.minLength(schema.minItems));
+        if (typeof schema2.minItems === "number") {
+          zodSchema = zodSchema.check(z.minLength(schema2.minItems));
         }
-        if (typeof schema.maxItems === "number") {
-          zodSchema = zodSchema.check(z.maxLength(schema.maxItems));
+        if (typeof schema2.maxItems === "number") {
+          zodSchema = zodSchema.check(z.maxLength(schema2.maxItems));
         }
       } else if (Array.isArray(items)) {
         const tupleItems = items.map((item) => convertSchema(item, ctx));
-        const rest = schema.additionalItems && typeof schema.additionalItems === "object" ? convertSchema(schema.additionalItems, ctx) : void 0;
+        const rest = schema2.additionalItems && typeof schema2.additionalItems === "object" ? convertSchema(schema2.additionalItems, ctx) : void 0;
         if (rest) {
           zodSchema = z.tuple(tupleItems).rest(rest);
         } else {
           zodSchema = z.tuple(tupleItems);
         }
-        if (typeof schema.minItems === "number") {
-          zodSchema = zodSchema.check(z.minLength(schema.minItems));
+        if (typeof schema2.minItems === "number") {
+          zodSchema = zodSchema.check(z.minLength(schema2.minItems));
         }
-        if (typeof schema.maxItems === "number") {
-          zodSchema = zodSchema.check(z.maxLength(schema.maxItems));
+        if (typeof schema2.maxItems === "number") {
+          zodSchema = zodSchema.check(z.maxLength(schema2.maxItems));
         }
       } else if (items !== void 0) {
         const element = convertSchema(items, ctx);
         let arraySchema = z.array(element);
-        if (typeof schema.minItems === "number") {
-          arraySchema = arraySchema.min(schema.minItems);
+        if (typeof schema2.minItems === "number") {
+          arraySchema = arraySchema.min(schema2.minItems);
         }
-        if (typeof schema.maxItems === "number") {
-          arraySchema = arraySchema.max(schema.maxItems);
+        if (typeof schema2.maxItems === "number") {
+          arraySchema = arraySchema.max(schema2.maxItems);
         }
         zodSchema = arraySchema;
       } else {
@@ -14427,80 +14427,80 @@ function convertBaseSchema(schema, ctx) {
       break;
     }
     default:
-      throw new Error(`Unsupported type: ${type}`);
+      throw new Error(`Unsupported type: ${type2}`);
   }
   return zodSchema;
 }
-function convertSchema(schema, ctx) {
-  if (typeof schema === "boolean") {
-    return schema ? z.any() : z.never();
+function convertSchema(schema2, ctx) {
+  if (typeof schema2 === "boolean") {
+    return schema2 ? z.any() : z.never();
   }
-  let baseSchema = convertBaseSchema(schema, ctx);
-  const hasExplicitType = schema.type || schema.enum !== void 0 || schema.const !== void 0;
-  if (schema.anyOf && Array.isArray(schema.anyOf)) {
-    const options = schema.anyOf.map((s) => convertSchema(s, ctx));
+  let baseSchema = convertBaseSchema(schema2, ctx);
+  const hasExplicitType = schema2.type || schema2.enum !== void 0 || schema2.const !== void 0;
+  if (schema2.anyOf && Array.isArray(schema2.anyOf)) {
+    const options = schema2.anyOf.map((s) => convertSchema(s, ctx));
     const anyOfUnion = z.union(options);
     baseSchema = hasExplicitType ? z.intersection(baseSchema, anyOfUnion) : anyOfUnion;
   }
-  if (schema.oneOf && Array.isArray(schema.oneOf)) {
-    const options = schema.oneOf.map((s) => convertSchema(s, ctx));
+  if (schema2.oneOf && Array.isArray(schema2.oneOf)) {
+    const options = schema2.oneOf.map((s) => convertSchema(s, ctx));
     const oneOfUnion = z.xor(options);
     baseSchema = hasExplicitType ? z.intersection(baseSchema, oneOfUnion) : oneOfUnion;
   }
-  if (schema.allOf && Array.isArray(schema.allOf)) {
-    if (schema.allOf.length === 0) {
+  if (schema2.allOf && Array.isArray(schema2.allOf)) {
+    if (schema2.allOf.length === 0) {
       baseSchema = hasExplicitType ? baseSchema : z.any();
     } else {
-      let result = hasExplicitType ? baseSchema : convertSchema(schema.allOf[0], ctx);
+      let result = hasExplicitType ? baseSchema : convertSchema(schema2.allOf[0], ctx);
       const startIdx = hasExplicitType ? 0 : 1;
-      for (let i = startIdx; i < schema.allOf.length; i++) {
-        result = z.intersection(result, convertSchema(schema.allOf[i], ctx));
+      for (let i = startIdx; i < schema2.allOf.length; i++) {
+        result = z.intersection(result, convertSchema(schema2.allOf[i], ctx));
       }
       baseSchema = result;
     }
   }
-  if (schema.nullable === true && ctx.version === "openapi-3.0") {
+  if (schema2.nullable === true && ctx.version === "openapi-3.0") {
     baseSchema = z.nullable(baseSchema);
   }
-  if (schema.readOnly === true) {
+  if (schema2.readOnly === true) {
     baseSchema = z.readonly(baseSchema);
   }
-  if (schema.default !== void 0) {
-    baseSchema = baseSchema.default(schema.default);
+  if (schema2.default !== void 0) {
+    baseSchema = baseSchema.default(schema2.default);
   }
   const extraMeta = {};
   const coreMetadataKeys = ["$id", "id", "$comment", "$anchor", "$vocabulary", "$dynamicRef", "$dynamicAnchor"];
   for (const key of coreMetadataKeys) {
-    if (key in schema) {
-      extraMeta[key] = schema[key];
+    if (key in schema2) {
+      extraMeta[key] = schema2[key];
     }
   }
   const contentMetadataKeys = ["contentEncoding", "contentMediaType", "contentSchema"];
   for (const key of contentMetadataKeys) {
-    if (key in schema) {
-      extraMeta[key] = schema[key];
+    if (key in schema2) {
+      extraMeta[key] = schema2[key];
     }
   }
-  for (const key of Object.keys(schema)) {
+  for (const key of Object.keys(schema2)) {
     if (!RECOGNIZED_KEYS.has(key)) {
-      extraMeta[key] = schema[key];
+      extraMeta[key] = schema2[key];
     }
   }
   if (Object.keys(extraMeta).length > 0) {
     ctx.registry.add(baseSchema, extraMeta);
   }
-  if (schema.description) {
-    baseSchema = baseSchema.describe(schema.description);
+  if (schema2.description) {
+    baseSchema = baseSchema.describe(schema2.description);
   }
   return baseSchema;
 }
-function fromJSONSchema(schema, params) {
-  if (typeof schema === "boolean") {
-    return schema ? z.any() : z.never();
+function fromJSONSchema(schema2, params) {
+  if (typeof schema2 === "boolean") {
+    return schema2 ? z.any() : z.never();
   }
   let normalized;
   try {
-    normalized = JSON.parse(JSON.stringify(schema));
+    normalized = JSON.parse(JSON.stringify(schema2));
   } catch {
     throw new Error("fromJSONSchema input is not valid JSON (possibly cyclic); use $defs/$ref for recursive schemas");
   }
@@ -14728,11 +14728,11 @@ function detectRoot() {
   return null;
 }
 function encodeRandom(len, prng) {
-  let str = "";
+  let str2 = "";
   for (; len > 0; len--) {
-    str = randomChar(prng) + str;
+    str2 = randomChar(prng) + str2;
   }
-  return str;
+  return str2;
 }
 function encodeTime(now, len = TIME_LEN) {
   if (isNaN(now)) {
@@ -14744,13 +14744,13 @@ function encodeTime(now, len = TIME_LEN) {
   } else if (Number.isInteger(now) === false) {
     throw new ULIDError(ULIDErrorCode.EncodeTimeValueMalformed, `Time must be an integer: ${now}`);
   }
-  let mod, str = "";
+  let mod, str2 = "";
   for (let currentLen = len; currentLen > 0; currentLen--) {
     mod = now % ENCODING_LEN;
-    str = ENCODING.charAt(mod) + str;
+    str2 = ENCODING.charAt(mod) + str2;
     now = (now - mod) / ENCODING_LEN;
   }
-  return str;
+  return str2;
 }
 function inWebWorker() {
   return typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope;
@@ -17032,30 +17032,4888 @@ var run19 = async (argv) => {
   return typeof result === "number" ? result : EXIT_CODES.OK;
 };
 
-// src/scaffold/component.ts
-import { existsSync as existsSync18, statSync as statSync2 } from "node:fs";
+// src/release/bump.ts
+import { spawnSync } from "node:child_process";
+import { existsSync as existsSync17, readFileSync as readFileSync14, writeFileSync as writeFileSync12 } from "node:fs";
+import path15 from "node:path";
+var HELP_TEXT9 = `Usage: gaia-maintainer release bump [--auto]
+
+  Compute the next semver bump from conventional-commit subjects since
+  the last tag. Without --auto, prints the proposal. With --auto, writes
+  package.json and .gaia/VERSION.
+
+  Exit codes:
+    0  success
+    1  user-correctable error (no commits, malformed package.json)
+    2  unexpected (git failure)
+`;
+var HELP_TOKENS9 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT7 = 2;
+var defaultRunner = (command, args, options) => spawnSync(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var parseFlags8 = (argv) => {
+  let auto = false;
+  for (const token of argv) {
+    if (token === "--auto") {
+      auto = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { flags: { auto }, ok: true };
+};
+var PATCH_TYPES = /* @__PURE__ */ new Set([
+  "chore",
+  "ci",
+  "docs",
+  "fix",
+  "perf",
+  "refactor",
+  "style",
+  "test"
+]);
+var CONVENTIONAL_HEADER_REGEX = /^(?<type>[a-z]+)(?:\([^)]*\))?(?<bang>!?):/u;
+var classifyCommit = (commit) => {
+  const subject = commit.subject.trim();
+  const body = commit.body;
+  if (/(^|\n)BREAKING CHANGE: /u.test(body)) return "major";
+  const match = CONVENTIONAL_HEADER_REGEX.exec(subject);
+  if (match === null) return null;
+  const groups = match.groups ?? {};
+  if (groups.bang === "!") return "major";
+  const type2 = groups.type;
+  if (type2 === "feat") return "minor";
+  if (type2 !== void 0 && PATCH_TYPES.has(type2)) return "patch";
+  return null;
+};
+var RANK = { major: 3, minor: 2, patch: 1 };
+var aggregateBump = (commits) => {
+  let highest = null;
+  for (const commit of commits) {
+    const classified = classifyCommit(commit);
+    if (classified === null) continue;
+    if (highest === null || RANK[classified] > RANK[highest]) {
+      highest = classified;
+    }
+  }
+  return highest;
+};
+var applyBump = (current, kind) => {
+  const parts = current.split(".").map((segment) => Number.parseInt(segment, 10));
+  if (parts.length !== 3 || parts.some((value) => Number.isNaN(value))) {
+    throw new Error(`current version is not semver: "${current}"`);
+  }
+  const [major, minor, patch] = parts;
+  if (kind === "major") return `${major + 1}.0.0`;
+  if (kind === "minor") return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
+};
+var expectSuccess = (result, command, args) => {
+  if (result.error !== void 0) {
+    throw new Error(`${command} ${args.join(" ")} failed: ${result.error.message}`);
+  }
+  if ((result.status ?? -1) !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
+    );
+  }
+  return result.stdout ?? "";
+};
+var tryRun = (runner, command, args, cwd) => {
+  const result = runner(command, args, { cwd });
+  if (result.error !== void 0 || (result.status ?? -1) !== 0) return null;
+  return result.stdout ?? "";
+};
+var RECORD_SEPARATOR = "---END-COMMIT---";
+var collectCommits = (cwd, runner, range) => {
+  const out = expectSuccess(
+    runner(
+      "git",
+      [
+        "log",
+        "--no-merges",
+        `--format=%s%n%b%n${RECORD_SEPARATOR}`,
+        range
+      ],
+      { cwd }
+    ),
+    "git",
+    ["log"]
+  );
+  const commits = [];
+  for (const chunk of out.split(RECORD_SEPARATOR)) {
+    const trimmed = chunk.replace(/^[\s\n]+/u, "").replace(/[\s\n]+$/u, "");
+    if (trimmed === "") continue;
+    const lines = trimmed.split("\n");
+    const subject = lines[0] ?? "";
+    const body = lines.slice(1).join("\n");
+    commits.push({ body, subject });
+  }
+  return commits;
+};
+var lastTag = (cwd, runner) => {
+  const out = tryRun(runner, "git", ["describe", "--tags", "--abbrev=0"], cwd);
+  if (out === null) return null;
+  const trimmed = out.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed;
+};
+var readPackageJson = (cwd) => {
+  const target = path15.join(cwd, "package.json");
+  if (!existsSync17(target)) {
+    throw new Error("package.json not found at repo root");
+  }
+  const raw = readFileSync14(target, "utf8");
+  const parsed = JSON.parse(raw);
+  if (typeof parsed.version !== "string") {
+    throw new Error('package.json has no string "version"');
+  }
+  return { path: target, raw, version: parsed.version };
+};
+var writePackageJsonVersion = (packagePath, raw, newVersion) => {
+  const replaced = raw.replace(
+    /"version"\s*:\s*"[^"]+"/u,
+    `"version": "${newVersion}"`
+  );
+  if (replaced === raw) {
+    throw new Error('failed to rewrite "version" field in package.json');
+  }
+  writeFileSync12(packagePath, replaced, "utf8");
+};
+var writeVersionFile = (cwd, newVersion) => {
+  const target = path15.join(cwd, ".gaia", "VERSION");
+  if (!existsSync17(target)) return;
+  const original = readFileSync14(target, "utf8");
+  const trailing = original.endsWith("\n") ? "\n" : "";
+  writeFileSync12(target, `${newVersion}${trailing}`, "utf8");
+};
+var run20 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS9.has(argv[0])) {
+    process.stdout.write(HELP_TEXT9);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags8(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release bump"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  let pkg;
+  try {
+    pkg = readPackageJson(cwd);
+  } catch (error51) {
+    structuredError({
+      code: "package_json_invalid",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release bump"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const tag = lastTag(cwd, runner);
+  const range = tag === null ? "HEAD" : `${tag}..HEAD`;
+  let commits;
+  try {
+    commits = collectCommits(cwd, runner, range);
+  } catch (error51) {
+    process.stderr.write(
+      `bump: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT7;
+  }
+  if (commits.length === 0) {
+    process.stderr.write("bump: no commits since last tag; nothing to bump\n");
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const kind = aggregateBump(commits);
+  if (kind === null) {
+    process.stderr.write(
+      "bump: no conventional-commit prefixes found; cannot determine bump\n"
+    );
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let nextVersion;
+  try {
+    nextVersion = applyBump(pkg.version, kind);
+  } catch (error51) {
+    structuredError({
+      code: "invalid_version",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release bump"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (!parsed.flags.auto) {
+    process.stdout.write(`v${pkg.version} -> v${nextVersion} (${kind})
+`);
+    return EXIT_CODES.OK;
+  }
+  if (kind === "major") {
+    process.stderr.write(
+      `bump: major bump detected (v${pkg.version} -> v${nextVersion}); refusing --auto without explicit confirmation
+`
+    );
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    writePackageJsonVersion(pkg.path, pkg.raw, nextVersion);
+    writeVersionFile(cwd, nextVersion);
+  } catch (error51) {
+    structuredError({
+      code: "version_write_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release bump"
+    });
+    return UNEXPECTED_EXIT7;
+  }
+  process.stdout.write(`${nextVersion}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/release/changelog.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { existsSync as existsSync18, readFileSync as readFileSync15, writeFileSync as writeFileSync13 } from "node:fs";
 import path16 from "node:path";
+var HELP_TEXT10 = `Usage: gaia-maintainer release changelog [--draft] [--version <X.Y.Z>]
+
+  Render a Keep-a-Changelog block for the new version from
+  conventional-commit subjects since the last tag.
+
+  Flags:
+    --draft               Print the rendered block to stdout, do not write.
+    --version <X.Y.Z>     Override the new version (default: package.json).
+
+  Exit codes:
+    0  success
+    1  user-correctable error
+    2  unexpected (git failure)
+`;
+var HELP_TOKENS10 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT8 = 2;
+var defaultRunner2 = (command, args, options) => spawnSync2(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var takeValue6 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags9 = (argv) => {
+  let draft = false;
+  let version2;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--draft") {
+      draft = true;
+      continue;
+    }
+    if (token === "--version") {
+      const taken = takeValue6(argv, index + 1, "--version");
+      if (!taken.ok) return taken;
+      version2 = taken.value;
+      index += 1;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { flags: { draft, version: version2 }, ok: true };
+};
+var TYPE_TO_SECTION = {
+  chore: null,
+  ci: null,
+  docs: "Changed",
+  feat: "Added",
+  fix: "Fixed",
+  perf: "Changed",
+  refactor: "Changed",
+  style: null,
+  test: null
+};
+var CONVENTIONAL_HEADER_REGEX2 = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?!?:\s*(?<rest>.*)$/u;
+var groupCommits = (commits) => {
+  const sections = { Added: [], Changed: [], Fixed: [] };
+  for (const commit of commits) {
+    const subject = commit.subject.trim();
+    const match = CONVENTIONAL_HEADER_REGEX2.exec(subject);
+    if (match === null) continue;
+    const groups = match.groups ?? {};
+    const type2 = (groups.type ?? "").toLowerCase();
+    const target = TYPE_TO_SECTION[type2];
+    if (!target) continue;
+    const message = (groups.rest ?? "").trim();
+    if (message.length === 0) continue;
+    sections[target].push(message);
+  }
+  return sections;
+};
+var todayUtc = (now = /* @__PURE__ */ new Date()) => {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+var renderBlock = (sections) => {
+  const lines = [];
+  const order = ["Added", "Changed", "Fixed"];
+  for (const section of order) {
+    const items = sections[section];
+    if (items.length === 0) continue;
+    lines.push(`### ${section}`, "");
+    for (const item of items) lines.push(`- ${item}`);
+    lines.push("");
+  }
+  return lines.join("\n").replace(/\n+$/u, "\n");
+};
+var RECORD_SEPARATOR2 = "---END-COMMIT---";
+var collectCommits2 = (cwd, runner, range) => {
+  const result = runner(
+    "git",
+    [
+      "log",
+      "--no-merges",
+      `--format=%s%n%b%n${RECORD_SEPARATOR2}`,
+      range
+    ],
+    { cwd }
+  );
+  if (result.error !== void 0) {
+    throw new Error(`git log failed: ${result.error.message}`);
+  }
+  if ((result.status ?? -1) !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(`git log exited ${result.status ?? -1}: ${stderr}`);
+  }
+  const out = result.stdout ?? "";
+  const commits = [];
+  for (const chunk of out.split(RECORD_SEPARATOR2)) {
+    const trimmed = chunk.replace(/^[\s\n]+/u, "").replace(/[\s\n]+$/u, "");
+    if (trimmed === "") continue;
+    const lines = trimmed.split("\n");
+    const subject = lines[0] ?? "";
+    const body = lines.slice(1).join("\n");
+    commits.push({ body, subject });
+  }
+  return commits;
+};
+var lastTag2 = (cwd, runner) => {
+  const result = runner("git", ["describe", "--tags", "--abbrev=0"], { cwd });
+  if (result.error !== void 0) return null;
+  if ((result.status ?? -1) !== 0) return null;
+  const out = (result.stdout ?? "").trim();
+  if (out.length === 0) return null;
+  return out;
+};
+var readVersion = (cwd, override) => {
+  if (override !== void 0 && override.length > 0) return override;
+  const target = path16.join(cwd, "package.json");
+  if (!existsSync18(target)) {
+    throw new Error("package.json not found at repo root");
+  }
+  const parsed = JSON.parse(readFileSync15(target, "utf8"));
+  if (typeof parsed.version !== "string") {
+    throw new Error('package.json has no string "version"');
+  }
+  return parsed.version;
+};
+var UNRELEASED_HEADING = "## [Unreleased]";
+var graduateChangelog = (current, newVersion, block, today) => {
+  const versionHeading = `## [${newVersion}] \u2014 ${today}`;
+  if (current.includes(`## [${newVersion}]`)) {
+    return { kind: "duplicate" };
+  }
+  const lines = current.split("\n");
+  const unreleasedIndex = lines.findIndex(
+    (line) => line.trim() === UNRELEASED_HEADING
+  );
+  if (unreleasedIndex === -1) {
+    return { kind: "no-unreleased" };
+  }
+  const blockLines = block.split("\n");
+  while (blockLines.length > 0 && (blockLines[0] ?? "").trim() === "") {
+    blockLines.shift();
+  }
+  while (blockLines.length > 0 && (blockLines.at(-1) ?? "").trim() === "") {
+    blockLines.pop();
+  }
+  const newSection = [
+    UNRELEASED_HEADING,
+    "",
+    versionHeading,
+    "",
+    ...blockLines,
+    ""
+  ];
+  const head = lines.slice(0, unreleasedIndex);
+  const tail = lines.slice(unreleasedIndex + 1);
+  while (tail.length > 0 && (tail[0] ?? "").trim() === "") {
+    tail.shift();
+  }
+  const updated = [...head, ...newSection, ...tail].join("\n");
+  return { kind: "ok", updated };
+};
+var run21 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS10.has(argv[0])) {
+    process.stdout.write(HELP_TEXT10);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags9(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release changelog"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner2;
+  let version2;
+  try {
+    version2 = readVersion(cwd, parsed.flags.version);
+  } catch (error51) {
+    structuredError({
+      code: "package_json_invalid",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release changelog"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const tag = lastTag2(cwd, runner);
+  const range = tag === null ? "HEAD" : `${tag}..HEAD`;
+  let commits;
+  try {
+    commits = collectCommits2(cwd, runner, range);
+  } catch (error51) {
+    process.stderr.write(
+      `changelog: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT8;
+  }
+  const sections = groupCommits(commits);
+  const block = renderBlock(sections);
+  if (parsed.flags.draft) {
+    process.stdout.write(block);
+    return EXIT_CODES.OK;
+  }
+  const changelogPath = path16.join(cwd, "CHANGELOG.md");
+  if (!existsSync18(changelogPath)) {
+    structuredError({
+      code: "changelog_missing",
+      message: "CHANGELOG.md not found at repo root",
+      subcommand: "release changelog"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const current = readFileSync15(changelogPath, "utf8");
+  const today = options.today ?? todayUtc();
+  const outcome = graduateChangelog(current, version2, block, today);
+  if (outcome.kind === "duplicate") {
+    return EXIT_CODES.OK;
+  }
+  if (outcome.kind === "no-unreleased") {
+    structuredError({
+      code: "no_unreleased_section",
+      message: "CHANGELOG.md has no `## [Unreleased]` heading to graduate",
+      subcommand: "release changelog"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    writeFileSync13(changelogPath, outcome.updated, "utf8");
+  } catch (error51) {
+    structuredError({
+      code: "changelog_write_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release changelog"
+    });
+    return UNEXPECTED_EXIT8;
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/release/commit-and-tag.ts
+import { spawnSync as spawnSync3 } from "node:child_process";
+import { existsSync as existsSync19, readFileSync as readFileSync16, writeFileSync as writeFileSync14 } from "node:fs";
+import path17 from "node:path";
+var HELP_TEXT11 = `Usage: gaia-maintainer release commit-and-tag (--commit | --tag) [--no-push]
+
+  --commit      Stage release-related files and commit, then amend
+                wiki/.state.json with the new commit SHA.
+  --tag         Tag HEAD as vX.Y.Z and push the tag to origin.
+  --no-push     With --tag: skip the tag push step.
+
+  Exit codes:
+    0  success
+    1  user-correctable error
+    2  unexpected (git failure)
+`;
+var HELP_TOKENS11 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT9 = 2;
+var defaultRunner3 = (command, args, options) => spawnSync3(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var parseFlags10 = (argv) => {
+  let mode;
+  let noPush = false;
+  for (const token of argv) {
+    if (token === "--commit") {
+      if (mode !== void 0) {
+        return { message: "--commit and --tag are mutually exclusive", ok: false };
+      }
+      mode = "commit";
+      continue;
+    }
+    if (token === "--tag") {
+      if (mode !== void 0) {
+        return { message: "--commit and --tag are mutually exclusive", ok: false };
+      }
+      mode = "tag";
+      continue;
+    }
+    if (token === "--no-push") {
+      noPush = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  if (mode === void 0) {
+    return { message: "one of --commit or --tag is required", ok: false };
+  }
+  return { flags: { mode, noPush }, ok: true };
+};
+var readVersion2 = (cwd) => {
+  const target = path17.join(cwd, "package.json");
+  if (!existsSync19(target)) {
+    throw new Error("package.json not found at repo root");
+  }
+  const parsed = JSON.parse(readFileSync16(target, "utf8"));
+  if (typeof parsed.version !== "string") {
+    throw new Error('package.json has no string "version"');
+  }
+  return parsed.version;
+};
+var stepSucceeded = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var passthroughFailure = (result, step) => {
+  const stderr = (result.stderr ?? "").trim();
+  const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
+  const status = result.status ?? -1;
+  process.stderr.write(
+    `commit-and-tag: ${step.command} ${step.args.join(" ")} exited ${status}${errorPart}
+`
+  );
+  if (stderr.length > 0) {
+    process.stderr.write(`${stderr}
+`);
+  }
+  return UNEXPECTED_EXIT9;
+};
+var RELEASE_FILES = [
+  "package.json",
+  ".gaia/VERSION",
+  ".gaia/manifest.json",
+  "CHANGELOG.md",
+  "wiki/hot.md",
+  "wiki/log.md"
+];
+var writeStateSha = (cwd, sha) => {
+  const target = path17.join(cwd, "wiki", ".state.json");
+  if (!existsSync19(target)) return;
+  const raw = readFileSync16(target, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("wiki/.state.json is not valid JSON");
+  }
+  const next = {};
+  let saw = false;
+  for (const key of Object.keys(parsed)) {
+    if (key === "last_evaluated_sha") {
+      next[key] = sha;
+      saw = true;
+    } else if (key === "last_evaluated_at") {
+      next[key] = (/* @__PURE__ */ new Date()).toISOString();
+    } else {
+      next[key] = parsed[key];
+    }
+  }
+  if (!saw) next.last_evaluated_sha = sha;
+  const trailingNewline = raw.endsWith("\n") ? "\n" : "";
+  writeFileSync14(target, `${JSON.stringify(next, null, 2)}${trailingNewline}`, "utf8");
+};
+var runCommitMode = (ctx) => {
+  const presentFiles = RELEASE_FILES.filter(
+    (file2) => existsSync19(path17.join(ctx.cwd, file2))
+  );
+  if (presentFiles.length === 0) {
+    process.stderr.write("commit-and-tag: no release files present to stage\n");
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const message = `chore(release): v${ctx.version}`;
+  const sequence = [
+    { args: ["add", ...presentFiles], command: "git" },
+    { args: ["commit", "-m", message], command: "git" }
+  ];
+  for (const step of sequence) {
+    const result = ctx.runner(step.command, step.args, { cwd: ctx.cwd });
+    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+  }
+  const headResult = ctx.runner("git", ["rev-parse", "HEAD"], { cwd: ctx.cwd });
+  if (!stepSucceeded(headResult)) {
+    return passthroughFailure(headResult, {
+      args: ["rev-parse", "HEAD"],
+      command: "git"
+    });
+  }
+  const newSha = (headResult.stdout ?? "").trim();
+  try {
+    writeStateSha(ctx.cwd, newSha);
+  } catch (error51) {
+    process.stderr.write(
+      `commit-and-tag: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT9;
+  }
+  const statePath = path17.join(ctx.cwd, "wiki", ".state.json");
+  if (existsSync19(statePath)) {
+    const amendSequence = [
+      { args: ["add", "wiki/.state.json"], command: "git" },
+      { args: ["commit", "--amend", "--no-edit"], command: "git" }
+    ];
+    for (const step of amendSequence) {
+      const result = ctx.runner(step.command, step.args, { cwd: ctx.cwd });
+      if (!stepSucceeded(result)) return passthroughFailure(result, step);
+    }
+  }
+  process.stdout.write(
+    `commit-and-tag: committed v${ctx.version} (${newSha.slice(0, 7)})
+`
+  );
+  return EXIT_CODES.OK;
+};
+var runTagMode = (ctx) => {
+  const tagName = `v${ctx.version}`;
+  const message = `Release v${ctx.version}`;
+  const sequence = [
+    { args: ["tag", "-a", tagName, "-m", message], command: "git" }
+  ];
+  if (!ctx.noPush) {
+    sequence.push({ args: ["push", "origin", tagName], command: "git" });
+  }
+  for (const step of sequence) {
+    const result = ctx.runner(step.command, step.args, { cwd: ctx.cwd });
+    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+  }
+  process.stdout.write(
+    `commit-and-tag: tagged ${tagName}${ctx.noPush ? " (push skipped)" : " and pushed"}
+`
+  );
+  return EXIT_CODES.OK;
+};
+var run22 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS11.has(argv[0])) {
+    process.stdout.write(HELP_TEXT11);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags10(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release commit-and-tag"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner3;
+  let version2;
+  try {
+    version2 = readVersion2(cwd);
+  } catch (error51) {
+    structuredError({
+      code: "package_json_invalid",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release commit-and-tag"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (parsed.flags.mode === "commit") {
+    return runCommitMode({ cwd, runner, version: version2 });
+  }
+  return runTagMode({ cwd, noPush: parsed.flags.noPush, runner, version: version2 });
+};
+
+// src/release/manifest.ts
+import { execFileSync } from "node:child_process";
+import { existsSync as existsSync20, readFileSync as readFileSync17, writeFileSync as writeFileSync15 } from "node:fs";
+import path18 from "node:path";
+var HELP_TEXT12 = `Usage: gaia-maintainer release manifest [--out <path>] [--stdout]
+       gaia-maintainer release manifest --check [--json]
+
+  Regenerate .gaia/manifest.json. Walks git ls-files, subtracts
+  release-exclude patterns and adopter-owned sentinels, classifies the
+  remainder, and writes a sorted JSON manifest.
+
+  Flags:
+    --out <path>   Override output path (default: .gaia/manifest.json).
+    --stdout       Print manifest JSON to stdout instead of writing the file.
+    --check        Verify the committed manifest matches what the
+                   classifier would produce against the current source,
+                   and lint classifier sets against release-exclude for
+                   dead-code overlap. Exits non-zero on drift / overlap.
+    --json         (with --check) Emit a structured JSON drift report.
+
+  Exit codes:
+    0  success / check clean
+    1  user-correctable error / check found drift or overlap
+    2  unexpected (filesystem / git failure)
+`;
+var HELP_TOKENS12 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT10 = 2;
+var ADOPTER_OWNED_SENTINELS = /* @__PURE__ */ new Set([
+  ".gaia/manifest.json",
+  ".gaia/VERSION",
+  "wiki/hot.md",
+  "wiki/log.md"
+]);
+var SHARED = /* @__PURE__ */ new Set([
+  ".claude/settings.json",
+  ".github/CODEOWNERS",
+  ".github/FUNDING.yml",
+  "CLAUDE.md",
+  "package.json",
+  "wiki/index.md"
+]);
+var SHARED_PREFIXES = [".github/workflows/"];
+var WIKI_OWNED_PREFIXES = [
+  "wiki/components/",
+  "wiki/concepts/",
+  "wiki/decisions/",
+  "wiki/dependencies/",
+  "wiki/flows/",
+  "wiki/modules/",
+  "wiki/sources/"
+];
+var WIKI_OWNED_EXACT = /* @__PURE__ */ new Set(["wiki/overview.md", "wiki/README.md"]);
+var escapeRegExp = (pattern) => pattern.replaceAll(".", String.raw`\.`).replaceAll("+", String.raw`\+`).replaceAll("?", String.raw`\?`).replaceAll("*", "[^/]*");
+var parseExcludePatterns = (text) => text.split("\n").map((line) => line.trim()).filter((line) => line.length > 0 && !line.startsWith("#")).map((pattern) => new RegExp(`^${escapeRegExp(pattern)}(/|$)`));
+var classifyPath = (relativePath) => {
+  if (ADOPTER_OWNED_SENTINELS.has(relativePath)) return null;
+  if (SHARED.has(relativePath)) return "shared";
+  if (SHARED_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) return "shared";
+  if (WIKI_OWNED_EXACT.has(relativePath)) return "wiki-owned";
+  if (WIKI_OWNED_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) return "wiki-owned";
+  return "owned";
+};
+var resolveRepoRoot2 = (cwd) => execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+}).trim();
+var listGitFiles = (cwd) => execFileSync("git", ["ls-files"], {
+  cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+}).split("\n").filter((line) => line.length > 0);
+var buildManifest = (cwd, options = {}) => {
+  const repoRoot2 = options.repoRoot ?? resolveRepoRoot2(cwd);
+  const versionPath = path18.resolve(repoRoot2, ".gaia/VERSION");
+  const excludePath = path18.resolve(repoRoot2, ".gaia/release-exclude");
+  const version2 = readFileSync17(versionPath, "utf8").trim();
+  const excludePatterns = parseExcludePatterns(readFileSync17(excludePath, "utf8"));
+  const isExcluded = (candidate) => excludePatterns.some((pattern) => pattern.test(candidate));
+  const tracked = listGitFiles(repoRoot2);
+  const entries = [];
+  for (const relativePath of tracked) {
+    if (isExcluded(relativePath)) continue;
+    const klass = classifyPath(relativePath);
+    if (klass === null) continue;
+    entries.push([relativePath, klass]);
+  }
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  const files = Object.fromEntries(entries);
+  return {
+    files,
+    generated: options.generatedAt ?? (/* @__PURE__ */ new Date()).toISOString(),
+    version: version2
+  };
+};
+var serialize = (manifest) => `${JSON.stringify(manifest, null, 2)}
+`;
+var lintClassifierSets = (excludePatterns) => {
+  const overlaps = [];
+  const findOverlap = (entry, setName) => {
+    const matched = excludePatterns.find((pattern) => pattern.test(entry));
+    if (matched !== void 0) {
+      overlaps.push({ entry, excludePattern: matched.source, setName });
+    }
+  };
+  for (const entry of ADOPTER_OWNED_SENTINELS) findOverlap(entry, "ADOPTER_OWNED_SENTINELS");
+  for (const entry of SHARED) findOverlap(entry, "SHARED");
+  for (const entry of WIKI_OWNED_EXACT) findOverlap(entry, "WIKI_OWNED_EXACT");
+  for (const prefix of SHARED_PREFIXES) {
+    findOverlap(prefix.replace(/\/$/, ""), "SHARED_PREFIXES");
+  }
+  for (const prefix of WIKI_OWNED_PREFIXES) {
+    findOverlap(prefix.replace(/\/$/, ""), "WIKI_OWNED_PREFIXES");
+  }
+  return overlaps;
+};
+var computeDrift = (expected, actual, classifierOverlaps) => {
+  const missing = [];
+  const extra = [];
+  const drift = [];
+  for (const [file2, expectedClass] of Object.entries(expected.files)) {
+    const actualClass = actual.files[file2];
+    if (actualClass === void 0) {
+      missing.push({ expected: expectedClass, file: file2 });
+      continue;
+    }
+    if (actualClass !== expectedClass) {
+      drift.push({ actual: actualClass, expected: expectedClass, file: file2 });
+    }
+  }
+  for (const [file2, actualClass] of Object.entries(actual.files)) {
+    if (expected.files[file2] === void 0) {
+      extra.push({ actual: actualClass, file: file2 });
+    }
+  }
+  missing.sort((a, b) => a.file.localeCompare(b.file));
+  extra.sort((a, b) => a.file.localeCompare(b.file));
+  drift.sort((a, b) => a.file.localeCompare(b.file));
+  const versionDrift = expected.version === actual.version ? void 0 : { actual: actual.version, expected: expected.version };
+  return { classifierOverlaps, drift, extra, missing, versionDrift };
+};
+var renderCheckReport = (result, jsonMode) => {
+  if (jsonMode) return `${JSON.stringify(result, null, 2)}
+`;
+  const out = [];
+  const total = result.missing.length + result.extra.length + result.drift.length + result.classifierOverlaps.length + (result.versionDrift === void 0 ? 0 : 1);
+  if (total === 0) {
+    out.push("release manifest --check: clean (manifest fresh, classifier sets coherent)");
+    return `${out.join("\n")}
+`;
+  }
+  out.push(`release manifest --check: ${total} issue(s)`);
+  if (result.versionDrift !== void 0) {
+    out.push(
+      "",
+      `version drift:`,
+      `  manifest version: ${result.versionDrift.actual}`,
+      `  .gaia/VERSION:    ${result.versionDrift.expected}`
+    );
+  }
+  if (result.missing.length > 0) {
+    out.push("", `missing from manifest (${result.missing.length}):`);
+    for (const entry of result.missing) {
+      out.push(`  + ${entry.file}  [${entry.expected}]`);
+    }
+  }
+  if (result.extra.length > 0) {
+    out.push("", `extra in manifest (${result.extra.length}):`);
+    for (const entry of result.extra) {
+      out.push(`  - ${entry.file}  [${entry.actual}]`);
+    }
+  }
+  if (result.drift.length > 0) {
+    out.push("", `class drift (${result.drift.length}):`);
+    for (const entry of result.drift) {
+      out.push(`  ~ ${entry.file}  ${entry.actual} \u2192 ${entry.expected}`);
+    }
+  }
+  if (result.classifierOverlaps.length > 0) {
+    out.push(
+      "",
+      `classifier-set overlaps with release-exclude (${result.classifierOverlaps.length}):`
+    );
+    for (const overlap of result.classifierOverlaps) {
+      out.push(`  ${overlap.setName}: ${overlap.entry} (matched by /${overlap.excludePattern}/)`);
+    }
+  }
+  return `${out.join("\n")}
+`;
+};
+var runCheck = (cwd, generatedAt, jsonMode) => {
+  let repoRoot2;
+  let expected;
+  let excludePatterns;
+  try {
+    repoRoot2 = resolveRepoRoot2(cwd);
+    expected = buildManifest(cwd, { generatedAt, repoRoot: repoRoot2 });
+    excludePatterns = parseExcludePatterns(
+      readFileSync17(path18.resolve(repoRoot2, ".gaia/release-exclude"), "utf8")
+    );
+  } catch (error51) {
+    structuredError({
+      code: "manifest_build_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release manifest"
+    });
+    return UNEXPECTED_EXIT10;
+  }
+  const manifestPath = path18.resolve(repoRoot2, ".gaia/manifest.json");
+  if (!existsSync20(manifestPath)) {
+    structuredError({
+      code: "manifest_missing",
+      message: `committed manifest not found at ${manifestPath}; run \`gaia-maintainer release manifest\` to generate it`,
+      subcommand: "release manifest"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let actual;
+  try {
+    actual = JSON.parse(readFileSync17(manifestPath, "utf8"));
+  } catch (error51) {
+    structuredError({
+      code: "manifest_parse_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      path: manifestPath,
+      subcommand: "release manifest"
+    });
+    return UNEXPECTED_EXIT10;
+  }
+  const classifierOverlaps = lintClassifierSets(excludePatterns);
+  const result = computeDrift(expected, actual, classifierOverlaps);
+  process.stdout.write(renderCheckReport(result, jsonMode));
+  const hasIssue = result.missing.length > 0 || result.extra.length > 0 || result.drift.length > 0 || result.classifierOverlaps.length > 0 || result.versionDrift !== void 0;
+  return hasIssue ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+};
+var takeValue7 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags11 = (argv) => {
+  let check2 = false;
+  let json3 = false;
+  let outPath;
+  let stdout = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--out") {
+      const taken = takeValue7(argv, index + 1, "--out");
+      if (!taken.ok) return taken;
+      outPath = taken.value;
+      index += 1;
+      continue;
+    }
+    if (token === "--stdout") {
+      stdout = true;
+      continue;
+    }
+    if (token === "--check") {
+      check2 = true;
+      continue;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  if (check2 && (outPath !== void 0 || stdout)) {
+    return { message: "--check is incompatible with --out / --stdout", ok: false };
+  }
+  if (!check2 && json3) {
+    return { message: "--json requires --check", ok: false };
+  }
+  return { flags: { check: check2, json: json3, outPath, stdout }, ok: true };
+};
+var run23 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS12.has(argv[0])) {
+    process.stdout.write(HELP_TEXT12);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags11(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release manifest"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  if (parsed.flags.check) {
+    return runCheck(cwd, options.generatedAt, parsed.flags.json);
+  }
+  let manifest;
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(cwd);
+    manifest = buildManifest(cwd, {
+      generatedAt: options.generatedAt,
+      repoRoot: repoRoot2
+    });
+  } catch (error51) {
+    structuredError({
+      code: "manifest_build_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release manifest"
+    });
+    return UNEXPECTED_EXIT10;
+  }
+  const serialized = serialize(manifest);
+  if (parsed.flags.stdout) {
+    process.stdout.write(serialized);
+    return EXIT_CODES.OK;
+  }
+  const target = parsed.flags.outPath ? path18.isAbsolute(parsed.flags.outPath) ? parsed.flags.outPath : path18.join(cwd, parsed.flags.outPath) : path18.join(repoRoot2, ".gaia", "manifest.json");
+  if (!existsSync20(path18.dirname(target))) {
+    structuredError({
+      code: "output_dir_missing",
+      message: `output directory does not exist: ${path18.dirname(target)}`,
+      subcommand: "release manifest"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    writeFileSync15(target, serialized, "utf8");
+  } catch (error51) {
+    structuredError({
+      code: "manifest_write_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release manifest"
+    });
+    return UNEXPECTED_EXIT10;
+  }
+  const counts = { owned: 0, shared: 0, "wiki-owned": 0 };
+  for (const klass of Object.values(manifest.files)) counts[klass] += 1;
+  const total = Object.keys(manifest.files).length;
+  process.stdout.write(
+    `release manifest: wrote ${total} files (owned=${counts.owned}, shared=${counts.shared}, wiki-owned=${counts["wiki-owned"]}) \u2192 ${path18.relative(cwd, target) || target}
+`
+  );
+  return EXIT_CODES.OK;
+};
+
+// src/release/preflight.ts
+import { spawnSync as spawnSync4 } from "node:child_process";
+
+// src/wiki/state.ts
+import { existsSync as existsSync21, readdirSync as readdirSync4, readFileSync as readFileSync18, statSync as statSync2 } from "node:fs";
+import path19 from "node:path";
+
+// src/wiki/util/git.ts
+import { execFileSync as execFileSync2 } from "node:child_process";
+var runGit = (args, options = {}) => {
+  const cwd = options.cwd ?? process.cwd();
+  const result = execFileSync2("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  return result.toString();
+};
+var tryRunGit = (args, options = {}) => {
+  try {
+    return runGit(args, options);
+  } catch {
+    return null;
+  }
+};
+var resolveRepoRoot3 = (cwd = process.cwd()) => runGit(["rev-parse", "--show-toplevel"], { cwd }).trim();
+var headSha = (cwd) => runGit(["rev-parse", "HEAD"], { cwd }).trim();
+var shortSha = (sha, cwd) => {
+  const result = tryRunGit(["rev-parse", "--short=7", sha], { cwd });
+  if (result === null) return sha.slice(0, 7);
+  return result.trim();
+};
+var isReachable = (sha, cwd) => {
+  try {
+    execFileSync2("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
+      cwd,
+      stdio: ["ignore", "ignore", "ignore"]
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+var commitsAhead = (sha, cwd) => {
+  const result = tryRunGit(["rev-list", "--count", `${sha}..HEAD`], { cwd });
+  if (result === null) return 0;
+  const parsed = Number.parseInt(result.trim(), 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+var recentCommits = (sinceSha, cwd, limit = 5) => {
+  const result = tryRunGit(
+    [
+      "log",
+      "--no-merges",
+      "--reverse",
+      "--format=%h%x09%s",
+      `${sinceSha}..HEAD`
+    ],
+    { cwd }
+  );
+  if (result === null) return [];
+  const lines = result.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+  return lines.slice(-limit).map((line) => {
+    const tabIndex = line.indexOf("	");
+    const sha = tabIndex === -1 ? line : line.slice(0, tabIndex);
+    const subject = tabIndex === -1 ? "" : line.slice(tabIndex + 1);
+    return { sha, subject };
+  });
+};
+var parseShortStat = (stat3) => {
+  let filesChanged = 0;
+  let insertions = 0;
+  let deletions = 0;
+  const filesMatch = /(\d+)\s+files?\s+changed/u.exec(stat3);
+  if (filesMatch !== null) filesChanged = Number.parseInt(filesMatch[1], 10);
+  const insertMatch = /(\d+)\s+insertions?\(\+\)/u.exec(stat3);
+  if (insertMatch !== null) insertions = Number.parseInt(insertMatch[1], 10);
+  const deleteMatch = /(\d+)\s+deletions?\(-\)/u.exec(stat3);
+  if (deleteMatch !== null) deletions = Number.parseInt(deleteMatch[1], 10);
+  return { deletions, files_changed: filesChanged, insertions };
+};
+var fileListForCommit = (sha, cwd) => {
+  const result = tryRunGit(
+    ["diff-tree", "--no-commit-id", "--name-only", "-r", sha],
+    { cwd }
+  );
+  if (result === null) return [];
+  return result.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+};
+var parseChunk = (chunk) => {
+  const trimmed = chunk.replace(/^[\s\n]+/u, "").replace(/[\s\n]+$/u, "");
+  if (trimmed === "") return { precedingStat: "", record: null };
+  const lines = trimmed.split("\n");
+  const commitLineIndex = lines.findIndex((line) => line.startsWith("COMMIT "));
+  if (commitLineIndex === -1) {
+    return { precedingStat: trimmed, record: null };
+  }
+  const statLines = lines.slice(0, commitLineIndex);
+  const precedingStat = statLines.find(
+    (line) => /\d+\s+files?\s+changed/u.test(line)
+  ) ?? "";
+  const commitBlock = lines.slice(commitLineIndex);
+  const sha = (commitBlock[0] ?? "").replace(/^COMMIT\s+/u, "").trim();
+  const subject = commitBlock[1] ?? "";
+  const bodyLines = commitBlock.slice(2);
+  while (bodyLines.length > 0 && (bodyLines.at(-1) ?? "").trim() === "") {
+    bodyLines.pop();
+  }
+  return {
+    precedingStat,
+    record: { body: bodyLines.join("\n"), sha, subject }
+  };
+};
+var commitDetails = (sinceSha, cwd) => {
+  const recordSeparator = "---END-COMMIT---";
+  const raw = tryRunGit(
+    [
+      "log",
+      "--no-merges",
+      "--reverse",
+      "--shortstat",
+      `--format=COMMIT %H%n%s%n%b%n${recordSeparator}`,
+      `${sinceSha}..HEAD`
+    ],
+    { cwd }
+  );
+  if (raw === null) return [];
+  const chunks = raw.split(recordSeparator);
+  const records = [];
+  const stats = [];
+  let pendingStat = null;
+  for (const chunk of chunks) {
+    const { precedingStat, record: record2 } = parseChunk(chunk);
+    if (record2 !== null) {
+      records.push(record2);
+      if (records.length > 1) stats.push(precedingStat);
+      pendingStat = null;
+    } else {
+      pendingStat = precedingStat;
+    }
+  }
+  if (records.length > 0) {
+    stats.push(pendingStat ?? "");
+  }
+  return records.map((record2, index) => {
+    const stat3 = stats[index] ?? "";
+    const parsed = parseShortStat(stat3);
+    const files = fileListForCommit(record2.sha, cwd);
+    return {
+      body: record2.body,
+      deletions: parsed.deletions,
+      files,
+      files_changed: parsed.files_changed,
+      insertions: parsed.insertions,
+      sha: record2.sha,
+      subject: record2.subject
+    };
+  });
+};
+
+// src/wiki/state.ts
+var HELP_TEXT13 = `Usage: gaia wiki state [--json]
+`;
+var HELP_TOKENS13 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var classifySeverity = (commitCount) => {
+  if (commitCount <= 0) return "none";
+  if (commitCount <= 5) return "low";
+  if (commitCount <= 20) return "medium";
+  return "high";
+};
+var DOMAIN_DIRS = [
+  "components",
+  "concepts",
+  "decisions",
+  "dependencies",
+  "entities",
+  "flows",
+  "meta",
+  "modules"
+];
+var countDomainPages = (wikiRoot) => {
+  const counts = {};
+  for (const domain2 of DOMAIN_DIRS) {
+    const domainDir = path19.join(wikiRoot, domain2);
+    if (!existsSync21(domainDir) || !statSync2(domainDir).isDirectory()) {
+      counts[domain2] = 0;
+      continue;
+    }
+    const entries = readdirSync4(domainDir, { withFileTypes: true });
+    let count = 0;
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".md")) continue;
+      if (entry.name === "_index.md") continue;
+      count += 1;
+    }
+    counts[domain2] = count;
+  }
+  return counts;
+};
+var readStateFile = (statePath) => {
+  if (!existsSync21(statePath)) return null;
+  const raw = readFileSync18(statePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
+var printHuman = (state) => {
+  const lines = [
+    "Wiki state",
+    `  HEAD:           ${state.head_short}`,
+    `  Last evaluated: ${state.state_sha}`,
+    `  Reachable:      ${state.reachable ? "yes" : "no"}`,
+    `  Drift:          ${state.commits_ahead} commits (${state.drift_severity})`
+  ];
+  if (state.recent_commits.length > 0) {
+    lines.push("  Recent unsynced:");
+    for (const commit of state.recent_commits) {
+      lines.push(`    - ${commit.sha} ${commit.subject}`);
+    }
+  }
+  lines.push("  Per-domain pages:");
+  for (const [domain2, count] of Object.entries(state.per_domain_page_counts)) {
+    lines.push(`    ${domain2}: ${count}`);
+  }
+  process.stdout.write(`${lines.join("\n")}
+`);
+};
+var run24 = (argv, options = {}) => {
+  let json3 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS13.has(token)) {
+      process.stdout.write(HELP_TEXT13);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "wiki state"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot3(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia wiki state must run inside a git repository",
+      subcommand: "wiki state"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const wikiRoot = path19.join(repoRoot2, "wiki");
+  const statePath = path19.join(wikiRoot, ".state.json");
+  const stateFile = readStateFile(statePath);
+  const stateSha = stateFile?.last_evaluated_sha ?? "";
+  const head = headSha(repoRoot2);
+  const headShort = shortSha(head, repoRoot2);
+  const stateShort = stateSha === "" ? "" : shortSha(stateSha, repoRoot2);
+  const reachable = stateSha !== "" && isReachable(stateSha, repoRoot2);
+  const ahead = stateSha === "" || !reachable ? 0 : commitsAhead(stateSha, repoRoot2);
+  const recent = stateSha === "" || !reachable ? [] : recentCommits(stateSha, repoRoot2, 5);
+  const severity = classifySeverity(ahead);
+  const counts = countDomainPages(wikiRoot);
+  const state = {
+    commits_ahead: ahead,
+    drift_severity: severity,
+    head_short: headShort,
+    per_domain_page_counts: counts,
+    reachable,
+    recent_commits: recent,
+    state_sha: stateShort
+  };
+  if (json3) {
+    process.stdout.write(`${JSON.stringify(state)}
+`);
+  } else {
+    printHuman(state);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/release/preflight.ts
+var HELP_TEXT14 = `Usage: gaia-maintainer release preflight [--branch <name>]
+
+  Verify branch state, working tree, and wiki sync before cutting a release.
+
+  Flags:
+    --branch <name>  Allowed release branch (default: main).
+
+  Exit codes:
+    0  preflight passed
+    1  user-correctable refusal (wrong branch, dirty tree, wiki drift)
+    2  unexpected (git failure)
+`;
+var HELP_TOKENS14 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT11 = 2;
+var DEFAULT_BRANCH = "main";
+var defaultRunner4 = (command, args, options) => spawnSync4(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var takeValue8 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags12 = (argv) => {
+  let allowedBranch = DEFAULT_BRANCH;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--branch") {
+      const taken = takeValue8(argv, index + 1, "--branch");
+      if (!taken.ok) return taken;
+      allowedBranch = taken.value;
+      index += 1;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { flags: { allowedBranch }, ok: true };
+};
+var expectSuccess2 = (result, command, args) => {
+  if (result.error !== void 0) {
+    throw new Error(`${command} ${args.join(" ")} failed: ${result.error.message}`);
+  }
+  if ((result.status ?? -1) !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
+    );
+  }
+  return result.stdout ?? "";
+};
+var refuse = (message) => {
+  process.stderr.write(`${message}
+`);
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+var runWikiStateJson = (cwd) => {
+  const chunks = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  };
+  let exit;
+  try {
+    exit = run24(["--json"], { cwd });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  if (exit !== EXIT_CODES.OK) return null;
+  const raw = chunks.join("").trim();
+  try {
+    const parsed = JSON.parse(raw);
+    const commitsAhead2 = parsed.commits_ahead;
+    if (typeof commitsAhead2 !== "number") return null;
+    return { commits_ahead: commitsAhead2 };
+  } catch {
+    return null;
+  }
+};
+var run25 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS14.has(argv[0])) {
+    process.stdout.write(HELP_TEXT14);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags12(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release preflight"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner4;
+  const wikiStateProbe = options.wikiStateProbe ?? runWikiStateJson;
+  let branch;
+  let status;
+  try {
+    branch = expectSuccess2(
+      runner("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd }),
+      "git",
+      ["rev-parse", "--abbrev-ref", "HEAD"]
+    ).trim();
+    status = expectSuccess2(
+      runner("git", ["status", "--porcelain=v1", "-uall"], { cwd }),
+      "git",
+      ["status", "--porcelain=v1", "-uall"]
+    );
+  } catch (error51) {
+    process.stderr.write(
+      `preflight: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT11;
+  }
+  if (branch !== parsed.flags.allowedBranch) {
+    return refuse(
+      `preflight: must be on ${parsed.flags.allowedBranch} (current: ${branch})`
+    );
+  }
+  if (status.trim().length > 0) {
+    return refuse("preflight: working tree is dirty; commit or stash first");
+  }
+  const wikiState = wikiStateProbe(cwd);
+  if (wikiState === null) {
+    return refuse("preflight: failed to read wiki state via `gaia wiki state --json`");
+  }
+  if (wikiState.commits_ahead !== 0) {
+    return refuse(
+      `preflight: wiki is ${wikiState.commits_ahead} commits behind HEAD; run /gaia wiki sync first`
+    );
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/release/runtime-deps.ts
+import { readdirSync as readdirSync5, readFileSync as readFileSync19, statSync as statSync3 } from "node:fs";
+import path20 from "node:path";
+var HELP_TEXT15 = `Usage: gaia-maintainer release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
+
+  Scan shipped shell scripts for runtime path references that resolve to
+  release-excluded files.
+
+  Flags:
+    --staging <dir>   Scan inside <dir> instead of process.cwd(). Used
+                      from release.yml to scan the post-scrub staging tree.
+    --manifest <path> Manifest file to verify against (default:
+                      .gaia/manifest.json under the staging or repo root).
+    --json            Emit a structured JSON report on stdout.
+
+  Exit codes:
+    0  no leaks
+    1  leaks detected, missing inputs, bad flags
+    2  unexpected (manifest parse failure, IO error)
+`;
+var HELP_TOKENS15 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT12 = 2;
+var SCAN_GLOBS = [".gaia/statusline", ".claude/hooks"];
+var ADOPTER_OWNED_SENTINELS2 = /* @__PURE__ */ new Set([
+  ".gaia/VERSION",
+  ".gaia/manifest.json",
+  "wiki/hot.md",
+  "wiki/log.md"
+]);
+var RUNTIME_PREFIXES = [
+  ".gaia/local",
+  ".gaia/cache",
+  ".claude/handoff",
+  ".claude/worktrees",
+  ".claude/agent-memory",
+  ".claude/audit"
+];
+var RUNTIME_MARKERS = /* @__PURE__ */ new Set([
+  ".claude/i18n-strings-checked",
+  ".claude/wiki-drift-checked",
+  ".claude/wiki-safety-checked"
+]);
+var PATH_PREFIXES = [".gaia/", ".claude/", ".specify/", ".github/"];
+var PATH_BODY_CHAR = /[a-zA-Z0-9._/-]/;
+var stripCommentSuffix = (line) => {
+  if (/^\s*#/.test(line)) return "";
+  return line;
+};
+var expandPath = (line, start) => {
+  let end = start;
+  while (end < line.length && PATH_BODY_CHAR.test(line[end])) {
+    end += 1;
+  }
+  return line.slice(start, end);
+};
+var isVariableExpansionContext = (line, found) => {
+  let cursor = found - 1;
+  while (cursor >= 0) {
+    const ch = line[cursor];
+    if (ch === "$") return true;
+    if (ch === "/" || ch === "{" || ch === "}" || PATH_BODY_CHAR.test(ch)) {
+      cursor -= 1;
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+var extractPathRefs = (filePath, source) => {
+  const refs = [];
+  const lines = source.split("\n");
+  for (const [index, line] of lines.entries()) {
+    const stripped = stripCommentSuffix(line);
+    if (stripped.length === 0) continue;
+    for (const prefix of PATH_PREFIXES) {
+      let cursor = 0;
+      while (cursor <= stripped.length - prefix.length) {
+        const found = stripped.indexOf(prefix, cursor);
+        if (found === -1) break;
+        const leading = found === 0 ? "" : stripped[found - 1];
+        if (leading.length > 0 && PATH_BODY_CHAR.test(leading) && !isVariableExpansionContext(stripped, found)) {
+          cursor = found + 1;
+          continue;
+        }
+        const candidate = expandPath(stripped, found);
+        if (candidate.length > prefix.length) {
+          const trimmed = candidate.replace(/[./]+$/, "");
+          if (trimmed.length > prefix.length) {
+            refs.push({ filePath, line: index + 1, path: trimmed });
+          }
+        }
+        cursor = found + candidate.length;
+      }
+    }
+  }
+  return refs;
+};
+var isShippedPath = (candidate, manifest) => {
+  if (manifest.has(candidate)) return true;
+  if (ADOPTER_OWNED_SENTINELS2.has(candidate)) return true;
+  if (RUNTIME_MARKERS.has(candidate)) return true;
+  if (RUNTIME_PREFIXES.some(
+    (prefix) => candidate === prefix || candidate.startsWith(`${prefix}/`)
+  )) {
+    return true;
+  }
+  return false;
+};
+var walkScripts = (root) => {
+  const out = [];
+  for (const sub of SCAN_GLOBS) {
+    const absolute = path20.join(root, sub);
+    try {
+      statSync3(absolute);
+    } catch {
+      continue;
+    }
+    out.push(...walkSh(root, absolute));
+  }
+  return out;
+};
+var walkSh = (root, dir) => {
+  const out = [];
+  for (const entry of readdirSync5(dir, { withFileTypes: true })) {
+    const full = path20.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkSh(root, full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".sh")) {
+      out.push(path20.relative(root, full).split(path20.sep).join("/"));
+    }
+  }
+  return out;
+};
+var loadManifest = (manifestPath) => {
+  const raw = readFileSync19(manifestPath, "utf8");
+  const parsed = JSON.parse(raw);
+  if (parsed.files === void 0) {
+    throw new Error(`manifest at ${manifestPath} has no "files" field`);
+  }
+  return new Set(Object.keys(parsed.files));
+};
+var takeValue9 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags13 = (argv) => {
+  let json3 = false;
+  let manifestPath;
+  let stagingDir;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--staging") {
+      const taken = takeValue9(argv, index + 1, "--staging");
+      if (!taken.ok) return taken;
+      stagingDir = taken.value;
+      index += 1;
+      continue;
+    }
+    if (token === "--manifest") {
+      const taken = takeValue9(argv, index + 1, "--manifest");
+      if (!taken.ok) return taken;
+      manifestPath = taken.value;
+      index += 1;
+      continue;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { flags: { json: json3, manifestPath, stagingDir }, ok: true };
+};
+var renderReport = (report, jsonMode) => {
+  if (jsonMode) return `${JSON.stringify(report, null, 2)}
+`;
+  const out = [];
+  out.push(
+    `release runtime-deps: scanned ${report.scanned_files.length} script(s)`
+  );
+  if (report.leaks.length > 0) {
+    out.push("", `runtime-dependency leaks (${report.leaks.length}):`);
+    for (const leak of report.leaks) {
+      out.push(`  ${leak.file}:${leak.line}  ${leak.path}`);
+    }
+  } else {
+    out.push("runtime-dependency leaks: none");
+  }
+  return `${out.join("\n")}
+`;
+};
+var run26 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS15.has(argv[0])) {
+    process.stdout.write(HELP_TEXT15);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags13(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release runtime-deps"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const root = parsed.flags.stagingDir ? path20.isAbsolute(parsed.flags.stagingDir) ? parsed.flags.stagingDir : path20.join(cwd, parsed.flags.stagingDir) : cwd;
+  try {
+    statSync3(root);
+  } catch {
+    structuredError({
+      code: "root_missing",
+      message: `scan root not found: ${root}`,
+      subcommand: "release runtime-deps"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const manifestPath = parsed.flags.manifestPath ? path20.isAbsolute(parsed.flags.manifestPath) ? parsed.flags.manifestPath : path20.join(cwd, parsed.flags.manifestPath) : path20.join(root, ".gaia", "manifest.json");
+  let manifest;
+  try {
+    manifest = loadManifest(manifestPath);
+  } catch (error51) {
+    structuredError({
+      code: "manifest_load_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      path: manifestPath,
+      subcommand: "release runtime-deps"
+    });
+    return UNEXPECTED_EXIT12;
+  }
+  let scriptFiles;
+  try {
+    scriptFiles = walkScripts(root);
+  } catch (error51) {
+    structuredError({
+      code: "walk_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release runtime-deps"
+    });
+    return UNEXPECTED_EXIT12;
+  }
+  const leaks = [];
+  for (const scriptPath of scriptFiles) {
+    const source = readFileSync19(path20.join(root, scriptPath), "utf8");
+    const refs = extractPathRefs(scriptPath, source);
+    for (const ref of refs) {
+      if (ref.path === scriptPath) continue;
+      if (isShippedPath(ref.path, manifest)) continue;
+      leaks.push({ file: ref.filePath, line: ref.line, path: ref.path });
+    }
+  }
+  const report = { leaks, scanned_files: scriptFiles };
+  process.stdout.write(renderReport(report, parsed.flags.json));
+  return leaks.length > 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+};
+
+// src/release/scrub.ts
+import { readdirSync as readdirSync6, readFileSync as readFileSync20, statSync as statSync4, writeFileSync as writeFileSync16 } from "node:fs";
+import path21 from "node:path";
+
+// node_modules/.pnpm/js-yaml@4.1.1/node_modules/js-yaml/dist/js-yaml.mjs
+function isNothing(subject) {
+  return typeof subject === "undefined" || subject === null;
+}
+function isObject2(subject) {
+  return typeof subject === "object" && subject !== null;
+}
+function toArray(sequence) {
+  if (Array.isArray(sequence)) return sequence;
+  else if (isNothing(sequence)) return [];
+  return [sequence];
+}
+function extend2(target, source) {
+  var index, length, key, sourceKeys;
+  if (source) {
+    sourceKeys = Object.keys(source);
+    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
+      key = sourceKeys[index];
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+function repeat(string4, count) {
+  var result = "", cycle;
+  for (cycle = 0; cycle < count; cycle += 1) {
+    result += string4;
+  }
+  return result;
+}
+function isNegativeZero(number4) {
+  return number4 === 0 && Number.NEGATIVE_INFINITY === 1 / number4;
+}
+var isNothing_1 = isNothing;
+var isObject_1 = isObject2;
+var toArray_1 = toArray;
+var repeat_1 = repeat;
+var isNegativeZero_1 = isNegativeZero;
+var extend_1 = extend2;
+var common = {
+  isNothing: isNothing_1,
+  isObject: isObject_1,
+  toArray: toArray_1,
+  repeat: repeat_1,
+  isNegativeZero: isNegativeZero_1,
+  extend: extend_1
+};
+function formatError2(exception2, compact) {
+  var where = "", message = exception2.reason || "(unknown reason)";
+  if (!exception2.mark) return message;
+  if (exception2.mark.name) {
+    where += 'in "' + exception2.mark.name + '" ';
+  }
+  where += "(" + (exception2.mark.line + 1) + ":" + (exception2.mark.column + 1) + ")";
+  if (!compact && exception2.mark.snippet) {
+    where += "\n\n" + exception2.mark.snippet;
+  }
+  return message + " " + where;
+}
+function YAMLException$1(reason, mark) {
+  Error.call(this);
+  this.name = "YAMLException";
+  this.reason = reason;
+  this.mark = mark;
+  this.message = formatError2(this, false);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  } else {
+    this.stack = new Error().stack || "";
+  }
+}
+YAMLException$1.prototype = Object.create(Error.prototype);
+YAMLException$1.prototype.constructor = YAMLException$1;
+YAMLException$1.prototype.toString = function toString(compact) {
+  return this.name + ": " + formatError2(this, compact);
+};
+var exception = YAMLException$1;
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+  var head = "";
+  var tail = "";
+  var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+  if (position - lineStart > maxHalfLength) {
+    head = " ... ";
+    lineStart = position - maxHalfLength + head.length;
+  }
+  if (lineEnd - position > maxHalfLength) {
+    tail = " ...";
+    lineEnd = position + maxHalfLength - tail.length;
+  }
+  return {
+    str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "\u2192") + tail,
+    pos: position - lineStart + head.length
+    // relative position
+  };
+}
+function padStart(string4, max) {
+  return common.repeat(" ", max - string4.length) + string4;
+}
+function makeSnippet(mark, options) {
+  options = Object.create(options || null);
+  if (!mark.buffer) return null;
+  if (!options.maxLength) options.maxLength = 79;
+  if (typeof options.indent !== "number") options.indent = 1;
+  if (typeof options.linesBefore !== "number") options.linesBefore = 3;
+  if (typeof options.linesAfter !== "number") options.linesAfter = 2;
+  var re = /\r?\n|\r|\0/g;
+  var lineStarts = [0];
+  var lineEnds = [];
+  var match;
+  var foundLineNo = -1;
+  while (match = re.exec(mark.buffer)) {
+    lineEnds.push(match.index);
+    lineStarts.push(match.index + match[0].length);
+    if (mark.position <= match.index && foundLineNo < 0) {
+      foundLineNo = lineStarts.length - 2;
+    }
+  }
+  if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+  var result = "", i, line;
+  var lineNoLength = Math.min(mark.line + options.linesAfter, lineEnds.length).toString().length;
+  var maxLineLength = options.maxLength - (options.indent + lineNoLength + 3);
+  for (i = 1; i <= options.linesBefore; i++) {
+    if (foundLineNo - i < 0) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo - i],
+      lineEnds[foundLineNo - i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
+      maxLineLength
+    );
+    result = common.repeat(" ", options.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line.str + "\n" + result;
+  }
+  line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+  result += common.repeat(" ", options.indent) + padStart((mark.line + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  result += common.repeat("-", options.indent + lineNoLength + 3 + line.pos) + "^\n";
+  for (i = 1; i <= options.linesAfter; i++) {
+    if (foundLineNo + i >= lineEnds.length) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo + i],
+      lineEnds[foundLineNo + i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
+      maxLineLength
+    );
+    result += common.repeat(" ", options.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  }
+  return result.replace(/\n$/, "");
+}
+var snippet = makeSnippet;
+var TYPE_CONSTRUCTOR_OPTIONS = [
+  "kind",
+  "multi",
+  "resolve",
+  "construct",
+  "instanceOf",
+  "predicate",
+  "represent",
+  "representName",
+  "defaultStyle",
+  "styleAliases"
+];
+var YAML_NODE_KINDS = [
+  "scalar",
+  "sequence",
+  "mapping"
+];
+function compileStyleAliases(map3) {
+  var result = {};
+  if (map3 !== null) {
+    Object.keys(map3).forEach(function(style) {
+      map3[style].forEach(function(alias) {
+        result[String(alias)] = style;
+      });
+    });
+  }
+  return result;
+}
+function Type$1(tag, options) {
+  options = options || {};
+  Object.keys(options).forEach(function(name) {
+    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
+      throw new exception('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
+    }
+  });
+  this.options = options;
+  this.tag = tag;
+  this.kind = options["kind"] || null;
+  this.resolve = options["resolve"] || function() {
+    return true;
+  };
+  this.construct = options["construct"] || function(data) {
+    return data;
+  };
+  this.instanceOf = options["instanceOf"] || null;
+  this.predicate = options["predicate"] || null;
+  this.represent = options["represent"] || null;
+  this.representName = options["representName"] || null;
+  this.defaultStyle = options["defaultStyle"] || null;
+  this.multi = options["multi"] || false;
+  this.styleAliases = compileStyleAliases(options["styleAliases"] || null);
+  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
+    throw new exception('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
+  }
+}
+var type = Type$1;
+function compileList(schema2, name) {
+  var result = [];
+  schema2[name].forEach(function(currentType) {
+    var newIndex = result.length;
+    result.forEach(function(previousType, previousIndex) {
+      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind && previousType.multi === currentType.multi) {
+        newIndex = previousIndex;
+      }
+    });
+    result[newIndex] = currentType;
+  });
+  return result;
+}
+function compileMap() {
+  var result = {
+    scalar: {},
+    sequence: {},
+    mapping: {},
+    fallback: {},
+    multi: {
+      scalar: [],
+      sequence: [],
+      mapping: [],
+      fallback: []
+    }
+  }, index, length;
+  function collectType(type2) {
+    if (type2.multi) {
+      result.multi[type2.kind].push(type2);
+      result.multi["fallback"].push(type2);
+    } else {
+      result[type2.kind][type2.tag] = result["fallback"][type2.tag] = type2;
+    }
+  }
+  for (index = 0, length = arguments.length; index < length; index += 1) {
+    arguments[index].forEach(collectType);
+  }
+  return result;
+}
+function Schema$1(definition) {
+  return this.extend(definition);
+}
+Schema$1.prototype.extend = function extend3(definition) {
+  var implicit = [];
+  var explicit = [];
+  if (definition instanceof type) {
+    explicit.push(definition);
+  } else if (Array.isArray(definition)) {
+    explicit = explicit.concat(definition);
+  } else if (definition && (Array.isArray(definition.implicit) || Array.isArray(definition.explicit))) {
+    if (definition.implicit) implicit = implicit.concat(definition.implicit);
+    if (definition.explicit) explicit = explicit.concat(definition.explicit);
+  } else {
+    throw new exception("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");
+  }
+  implicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+    if (type$1.loadKind && type$1.loadKind !== "scalar") {
+      throw new exception("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");
+    }
+    if (type$1.multi) {
+      throw new exception("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.");
+    }
+  });
+  explicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+  });
+  var result = Object.create(Schema$1.prototype);
+  result.implicit = (this.implicit || []).concat(implicit);
+  result.explicit = (this.explicit || []).concat(explicit);
+  result.compiledImplicit = compileList(result, "implicit");
+  result.compiledExplicit = compileList(result, "explicit");
+  result.compiledTypeMap = compileMap(result.compiledImplicit, result.compiledExplicit);
+  return result;
+};
+var schema = Schema$1;
+var str = new type("tag:yaml.org,2002:str", {
+  kind: "scalar",
+  construct: function(data) {
+    return data !== null ? data : "";
+  }
+});
+var seq = new type("tag:yaml.org,2002:seq", {
+  kind: "sequence",
+  construct: function(data) {
+    return data !== null ? data : [];
+  }
+});
+var map2 = new type("tag:yaml.org,2002:map", {
+  kind: "mapping",
+  construct: function(data) {
+    return data !== null ? data : {};
+  }
+});
+var failsafe = new schema({
+  explicit: [
+    str,
+    seq,
+    map2
+  ]
+});
+function resolveYamlNull(data) {
+  if (data === null) return true;
+  var max = data.length;
+  return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
+}
+function constructYamlNull() {
+  return null;
+}
+function isNull(object2) {
+  return object2 === null;
+}
+var _null4 = new type("tag:yaml.org,2002:null", {
+  kind: "scalar",
+  resolve: resolveYamlNull,
+  construct: constructYamlNull,
+  predicate: isNull,
+  represent: {
+    canonical: function() {
+      return "~";
+    },
+    lowercase: function() {
+      return "null";
+    },
+    uppercase: function() {
+      return "NULL";
+    },
+    camelcase: function() {
+      return "Null";
+    },
+    empty: function() {
+      return "";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function resolveYamlBoolean(data) {
+  if (data === null) return false;
+  var max = data.length;
+  return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
+}
+function constructYamlBoolean(data) {
+  return data === "true" || data === "True" || data === "TRUE";
+}
+function isBoolean(object2) {
+  return Object.prototype.toString.call(object2) === "[object Boolean]";
+}
+var bool = new type("tag:yaml.org,2002:bool", {
+  kind: "scalar",
+  resolve: resolveYamlBoolean,
+  construct: constructYamlBoolean,
+  predicate: isBoolean,
+  represent: {
+    lowercase: function(object2) {
+      return object2 ? "true" : "false";
+    },
+    uppercase: function(object2) {
+      return object2 ? "TRUE" : "FALSE";
+    },
+    camelcase: function(object2) {
+      return object2 ? "True" : "False";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function isHexCode(c) {
+  return 48 <= c && c <= 57 || 65 <= c && c <= 70 || 97 <= c && c <= 102;
+}
+function isOctCode(c) {
+  return 48 <= c && c <= 55;
+}
+function isDecCode(c) {
+  return 48 <= c && c <= 57;
+}
+function resolveYamlInteger(data) {
+  if (data === null) return false;
+  var max = data.length, index = 0, hasDigits = false, ch;
+  if (!max) return false;
+  ch = data[index];
+  if (ch === "-" || ch === "+") {
+    ch = data[++index];
+  }
+  if (ch === "0") {
+    if (index + 1 === max) return true;
+    ch = data[++index];
+    if (ch === "b") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (ch !== "0" && ch !== "1") return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "x") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isHexCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "o") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isOctCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+  }
+  if (ch === "_") return false;
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === "_") continue;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+  if (!hasDigits || ch === "_") return false;
+  return true;
+}
+function constructYamlInteger(data) {
+  var value = data, sign = 1, ch;
+  if (value.indexOf("_") !== -1) {
+    value = value.replace(/_/g, "");
+  }
+  ch = value[0];
+  if (ch === "-" || ch === "+") {
+    if (ch === "-") sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+  if (value === "0") return 0;
+  if (ch === "0") {
+    if (value[1] === "b") return sign * parseInt(value.slice(2), 2);
+    if (value[1] === "x") return sign * parseInt(value.slice(2), 16);
+    if (value[1] === "o") return sign * parseInt(value.slice(2), 8);
+  }
+  return sign * parseInt(value, 10);
+}
+function isInteger(object2) {
+  return Object.prototype.toString.call(object2) === "[object Number]" && (object2 % 1 === 0 && !common.isNegativeZero(object2));
+}
+var int2 = new type("tag:yaml.org,2002:int", {
+  kind: "scalar",
+  resolve: resolveYamlInteger,
+  construct: constructYamlInteger,
+  predicate: isInteger,
+  represent: {
+    binary: function(obj) {
+      return obj >= 0 ? "0b" + obj.toString(2) : "-0b" + obj.toString(2).slice(1);
+    },
+    octal: function(obj) {
+      return obj >= 0 ? "0o" + obj.toString(8) : "-0o" + obj.toString(8).slice(1);
+    },
+    decimal: function(obj) {
+      return obj.toString(10);
+    },
+    /* eslint-disable max-len */
+    hexadecimal: function(obj) {
+      return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);
+    }
+  },
+  defaultStyle: "decimal",
+  styleAliases: {
+    binary: [2, "bin"],
+    octal: [8, "oct"],
+    decimal: [10, "dec"],
+    hexadecimal: [16, "hex"]
+  }
+});
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  "^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+);
+function resolveYamlFloat(data) {
+  if (data === null) return false;
+  if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
+  // Probably should update regexp & check speed
+  data[data.length - 1] === "_") {
+    return false;
+  }
+  return true;
+}
+function constructYamlFloat(data) {
+  var value, sign;
+  value = data.replace(/_/g, "").toLowerCase();
+  sign = value[0] === "-" ? -1 : 1;
+  if ("+-".indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+  if (value === ".inf") {
+    return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  } else if (value === ".nan") {
+    return NaN;
+  }
+  return sign * parseFloat(value, 10);
+}
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+function representYamlFloat(object2, style) {
+  var res;
+  if (isNaN(object2)) {
+    switch (style) {
+      case "lowercase":
+        return ".nan";
+      case "uppercase":
+        return ".NAN";
+      case "camelcase":
+        return ".NaN";
+    }
+  } else if (Number.POSITIVE_INFINITY === object2) {
+    switch (style) {
+      case "lowercase":
+        return ".inf";
+      case "uppercase":
+        return ".INF";
+      case "camelcase":
+        return ".Inf";
+    }
+  } else if (Number.NEGATIVE_INFINITY === object2) {
+    switch (style) {
+      case "lowercase":
+        return "-.inf";
+      case "uppercase":
+        return "-.INF";
+      case "camelcase":
+        return "-.Inf";
+    }
+  } else if (common.isNegativeZero(object2)) {
+    return "-0.0";
+  }
+  res = object2.toString(10);
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
+}
+function isFloat(object2) {
+  return Object.prototype.toString.call(object2) === "[object Number]" && (object2 % 1 !== 0 || common.isNegativeZero(object2));
+}
+var float = new type("tag:yaml.org,2002:float", {
+  kind: "scalar",
+  resolve: resolveYamlFloat,
+  construct: constructYamlFloat,
+  predicate: isFloat,
+  represent: representYamlFloat,
+  defaultStyle: "lowercase"
+});
+var json2 = failsafe.extend({
+  implicit: [
+    _null4,
+    bool,
+    int2,
+    float
+  ]
+});
+var core = json2;
+var YAML_DATE_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
+);
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$"
+);
+function resolveYamlTimestamp(data) {
+  if (data === null) return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
+  return false;
+}
+function constructYamlTimestamp(data) {
+  var match, year, month, day, hour, minute, second, fraction = 0, delta = null, tz_hour, tz_minute, date5;
+  match = YAML_DATE_REGEXP.exec(data);
+  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
+  if (match === null) throw new Error("Date resolve error");
+  year = +match[1];
+  month = +match[2] - 1;
+  day = +match[3];
+  if (!match[4]) {
+    return new Date(Date.UTC(year, month, day));
+  }
+  hour = +match[4];
+  minute = +match[5];
+  second = +match[6];
+  if (match[7]) {
+    fraction = match[7].slice(0, 3);
+    while (fraction.length < 3) {
+      fraction += "0";
+    }
+    fraction = +fraction;
+  }
+  if (match[9]) {
+    tz_hour = +match[10];
+    tz_minute = +(match[11] || 0);
+    delta = (tz_hour * 60 + tz_minute) * 6e4;
+    if (match[9] === "-") delta = -delta;
+  }
+  date5 = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+  if (delta) date5.setTime(date5.getTime() - delta);
+  return date5;
+}
+function representYamlTimestamp(object2) {
+  return object2.toISOString();
+}
+var timestamp = new type("tag:yaml.org,2002:timestamp", {
+  kind: "scalar",
+  resolve: resolveYamlTimestamp,
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  represent: representYamlTimestamp
+});
+function resolveYamlMerge(data) {
+  return data === "<<" || data === null;
+}
+var merge2 = new type("tag:yaml.org,2002:merge", {
+  kind: "scalar",
+  resolve: resolveYamlMerge
+});
+var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
+function resolveYamlBinary(data) {
+  if (data === null) return false;
+  var code, idx, bitlen = 0, max = data.length, map3 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    code = map3.indexOf(data.charAt(idx));
+    if (code > 64) continue;
+    if (code < 0) return false;
+    bitlen += 6;
+  }
+  return bitlen % 8 === 0;
+}
+function constructYamlBinary(data) {
+  var idx, tailbits, input = data.replace(/[\r\n=]/g, ""), max = input.length, map3 = BASE64_MAP, bits = 0, result = [];
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 4 === 0 && idx) {
+      result.push(bits >> 16 & 255);
+      result.push(bits >> 8 & 255);
+      result.push(bits & 255);
+    }
+    bits = bits << 6 | map3.indexOf(input.charAt(idx));
+  }
+  tailbits = max % 4 * 6;
+  if (tailbits === 0) {
+    result.push(bits >> 16 & 255);
+    result.push(bits >> 8 & 255);
+    result.push(bits & 255);
+  } else if (tailbits === 18) {
+    result.push(bits >> 10 & 255);
+    result.push(bits >> 2 & 255);
+  } else if (tailbits === 12) {
+    result.push(bits >> 4 & 255);
+  }
+  return new Uint8Array(result);
+}
+function representYamlBinary(object2) {
+  var result = "", bits = 0, idx, tail, max = object2.length, map3 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 3 === 0 && idx) {
+      result += map3[bits >> 18 & 63];
+      result += map3[bits >> 12 & 63];
+      result += map3[bits >> 6 & 63];
+      result += map3[bits & 63];
+    }
+    bits = (bits << 8) + object2[idx];
+  }
+  tail = max % 3;
+  if (tail === 0) {
+    result += map3[bits >> 18 & 63];
+    result += map3[bits >> 12 & 63];
+    result += map3[bits >> 6 & 63];
+    result += map3[bits & 63];
+  } else if (tail === 2) {
+    result += map3[bits >> 10 & 63];
+    result += map3[bits >> 4 & 63];
+    result += map3[bits << 2 & 63];
+    result += map3[64];
+  } else if (tail === 1) {
+    result += map3[bits >> 2 & 63];
+    result += map3[bits << 4 & 63];
+    result += map3[64];
+    result += map3[64];
+  }
+  return result;
+}
+function isBinary(obj) {
+  return Object.prototype.toString.call(obj) === "[object Uint8Array]";
+}
+var binary = new type("tag:yaml.org,2002:binary", {
+  kind: "scalar",
+  resolve: resolveYamlBinary,
+  construct: constructYamlBinary,
+  predicate: isBinary,
+  represent: representYamlBinary
+});
+var _hasOwnProperty$3 = Object.prototype.hasOwnProperty;
+var _toString$2 = Object.prototype.toString;
+function resolveYamlOmap(data) {
+  if (data === null) return true;
+  var objectKeys = [], index, length, pair, pairKey, pairHasKey, object2 = data;
+  for (index = 0, length = object2.length; index < length; index += 1) {
+    pair = object2[index];
+    pairHasKey = false;
+    if (_toString$2.call(pair) !== "[object Object]") return false;
+    for (pairKey in pair) {
+      if (_hasOwnProperty$3.call(pair, pairKey)) {
+        if (!pairHasKey) pairHasKey = true;
+        else return false;
+      }
+    }
+    if (!pairHasKey) return false;
+    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
+    else return false;
+  }
+  return true;
+}
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+var omap = new type("tag:yaml.org,2002:omap", {
+  kind: "sequence",
+  resolve: resolveYamlOmap,
+  construct: constructYamlOmap
+});
+var _toString$1 = Object.prototype.toString;
+function resolveYamlPairs(data) {
+  if (data === null) return true;
+  var index, length, pair, keys, result, object2 = data;
+  result = new Array(object2.length);
+  for (index = 0, length = object2.length; index < length; index += 1) {
+    pair = object2[index];
+    if (_toString$1.call(pair) !== "[object Object]") return false;
+    keys = Object.keys(pair);
+    if (keys.length !== 1) return false;
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return true;
+}
+function constructYamlPairs(data) {
+  if (data === null) return [];
+  var index, length, pair, keys, result, object2 = data;
+  result = new Array(object2.length);
+  for (index = 0, length = object2.length; index < length; index += 1) {
+    pair = object2[index];
+    keys = Object.keys(pair);
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return result;
+}
+var pairs = new type("tag:yaml.org,2002:pairs", {
+  kind: "sequence",
+  resolve: resolveYamlPairs,
+  construct: constructYamlPairs
+});
+var _hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+function resolveYamlSet(data) {
+  if (data === null) return true;
+  var key, object2 = data;
+  for (key in object2) {
+    if (_hasOwnProperty$2.call(object2, key)) {
+      if (object2[key] !== null) return false;
+    }
+  }
+  return true;
+}
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+var set2 = new type("tag:yaml.org,2002:set", {
+  kind: "mapping",
+  resolve: resolveYamlSet,
+  construct: constructYamlSet
+});
+var _default3 = core.extend({
+  implicit: [
+    timestamp,
+    merge2
+  ],
+  explicit: [
+    binary,
+    omap,
+    pairs,
+    set2
+  ]
+});
+var _hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+function _class(obj) {
+  return Object.prototype.toString.call(obj);
+}
+function is_EOL(c) {
+  return c === 10 || c === 13;
+}
+function is_WHITE_SPACE(c) {
+  return c === 9 || c === 32;
+}
+function is_WS_OR_EOL(c) {
+  return c === 9 || c === 32 || c === 10 || c === 13;
+}
+function is_FLOW_INDICATOR(c) {
+  return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromHexCode(c) {
+  var lc;
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  lc = c | 32;
+  if (97 <= lc && lc <= 102) {
+    return lc - 97 + 10;
+  }
+  return -1;
+}
+function escapedHexLen(c) {
+  if (c === 120) {
+    return 2;
+  }
+  if (c === 117) {
+    return 4;
+  }
+  if (c === 85) {
+    return 8;
+  }
+  return 0;
+}
+function fromDecimalCode(c) {
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  return -1;
+}
+function simpleEscapeSequence(c) {
+  return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
+}
+function charFromCodepoint(c) {
+  if (c <= 65535) {
+    return String.fromCharCode(c);
+  }
+  return String.fromCharCode(
+    (c - 65536 >> 10) + 55296,
+    (c - 65536 & 1023) + 56320
+  );
+}
+function setProperty(object2, key, value) {
+  if (key === "__proto__") {
+    Object.defineProperty(object2, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value
+    });
+  } else {
+    object2[key] = value;
+  }
+}
+var simpleEscapeCheck = new Array(256);
+var simpleEscapeMap = new Array(256);
+for (i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+var i;
+function State$1(input, options) {
+  this.input = input;
+  this.filename = options["filename"] || null;
+  this.schema = options["schema"] || _default3;
+  this.onWarning = options["onWarning"] || null;
+  this.legacy = options["legacy"] || false;
+  this.json = options["json"] || false;
+  this.listener = options["listener"] || null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.typeMap = this.schema.compiledTypeMap;
+  this.length = input.length;
+  this.position = 0;
+  this.line = 0;
+  this.lineStart = 0;
+  this.lineIndent = 0;
+  this.firstTabInLine = -1;
+  this.documents = [];
+}
+function generateError(state, message) {
+  var mark = {
+    name: state.filename,
+    buffer: state.input.slice(0, -1),
+    // omit trailing \0
+    position: state.position,
+    line: state.line,
+    column: state.position - state.lineStart
+  };
+  mark.snippet = snippet(mark);
+  return new exception(message, mark);
+}
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+var directiveHandlers = {
+  YAML: function handleYamlDirective(state, name, args) {
+    var match, major, minor;
+    if (state.version !== null) {
+      throwError(state, "duplication of %YAML directive");
+    }
+    if (args.length !== 1) {
+      throwError(state, "YAML directive accepts exactly one argument");
+    }
+    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+    if (match === null) {
+      throwError(state, "ill-formed argument of the YAML directive");
+    }
+    major = parseInt(match[1], 10);
+    minor = parseInt(match[2], 10);
+    if (major !== 1) {
+      throwError(state, "unacceptable YAML version of the document");
+    }
+    state.version = args[0];
+    state.checkLineBreaks = minor < 2;
+    if (minor !== 1 && minor !== 2) {
+      throwWarning(state, "unsupported YAML version of the document");
+    }
+  },
+  TAG: function handleTagDirective(state, name, args) {
+    var handle, prefix;
+    if (args.length !== 2) {
+      throwError(state, "TAG directive accepts exactly two arguments");
+    }
+    handle = args[0];
+    prefix = args[1];
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
+    }
+    if (_hasOwnProperty$1.call(state.tagMap, handle)) {
+      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
+    }
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
+    }
+    try {
+      prefix = decodeURIComponent(prefix);
+    } catch (err) {
+      throwError(state, "tag prefix is malformed: " + prefix);
+    }
+    state.tagMap[handle] = prefix;
+  }
+};
+function captureSegment(state, start, end, checkJson) {
+  var _position, _length2, _character, _result;
+  if (start < end) {
+    _result = state.input.slice(start, end);
+    if (checkJson) {
+      for (_position = 0, _length2 = _result.length; _position < _length2; _position += 1) {
+        _character = _result.charCodeAt(_position);
+        if (!(_character === 9 || 32 <= _character && _character <= 1114111)) {
+          throwError(state, "expected valid JSON character");
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, "the stream contains non-printable characters");
+    }
+    state.result += _result;
+  }
+}
+function mergeMappings(state, destination, source, overridableKeys) {
+  var sourceKeys, key, index, quantity;
+  if (!common.isObject(source)) {
+    throwError(state, "cannot merge mappings; the provided source object is unacceptable");
+  }
+  sourceKeys = Object.keys(source);
+  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+    key = sourceKeys[index];
+    if (!_hasOwnProperty$1.call(destination, key)) {
+      setProperty(destination, key, source[key]);
+      overridableKeys[key] = true;
+    }
+  }
+}
+function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startLineStart, startPos) {
+  var index, quantity;
+  if (Array.isArray(keyNode)) {
+    keyNode = Array.prototype.slice.call(keyNode);
+    for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
+      if (Array.isArray(keyNode[index])) {
+        throwError(state, "nested arrays are not supported inside keys");
+      }
+      if (typeof keyNode === "object" && _class(keyNode[index]) === "[object Object]") {
+        keyNode[index] = "[object Object]";
+      }
+    }
+  }
+  if (typeof keyNode === "object" && _class(keyNode) === "[object Object]") {
+    keyNode = "[object Object]";
+  }
+  keyNode = String(keyNode);
+  if (_result === null) {
+    _result = {};
+  }
+  if (keyTag === "tag:yaml.org,2002:merge") {
+    if (Array.isArray(valueNode)) {
+      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+        mergeMappings(state, _result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, _result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json && !_hasOwnProperty$1.call(overridableKeys, keyNode) && _hasOwnProperty$1.call(_result, keyNode)) {
+      state.line = startLine || state.line;
+      state.lineStart = startLineStart || state.lineStart;
+      state.position = startPos || state.position;
+      throwError(state, "duplicated mapping key");
+    }
+    setProperty(_result, keyNode, valueNode);
+    delete overridableKeys[keyNode];
+  }
+  return _result;
+}
+function readLineBreak(state) {
+  var ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 10) {
+    state.position++;
+  } else if (ch === 13) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 10) {
+      state.position++;
+    }
+  } else {
+    throwError(state, "a line break is expected");
+  }
+  state.line += 1;
+  state.lineStart = state.position;
+  state.firstTabInLine = -1;
+}
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  var lineBreaks = 0, ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    while (is_WHITE_SPACE(ch)) {
+      if (ch === 9 && state.firstTabInLine === -1) {
+        state.firstTabInLine = state.position;
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (allowComments && ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 10 && ch !== 13 && ch !== 0);
+    }
+    if (is_EOL(ch)) {
+      readLineBreak(state);
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+      while (ch === 32) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, "deficient indentation");
+  }
+  return lineBreaks;
+}
+function testDocumentSeparator(state) {
+  var _position = state.position, ch;
+  ch = state.input.charCodeAt(_position);
+  if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
+    _position += 3;
+    ch = state.input.charCodeAt(_position);
+    if (ch === 0 || is_WS_OR_EOL(ch)) {
+      return true;
+    }
+  }
+  return false;
+}
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += " ";
+  } else if (count > 1) {
+    state.result += common.repeat("\n", count - 1);
+  }
+}
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  var preceding, following, captureStart, captureEnd, hasPendingContent, _line, _lineStart, _lineIndent, _kind = state.kind, _result = state.result, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (is_WS_OR_EOL(ch) || is_FLOW_INDICATOR(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
+    return false;
+  }
+  if (ch === 63 || ch === 45) {
+    following = state.input.charCodeAt(state.position + 1);
+    if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+      return false;
+    }
+  }
+  state.kind = "scalar";
+  state.result = "";
+  captureStart = captureEnd = state.position;
+  hasPendingContent = false;
+  while (ch !== 0) {
+    if (ch === 58) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        break;
+      }
+    } else if (ch === 35) {
+      preceding = state.input.charCodeAt(state.position - 1);
+      if (is_WS_OR_EOL(preceding)) {
+        break;
+      }
+    } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+      break;
+    } else if (is_EOL(ch)) {
+      _line = state.line;
+      _lineStart = state.lineStart;
+      _lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = _line;
+        state.lineStart = _lineStart;
+        state.lineIndent = _lineIndent;
+        break;
+      }
+    }
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - _line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+    if (!is_WHITE_SPACE(ch)) {
+      captureEnd = state.position + 1;
+    }
+    ch = state.input.charCodeAt(++state.position);
+  }
+  captureSegment(state, captureStart, captureEnd, false);
+  if (state.result) {
+    return true;
+  }
+  state.kind = _kind;
+  state.result = _result;
+  return false;
+}
+function readSingleQuotedScalar(state, nodeIndent) {
+  var ch, captureStart, captureEnd;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 39) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 39) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (ch === 39) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a single quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a single quoted scalar");
+}
+function readDoubleQuotedScalar(state, nodeIndent) {
+  var captureStart, captureEnd, hexLength, hexResult, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 34) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 34) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+    } else if (ch === 92) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (is_EOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        hexLength = tmp;
+        hexResult = 0;
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+          } else {
+            throwError(state, "expected hexadecimal character");
+          }
+        }
+        state.result += charFromCodepoint(hexResult);
+        state.position++;
+      } else {
+        throwError(state, "unknown escape sequence");
+      }
+      captureStart = captureEnd = state.position;
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a double quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a double quoted scalar");
+}
+function readFlowCollection(state, nodeIndent) {
+  var readNext = true, _line, _lineStart, _pos, _tag = state.tag, _result, _anchor = state.anchor, following, terminator, isPair, isExplicitPair, isMapping, overridableKeys = /* @__PURE__ */ Object.create(null), keyNode, keyTag, valueNode, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 91) {
+    terminator = 93;
+    isMapping = false;
+    _result = [];
+  } else if (ch === 123) {
+    terminator = 125;
+    isMapping = true;
+    _result = {};
+  } else {
+    return false;
+  }
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(++state.position);
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === terminator) {
+      state.position++;
+      state.tag = _tag;
+      state.anchor = _anchor;
+      state.kind = isMapping ? "mapping" : "sequence";
+      state.result = _result;
+      return true;
+    } else if (!readNext) {
+      throwError(state, "missed comma between flow collection entries");
+    } else if (ch === 44) {
+      throwError(state, "expected the node content, but found ','");
+    }
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+    if (ch === 63) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+    _line = state.line;
+    _lineStart = state.lineStart;
+    _pos = state.position;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if ((isExplicitPair || state.line === _line) && ch === 58) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+    if (isMapping) {
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos);
+    } else if (isPair) {
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos));
+    } else {
+      _result.push(keyNode);
+    }
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === 44) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a flow collection");
+}
+function readBlockScalar(state, nodeIndent) {
+  var captureStart, folding, chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 124) {
+    folding = false;
+  } else if (ch === 62) {
+    folding = true;
+  } else {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+    if (ch === 43 || ch === 45) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = ch === 43 ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        throwError(state, "repeat of a chomping mode identifier");
+      }
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        throwError(state, "repeat of an indentation width identifier");
+      }
+    } else {
+      break;
+    }
+  }
+  if (is_WHITE_SPACE(ch)) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (is_WHITE_SPACE(ch));
+    if (ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (!is_EOL(ch) && ch !== 0);
+    }
+  }
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+    ch = state.input.charCodeAt(state.position);
+    while ((!detectedIndent || state.lineIndent < textIndent) && ch === 32) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+    if (is_EOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+    if (state.lineIndent < textIndent) {
+      if (chomping === CHOMPING_KEEP) {
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) {
+          state.result += "\n";
+        }
+      }
+      break;
+    }
+    if (folding) {
+      if (is_WHITE_SPACE(ch)) {
+        atMoreIndented = true;
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += common.repeat("\n", emptyLines + 1);
+      } else if (emptyLines === 0) {
+        if (didReadContent) {
+          state.result += " ";
+        }
+      } else {
+        state.result += common.repeat("\n", emptyLines);
+      }
+    } else {
+      state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+    }
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    captureStart = state.position;
+    while (!is_EOL(ch) && ch !== 0) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    captureSegment(state, captureStart, state.position, false);
+  }
+  return true;
+}
+function readBlockSequence(state, nodeIndent) {
+  var _line, _tag = state.tag, _anchor = state.anchor, _result = [], following, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    if (ch !== 45) {
+      break;
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    if (!is_WS_OR_EOL(following)) {
+      break;
+    }
+    detected = true;
+    state.position++;
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        _result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    _result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a sequence entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "sequence";
+    state.result = _result;
+    return true;
+  }
+  return false;
+}
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  var following, allowCompact, _line, _keyLine, _keyLineStart, _keyPos, _tag = state.tag, _anchor = state.anchor, _result = {}, overridableKeys = /* @__PURE__ */ Object.create(null), keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (!atExplicitKey && state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    _line = state.line;
+    if ((ch === 63 || ch === 58) && is_WS_OR_EOL(following)) {
+      if (ch === 63) {
+        if (atExplicitKey) {
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+          keyTag = keyNode = valueNode = null;
+        }
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+      } else if (atExplicitKey) {
+        atExplicitKey = false;
+        allowCompact = true;
+      } else {
+        throwError(state, "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line");
+      }
+      state.position += 1;
+      ch = following;
+    } else {
+      _keyLine = state.line;
+      _keyLineStart = state.lineStart;
+      _keyPos = state.position;
+      if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+        break;
+      }
+      if (state.line === _line) {
+        ch = state.input.charCodeAt(state.position);
+        while (is_WHITE_SPACE(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+        if (ch === 58) {
+          ch = state.input.charCodeAt(++state.position);
+          if (!is_WS_OR_EOL(ch)) {
+            throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
+          }
+          if (atExplicitKey) {
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+            keyTag = keyNode = valueNode = null;
+          }
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+        } else if (detected) {
+          throwError(state, "can not read an implicit mapping pair; a colon is missed");
+        } else {
+          state.tag = _tag;
+          state.anchor = _anchor;
+          return true;
+        }
+      } else if (detected) {
+        throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
+      } else {
+        state.tag = _tag;
+        state.anchor = _anchor;
+        return true;
+      }
+    }
+    if (state.line === _line || state.lineIndent > nodeIndent) {
+      if (atExplicitKey) {
+        _keyLine = state.line;
+        _keyLineStart = state.lineStart;
+        _keyPos = state.position;
+      }
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+      if (!atExplicitKey) {
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos);
+        keyTag = keyNode = valueNode = null;
+      }
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a mapping entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (atExplicitKey) {
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "mapping";
+    state.result = _result;
+  }
+  return detected;
+}
+function readTagProperty(state) {
+  var _position, isVerbatim = false, isNamed = false, tagHandle, tagName, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 33) return false;
+  if (state.tag !== null) {
+    throwError(state, "duplication of a tag property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  if (ch === 60) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+  } else if (ch === 33) {
+    isNamed = true;
+    tagHandle = "!!";
+    ch = state.input.charCodeAt(++state.position);
+  } else {
+    tagHandle = "!";
+  }
+  _position = state.position;
+  if (isVerbatim) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (ch !== 0 && ch !== 62);
+    if (state.position < state.length) {
+      tagName = state.input.slice(_position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      throwError(state, "unexpected end of the stream within a verbatim tag");
+    }
+  } else {
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      if (ch === 33) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(_position - 1, state.position + 1);
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            throwError(state, "named tag handle cannot contain such characters");
+          }
+          isNamed = true;
+          _position = state.position + 1;
+        } else {
+          throwError(state, "tag suffix cannot contain exclamation marks");
+        }
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    tagName = state.input.slice(_position, state.position);
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      throwError(state, "tag suffix cannot contain flow indicator characters");
+    }
+  }
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    throwError(state, "tag name cannot contain such characters: " + tagName);
+  }
+  try {
+    tagName = decodeURIComponent(tagName);
+  } catch (err) {
+    throwError(state, "tag name is malformed: " + tagName);
+  }
+  if (isVerbatim) {
+    state.tag = tagName;
+  } else if (_hasOwnProperty$1.call(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+  } else if (tagHandle === "!") {
+    state.tag = "!" + tagName;
+  } else if (tagHandle === "!!") {
+    state.tag = "tag:yaml.org,2002:" + tagName;
+  } else {
+    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
+  }
+  return true;
+}
+function readAnchorProperty(state) {
+  var _position, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 38) return false;
+  if (state.anchor !== null) {
+    throwError(state, "duplication of an anchor property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an anchor node must contain at least one character");
+  }
+  state.anchor = state.input.slice(_position, state.position);
+  return true;
+}
+function readAlias(state) {
+  var _position, alias, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 42) return false;
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an alias node must contain at least one character");
+  }
+  alias = state.input.slice(_position, state.position);
+  if (!_hasOwnProperty$1.call(state.anchorMap, alias)) {
+    throwError(state, 'unidentified alias "' + alias + '"');
+  }
+  state.result = state.anchorMap[alias];
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  var allowBlockStyles, allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, typeIndex, typeQuantity, typeList, type2, flowIndent, blockIndent;
+  if (state.listener !== null) {
+    state.listener("open", state);
+  }
+  state.tag = null;
+  state.anchor = null;
+  state.kind = null;
+  state.result = null;
+  allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
+      flowIndent = parentIndent;
+    } else {
+      flowIndent = parentIndent + 1;
+    }
+    blockIndent = state.position - state.lineStart;
+    if (indentStatus === 1) {
+      if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+        } else if (readAlias(state)) {
+          hasContent = true;
+          if (state.tag !== null || state.anchor !== null) {
+            throwError(state, "alias node should not have any properties");
+          }
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+          if (state.tag === null) {
+            state.tag = "?";
+          }
+        }
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+  if (state.tag === null) {
+    if (state.anchor !== null) {
+      state.anchorMap[state.anchor] = state.result;
+    }
+  } else if (state.tag === "?") {
+    if (state.result !== null && state.kind !== "scalar") {
+      throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
+    }
+    for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+      type2 = state.implicitTypes[typeIndex];
+      if (type2.resolve(state.result)) {
+        state.result = type2.construct(state.result);
+        state.tag = type2.tag;
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+        break;
+      }
+    }
+  } else if (state.tag !== "!") {
+    if (_hasOwnProperty$1.call(state.typeMap[state.kind || "fallback"], state.tag)) {
+      type2 = state.typeMap[state.kind || "fallback"][state.tag];
+    } else {
+      type2 = null;
+      typeList = state.typeMap.multi[state.kind || "fallback"];
+      for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
+        if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
+          type2 = typeList[typeIndex];
+          break;
+        }
+      }
+    }
+    if (!type2) {
+      throwError(state, "unknown tag !<" + state.tag + ">");
+    }
+    if (state.result !== null && type2.kind !== state.kind) {
+      throwError(state, "unacceptable node kind for !<" + state.tag + '> tag; it should be "' + type2.kind + '", not "' + state.kind + '"');
+    }
+    if (!type2.resolve(state.result, state.tag)) {
+      throwError(state, "cannot resolve a node with !<" + state.tag + "> explicit tag");
+    } else {
+      state.result = type2.construct(state.result, state.tag);
+      if (state.anchor !== null) {
+        state.anchorMap[state.anchor] = state.result;
+      }
+    }
+  }
+  if (state.listener !== null) {
+    state.listener("close", state);
+  }
+  return state.tag !== null || state.anchor !== null || hasContent;
+}
+function readDocument(state) {
+  var documentStart = state.position, _position, directiveName, directiveArgs, hasDirectives = false, ch;
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = /* @__PURE__ */ Object.create(null);
+  state.anchorMap = /* @__PURE__ */ Object.create(null);
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if (state.lineIndent > 0 || ch !== 37) {
+      break;
+    }
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    _position = state.position;
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    directiveName = state.input.slice(_position, state.position);
+    directiveArgs = [];
+    if (directiveName.length < 1) {
+      throwError(state, "directive name must not be less than one character in length");
+    }
+    while (ch !== 0) {
+      while (is_WHITE_SPACE(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      if (ch === 35) {
+        do {
+          ch = state.input.charCodeAt(++state.position);
+        } while (ch !== 0 && !is_EOL(ch));
+        break;
+      }
+      if (is_EOL(ch)) break;
+      _position = state.position;
+      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      directiveArgs.push(state.input.slice(_position, state.position));
+    }
+    if (ch !== 0) readLineBreak(state);
+    if (_hasOwnProperty$1.call(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, directiveArgs);
+    } else {
+      throwWarning(state, 'unknown document directive "' + directiveName + '"');
+    }
+  }
+  skipSeparationSpace(state, true, -1);
+  if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+  } else if (hasDirectives) {
+    throwError(state, "directives end mark is expected");
+  }
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+  if (state.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
+    throwWarning(state, "non-ASCII line breaks are interpreted as content");
+  }
+  state.documents.push(state.result);
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+    if (state.input.charCodeAt(state.position) === 46) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+  if (state.position < state.length - 1) {
+    throwError(state, "end of the stream or a document separator is expected");
+  } else {
+    return;
+  }
+}
+function loadDocuments(input, options) {
+  input = String(input);
+  options = options || {};
+  if (input.length !== 0) {
+    if (input.charCodeAt(input.length - 1) !== 10 && input.charCodeAt(input.length - 1) !== 13) {
+      input += "\n";
+    }
+    if (input.charCodeAt(0) === 65279) {
+      input = input.slice(1);
+    }
+  }
+  var state = new State$1(input, options);
+  var nullpos = input.indexOf("\0");
+  if (nullpos !== -1) {
+    state.position = nullpos;
+    throwError(state, "null byte is not allowed in input");
+  }
+  state.input += "\0";
+  while (state.input.charCodeAt(state.position) === 32) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+  while (state.position < state.length - 1) {
+    readDocument(state);
+  }
+  return state.documents;
+}
+function loadAll$1(input, iterator, options) {
+  if (iterator !== null && typeof iterator === "object" && typeof options === "undefined") {
+    options = iterator;
+    iterator = null;
+  }
+  var documents = loadDocuments(input, options);
+  if (typeof iterator !== "function") {
+    return documents;
+  }
+  for (var index = 0, length = documents.length; index < length; index += 1) {
+    iterator(documents[index]);
+  }
+}
+function load$1(input, options) {
+  var documents = loadDocuments(input, options);
+  if (documents.length === 0) {
+    return void 0;
+  } else if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new exception("expected a single document in the stream, but found more");
+}
+var loadAll_1 = loadAll$1;
+var load_1 = load$1;
+var loader = {
+  loadAll: loadAll_1,
+  load: load_1
+};
+var _toString = Object.prototype.toString;
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+var CHAR_BOM = 65279;
+var CHAR_TAB = 9;
+var CHAR_LINE_FEED = 10;
+var CHAR_CARRIAGE_RETURN = 13;
+var CHAR_SPACE = 32;
+var CHAR_EXCLAMATION = 33;
+var CHAR_DOUBLE_QUOTE = 34;
+var CHAR_SHARP = 35;
+var CHAR_PERCENT = 37;
+var CHAR_AMPERSAND = 38;
+var CHAR_SINGLE_QUOTE = 39;
+var CHAR_ASTERISK = 42;
+var CHAR_COMMA = 44;
+var CHAR_MINUS = 45;
+var CHAR_COLON = 58;
+var CHAR_EQUALS = 61;
+var CHAR_GREATER_THAN = 62;
+var CHAR_QUESTION = 63;
+var CHAR_COMMERCIAL_AT = 64;
+var CHAR_LEFT_SQUARE_BRACKET = 91;
+var CHAR_RIGHT_SQUARE_BRACKET = 93;
+var CHAR_GRAVE_ACCENT = 96;
+var CHAR_LEFT_CURLY_BRACKET = 123;
+var CHAR_VERTICAL_LINE = 124;
+var CHAR_RIGHT_CURLY_BRACKET = 125;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = '\\"';
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+var DEPRECATED_BOOLEANS_SYNTAX = [
+  "y",
+  "Y",
+  "yes",
+  "Yes",
+  "YES",
+  "on",
+  "On",
+  "ON",
+  "n",
+  "N",
+  "no",
+  "No",
+  "NO",
+  "off",
+  "Off",
+  "OFF"
+];
+var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
+function compileStyleMap(schema2, map3) {
+  var result, keys, index, length, tag, style, type2;
+  if (map3 === null) return {};
+  result = {};
+  keys = Object.keys(map3);
+  for (index = 0, length = keys.length; index < length; index += 1) {
+    tag = keys[index];
+    style = String(map3[tag]);
+    if (tag.slice(0, 2) === "!!") {
+      tag = "tag:yaml.org,2002:" + tag.slice(2);
+    }
+    type2 = schema2.compiledTypeMap["fallback"][tag];
+    if (type2 && _hasOwnProperty.call(type2.styleAliases, style)) {
+      style = type2.styleAliases[style];
+    }
+    result[tag] = style;
+  }
+  return result;
+}
+function encodeHex(character) {
+  var string4, handle, length;
+  string4 = character.toString(16).toUpperCase();
+  if (character <= 255) {
+    handle = "x";
+    length = 2;
+  } else if (character <= 65535) {
+    handle = "u";
+    length = 4;
+  } else if (character <= 4294967295) {
+    handle = "U";
+    length = 8;
+  } else {
+    throw new exception("code point within a string may not be greater than 0xFFFFFFFF");
+  }
+  return "\\" + handle + common.repeat("0", length - string4.length) + string4;
+}
+var QUOTING_TYPE_SINGLE = 1;
+var QUOTING_TYPE_DOUBLE = 2;
+function State(options) {
+  this.schema = options["schema"] || _default3;
+  this.indent = Math.max(1, options["indent"] || 2);
+  this.noArrayIndent = options["noArrayIndent"] || false;
+  this.skipInvalid = options["skipInvalid"] || false;
+  this.flowLevel = common.isNothing(options["flowLevel"]) ? -1 : options["flowLevel"];
+  this.styleMap = compileStyleMap(this.schema, options["styles"] || null);
+  this.sortKeys = options["sortKeys"] || false;
+  this.lineWidth = options["lineWidth"] || 80;
+  this.noRefs = options["noRefs"] || false;
+  this.noCompatMode = options["noCompatMode"] || false;
+  this.condenseFlow = options["condenseFlow"] || false;
+  this.quotingType = options["quotingType"] === '"' ? QUOTING_TYPE_DOUBLE : QUOTING_TYPE_SINGLE;
+  this.forceQuotes = options["forceQuotes"] || false;
+  this.replacer = typeof options["replacer"] === "function" ? options["replacer"] : null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.explicitTypes = this.schema.compiledExplicit;
+  this.tag = null;
+  this.result = "";
+  this.duplicates = [];
+  this.usedDuplicates = null;
+}
+function indentString(string4, spaces) {
+  var ind = common.repeat(" ", spaces), position = 0, next = -1, result = "", line, length = string4.length;
+  while (position < length) {
+    next = string4.indexOf("\n", position);
+    if (next === -1) {
+      line = string4.slice(position);
+      position = length;
+    } else {
+      line = string4.slice(position, next + 1);
+      position = next + 1;
+    }
+    if (line.length && line !== "\n") result += ind;
+    result += line;
+  }
+  return result;
+}
+function generateNextLine(state, level) {
+  return "\n" + common.repeat(" ", state.indent * level);
+}
+function testImplicitResolving(state, str2) {
+  var index, length, type2;
+  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+    type2 = state.implicitTypes[index];
+    if (type2.resolve(str2)) {
+      return true;
+    }
+  }
+  return false;
+}
+function isWhitespace(c) {
+  return c === CHAR_SPACE || c === CHAR_TAB;
+}
+function isPrintable(c) {
+  return 32 <= c && c <= 126 || 161 <= c && c <= 55295 && c !== 8232 && c !== 8233 || 57344 <= c && c <= 65533 && c !== CHAR_BOM || 65536 <= c && c <= 1114111;
+}
+function isNsCharOrWhitespace(c) {
+  return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+}
+function isPlainSafe(c, prev, inblock) {
+  var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+  var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+  return (
+    // ns-plain-safe
+    (inblock ? (
+      // c = flow-in
+      cIsNsCharOrWhitespace
+    ) : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar
+  );
+}
+function isPlainSafeFirst(c) {
+  return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+}
+function isPlainSafeLast(c) {
+  return !isWhitespace(c) && c !== CHAR_COLON;
+}
+function codePointAt(string4, pos) {
+  var first = string4.charCodeAt(pos), second;
+  if (first >= 55296 && first <= 56319 && pos + 1 < string4.length) {
+    second = string4.charCodeAt(pos + 1);
+    if (second >= 56320 && second <= 57343) {
+      return (first - 55296) * 1024 + second - 56320 + 65536;
+    }
+  }
+  return first;
+}
+function needIndentIndicator(string4) {
+  var leadingSpaceRe = /^\n* /;
+  return leadingSpaceRe.test(string4);
+}
+var STYLE_PLAIN = 1;
+var STYLE_SINGLE = 2;
+var STYLE_LITERAL = 3;
+var STYLE_FOLDED = 4;
+var STYLE_DOUBLE = 5;
+function chooseScalarStyle(string4, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, quotingType, forceQuotes, inblock) {
+  var i;
+  var char = 0;
+  var prevChar = null;
+  var hasLineBreak = false;
+  var hasFoldableLine = false;
+  var shouldTrackWidth = lineWidth !== -1;
+  var previousLineBreak = -1;
+  var plain = isPlainSafeFirst(codePointAt(string4, 0)) && isPlainSafeLast(codePointAt(string4, string4.length - 1));
+  if (singleLineOnly || forceQuotes) {
+    for (i = 0; i < string4.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string4, i);
+      if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+  } else {
+    for (i = 0; i < string4.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string4, i);
+      if (char === CHAR_LINE_FEED) {
+        hasLineBreak = true;
+        if (shouldTrackWidth) {
+          hasFoldableLine = hasFoldableLine || // Foldable line = too long, and not more-indented.
+          i - previousLineBreak - 1 > lineWidth && string4[previousLineBreak + 1] !== " ";
+          previousLineBreak = i;
+        }
+      } else if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+    hasFoldableLine = hasFoldableLine || shouldTrackWidth && (i - previousLineBreak - 1 > lineWidth && string4[previousLineBreak + 1] !== " ");
+  }
+  if (!hasLineBreak && !hasFoldableLine) {
+    if (plain && !forceQuotes && !testAmbiguousType(string4)) {
+      return STYLE_PLAIN;
+    }
+    return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+  }
+  if (indentPerLevel > 9 && needIndentIndicator(string4)) {
+    return STYLE_DOUBLE;
+  }
+  if (!forceQuotes) {
+    return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+  }
+  return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+}
+function writeScalar(state, string4, level, iskey, inblock) {
+  state.dump = (function() {
+    if (string4.length === 0) {
+      return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''";
+    }
+    if (!state.noCompatMode) {
+      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string4) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string4)) {
+        return state.quotingType === QUOTING_TYPE_DOUBLE ? '"' + string4 + '"' : "'" + string4 + "'";
+      }
+    }
+    var indent = state.indent * Math.max(1, level);
+    var lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+    var singleLineOnly = iskey || state.flowLevel > -1 && level >= state.flowLevel;
+    function testAmbiguity(string5) {
+      return testImplicitResolving(state, string5);
+    }
+    switch (chooseScalarStyle(
+      string4,
+      singleLineOnly,
+      state.indent,
+      lineWidth,
+      testAmbiguity,
+      state.quotingType,
+      state.forceQuotes && !iskey,
+      inblock
+    )) {
+      case STYLE_PLAIN:
+        return string4;
+      case STYLE_SINGLE:
+        return "'" + string4.replace(/'/g, "''") + "'";
+      case STYLE_LITERAL:
+        return "|" + blockHeader(string4, state.indent) + dropEndingNewline(indentString(string4, indent));
+      case STYLE_FOLDED:
+        return ">" + blockHeader(string4, state.indent) + dropEndingNewline(indentString(foldString(string4, lineWidth), indent));
+      case STYLE_DOUBLE:
+        return '"' + escapeString(string4) + '"';
+      default:
+        throw new exception("impossible error: invalid scalar style");
+    }
+  })();
+}
+function blockHeader(string4, indentPerLevel) {
+  var indentIndicator = needIndentIndicator(string4) ? String(indentPerLevel) : "";
+  var clip = string4[string4.length - 1] === "\n";
+  var keep = clip && (string4[string4.length - 2] === "\n" || string4 === "\n");
+  var chomp = keep ? "+" : clip ? "" : "-";
+  return indentIndicator + chomp + "\n";
+}
+function dropEndingNewline(string4) {
+  return string4[string4.length - 1] === "\n" ? string4.slice(0, -1) : string4;
+}
+function foldString(string4, width) {
+  var lineRe = /(\n+)([^\n]*)/g;
+  var result = (function() {
+    var nextLF = string4.indexOf("\n");
+    nextLF = nextLF !== -1 ? nextLF : string4.length;
+    lineRe.lastIndex = nextLF;
+    return foldLine(string4.slice(0, nextLF), width);
+  })();
+  var prevMoreIndented = string4[0] === "\n" || string4[0] === " ";
+  var moreIndented;
+  var match;
+  while (match = lineRe.exec(string4)) {
+    var prefix = match[1], line = match[2];
+    moreIndented = line[0] === " ";
+    result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
+    prevMoreIndented = moreIndented;
+  }
+  return result;
+}
+function foldLine(line, width) {
+  if (line === "" || line[0] === " ") return line;
+  var breakRe = / [^ ]/g;
+  var match;
+  var start = 0, end, curr = 0, next = 0;
+  var result = "";
+  while (match = breakRe.exec(line)) {
+    next = match.index;
+    if (next - start > width) {
+      end = curr > start ? curr : next;
+      result += "\n" + line.slice(start, end);
+      start = end + 1;
+    }
+    curr = next;
+  }
+  result += "\n";
+  if (line.length - start > width && curr > start) {
+    result += line.slice(start, curr) + "\n" + line.slice(curr + 1);
+  } else {
+    result += line.slice(start);
+  }
+  return result.slice(1);
+}
+function escapeString(string4) {
+  var result = "";
+  var char = 0;
+  var escapeSeq;
+  for (var i = 0; i < string4.length; char >= 65536 ? i += 2 : i++) {
+    char = codePointAt(string4, i);
+    escapeSeq = ESCAPE_SEQUENCES[char];
+    if (!escapeSeq && isPrintable(char)) {
+      result += string4[i];
+      if (char >= 65536) result += string4[i + 1];
+    } else {
+      result += escapeSeq || encodeHex(char);
+    }
+  }
+  return result;
+}
+function writeFlowSequence(state, level, object2) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object2.length; index < length; index += 1) {
+    value = object2[index];
+    if (state.replacer) {
+      value = state.replacer.call(object2, String(index), value);
+    }
+    if (writeNode(state, level, value, false, false) || typeof value === "undefined" && writeNode(state, level, null, false, false)) {
+      if (_result !== "") _result += "," + (!state.condenseFlow ? " " : "");
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = "[" + _result + "]";
+}
+function writeBlockSequence(state, level, object2, compact) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object2.length; index < length; index += 1) {
+    value = object2[index];
+    if (state.replacer) {
+      value = state.replacer.call(object2, String(index), value);
+    }
+    if (writeNode(state, level + 1, value, true, true, false, true) || typeof value === "undefined" && writeNode(state, level + 1, null, true, true, false, true)) {
+      if (!compact || _result !== "") {
+        _result += generateNextLine(state, level);
+      }
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        _result += "-";
+      } else {
+        _result += "- ";
+      }
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = _result || "[]";
+}
+function writeFlowMapping(state, level, object2) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object2), index, length, objectKey, objectValue, pairBuffer;
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (_result !== "") pairBuffer += ", ";
+    if (state.condenseFlow) pairBuffer += '"';
+    objectKey = objectKeyList[index];
+    objectValue = object2[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object2, objectKey, objectValue);
+    }
+    if (!writeNode(state, level, objectKey, false, false)) {
+      continue;
+    }
+    if (state.dump.length > 1024) pairBuffer += "? ";
+    pairBuffer += state.dump + (state.condenseFlow ? '"' : "") + ":" + (state.condenseFlow ? "" : " ");
+    if (!writeNode(state, level, objectValue, false, false)) {
+      continue;
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = "{" + _result + "}";
+}
+function writeBlockMapping(state, level, object2, compact) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object2), index, length, objectKey, objectValue, explicitPair, pairBuffer;
+  if (state.sortKeys === true) {
+    objectKeyList.sort();
+  } else if (typeof state.sortKeys === "function") {
+    objectKeyList.sort(state.sortKeys);
+  } else if (state.sortKeys) {
+    throw new exception("sortKeys must be a boolean or a function");
+  }
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (!compact || _result !== "") {
+      pairBuffer += generateNextLine(state, level);
+    }
+    objectKey = objectKeyList[index];
+    objectValue = object2[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object2, objectKey, objectValue);
+    }
+    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
+      continue;
+    }
+    explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
+    if (explicitPair) {
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        pairBuffer += "?";
+      } else {
+        pairBuffer += "? ";
+      }
+    }
+    pairBuffer += state.dump;
+    if (explicitPair) {
+      pairBuffer += generateNextLine(state, level);
+    }
+    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
+      continue;
+    }
+    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+      pairBuffer += ":";
+    } else {
+      pairBuffer += ": ";
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = _result || "{}";
+}
+function detectType(state, object2, explicit) {
+  var _result, typeList, index, length, type2, style;
+  typeList = explicit ? state.explicitTypes : state.implicitTypes;
+  for (index = 0, length = typeList.length; index < length; index += 1) {
+    type2 = typeList[index];
+    if ((type2.instanceOf || type2.predicate) && (!type2.instanceOf || typeof object2 === "object" && object2 instanceof type2.instanceOf) && (!type2.predicate || type2.predicate(object2))) {
+      if (explicit) {
+        if (type2.multi && type2.representName) {
+          state.tag = type2.representName(object2);
+        } else {
+          state.tag = type2.tag;
+        }
+      } else {
+        state.tag = "?";
+      }
+      if (type2.represent) {
+        style = state.styleMap[type2.tag] || type2.defaultStyle;
+        if (_toString.call(type2.represent) === "[object Function]") {
+          _result = type2.represent(object2, style);
+        } else if (_hasOwnProperty.call(type2.represent, style)) {
+          _result = type2.represent[style](object2, style);
+        } else {
+          throw new exception("!<" + type2.tag + '> tag resolver accepts not "' + style + '" style');
+        }
+        state.dump = _result;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+function writeNode(state, level, object2, block, compact, iskey, isblockseq) {
+  state.tag = null;
+  state.dump = object2;
+  if (!detectType(state, object2, false)) {
+    detectType(state, object2, true);
+  }
+  var type2 = _toString.call(state.dump);
+  var inblock = block;
+  var tagStr;
+  if (block) {
+    block = state.flowLevel < 0 || state.flowLevel > level;
+  }
+  var objectOrArray = type2 === "[object Object]" || type2 === "[object Array]", duplicateIndex, duplicate;
+  if (objectOrArray) {
+    duplicateIndex = state.duplicates.indexOf(object2);
+    duplicate = duplicateIndex !== -1;
+  }
+  if (state.tag !== null && state.tag !== "?" || duplicate || state.indent !== 2 && level > 0) {
+    compact = false;
+  }
+  if (duplicate && state.usedDuplicates[duplicateIndex]) {
+    state.dump = "*ref_" + duplicateIndex;
+  } else {
+    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
+      state.usedDuplicates[duplicateIndex] = true;
+    }
+    if (type2 === "[object Object]") {
+      if (block && Object.keys(state.dump).length !== 0) {
+        writeBlockMapping(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowMapping(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object Array]") {
+      if (block && state.dump.length !== 0) {
+        if (state.noArrayIndent && !isblockseq && level > 0) {
+          writeBlockSequence(state, level - 1, state.dump, compact);
+        } else {
+          writeBlockSequence(state, level, state.dump, compact);
+        }
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowSequence(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object String]") {
+      if (state.tag !== "?") {
+        writeScalar(state, state.dump, level, iskey, inblock);
+      }
+    } else if (type2 === "[object Undefined]") {
+      return false;
+    } else {
+      if (state.skipInvalid) return false;
+      throw new exception("unacceptable kind of an object to dump " + type2);
+    }
+    if (state.tag !== null && state.tag !== "?") {
+      tagStr = encodeURI(
+        state.tag[0] === "!" ? state.tag.slice(1) : state.tag
+      ).replace(/!/g, "%21");
+      if (state.tag[0] === "!") {
+        tagStr = "!" + tagStr;
+      } else if (tagStr.slice(0, 18) === "tag:yaml.org,2002:") {
+        tagStr = "!!" + tagStr.slice(18);
+      } else {
+        tagStr = "!<" + tagStr + ">";
+      }
+      state.dump = tagStr + " " + state.dump;
+    }
+  }
+  return true;
+}
+function getDuplicateReferences(object2, state) {
+  var objects = [], duplicatesIndexes = [], index, length;
+  inspectNode(object2, objects, duplicatesIndexes);
+  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+    state.duplicates.push(objects[duplicatesIndexes[index]]);
+  }
+  state.usedDuplicates = new Array(length);
+}
+function inspectNode(object2, objects, duplicatesIndexes) {
+  var objectKeyList, index, length;
+  if (object2 !== null && typeof object2 === "object") {
+    index = objects.indexOf(object2);
+    if (index !== -1) {
+      if (duplicatesIndexes.indexOf(index) === -1) {
+        duplicatesIndexes.push(index);
+      }
+    } else {
+      objects.push(object2);
+      if (Array.isArray(object2)) {
+        for (index = 0, length = object2.length; index < length; index += 1) {
+          inspectNode(object2[index], objects, duplicatesIndexes);
+        }
+      } else {
+        objectKeyList = Object.keys(object2);
+        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+          inspectNode(object2[objectKeyList[index]], objects, duplicatesIndexes);
+        }
+      }
+    }
+  }
+}
+function dump$1(input, options) {
+  options = options || {};
+  var state = new State(options);
+  if (!state.noRefs) getDuplicateReferences(input, state);
+  var value = input;
+  if (state.replacer) {
+    value = state.replacer.call({ "": value }, "", value);
+  }
+  if (writeNode(state, 0, value, true, true)) return state.dump + "\n";
+  return "";
+}
+var dump_1 = dump$1;
+var dumper = {
+  dump: dump_1
+};
+function renamed(from, to) {
+  return function() {
+    throw new Error("Function yaml." + from + " is removed in js-yaml 4. Use yaml." + to + " instead, which is now safe by default.");
+  };
+}
+var load = loader.load;
+var loadAll = loader.loadAll;
+var dump = dumper.dump;
+var safeLoad = renamed("safeLoad", "load");
+var safeLoadAll = renamed("safeLoadAll", "loadAll");
+var safeDump = renamed("safeDump", "dump");
+
+// src/release/scrub.ts
+var HELP_TEXT16 = `Usage: gaia-maintainer release scrub <staging-dir> [--config <path>] [--json]
+
+  Apply bundle-time scrub transforms (marker-strip + leak-check) to a
+  staging directory produced by release.yml. Writes in place inside
+  <staging-dir>; treats the source repo as read-only.
+
+  Flags:
+    --config <path>  Override config path (default: .gaia/release-scrub.yml
+                     resolved against process.cwd()).
+    --json           Emit a structured JSON report on stdout instead of
+                     human-readable summary.
+
+  Exit codes:
+    0  clean
+    1  leaks detected, unbalanced markers, missing staging dir, bad flags
+    2  config parse error or filesystem IO failure
+`;
+var HELP_TOKENS16 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT13 = 2;
+var DEFAULT_CONFIG_PATH = ".gaia/release-scrub.yml";
+var MarkerStripSchema = external_exports.object({
+  end: external_exports.string().min(1),
+  paths: external_exports.array(external_exports.string().min(1)).min(1),
+  start: external_exports.string().min(1),
+  type: external_exports.literal("marker-strip")
+});
+var LeakCheckSchema = external_exports.object({
+  checks: external_exports.array(
+    external_exports.object({
+      description: external_exports.string().optional(),
+      id: external_exports.string().min(1),
+      "line-allowlist": external_exports.array(external_exports.string()).optional(),
+      "path-allowlist": external_exports.array(external_exports.string()).optional(),
+      pattern: external_exports.string().min(1),
+      scope: external_exports.array(external_exports.string().min(1)).min(1)
+    })
+  ).min(1),
+  type: external_exports.literal("leak-check")
+});
+var ConfigSchema = external_exports.object({
+  transforms: external_exports.array(external_exports.union([MarkerStripSchema, LeakCheckSchema])).min(1)
+});
+var REGEX_SPECIAL = /[.+^$()[\]{}|\\]/g;
+var SENTINEL_DIRSTAR = " DIRSTAR ";
+var SENTINEL_STAR = " STAR ";
+var globToRegex = (glob) => {
+  const escaped = glob.replaceAll(REGEX_SPECIAL, String.raw`\$&`);
+  const transformed = escaped.replaceAll("**/", SENTINEL_DIRSTAR).replaceAll("**", SENTINEL_STAR).replaceAll("*", "[^/]*").replaceAll(SENTINEL_STAR, ".*").replaceAll(SENTINEL_DIRSTAR, "(?:.*/)?");
+  return new RegExp(`^${transformed}$`);
+};
+var matchesAnyGlob = (relativePath, globs) => globs.some((glob) => globToRegex(glob).test(relativePath));
+var walkFiles = (root, current = root) => {
+  const out = [];
+  for (const entry of readdirSync6(current, { withFileTypes: true })) {
+    const full = path21.join(current, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(root, full));
+      continue;
+    }
+    if (entry.isFile()) {
+      out.push(path21.relative(root, full).split(path21.sep).join("/"));
+    }
+  }
+  return out;
+};
+var stripMarkerBlocks = (source, startMarker, endMarker) => {
+  const lines = source.split("\n");
+  const out = [];
+  const unbalanced = [];
+  let inBlock = false;
+  let blockStartLine = 0;
+  let blocks = 0;
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    const hasStart = line.includes(startMarker);
+    const hasEnd = line.includes(endMarker);
+    if (!inBlock && hasStart && hasEnd) {
+      blocks += 1;
+      continue;
+    }
+    if (!inBlock && hasStart) {
+      inBlock = true;
+      blockStartLine = lineNumber;
+      continue;
+    }
+    if (inBlock && hasEnd) {
+      inBlock = false;
+      blocks += 1;
+      continue;
+    }
+    if (!inBlock && hasEnd) {
+      unbalanced.push({ line: lineNumber, reason: "end_without_start" });
+      out.push(line);
+      continue;
+    }
+    if (!inBlock) out.push(line);
+  }
+  if (inBlock) {
+    unbalanced.push({ line: blockStartLine, reason: "start_without_end" });
+  }
+  return { blocks, output: out.join("\n"), unbalanced };
+};
+var applyMarkerStrip = (stagingRoot, files, transform2) => {
+  const filesTouched = [];
+  const unbalanced = [];
+  let blocksStripped = 0;
+  for (const relativePath of files) {
+    if (!matchesAnyGlob(relativePath, transform2.paths)) continue;
+    const absolutePath = path21.join(stagingRoot, relativePath);
+    const source = readFileSync20(absolutePath, "utf8");
+    if (!source.includes(transform2.start) && !source.includes(transform2.end)) {
+      continue;
+    }
+    const result = stripMarkerBlocks(source, transform2.start, transform2.end);
+    for (const issue2 of result.unbalanced) {
+      unbalanced.push({ file: relativePath, line: issue2.line, reason: issue2.reason });
+    }
+    if (result.blocks > 0) {
+      writeFileSync16(absolutePath, result.output, "utf8");
+      filesTouched.push(relativePath);
+      blocksStripped += result.blocks;
+    }
+  }
+  return { blocksStripped, filesTouched, unbalanced };
+};
+var runLeakCheck = (stagingRoot, files, check2) => {
+  const pattern = new RegExp(check2.pattern);
+  const lineAllowlist = (check2["line-allowlist"] ?? []).map(
+    (raw) => new RegExp(raw)
+  );
+  const pathAllowlist = check2["path-allowlist"] ?? [];
+  const leaks = [];
+  for (const relativePath of files) {
+    if (!matchesAnyGlob(relativePath, check2.scope)) continue;
+    if (matchesAnyGlob(relativePath, pathAllowlist)) continue;
+    const source = readFileSync20(path21.join(stagingRoot, relativePath), "utf8");
+    const lines = source.split("\n");
+    for (const [index, line] of lines.entries()) {
+      if (lineAllowlist.some((rx) => rx.test(line))) continue;
+      const match = pattern.exec(line);
+      if (match === null) continue;
+      leaks.push({
+        check: check2.id,
+        file: relativePath,
+        line: index + 1,
+        match: match[0]
+      });
+    }
+  }
+  return leaks;
+};
+var loadConfig = (configPath) => {
+  const raw = readFileSync20(configPath, "utf8");
+  const parsed = load(raw);
+  return ConfigSchema.parse(parsed);
+};
+var takeValue10 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags14 = (argv) => {
+  let configPath;
+  let json3 = false;
+  let stagingDir;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--config") {
+      const taken = takeValue10(argv, index + 1, "--config");
+      if (!taken.ok) return taken;
+      configPath = taken.value;
+      index += 1;
+      continue;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      return { message: `unknown flag: ${token}`, ok: false };
+    }
+    if (stagingDir !== void 0) {
+      return { message: `unexpected positional: ${token}`, ok: false };
+    }
+    stagingDir = token;
+  }
+  return { flags: { configPath, json: json3, stagingDir }, ok: true };
+};
+var renderHumanReport = (report, jsonMode) => {
+  if (jsonMode) return `${JSON.stringify(report, null, 2)}
+`;
+  const out = [];
+  out.push(
+    `release scrub: stripped ${report.marker_strip.blocks_stripped} marker block(s) across ${report.marker_strip.files_touched.length} file(s)`
+  );
+  if (report.unbalanced_markers.length > 0) {
+    out.push("", `unbalanced markers (${report.unbalanced_markers.length}):`);
+    for (const issue2 of report.unbalanced_markers) {
+      out.push(`  ${issue2.file}:${issue2.line}  ${issue2.reason}`);
+    }
+  }
+  if (report.leaks.length > 0) {
+    out.push("", `leaks (${report.leaks.length}):`);
+    for (const leak of report.leaks) {
+      out.push(`  [${leak.check}] ${leak.file}:${leak.line}  ${leak.match}`);
+    }
+  } else {
+    out.push("leaks: none");
+  }
+  return `${out.join("\n")}
+`;
+};
+var run27 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS16.has(argv[0])) {
+    process.stdout.write(HELP_TEXT16);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags14(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release scrub"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (parsed.flags.stagingDir === void 0) {
+    structuredError({
+      code: "missing_staging_dir",
+      message: "staging directory argument required",
+      subcommand: "release scrub"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const stagingDir = path21.isAbsolute(parsed.flags.stagingDir) ? parsed.flags.stagingDir : path21.join(cwd, parsed.flags.stagingDir);
+  const configPath = parsed.flags.configPath ? path21.isAbsolute(parsed.flags.configPath) ? parsed.flags.configPath : path21.join(cwd, parsed.flags.configPath) : path21.join(cwd, DEFAULT_CONFIG_PATH);
+  try {
+    statSync4(stagingDir);
+  } catch {
+    structuredError({
+      code: "staging_dir_missing",
+      message: `staging directory not found: ${stagingDir}`,
+      subcommand: "release scrub"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let config2;
+  try {
+    config2 = loadConfig(configPath);
+  } catch (error51) {
+    structuredError({
+      code: "config_load_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      path: configPath,
+      subcommand: "release scrub"
+    });
+    return UNEXPECTED_EXIT13;
+  }
+  let stagedFiles;
+  try {
+    stagedFiles = walkFiles(stagingDir);
+  } catch (error51) {
+    structuredError({
+      code: "staging_walk_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release scrub"
+    });
+    return UNEXPECTED_EXIT13;
+  }
+  let stripBlocks = 0;
+  const stripFiles = [];
+  const unbalanced = [];
+  const leaks = [];
+  try {
+    for (const transform2 of config2.transforms) {
+      if (transform2.type === "marker-strip") {
+        const result = applyMarkerStrip(stagingDir, stagedFiles, transform2);
+        stripBlocks += result.blocksStripped;
+        stripFiles.push(...result.filesTouched);
+        for (const issue2 of result.unbalanced) unbalanced.push(issue2);
+        continue;
+      }
+      for (const check2 of transform2.checks) {
+        leaks.push(...runLeakCheck(stagingDir, stagedFiles, check2));
+      }
+    }
+  } catch (error51) {
+    structuredError({
+      code: "transform_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release scrub"
+    });
+    return UNEXPECTED_EXIT13;
+  }
+  const report = {
+    leaks,
+    marker_strip: {
+      blocks_stripped: stripBlocks,
+      files_touched: stripFiles
+    },
+    unbalanced_markers: unbalanced
+  };
+  process.stdout.write(renderHumanReport(report, parsed.flags.json));
+  if (unbalanced.length > 0 || leaks.length > 0) {
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/release/scrub-wiki.ts
+import { existsSync as existsSync22, mkdirSync as mkdirSync9, readFileSync as readFileSync21, writeFileSync as writeFileSync17 } from "node:fs";
+import path22 from "node:path";
+var HELP_TEXT17 = `Usage: gaia-maintainer release scrub-wiki [--version <X.Y.Z>] [--date <YYYY-MM-DD>]
+
+  Overwrite wiki/hot.md and wiki/log.md with release-clean content
+  (Step 8 + Step 9 of the runbook).
+
+  Flags:
+    --version <X.Y.Z>     Override the new version (default: package.json).
+    --date <YYYY-MM-DD>   Override the release date (default: today UTC).
+
+  Exit codes:
+    0  success (no stdout)
+    1  user-correctable error
+    2  unexpected (filesystem failure)
+`;
+var HELP_TOKENS17 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT14 = 2;
+var takeValue11 = (argv, index, flag) => {
+  const value = argv[index];
+  if (value === void 0) return { message: `${flag} requires a value`, ok: false };
+  return { ok: true, value };
+};
+var parseFlags15 = (argv) => {
+  let date5;
+  let version2;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--version") {
+      const taken = takeValue11(argv, index + 1, "--version");
+      if (!taken.ok) return taken;
+      version2 = taken.value;
+      index += 1;
+      continue;
+    }
+    if (token === "--date") {
+      const taken = takeValue11(argv, index + 1, "--date");
+      if (!taken.ok) return taken;
+      date5 = taken.value;
+      index += 1;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { flags: { date: date5, version: version2 }, ok: true };
+};
+var todayUtc2 = (now = /* @__PURE__ */ new Date()) => {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+var readVersion3 = (cwd, override) => {
+  if (override !== void 0 && override.length > 0) return override;
+  const target = path22.join(cwd, "package.json");
+  if (!existsSync22(target)) {
+    throw new Error("package.json not found at repo root");
+  }
+  const parsed = JSON.parse(readFileSync21(target, "utf8"));
+  if (typeof parsed.version !== "string") {
+    throw new Error('package.json has no string "version"');
+  }
+  return parsed.version;
+};
+var renderHotMd = (version2, date5) => `---
+type: meta
+title: Hot Cache
+status: active
+created: ${date5}
+updated: ${date5}
+tags: [meta, cache]
+---
+
+# Recent Context
+
+## Last Updated
+
+${date5}. Released as GAIA v${version2}. Fresh slate.
+
+## Active Threads
+
+- None.
+`;
+var renderLogMd = (version2, date5) => `---
+type: meta
+title: Log
+status: active
+created: ${date5}
+updated: ${date5}
+tags: [meta, log]
+---
+
+# Log
+
+## [v${version2}] ${date5} | Released
+
+See CHANGELOG.md for details.
+`;
+var run28 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS17.has(argv[0])) {
+    process.stdout.write(HELP_TEXT17);
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseFlags15(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "release scrub-wiki"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  let version2;
+  try {
+    version2 = readVersion3(cwd, parsed.flags.version);
+  } catch (error51) {
+    structuredError({
+      code: "package_json_invalid",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release scrub-wiki"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const date5 = parsed.flags.date ?? options.today ?? todayUtc2();
+  const wikiDir = path22.join(cwd, "wiki");
+  if (!existsSync22(wikiDir)) {
+    structuredError({
+      code: "wiki_dir_missing",
+      message: `wiki/ directory not found at ${wikiDir}`,
+      subcommand: "release scrub-wiki"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const hotPath = path22.join(wikiDir, "hot.md");
+  const logPath = path22.join(wikiDir, "log.md");
+  try {
+    mkdirSync9(wikiDir, { recursive: true });
+    writeFileSync17(hotPath, renderHotMd(version2, date5), "utf8");
+    writeFileSync17(logPath, renderLogMd(version2, date5), "utf8");
+  } catch (error51) {
+    structuredError({
+      code: "scrub_write_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "release scrub-wiki"
+    });
+    return UNEXPECTED_EXIT14;
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/release/index.ts
+var HELP_TEXT18 = `Usage: gaia-maintainer release <subcommand> [args]
+
+  preflight [--branch <name>]                 Branch + working-tree + wiki state checks.
+  bump [--auto]                               Conventional-commit semver bump.
+  changelog [--draft] [--version <X.Y.Z>]     Render / graduate the CHANGELOG block.
+  scrub-wiki [--version <X.Y.Z>] [--date <D>] Reset wiki/hot.md and wiki/log.md.
+  manifest [--out <path>] [--stdout]          Regenerate .gaia/manifest.json.
+  manifest --check [--json]                   Verify committed manifest is fresh + lint classifier sets.
+  scrub <staging-dir> [--config <path>] [--json]
+                                              Apply bundle-time marker-strip + leak-check.
+  runtime-deps [--staging <dir>] [--manifest <path>] [--json]
+                                              Verify shipped scripts only call shipped paths.
+  commit-and-tag (--commit | --tag) [--no-push]
+                                              Commit + amend state, or tag + push.
+`;
+var HELP_TOKENS18 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS2 = {
+  "bump": run20,
+  "changelog": run21,
+  "commit-and-tag": run22,
+  "manifest": run23,
+  "preflight": run25,
+  "runtime-deps": run26,
+  "scrub": run27,
+  "scrub-wiki": run28
+};
+var run29 = async (argv) => {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
+  if (subcommand === void 0 || HELP_TOKENS18.has(subcommand)) {
+    process.stdout.write(HELP_TEXT18);
+    return EXIT_CODES.OK;
+  }
+  const handler = SUBCOMMAND_HANDLERS2[subcommand];
+  if (handler !== void 0) {
+    const result = await handler(rest);
+    return typeof result === "number" ? result : EXIT_CODES.OK;
+  }
+  structuredError({
+    code: "unknown_subcommand",
+    message: `unknown release subcommand: ${subcommand}`,
+    subcommand: `release ${subcommand}`
+  });
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
+// src/scaffold/component.ts
+import { existsSync as existsSync24, statSync as statSync5 } from "node:fs";
+import path24 from "node:path";
 import { fileURLToPath } from "node:url";
 
 // src/scaffold/fs.ts
-import { existsSync as existsSync17, mkdirSync as mkdirSync9, readFileSync as readFileSync14, writeFileSync as writeFileSync12 } from "node:fs";
-import path15 from "node:path";
+import { existsSync as existsSync23, mkdirSync as mkdirSync10, readFileSync as readFileSync22, writeFileSync as writeFileSync18 } from "node:fs";
+import path23 from "node:path";
 var ensureDir = (absPath) => {
-  mkdirSync9(absPath, { recursive: true });
+  mkdirSync10(absPath, { recursive: true });
 };
 var writeFileIfAbsent = (absPath, contents) => {
-  if (existsSync17(absPath)) {
-    const existing = readFileSync14(absPath, "utf8");
+  if (existsSync23(absPath)) {
+    const existing = readFileSync22(absPath, "utf8");
     if (existing === contents) return { written: false };
     throw new Error(`refusing to overwrite ${absPath}`);
   }
-  ensureDir(path15.dirname(absPath));
-  writeFileSync12(absPath, contents, "utf8");
+  ensureDir(path23.dirname(absPath));
+  writeFileSync18(absPath, contents, "utf8");
   return { written: true };
 };
 
 // src/scaffold/template.ts
-import { readFileSync as readFileSync15 } from "node:fs";
+import { readFileSync as readFileSync23 } from "node:fs";
 var VAR_PATTERN = /\{\{\s*([\w.]+)\s*\}\}/gu;
 var SECTION_PATTERN = /\{\{#\s*(\w+)\s*\}\}([\s\S]*?)\{\{\/\s*\1\s*\}\}/gu;
 var EACH_PATTERN = /\{\{#each\s+(\w+)\s*\}\}([\s\S]*?)\{\{\/each\s*\}\}/gu;
@@ -17084,7 +21942,7 @@ var renderScalars = (template, vars) => template.replaceAll(VAR_PATTERN, (_match
   return value;
 });
 var renderTemplate = (templatePath, vars) => {
-  const raw = readFileSync15(templatePath, "utf8");
+  const raw = readFileSync23(templatePath, "utf8");
   const eached = renderEachBlocks(raw, vars);
   const sectioned = renderBooleanSections(eached, vars);
   return renderScalars(sectioned, vars);
@@ -17095,7 +21953,7 @@ var PASCAL_CASE_PATTERN = /^[A-Z][\dA-Za-z]*$/u;
 var PROP_ENTRY_PATTERN = /^([A-Za-z_][\w$]*)\s*:\s*(.+)$/u;
 var TEMPLATES_DIR = "component";
 var COMPONENTS_DEFAULT_PARENT = "app/components";
-var HELP_TEXT9 = `Usage: gaia scaffold component <Name> [flags]
+var HELP_TEXT19 = `Usage: gaia scaffold component <Name> [flags]
 
   --no-story          Skip the index.stories.tsx file
   --parent <dir>      Parent dir under app/components/ (default: app/components/)
@@ -17103,7 +21961,7 @@ var HELP_TEXT9 = `Usage: gaia scaffold component <Name> [flags]
                       Typed props rendered as a Props type alias
   --json              Emit ScaffoldResult JSON on stdout
 `;
-var HELP_TOKENS9 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS19 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseProps = (raw) => {
   const entries = raw.split(",").map((entry) => entry.trim()).filter((entry) => entry.length > 0);
   if (entries.length === 0) {
@@ -17131,18 +21989,18 @@ var parseProps = (raw) => {
     ok: true
   };
 };
-var takeValue6 = (argv, index, flag) => {
+var takeValue12 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0 || value.startsWith("--")) {
     return { message: `${flag} requires a value`, ok: false };
   }
   return value;
 };
-var parseFlags8 = (argv) => {
+var parseFlags16 = (argv) => {
   let name;
   let parent = COMPONENTS_DEFAULT_PARENT;
   let story = true;
-  let json2 = false;
+  let json3 = false;
   let props = [];
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -17151,18 +22009,18 @@ var parseFlags8 = (argv) => {
       continue;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     if (token === "--parent") {
-      const value = takeValue6(argv, index + 1, "--parent");
+      const value = takeValue12(argv, index + 1, "--parent");
       if (typeof value !== "string") return value;
       parent = value;
       index += 1;
       continue;
     }
     if (token === "--props") {
-      const value = takeValue6(argv, index + 1, "--props");
+      const value = takeValue12(argv, index + 1, "--props");
       if (typeof value !== "string") return value;
       const parsed = parseProps(value);
       if (!parsed.ok) return parsed;
@@ -17188,7 +22046,7 @@ var parseFlags8 = (argv) => {
       ok: false
     };
   }
-  return { flags: { json: json2, name, parent, props, story }, ok: true };
+  return { flags: { json: json3, name, parent, props, story }, ok: true };
 };
 var buildPropsTypeBlock = (componentName, props) => {
   if (props.length === 0) return "";
@@ -17222,9 +22080,9 @@ var buildStoryTitle = (parent, componentName) => {
   if (stripped === "") return `Components/${componentName}`;
   return `Components/${stripped}/${componentName}`;
 };
-var defaultIsDirectory = (absPath) => existsSync18(absPath) && statSync2(absPath).isDirectory();
+var defaultIsDirectory = (absPath) => existsSync24(absPath) && statSync5(absPath).isDirectory();
 var renderComponentFile = (templatesRoot, componentName, props) => {
-  const templatePath = path16.join(templatesRoot, `${TEMPLATES_DIR}/index.tsx.tmpl`);
+  const templatePath = path24.join(templatesRoot, `${TEMPLATES_DIR}/index.tsx.tmpl`);
   const propsTypeBlock = buildPropsTypeBlock(componentName, props);
   const propsGeneric = buildPropsGeneric(componentName, props);
   const propsParam = props.length === 0 ? "" : `{${props.map((prop) => prop.name).join(", ")}}`;
@@ -17236,7 +22094,7 @@ var renderComponentFile = (templatesRoot, componentName, props) => {
   });
 };
 var renderTestFile = (templatesRoot, componentName, withStory) => {
-  const templatePath = path16.join(
+  const templatePath = path24.join(
     templatesRoot,
     `${TEMPLATES_DIR}/index.test.tsx.tmpl`
   );
@@ -17246,7 +22104,7 @@ var renderTestFile = (templatesRoot, componentName, withStory) => {
   });
 };
 var renderStoryFile = (templatesRoot, componentName, parent) => {
-  const templatePath = path16.join(
+  const templatePath = path24.join(
     templatesRoot,
     `${TEMPLATES_DIR}/index.stories.tsx.tmpl`
   );
@@ -17257,7 +22115,7 @@ var renderStoryFile = (templatesRoot, componentName, parent) => {
 };
 var resolveTemplatesRoot = () => {
   const here = fileURLToPath(import.meta.url);
-  return path16.join(path16.dirname(here), "templates");
+  return path24.join(path24.dirname(here), "templates");
 };
 var writeOne = (absPath, contents, result) => {
   const { written } = writeFileIfAbsent(absPath, contents);
@@ -17280,13 +22138,13 @@ var printHumanResult = (result, componentName) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run20 = (argv, options = {}) => {
+var run30 = (argv, options = {}) => {
   const subcommand = argv[0];
-  if (subcommand !== void 0 && HELP_TOKENS9.has(subcommand)) {
-    process.stdout.write(HELP_TEXT9);
+  if (subcommand !== void 0 && HELP_TOKENS19.has(subcommand)) {
+    process.stdout.write(HELP_TEXT19);
     return EXIT_CODES.OK;
   }
-  const parsed = parseFlags8(argv);
+  const parsed = parseFlags16(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -17298,7 +22156,7 @@ var run20 = (argv, options = {}) => {
   const { flags } = parsed;
   const cwd = options.cwd ?? process.cwd();
   const isDirectory = options.isDirectory ?? defaultIsDirectory;
-  const parentAbs = path16.resolve(cwd, flags.parent);
+  const parentAbs = path24.resolve(cwd, flags.parent);
   if (!isDirectory(parentAbs)) {
     structuredError({
       code: "parent_not_found",
@@ -17308,11 +22166,11 @@ var run20 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const componentDir = path16.join(parentAbs, flags.name);
-  const indexPath = path16.join(componentDir, "index.tsx");
-  const testsDir = path16.join(componentDir, "tests");
-  const testPath = path16.join(testsDir, "index.test.tsx");
-  const storyPath = path16.join(testsDir, "index.stories.tsx");
+  const componentDir = path24.join(parentAbs, flags.name);
+  const indexPath = path24.join(componentDir, "index.tsx");
+  const testsDir = path24.join(componentDir, "tests");
+  const testPath = path24.join(testsDir, "index.test.tsx");
+  const storyPath = path24.join(testsDir, "index.stories.tsx");
   const templatesRoot = resolveTemplatesRoot();
   const result = { edited: [], skipped: [], written: [] };
   try {
@@ -17352,7 +22210,7 @@ var run20 = (argv, options = {}) => {
 
 // src/scaffold/hook.ts
 import { execSync as execSync2 } from "node:child_process";
-import path17 from "node:path";
+import path25 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 var HOOK_NAME_PATTERN = /^use[A-Z][A-Za-z0-9]*$/u;
 var TEMPLATE_DIR_NAME = "hook";
@@ -17366,19 +22224,19 @@ var parseParams = (raw) => {
       return { name: entry, type: "unknown" };
     }
     const name = entry.slice(0, colonIndex).trim();
-    const type = entry.slice(colonIndex + 1).trim();
-    return { name, type: type.length > 0 ? type : "unknown" };
+    const type2 = entry.slice(colonIndex + 1).trim();
+    return { name, type: type2.length > 0 ? type2 : "unknown" };
   });
 };
 var readFlags = (argv) => {
   const positional = [];
-  let json2 = false;
+  let json3 = false;
   let paramsRaw;
   let returns;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     if (token === "--params") {
@@ -17398,7 +22256,7 @@ var readFlags = (argv) => {
   }
   return {
     flags: {
-      json: json2,
+      json: json3,
       params: parseParams(paramsRaw),
       returns: returns !== void 0 && returns.length > 0 ? returns : void 0
     },
@@ -17406,8 +22264,8 @@ var readFlags = (argv) => {
   };
 };
 var formatParamsString = (params) => params.map((param) => `${param.name}: ${param.type}`).join(", ");
-var sentinelForType = (type) => {
-  const trimmed = type.trim();
+var sentinelForType = (type2) => {
+  const trimmed = type2.trim();
   if (trimmed === "string") return "''";
   if (trimmed === "number") return "0";
   if (trimmed === "boolean") return "false";
@@ -17430,9 +22288,9 @@ var detectReactImports = (paramsString, returnsAnnotation) => {
 };
 var resolveTemplateFile = (filename) => {
   const here = fileURLToPath2(import.meta.url);
-  return path17.join(path17.dirname(here), "templates", TEMPLATE_DIR_NAME, filename);
+  return path25.join(path25.dirname(here), "templates", TEMPLATE_DIR_NAME, filename);
 };
-var resolveRepoRoot2 = () => {
+var resolveRepoRoot4 = () => {
   try {
     const out = execSync2("git rev-parse --show-toplevel", {
       encoding: "utf8",
@@ -17488,7 +22346,7 @@ var printResult = (result, jsonMode) => {
 `);
   }
 };
-var run21 = (argv, options = {}) => {
+var run31 = (argv, options = {}) => {
   let parsed;
   try {
     parsed = readFlags(argv);
@@ -17517,10 +22375,10 @@ var run21 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const repoRoot2 = options.repoRoot ?? resolveRepoRoot2();
-  const hooksDir = path17.join(repoRoot2, "app", "hooks");
-  const hookFilePath = path17.join(hooksDir, `${name}.ts`);
-  const testFilePath = path17.join(hooksDir, "tests", `${name}.test.ts`);
+  const repoRoot2 = options.repoRoot ?? resolveRepoRoot4();
+  const hooksDir = path25.join(repoRoot2, "app", "hooks");
+  const hookFilePath = path25.join(hooksDir, `${name}.ts`);
+  const testFilePath = path25.join(hooksDir, "tests", `${name}.test.ts`);
   let result;
   try {
     result = emitFiles({
@@ -17543,8 +22401,8 @@ var run21 = (argv, options = {}) => {
 };
 
 // src/scaffold/route.ts
-import { existsSync as existsSync19, readFileSync as readFileSync16, writeFileSync as writeFileSync13 } from "node:fs";
-import path18 from "node:path";
+import { existsSync as existsSync25, readFileSync as readFileSync24, writeFileSync as writeFileSync19 } from "node:fs";
+import path26 from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 var VALID_GROUPS = /* @__PURE__ */ new Set(["_public+", "_session+"]);
 var GROUP_TO_SEGMENT = {
@@ -17552,7 +22410,7 @@ var GROUP_TO_SEGMENT = {
   "_session+": "Session"
 };
 var KEBAB_PATTERN = /^[a-z\d]+(?:-[a-z\d]+)*$/u;
-var HELP_TEXT10 = `Usage: gaia scaffold route <name> --group <_public+|_session+> [flags]
+var HELP_TEXT20 = `Usage: gaia scaffold route <name> --group <_public+|_session+> [flags]
 
   --group     required, _public+ or _session+
   --loader    emit a loader stub
@@ -17564,7 +22422,7 @@ var userError = (message, subcommand = "scaffold route") => {
   structuredError({ code: "invalid_input", message, subcommand });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-var parseFlags9 = (rest) => {
+var parseFlags17 = (rest) => {
   const flags = {
     action: false,
     group: null,
@@ -17601,15 +22459,15 @@ var toCamelCase = (kebab) => {
 };
 var repoRoot = () => {
   const here = fileURLToPath3(import.meta.url);
-  return path18.resolve(path18.dirname(here), "..", "..", "..", "..");
+  return path26.resolve(path26.dirname(here), "..", "..", "..", "..");
 };
 var templateDir = () => {
   const here = fileURLToPath3(import.meta.url);
-  return path18.join(path18.dirname(here), "templates", "route");
+  return path26.join(path26.dirname(here), "templates", "route");
 };
 var insertIntoLocaleBarrel = (barrelPath, importName, folderName) => {
-  if (!existsSync19(barrelPath)) return "missing";
-  const original = readFileSync16(barrelPath, "utf8");
+  if (!existsSync25(barrelPath)) return "missing";
+  const original = readFileSync24(barrelPath, "utf8");
   const importLine = `import ${importName} from './${folderName}';`;
   if (original.includes(importLine)) return "present";
   const lines = original.split("\n");
@@ -17669,17 +22527,17 @@ var insertIntoLocaleBarrel = (barrelPath, importName, folderName) => {
       }
     }
   }
-  writeFileSync13(barrelPath, lines.join("\n"), "utf8");
+  writeFileSync19(barrelPath, lines.join("\n"), "utf8");
   return "inserted";
 };
 var templatePaths = () => {
   const dir = templateDir();
   return {
-    locale: path18.join(dir, "locale.ts.tmpl"),
-    pageIndex: path18.join(dir, "page.index.tsx.tmpl"),
-    pageStories: path18.join(dir, "page.stories.tsx.tmpl"),
-    pageTest: path18.join(dir, "page.test.tsx.tmpl"),
-    route: path18.join(dir, "route.tsx.tmpl")
+    locale: path26.join(dir, "locale.ts.tmpl"),
+    pageIndex: path26.join(dir, "page.index.tsx.tmpl"),
+    pageStories: path26.join(dir, "page.stories.tsx.tmpl"),
+    pageTest: path26.join(dir, "page.test.tsx.tmpl"),
+    route: path26.join(dir, "route.tsx.tmpl")
   };
 };
 var resolveNames = (kebabName, group) => {
@@ -17723,14 +22581,14 @@ var printJson = (result) => {
   process.stdout.write(`${JSON.stringify(result)}
 `);
 };
-var run22 = (rest) => {
+var run32 = (rest) => {
   const [first] = rest;
   if (first === void 0 || first === "--help" || first === "-h") {
-    process.stdout.write(HELP_TEXT10);
+    process.stdout.write(HELP_TEXT20);
     return first === void 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const name = first;
-  const flags = parseFlags9(rest.slice(1));
+  const flags = parseFlags17(rest.slice(1));
   if (flags === null) {
     return userError("invalid or unknown flag (see --help)");
   }
@@ -17753,9 +22611,9 @@ var run22 = (rest) => {
   const result = { edited: [], skipped: [], written: [] };
   try {
     const routeVars = buildRouteVars(names, flags, name);
-    const routeAbs = path18.join(root, "app", "routes", flags.group, `${name}.tsx`);
+    const routeAbs = path26.join(root, "app", "routes", flags.group, `${name}.tsx`);
     writeFile(result, routeAbs, renderTemplate(tmpls.route, routeVars));
-    const pageDir = path18.join(root, "app", "pages", names.groupSegment, names.pageName);
+    const pageDir = path26.join(root, "app", "pages", names.groupSegment, names.pageName);
     const pageVars = {
       groupSegment: names.groupSegment,
       hasI18n: flags.i18n,
@@ -17765,21 +22623,21 @@ var run22 = (rest) => {
     };
     writeFile(
       result,
-      path18.join(pageDir, "index.tsx"),
+      path26.join(pageDir, "index.tsx"),
       renderTemplate(tmpls.pageIndex, pageVars)
     );
     writeFile(
       result,
-      path18.join(pageDir, "tests", "index.test.tsx"),
+      path26.join(pageDir, "tests", "index.test.tsx"),
       renderTemplate(tmpls.pageTest, pageVars)
     );
     writeFile(
       result,
-      path18.join(pageDir, "tests", "index.stories.tsx"),
+      path26.join(pageDir, "tests", "index.stories.tsx"),
       renderTemplate(tmpls.pageStories, pageVars)
     );
     if (flags.i18n) {
-      const localeFile = path18.join(
+      const localeFile = path26.join(
         root,
         "app",
         "languages",
@@ -17794,7 +22652,7 @@ var run22 = (rest) => {
         routeName: name
       };
       writeFile(result, localeFile, renderTemplate(tmpls.locale, localeVars));
-      const localeBarrel = path18.join(
+      const localeBarrel = path26.join(
         root,
         "app",
         "languages",
@@ -17816,13 +22674,13 @@ var run22 = (rest) => {
 };
 
 // src/scaffold/service.ts
-import { existsSync as existsSync20, readFileSync as readFileSync17, writeFileSync as writeFileSync14 } from "node:fs";
-import path19 from "node:path";
+import { existsSync as existsSync26, readFileSync as readFileSync25, writeFileSync as writeFileSync20 } from "node:fs";
+import path27 from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 var KEBAB_PATTERN2 = /^[a-z][a-z\d]*(?:-[a-z\d]+)*$/u;
 var NAME_TOKEN_PATTERN = /^[a-zA-Z][a-zA-Z\d]*(?::[a-zA-Z][a-zA-Z\d]*(?:\([^)]*\))?)?$/u;
 var ALL_ENDPOINTS = ["get", "post", "put", "delete"];
-var HELP_TEXT11 = `Usage: gaia scaffold service <name> --endpoints "get,post,put,delete" --schema "id:string,name:string"
+var HELP_TEXT21 = `Usage: gaia scaffold service <name> --endpoints "get,post,put,delete" --schema "id:string,name:string"
 
   --endpoints "get,post,put,delete"  required: comma-separated subset of get/post/put/delete
   --schema "id:string,name:string"   required: comma-separated <name>:<type> pairs
@@ -17832,13 +22690,13 @@ var HELP_TEXT11 = `Usage: gaia scaffold service <name> --endpoints "get,post,put
   --json                             emit ScaffoldResult JSON on stdout
 `;
 var printHelp = () => {
-  process.stdout.write(HELP_TEXT11);
+  process.stdout.write(HELP_TEXT21);
 };
 var userError2 = (message, subcommand) => {
   structuredError({ code: "invalid_arguments", message, subcommand });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-var parseFlags10 = (argv) => {
+var parseFlags18 = (argv) => {
   const result = { json: false, mocks: false, positional: [] };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -17919,7 +22777,7 @@ var parseSchema = (raw) => {
   return fields;
 };
 var parseArgs = (argv) => {
-  const flags = parseFlags10(argv);
+  const flags = parseFlags18(argv);
   const name = flags.positional[0];
   if (name === void 0) return "missing required <name>";
   if (!KEBAB_PATTERN2.test(name)) {
@@ -18004,13 +22862,13 @@ var composeMockBarrel = (endpoints) => {
   return { handlersArray, imports };
 };
 var updateDatabaseBarrel = (databasePath, derived) => {
-  const raw = readFileSync17(databasePath, "utf8");
+  const raw = readFileSync25(databasePath, "utf8");
   const importLine = `import {${derived.plural}, reset${derived.Plural}} from './${derived.name}/data';`;
   const resetCall = `reset${derived.Plural}()`;
   if (raw.includes(importLine)) return { written: false };
   const next = applyDatabaseEdits(raw, derived, importLine, resetCall);
   if (next === raw) return { written: false };
-  writeFileSync14(databasePath, next, "utf8");
+  writeFileSync20(databasePath, next, "utf8");
   return { written: true };
 };
 var insertImportAlphabetically = (source, importLine) => {
@@ -18090,11 +22948,11 @@ var applyDatabaseEdits = (source, derived, importLine, resetCall) => {
   next = insertCollectionExportAlphabetically(next, derived);
   return next;
 };
-var TEMPLATES_DIR2 = path19.join(
-  path19.dirname(fileURLToPath4(import.meta.url)),
+var TEMPLATES_DIR2 = path27.join(
+  path27.dirname(fileURLToPath4(import.meta.url)),
   "templates"
 );
-var renderServiceTemplate = (templateName, vars) => renderTemplate(path19.join(TEMPLATES_DIR2, templateName), vars);
+var renderServiceTemplate = (templateName, vars) => renderTemplate(path27.join(TEMPLATES_DIR2, templateName), vars);
 var writeRendered = (absPath, contents, result) => {
   const { written } = writeFileIfAbsent(absPath, contents);
   if (written) {
@@ -18105,7 +22963,7 @@ var writeRendered = (absPath, contents, result) => {
 };
 var emitServiceFiles = (context, result) => {
   const { derived, endpoints, fields, repoRoot: repoRoot2 } = context;
-  const serviceDir = path19.join(repoRoot2, "app", "services", "gaia", derived.name);
+  const serviceDir = path27.join(repoRoot2, "app", "services", "gaia", derived.name);
   ensureDir(serviceDir);
   const baseVars = {
     NAME_UPPER: derived.NAME_UPPER,
@@ -18119,9 +22977,9 @@ var emitServiceFiles = (context, result) => {
     ...baseVars,
     fields: renderClientFields(fields)
   });
-  writeRendered(path19.join(serviceDir, "parsers.ts"), parsersBody, result);
+  writeRendered(path27.join(serviceDir, "parsers.ts"), parsersBody, result);
   const typesBody = renderServiceTemplate("service/types.ts.tmpl", baseVars);
-  writeRendered(path19.join(serviceDir, "types.ts"), typesBody, result);
+  writeRendered(path27.join(serviceDir, "types.ts"), typesBody, result);
   const requestsBody = renderServiceTemplate("service/requests.ts.tmpl", {
     ...baseVars,
     hasDelete: endpoints.has("delete"),
@@ -18129,15 +22987,15 @@ var emitServiceFiles = (context, result) => {
     hasPost: endpoints.has("post"),
     hasPut: endpoints.has("put")
   });
-  writeRendered(path19.join(serviceDir, "requests.ts"), requestsBody, result);
+  writeRendered(path27.join(serviceDir, "requests.ts"), requestsBody, result);
   const urlsBody = renderServiceTemplate("service/urls.ts.tmpl", baseVars);
-  writeRendered(path19.join(serviceDir, "urls.ts"), urlsBody, result);
+  writeRendered(path27.join(serviceDir, "urls.ts"), urlsBody, result);
   const indexBody = renderServiceTemplate("service/index.ts.tmpl", baseVars);
-  writeRendered(path19.join(serviceDir, "index.ts"), indexBody, result);
+  writeRendered(path27.join(serviceDir, "index.ts"), indexBody, result);
 };
 var emitMockFiles = (context, result) => {
   const { derived, endpoints, fields, repoRoot: repoRoot2 } = context;
-  const mockDir = path19.join(repoRoot2, "test", "mocks", derived.name);
+  const mockDir = path27.join(repoRoot2, "test", "mocks", derived.name);
   ensureDir(mockDir);
   const baseVars = {
     NAME_UPPER: derived.NAME_UPPER,
@@ -18151,31 +23009,31 @@ var emitMockFiles = (context, result) => {
     ...baseVars,
     serverFields: renderServerFields(fields)
   });
-  writeRendered(path19.join(mockDir, "data.ts"), dataBody, result);
+  writeRendered(path27.join(mockDir, "data.ts"), dataBody, result);
   if (endpoints.has("get")) {
     writeRendered(
-      path19.join(mockDir, "get.ts"),
+      path27.join(mockDir, "get.ts"),
       renderServiceTemplate("service/mock.get.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("post")) {
     writeRendered(
-      path19.join(mockDir, "post.ts"),
+      path27.join(mockDir, "post.ts"),
       renderServiceTemplate("service/mock.post.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("put")) {
     writeRendered(
-      path19.join(mockDir, "put.ts"),
+      path27.join(mockDir, "put.ts"),
       renderServiceTemplate("service/mock.put.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("delete")) {
     writeRendered(
-      path19.join(mockDir, "delete.ts"),
+      path27.join(mockDir, "delete.ts"),
       renderServiceTemplate("service/mock.delete.ts.tmpl", baseVars),
       result
     );
@@ -18184,15 +23042,15 @@ var emitMockFiles = (context, result) => {
     ...baseVars,
     ...composeMockBarrel(endpoints)
   });
-  writeRendered(path19.join(mockDir, "index.ts"), barrelBody, result);
-  const databasePath = path19.join(repoRoot2, "test", "mocks", "database.ts");
-  if (existsSync20(databasePath)) {
+  writeRendered(path27.join(mockDir, "index.ts"), barrelBody, result);
+  const databasePath = path27.join(repoRoot2, "test", "mocks", "database.ts");
+  if (existsSync26(databasePath)) {
     const { written } = updateDatabaseBarrel(databasePath, derived);
     if (written) result.edited.push(databasePath);
     else result.skipped.push(databasePath);
   }
 };
-var run23 = (argv, options = {}) => {
+var run33 = (argv, options = {}) => {
   if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
     printHelp();
     return EXIT_CODES.OK;
@@ -18235,14 +23093,14 @@ var run23 = (argv, options = {}) => {
 };
 
 // src/scaffold/index.ts
-var HELP_TEXT12 = `Usage: gaia scaffold <subcommand> [args]
+var HELP_TEXT22 = `Usage: gaia scaffold <subcommand> [args]
 
   component <Name>         Scaffold a new React component (Phase 2).
   hook <useFoo>            Scaffold a new custom hook (Phase 2).
   route <name>             Scaffold a new route + page (Phase 2).
   service <name>           Scaffold a new API service (Phase 2).
 `;
-var HELP_TOKENS10 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var STUBBED_KINDS = /* @__PURE__ */ new Set();
 var printNotImplemented = (kind) => {
   structuredError({
@@ -18252,27 +23110,27 @@ var printNotImplemented = (kind) => {
   });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-var run24 = (argv) => {
+var run34 = (argv) => {
   const subcommand = argv[0];
   if (subcommand === void 0) {
-    process.stderr.write(HELP_TEXT12);
+    process.stderr.write(HELP_TEXT22);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS10.has(subcommand)) {
-    process.stdout.write(HELP_TEXT12);
+  if (HELP_TOKENS20.has(subcommand)) {
+    process.stdout.write(HELP_TEXT22);
     return EXIT_CODES.OK;
   }
   if (subcommand === "component") {
-    return run20(argv.slice(1));
+    return run30(argv.slice(1));
   }
   if (subcommand === "hook") {
-    return run21(argv.slice(1));
+    return run31(argv.slice(1));
   }
   if (subcommand === "route") {
-    return run22(argv.slice(1));
+    return run32(argv.slice(1));
   }
   if (subcommand === "service") {
-    return run23(argv.slice(1));
+    return run33(argv.slice(1));
   }
   if (STUBBED_KINDS.has(subcommand)) {
     return printNotImplemented(subcommand);
@@ -18286,25 +23144,25 @@ var run24 = (argv) => {
 };
 
 // src/setup/util/state-file.ts
-import { execFileSync } from "node:child_process";
+import { execFileSync as execFileSync3 } from "node:child_process";
 import {
-  existsSync as existsSync21,
-  mkdirSync as mkdirSync10,
-  readFileSync as readFileSync18,
+  existsSync as existsSync27,
+  mkdirSync as mkdirSync11,
+  readFileSync as readFileSync26,
   renameSync as renameSync5,
-  writeFileSync as writeFileSync15
+  writeFileSync as writeFileSync21
 } from "node:fs";
-import path20 from "node:path";
+import path28 from "node:path";
 var STATE_FILENAME = "setup-state.json";
-var STATE_DIRECTORY_RELATIVE = path20.join(".gaia", "local");
+var STATE_DIRECTORY_RELATIVE = path28.join(".gaia", "local");
 var resolveMainWorktreeRoot = (cwd) => {
-  const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+  const commonDir = execFileSync3("git", ["rev-parse", "--git-common-dir"], {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();
-  const absoluteCommonDir = path20.isAbsolute(commonDir) ? commonDir : path20.resolve(cwd, commonDir);
-  return path20.dirname(absoluteCommonDir);
+  const absoluteCommonDir = path28.isAbsolute(commonDir) ? commonDir : path28.resolve(cwd, commonDir);
+  return path28.dirname(absoluteCommonDir);
 };
 var SETUP_STEPS = [
   "install-tools",
@@ -18315,11 +23173,11 @@ var SETUP_STEPS = [
   "mentorship-decision"
 ];
 var isSetupStep = (value) => SETUP_STEPS.includes(value);
-var resolveStateFilePath = (repoRoot2) => path20.join(repoRoot2, STATE_DIRECTORY_RELATIVE, STATE_FILENAME);
-var readStateFile = (repoRoot2) => {
+var resolveStateFilePath = (repoRoot2) => path28.join(repoRoot2, STATE_DIRECTORY_RELATIVE, STATE_FILENAME);
+var readStateFile2 = (repoRoot2) => {
   const filePath = resolveStateFilePath(repoRoot2);
-  if (!existsSync21(filePath)) return null;
-  const raw = readFileSync18(filePath, "utf8");
+  if (!existsSync27(filePath)) return null;
+  const raw = readFileSync26(filePath, "utf8");
   const parsed = JSON.parse(raw);
   if (parsed.version !== 1) {
     throw new Error(
@@ -18335,14 +23193,14 @@ var readStateFile = (repoRoot2) => {
 };
 var writeStateFile = (repoRoot2, state) => {
   const filePath = resolveStateFilePath(repoRoot2);
-  const parent = path20.dirname(filePath);
-  if (!existsSync21(parent)) {
-    mkdirSync10(parent, { mode: 493, recursive: true });
+  const parent = path28.dirname(filePath);
+  if (!existsSync27(parent)) {
+    mkdirSync11(parent, { mode: 493, recursive: true });
   }
   const serialized = `${JSON.stringify(state, null, 2)}
 `;
   const tmpPath = `${filePath}.tmp`;
-  writeFileSync15(tmpPath, serialized, "utf8");
+  writeFileSync21(tmpPath, serialized, "utf8");
   renameSync5(tmpPath, filePath);
 };
 var pendingSteps = (state) => {
@@ -18352,17 +23210,17 @@ var pendingSteps = (state) => {
 var isComplete = (state) => state?.completed_at !== null && state?.completed_at !== void 0;
 
 // src/setup/finalize.ts
-var HELP_TEXT13 = `Usage: gaia setup finalize [--force]
+var HELP_TEXT23 = `Usage: gaia setup finalize [--force]
 
   Marks .gaia/local/setup-state.json as complete (sets completed_at).
   Refuses if any step is still pending unless --force is passed.
 `;
-var HELP_TOKENS11 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run25 = (argv, options = {}) => {
+var HELP_TOKENS21 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run35 = (argv, options = {}) => {
   let force = false;
   for (const token of argv) {
-    if (HELP_TOKENS11.has(token)) {
-      process.stdout.write(HELP_TEXT13);
+    if (HELP_TOKENS21.has(token)) {
+      process.stdout.write(HELP_TEXT23);
       return EXIT_CODES.OK;
     }
     if (token === "--force") {
@@ -18389,7 +23247,7 @@ var run25 = (argv, options = {}) => {
   }
   let state;
   try {
-    state = readStateFile(repoRoot2);
+    state = readStateFile2(repoRoot2);
   } catch (error51) {
     structuredError({
       code: "state_malformed",
@@ -18430,18 +23288,18 @@ var run25 = (argv, options = {}) => {
 };
 
 // src/setup/link-worktree.ts
-import { execFileSync as execFileSync2 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import {
-  existsSync as existsSync22,
+  existsSync as existsSync28,
   lstatSync,
-  mkdirSync as mkdirSync11,
+  mkdirSync as mkdirSync12,
   readlinkSync,
   realpathSync,
   renameSync as renameSync6,
   symlinkSync
 } from "node:fs";
-import path21 from "node:path";
-var HELP_TEXT14 = `Usage: gaia setup link-worktree [--json]
+import path29 from "node:path";
+var HELP_TEXT24 = `Usage: gaia setup link-worktree [--json]
 
   Idempotently create the three worktree shared-state symlinks pointing at
   the main checkout. Backs up pre-existing plain files to <path>.bak.<ts>.
@@ -18451,7 +23309,7 @@ var HELP_TEXT14 = `Usage: gaia setup link-worktree [--json]
   --json   Print a single JSON line describing the result instead of the
            human-readable summary.
 `;
-var HELP_TOKENS12 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS22 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SHARED_PATHS = [
   { ensureTargetDir: false, relativePath: ".gaia/local/setup-state.json" },
   { ensureTargetDir: true, relativePath: ".gaia/cache" },
@@ -18468,19 +23326,19 @@ var formatTimestamp = (date5) => {
   return `${String(yyyy)}${mm}${dd}-${hh}${mi}${ss}`;
 };
 var ensureParentDir = (filePath) => {
-  const parent = path21.dirname(filePath);
-  if (!existsSync22(parent)) {
-    mkdirSync11(parent, { mode: 493, recursive: true });
+  const parent = path29.dirname(filePath);
+  if (!existsSync28(parent)) {
+    mkdirSync12(parent, { mode: 493, recursive: true });
   }
 };
 var linkOne = (inputs) => {
-  const { mainRoot, spec, symlink, timestamp, worktreeRoot } = inputs;
-  const sourcePath = path21.join(worktreeRoot, spec.relativePath);
-  const targetPath = path21.join(mainRoot, spec.relativePath);
+  const { mainRoot, spec, symlink, timestamp: timestamp2, worktreeRoot } = inputs;
+  const sourcePath = path29.join(worktreeRoot, spec.relativePath);
+  const targetPath = path29.join(mainRoot, spec.relativePath);
   try {
     ensureParentDir(sourcePath);
-    if (spec.ensureTargetDir && !existsSync22(targetPath)) {
-      mkdirSync11(targetPath, { mode: 493, recursive: true });
+    if (spec.ensureTargetDir && !existsSync28(targetPath)) {
+      mkdirSync12(targetPath, { mode: 493, recursive: true });
     }
     let sourceStat;
     try {
@@ -18497,20 +23355,20 @@ var linkOne = (inputs) => {
       if (existing === targetPath) {
         return { path: spec.relativePath, result: "already-linked" };
       }
-      const backupPath2 = `${sourcePath}.bak.${timestamp}`;
+      const backupPath2 = `${sourcePath}.bak.${timestamp2}`;
       renameSync6(sourcePath, backupPath2);
       symlink(targetPath, sourcePath);
       return {
-        backup: path21.relative(worktreeRoot, backupPath2),
+        backup: path29.relative(worktreeRoot, backupPath2),
         path: spec.relativePath,
         result: "linked-after-backup"
       };
     }
-    const backupPath = `${sourcePath}.bak.${timestamp}`;
+    const backupPath = `${sourcePath}.bak.${timestamp2}`;
     renameSync6(sourcePath, backupPath);
     symlink(targetPath, sourcePath);
     return {
-      backup: path21.relative(worktreeRoot, backupPath),
+      backup: path29.relative(worktreeRoot, backupPath),
       path: spec.relativePath,
       result: "linked-after-backup"
     };
@@ -18529,7 +23387,7 @@ var ACTION_HUMAN_LABELS = {
   "linked-after-backup": "linked-after-backup",
   "skipped-no-target": "skipped-no-target"
 };
-var printHuman = (output) => {
+var printHuman2 = (output) => {
   if (!output.is_worktree) {
     process.stdout.write("not a linked worktree\n");
     return;
@@ -18577,15 +23435,15 @@ var printHuman = (output) => {
 `
   );
 };
-var run26 = (argv, options = {}) => {
-  let json2 = false;
+var run36 = (argv, options = {}) => {
+  let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS12.has(token)) {
-      process.stdout.write(HELP_TEXT14);
+    if (HELP_TOKENS22.has(token)) {
+      process.stdout.write(HELP_TEXT24);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     structuredError({
@@ -18615,7 +23473,7 @@ var run26 = (argv, options = {}) => {
   }
   let worktreeRoot;
   try {
-    worktreeRoot = execFileSync2("git", ["rev-parse", "--show-toplevel"], {
+    worktreeRoot = execFileSync4("git", ["rev-parse", "--show-toplevel"], {
       cwd: canonicalCwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"]
@@ -18635,19 +23493,19 @@ var run26 = (argv, options = {}) => {
       main_root: mainRoot,
       worktree_root: worktreeRoot
     };
-    if (json2) {
+    if (json3) {
       process.stdout.write(`${JSON.stringify(output2)}
 `);
     } else {
-      printHuman(output2);
+      printHuman2(output2);
     }
     return EXIT_CODES.OK;
   }
   const nowDate = (options.now ?? (() => /* @__PURE__ */ new Date()))();
-  const timestamp = formatTimestamp(nowDate);
+  const timestamp2 = formatTimestamp(nowDate);
   const symlink = options.symlink ?? symlinkSync;
   const actions = SHARED_PATHS.map(
-    (spec) => linkOne({ mainRoot, spec, symlink, timestamp, worktreeRoot })
+    (spec) => linkOne({ mainRoot, spec, symlink, timestamp: timestamp2, worktreeRoot })
   );
   const output = {
     actions,
@@ -18655,34 +23513,34 @@ var run26 = (argv, options = {}) => {
     main_root: mainRoot,
     worktree_root: worktreeRoot
   };
-  if (json2) {
+  if (json3) {
     process.stdout.write(`${JSON.stringify(output)}
 `);
   } else {
-    printHuman(output);
+    printHuman2(output);
   }
   const anyFailed = actions.some((action) => action.result === "failed");
   return anyFailed ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
 };
 
 // src/setup/mark-step.ts
-var HELP_TEXT15 = `Usage: gaia setup mark-step <step>
+var HELP_TEXT25 = `Usage: gaia setup mark-step <step>
 
   <step> must be one of: ${SETUP_STEPS.join(" | ")}
 
   Records the step as complete in .gaia/local/setup-state.json. Creates
   the state file on first invocation (stamping started_at to now).
 `;
-var HELP_TOKENS13 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS23 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var isSetupStep2 = (value) => SETUP_STEPS.includes(value);
-var run27 = (argv, options = {}) => {
+var run37 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT15);
+    process.stdout.write(HELP_TEXT25);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS13.has(first)) {
-    process.stdout.write(HELP_TEXT15);
+  if (HELP_TOKENS23.has(first)) {
+    process.stdout.write(HELP_TEXT25);
     return EXIT_CODES.OK;
   }
   if (argv.length !== 1) {
@@ -18716,7 +23574,7 @@ var run27 = (argv, options = {}) => {
   const isoNow = nowDate.toISOString();
   let state;
   try {
-    state = readStateFile(repoRoot2);
+    state = readStateFile2(repoRoot2);
   } catch (error51) {
     structuredError({
       code: "state_malformed",
@@ -18747,13 +23605,13 @@ var run27 = (argv, options = {}) => {
 };
 
 // src/setup/status.ts
-var HELP_TEXT16 = `Usage: gaia setup status [--json]
+var HELP_TEXT26 = `Usage: gaia setup status [--json]
 
   Print the per-machine setup state. Without --json, prints a human-readable
   summary. With --json, prints a single JSON line consumed by tooling.
 `;
-var HELP_TOKENS14 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var printHuman2 = (output) => {
+var HELP_TOKENS24 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var printHuman3 = (output) => {
   if (output.complete) {
     process.stdout.write(
       `Setup complete (started ${String(output.started_at)}, finished ${String(output.completed_at)}).
@@ -18773,15 +23631,15 @@ var printHuman2 = (output) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run28 = (argv, options = {}) => {
-  let json2 = false;
+var run38 = (argv, options = {}) => {
+  let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS14.has(token)) {
-      process.stdout.write(HELP_TEXT16);
+    if (HELP_TOKENS24.has(token)) {
+      process.stdout.write(HELP_TEXT26);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     structuredError({
@@ -18804,7 +23662,7 @@ var run28 = (argv, options = {}) => {
   }
   let state;
   try {
-    state = readStateFile(repoRoot2);
+    state = readStateFile2(repoRoot2);
   } catch (error51) {
     structuredError({
       code: "state_malformed",
@@ -18820,38 +23678,38 @@ var run28 = (argv, options = {}) => {
     pending_steps: pendingSteps(state),
     started_at: state?.started_at ?? null
   };
-  if (json2) {
+  if (json3) {
     process.stdout.write(`${JSON.stringify(output)}
 `);
   } else {
-    printHuman2(output);
+    printHuman3(output);
   }
   return EXIT_CODES.OK;
 };
 
 // src/setup/index.ts
-var HELP_TEXT17 = `Usage: gaia setup <subcommand> [args]
+var HELP_TEXT27 = `Usage: gaia setup <subcommand> [args]
 
   status [--json]            Print whether per-machine setup is complete.
   mark-step <step>           Record a setup step as complete.
   finalize [--force]         Mark setup as complete (refuses if steps pending).
   link-worktree [--json]     Create the worktree shared-state symlinks.
 `;
-var HELP_TOKENS15 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var SUBCOMMAND_HANDLERS2 = {
-  finalize: run25,
-  "link-worktree": run26,
-  "mark-step": run27,
-  status: run28
+var HELP_TOKENS25 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS3 = {
+  finalize: run35,
+  "link-worktree": run36,
+  "mark-step": run37,
+  status: run38
 };
-var run29 = async (argv) => {
+var run39 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS15.has(subcommand)) {
-    process.stdout.write(HELP_TEXT17);
+  if (subcommand === void 0 || HELP_TOKENS25.has(subcommand)) {
+    process.stdout.write(HELP_TEXT27);
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS2[subcommand];
+  const handler = SUBCOMMAND_HANDLERS3[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -18972,8 +23830,8 @@ var computeAuditBlock = (report) => {
 };
 
 // src/analytics/generator.ts
-import { existsSync as existsSync23, readdirSync as readdirSync4, readFileSync as readFileSync19 } from "node:fs";
-import path22 from "node:path";
+import { existsSync as existsSync29, readdirSync as readdirSync7, readFileSync as readFileSync27 } from "node:fs";
+import path30 from "node:path";
 var REPORT_WINDOW_DAYS = 30;
 var MS_PER_DAY = 864e5;
 var MS_PER_WEEK = MS_PER_DAY * 7;
@@ -18985,13 +23843,13 @@ var isoDateUtc = (date5) => {
   return `${year}-${month}-${day}`;
 };
 var readGaiaVersion = (roots) => {
-  const repoRoot2 = path22.dirname(
-    path22.dirname(path22.dirname(roots.projectIdPath))
+  const repoRoot2 = path30.dirname(
+    path30.dirname(path30.dirname(roots.projectIdPath))
   );
-  const packagePath = path22.join(repoRoot2, "package.json");
-  if (!existsSync23(packagePath)) return "unknown";
+  const packagePath = path30.join(repoRoot2, "package.json");
+  if (!existsSync29(packagePath)) return "unknown";
   try {
-    const raw = readFileSync19(packagePath, "utf8");
+    const raw = readFileSync27(packagePath, "utf8");
     const parsed = JSON.parse(raw);
     return typeof parsed.version === "string" ? parsed.version : "unknown";
   } catch {
@@ -19022,9 +23880,9 @@ var newEngagementCounts = () => ({
   specsClosed: 0,
   tasksCompleted: 0
 });
-var isWithinWindow = (timestamp, bounds) => {
-  if (typeof timestamp !== "string") return false;
-  return timestamp >= bounds.startIso && timestamp <= bounds.endIso;
+var isWithinWindow = (timestamp2, bounds) => {
+  if (typeof timestamp2 !== "string") return false;
+  return timestamp2 >= bounds.startIso && timestamp2 <= bounds.endIso;
 };
 var accumulateEvent = (line, bounds, counts) => {
   if (line.length === 0) return;
@@ -19051,7 +23909,7 @@ var accumulateEvent = (line, bounds, counts) => {
 var consumeFile = (filePath, bounds, counts) => {
   let raw;
   try {
-    raw = readFileSync19(filePath, "utf8");
+    raw = readFileSync27(filePath, "utf8");
   } catch {
     return;
   }
@@ -19061,10 +23919,10 @@ var consumeFile = (filePath, bounds, counts) => {
 };
 var readMentorshipEngagement = (roots, bounds) => {
   const counts = newEngagementCounts();
-  if (!existsSync23(roots.mentorshipDir)) return counts;
+  if (!existsSync29(roots.mentorshipDir)) return counts;
   let entries;
   try {
-    entries = readdirSync4(roots.mentorshipDir);
+    entries = readdirSync7(roots.mentorshipDir);
   } catch {
     return counts;
   }
@@ -19073,7 +23931,7 @@ var readMentorshipEngagement = (roots, bounds) => {
     const match = MENTORSHIP_FILENAME_REGEX.exec(entry);
     const fileDate = match?.[1];
     if (fileDate !== void 0 && fileDate >= startDate) {
-      consumeFile(path22.join(roots.mentorshipDir, entry), bounds, counts);
+      consumeFile(path30.join(roots.mentorshipDir, entry), bounds, counts);
     }
   }
   return counts;
@@ -19120,17 +23978,17 @@ var generateAnalyticsReport = async (args) => {
 };
 
 // src/analytics/writer.ts
-import { existsSync as existsSync24, mkdirSync as mkdirSync12, renameSync as renameSync7, writeFileSync as writeFileSync16 } from "node:fs";
-import path23 from "node:path";
+import { existsSync as existsSync30, mkdirSync as mkdirSync13, renameSync as renameSync7, writeFileSync as writeFileSync22 } from "node:fs";
+import path31 from "node:path";
 var ANALYTICS_DIR_MODE = 493;
 var REPORT_FILE_MODE = 420;
 var writeAnalyticsReport = async (args) => {
   const { report, roots } = args;
   const generatedAt = args.generatedAt ?? /* @__PURE__ */ new Date();
   const dateSegment = isoDateUtc(generatedAt);
-  const filePath = path23.join(roots.analyticsDir, `report-${dateSegment}.json`);
-  if (!existsSync24(roots.analyticsDir)) {
-    mkdirSync12(roots.analyticsDir, {
+  const filePath = path31.join(roots.analyticsDir, `report-${dateSegment}.json`);
+  if (!existsSync30(roots.analyticsDir)) {
+    mkdirSync13(roots.analyticsDir, {
       mode: ANALYTICS_DIR_MODE,
       recursive: true
     });
@@ -19138,7 +23996,7 @@ var writeAnalyticsReport = async (args) => {
   const contents = `${JSON.stringify(report, null, 2)}
 `;
   const temporaryPath = `${filePath}.tmp-${process.pid}-${process.hrtime.bigint().toString()}`;
-  writeFileSync16(temporaryPath, contents, { mode: REPORT_FILE_MODE });
+  writeFileSync22(temporaryPath, contents, { mode: REPORT_FILE_MODE });
   renameSync7(temporaryPath, filePath);
   return { filePath };
 };
@@ -19177,9 +24035,9 @@ var buildAreaIndex = (events) => {
   for (const event of events) {
     const taskId = eventTaskId(event);
     for (const area of eventAreaTags(event)) {
-      const set2 = index.get(area) ?? /* @__PURE__ */ new Set();
-      if (taskId !== void 0) set2.add(taskId);
-      index.set(area, set2);
+      const set3 = index.get(area) ?? /* @__PURE__ */ new Set();
+      if (taskId !== void 0) set3.add(taskId);
+      index.set(area, set3);
     }
   }
   return index;
@@ -19263,7 +24121,7 @@ var arrayStringField = (payload, key) => {
   ) : [];
 };
 var buildSpecAreaIndex = (events) => {
-  const map2 = /* @__PURE__ */ new Map();
+  const map3 = /* @__PURE__ */ new Map();
   const ttrEvents = events.filter(
     (event) => event.event_type === "time_to_resolved_spec"
   );
@@ -19271,10 +24129,10 @@ var buildSpecAreaIndex = (events) => {
     const specId = stringFieldOrUndefined(event.payload, "spec_id");
     const areaTags = arrayStringField(event.payload, "area_tags");
     if (specId !== void 0 && areaTags.length > 0) {
-      map2.set(specId, areaTags);
+      map3.set(specId, areaTags);
     }
   }
-  return map2;
+  return map3;
 };
 var accumulateTimeToResolved = (event, stats) => {
   const specId = stringFieldOrUndefined(event.payload, "spec_id");
@@ -19395,7 +24253,7 @@ var runAllPatternDetectors = (args) => {
 
 // src/profile/reader.ts
 import { readFile } from "node:fs/promises";
-import path24 from "node:path";
+import path32 from "node:path";
 
 // src/schemas/mentorship-payloads.ts
 var SPEC_ID_REGEX = /^SPEC-\d{3,}$/;
@@ -19579,7 +24437,7 @@ var readMentorshipEvents = async (args) => {
   const dates = enumerateWindowDates(now, windowDays);
   const events = [];
   for (const date5 of dates) {
-    const filePath = path24.join(roots.mentorshipDir, `events-${date5}.jsonl`);
+    const filePath = path32.join(roots.mentorshipDir, `events-${date5}.jsonl`);
     const raw = await readFileIfExists(filePath);
     if (raw !== null) events.push(...parseFileLines(raw, filePath));
   }
@@ -19709,8 +24567,8 @@ var WINDOW_DAYS = 30;
 var RECENT_WINDOW_DAYS = 7;
 var FADE_ELIGIBLE_AGE_DAYS = 7;
 var MS_PER_DAY3 = 864e5;
-var parseTimestampMs = (timestamp) => {
-  const parsed = Date.parse(timestamp);
+var parseTimestampMs = (timestamp2) => {
+  const parsed = Date.parse(timestamp2);
   return Number.isNaN(parsed) ? 0 : parsed;
 };
 var computeAdaptationRecord = (args) => {
@@ -19786,21 +24644,21 @@ var computeProfileCore = async (args) => {
   return { adaptations, events, patterns };
 };
 var renderAndWriteProfile = async (args) => {
-  const { core, now, roots } = args;
+  const { core: core2, now, roots } = args;
   const profileContents = renderProfile({
-    adaptations: core.adaptations,
+    adaptations: core2.adaptations,
     generatedAt: now,
     mentorshipEnabled: true,
-    patterns: core.patterns,
+    patterns: core2.patterns,
     windowDays: WINDOW_DAYS
   });
   await atomicWriteProfile(roots.profilePath, profileContents);
 };
 var writeAnalytics = async (args) => {
-  const { core, now, roots } = args;
+  const { core: core2, now, roots } = args;
   const report = await generateAnalyticsReport({
     generatedAt: now,
-    patternResults: core.patterns,
+    patternResults: core2.patterns,
     roots,
     windowDays: WINDOW_DAYS
   });
@@ -19882,7 +24740,7 @@ var computeProfile = async (options = {}) => {
 
 // src/telemetry/emit.ts
 import { createHash as createHash3 } from "node:crypto";
-import path25 from "node:path";
+import path33 from "node:path";
 
 // src/telemetry/envelope.ts
 import { createHash as createHash2 } from "node:crypto";
@@ -19960,13 +24818,13 @@ var buildEnvelope = (args) => {
 };
 
 // src/telemetry/ndjson-writer.ts
-import { existsSync as existsSync25, readFileSync as readFileSync20 } from "node:fs";
+import { existsSync as existsSync31, readFileSync as readFileSync28 } from "node:fs";
 import { appendFile, chmod as chmod2, stat as stat2 } from "node:fs/promises";
 var appendIdempotent = async (args) => {
   const { eventId, fileMode, filePath, line } = args;
   const dedupNeedle = `"event_id":"${eventId}"`;
-  if (existsSync25(filePath)) {
-    const existing = readFileSync20(filePath, "utf8");
+  if (existsSync31(filePath)) {
+    const existing = readFileSync28(filePath, "utf8");
     if (existing.includes(dedupNeedle)) {
       return { written: false };
     }
@@ -20320,8 +25178,8 @@ var flagsToPayload = (eventType, flags) => {
 };
 var validatePayload = (eventType, candidate) => {
   if (isMentorshipEventType2(eventType)) {
-    const schema = MentorshipPayloadByType[eventType];
-    const parsed = schema.safeParse(candidate);
+    const schema2 = MentorshipPayloadByType[eventType];
+    const parsed = schema2.safeParse(candidate);
     if (!parsed.success) {
       return { issues: parsed.error.issues, ok: false };
     }
@@ -20365,7 +25223,7 @@ var writeCloud = async (envelope, roots, now) => {
       ok: false
     };
   }
-  const cloudPath = path25.join(
+  const cloudPath = path33.join(
     roots.cloudDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -20379,7 +25237,7 @@ var writeCloud = async (envelope, roots, now) => {
 };
 var writeMentorship = async (envelope, roots, now) => {
   const mentorshipLine = JSON.stringify(envelope);
-  const mentorshipPath = path25.join(
+  const mentorshipPath = path33.join(
     roots.mentorshipDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -20801,19 +25659,19 @@ var handleParseStdin = async () => {
 };
 
 // src/telemetry/index.ts
-var HELP_TEXT18 = `Usage: gaia telemetry <subcommand> [args]
+var HELP_TEXT28 = `Usage: gaia telemetry <subcommand> [args]
 
   emit <event_type> [--field value ...]   Emit one telemetry event.
   compute-profile                          Regenerate profile.md from events.
   parse-stdin                              Read PostToolUse hook JSON on stdin,
                                            dispatch emits from trailer YAML.
 `;
-var HELP_TOKENS16 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run30 = async (argv) => {
+var HELP_TOKENS26 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run40 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS16.has(subcommand)) {
-    process.stdout.write(HELP_TEXT18);
+  if (subcommand === void 0 || HELP_TOKENS26.has(subcommand)) {
+    process.stdout.write(HELP_TEXT28);
     return EXIT_CODES.OK;
   }
   if (subcommand === "emit") {
@@ -20834,24 +25692,24 @@ var run30 = async (argv) => {
 
 // src/update/merge.ts
 import {
-  existsSync as existsSync28,
-  mkdirSync as mkdirSync13,
-  readdirSync as readdirSync5,
-  statSync as statSync3,
-  writeFileSync as writeFileSync18
+  existsSync as existsSync34,
+  mkdirSync as mkdirSync14,
+  readdirSync as readdirSync8,
+  statSync as statSync6,
+  writeFileSync as writeFileSync24
 } from "node:fs";
-import path27 from "node:path";
+import path35 from "node:path";
 
 // src/update/util/manifest.ts
-import { existsSync as existsSync26, readFileSync as readFileSync21 } from "node:fs";
+import { existsSync as existsSync32, readFileSync as readFileSync29 } from "node:fs";
 var VALID_RAW_CLASSES = /* @__PURE__ */ new Set(["owned", "shared", "wiki-owned"]);
 var normalizeClass = (rawClass) => {
   if (rawClass === "owned") return "owned";
   return "shared";
 };
-var isObject2 = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
-var loadManifest = (manifestPath) => {
-  if (!existsSync26(manifestPath)) {
+var isObject3 = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+var loadManifest2 = (manifestPath) => {
+  if (!existsSync32(manifestPath)) {
     return {
       ok: false,
       message: `manifest not found: ${manifestPath}`
@@ -20859,7 +25717,7 @@ var loadManifest = (manifestPath) => {
   }
   let raw;
   try {
-    raw = readFileSync21(manifestPath, "utf8");
+    raw = readFileSync29(manifestPath, "utf8");
   } catch (error51) {
     return {
       ok: false,
@@ -20875,29 +25733,29 @@ var loadManifest = (manifestPath) => {
       message: `manifest is not valid JSON: ${error51 instanceof Error ? error51.message : String(error51)}`
     };
   }
-  if (!isObject2(parsed)) {
+  if (!isObject3(parsed)) {
     return { ok: false, message: "manifest root is not an object" };
   }
   const shape = parsed;
-  if (!isObject2(shape.files)) {
+  if (!isObject3(shape.files)) {
     return { ok: false, message: "manifest.files is missing or not an object" };
   }
   const files = /* @__PURE__ */ new Map();
-  for (const [path35, value] of Object.entries(shape.files)) {
+  for (const [path42, value] of Object.entries(shape.files)) {
     if (typeof value !== "string") {
       return {
         ok: false,
-        message: `manifest.files["${path35}"] is not a string`
+        message: `manifest.files["${path42}"] is not a string`
       };
     }
     if (!VALID_RAW_CLASSES.has(value)) {
       return {
         ok: false,
-        message: `manifest.files["${path35}"] has unknown class: "${value}"`
+        message: `manifest.files["${path42}"] has unknown class: "${value}"`
       };
     }
     const rawClass = value;
-    files.set(path35, {
+    files.set(path42, {
       normalizedClass: normalizeClass(rawClass),
       rawClass
     });
@@ -20910,23 +25768,23 @@ var loadManifest = (manifestPath) => {
 };
 
 // src/update/util/three-way.ts
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync5 } from "node:child_process";
 import {
-  existsSync as existsSync27,
+  existsSync as existsSync33,
   mkdtempSync,
-  readFileSync as readFileSync22,
+  readFileSync as readFileSync30,
   rmSync as rmSync4,
-  writeFileSync as writeFileSync17
+  writeFileSync as writeFileSync23
 } from "node:fs";
 import { tmpdir } from "node:os";
-import path26 from "node:path";
+import path34 from "node:path";
 var snapshot = (absPath) => {
-  if (!existsSync27(absPath)) {
+  if (!existsSync33(absPath)) {
     return { absPath, bytes: null, exists: false };
   }
   let bytes;
   try {
-    bytes = readFileSync22(absPath);
+    bytes = readFileSync30(absPath);
   } catch {
     return { absPath, bytes: null, exists: false };
   }
@@ -20939,15 +25797,15 @@ var bytesEqual = (a, b) => {
   return a.equals(b);
 };
 var cleanMerge = (current, baseline, latest) => {
-  const dir = mkdtempSync(path26.join(tmpdir(), "gaia-merge-"));
-  const currentPath = path26.join(dir, "current");
-  const baselinePath = path26.join(dir, "baseline");
-  const latestPath = path26.join(dir, "latest");
+  const dir = mkdtempSync(path34.join(tmpdir(), "gaia-merge-"));
+  const currentPath = path34.join(dir, "current");
+  const baselinePath = path34.join(dir, "baseline");
+  const latestPath = path34.join(dir, "latest");
   try {
-    writeFileSync17(currentPath, current);
-    writeFileSync17(baselinePath, baseline);
-    writeFileSync17(latestPath, latest);
-    const result = spawnSync(
+    writeFileSync23(currentPath, current);
+    writeFileSync23(baselinePath, baseline);
+    writeFileSync23(latestPath, latest);
+    const result = spawnSync5(
       "git",
       ["merge-file", "--stdout", currentPath, baselinePath, latestPath],
       { encoding: "buffer" }
@@ -21129,7 +25987,7 @@ var buildUnifiedDiff = (fromText, toText, options) => {
 };
 
 // src/update/merge.ts
-var HELP_TEXT19 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
+var HELP_TEXT29 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
 
   Three-way file compare across baseline and latest tarball trees,
   classified by .gaia/manifest.json. Replaces the prose Step 7 of the
@@ -21143,44 +26001,44 @@ var HELP_TEXT19 = `Usage: gaia update merge --baseline <dir> --latest <dir> --ma
     1  user-correctable error (missing dir, malformed manifest)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS17 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var UNEXPECTED_EXIT7 = 2;
+var HELP_TOKENS27 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT15 = 2;
 var MERGE_DIR = ".gaia-merge";
-var takeValue7 = (argv, index, flag) => {
+var takeValue13 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) return { message: `${flag} requires a value`, ok: false };
   return { ok: true, value };
 };
-var parseFlags11 = (argv) => {
+var parseFlags19 = (argv) => {
   let baseline;
   let latest;
   let manifest;
-  let json2 = false;
+  let json3 = false;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--baseline") {
-      const taken = takeValue7(argv, index + 1, "--baseline");
+      const taken = takeValue13(argv, index + 1, "--baseline");
       if (!taken.ok) return taken;
       baseline = taken.value;
       index += 1;
       continue;
     }
     if (token === "--latest") {
-      const taken = takeValue7(argv, index + 1, "--latest");
+      const taken = takeValue13(argv, index + 1, "--latest");
       if (!taken.ok) return taken;
       latest = taken.value;
       index += 1;
       continue;
     }
     if (token === "--manifest") {
-      const taken = takeValue7(argv, index + 1, "--manifest");
+      const taken = takeValue13(argv, index + 1, "--manifest");
       if (!taken.ok) return taken;
       manifest = taken.value;
       index += 1;
       continue;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     return { message: `unknown flag: ${token}`, ok: false };
@@ -21188,24 +26046,24 @@ var parseFlags11 = (argv) => {
   if (baseline === void 0) return { message: "--baseline is required", ok: false };
   if (latest === void 0) return { message: "--latest is required", ok: false };
   if (manifest === void 0) return { message: "--manifest is required", ok: false };
-  return { flags: { baseline, json: json2, latest, manifest }, ok: true };
+  return { flags: { baseline, json: json3, latest, manifest }, ok: true };
 };
 var walkRelative = (rootDir) => {
   const out = [];
   const visit = (relative) => {
-    const absolute = path27.join(rootDir, relative);
+    const absolute = path35.join(rootDir, relative);
     let names;
     try {
-      names = readdirSync5(absolute);
+      names = readdirSync8(absolute);
     } catch {
       return;
     }
     for (const name of names) {
-      const child = relative === "" ? name : path27.join(relative, name);
-      const childAbs = path27.join(rootDir, child);
+      const child = relative === "" ? name : path35.join(relative, name);
+      const childAbs = path35.join(rootDir, child);
       let info;
       try {
-        info = statSync3(childAbs);
+        info = statSync6(childAbs);
       } catch {
         continue;
       }
@@ -21216,29 +26074,29 @@ var walkRelative = (rootDir) => {
       if (info.isFile()) out.push(child);
     }
   };
-  if (!existsSync28(rootDir) || !statSync3(rootDir).isDirectory()) return out;
+  if (!existsSync34(rootDir) || !statSync6(rootDir).isDirectory()) return out;
   visit("");
   return out.sort();
 };
 var ensureDir2 = (absDir) => {
-  mkdirSync13(absDir, { recursive: true });
+  mkdirSync14(absDir, { recursive: true });
 };
 var writePatch = (ctx, relativePath, patch) => {
-  const mergeRoot = path27.join(ctx.cwd, MERGE_DIR);
-  const patchAbs = path27.join(mergeRoot, `${relativePath}.patch`);
-  ensureDir2(path27.dirname(patchAbs));
-  writeFileSync18(patchAbs, patch, "utf8");
-  return path27.relative(ctx.cwd, patchAbs);
+  const mergeRoot = path35.join(ctx.cwd, MERGE_DIR);
+  const patchAbs = path35.join(mergeRoot, `${relativePath}.patch`);
+  ensureDir2(path35.dirname(patchAbs));
+  writeFileSync24(patchAbs, patch, "utf8");
+  return path35.relative(ctx.cwd, patchAbs);
 };
 var writeWorkingTree = (ctx, relativePath, bytes) => {
-  const target = path27.join(ctx.cwd, relativePath);
-  ensureDir2(path27.dirname(target));
-  writeFileSync18(target, bytes);
+  const target = path35.join(ctx.cwd, relativePath);
+  ensureDir2(path35.dirname(target));
+  writeFileSync24(target, bytes);
 };
 var handleManifestPath = (ctx, relativePath, klass) => {
-  const baselineSnap = snapshot(path27.join(ctx.baselineDir, relativePath));
-  const latestSnap = snapshot(path27.join(ctx.latestDir, relativePath));
-  const currentSnap = snapshot(path27.join(ctx.cwd, relativePath));
+  const baselineSnap = snapshot(path35.join(ctx.baselineDir, relativePath));
+  const latestSnap = snapshot(path35.join(ctx.latestDir, relativePath));
+  const currentSnap = snapshot(path35.join(ctx.cwd, relativePath));
   if (!latestSnap.exists) return null;
   if (!currentSnap.exists) {
     if (!baselineSnap.exists) {
@@ -21332,16 +26190,16 @@ var computeReport = (ctx) => {
   }
   for (const relativePath of [...latestPaths].sort()) {
     if (manifestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path27.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path35.join(ctx.cwd, relativePath));
     if (currentSnap.exists) continue;
-    const latestSnap = snapshot(path27.join(ctx.latestDir, relativePath));
+    const latestSnap = snapshot(path35.join(ctx.latestDir, relativePath));
     if (!latestSnap.exists) continue;
     writeWorkingTree(ctx, relativePath, latestSnap.bytes);
     add.push(relativePath);
   }
   for (const relativePath of [...baselinePaths].sort()) {
     if (latestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path27.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path35.join(ctx.cwd, relativePath));
     if (!currentSnap.exists) continue;
     deleteList.push(relativePath);
   }
@@ -21354,7 +26212,7 @@ var computeReport = (ctx) => {
     skip: skip.sort()
   };
 };
-var printHuman3 = (report) => {
+var printHuman4 = (report) => {
   const lines = [
     "gaia update merge",
     `  Overwrite: ${report.overwrite.length}`,
@@ -21385,12 +26243,12 @@ var printHuman3 = (report) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run31 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS17.has(argv[0])) {
-    process.stdout.write(HELP_TEXT19);
+var run41 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS27.has(argv[0])) {
+    process.stdout.write(HELP_TEXT29);
     return EXIT_CODES.OK;
   }
-  const parsed = parseFlags11(argv);
+  const parsed = parseFlags19(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -21400,10 +26258,10 @@ var run31 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwd = options.cwd ?? process.cwd();
-  const baselineDir = path27.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path27.join(cwd, parsed.flags.baseline);
-  const latestDir = path27.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path27.join(cwd, parsed.flags.latest);
-  const manifestPath = path27.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path27.join(cwd, parsed.flags.manifest);
-  if (!existsSync28(baselineDir) || !statSync3(baselineDir).isDirectory()) {
+  const baselineDir = path35.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path35.join(cwd, parsed.flags.baseline);
+  const latestDir = path35.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path35.join(cwd, parsed.flags.latest);
+  const manifestPath = path35.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path35.join(cwd, parsed.flags.manifest);
+  if (!existsSync34(baselineDir) || !statSync6(baselineDir).isDirectory()) {
     structuredError({
       code: "baseline_missing",
       message: `--baseline directory not found: ${baselineDir}`,
@@ -21411,7 +26269,7 @@ var run31 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (!existsSync28(latestDir) || !statSync3(latestDir).isDirectory()) {
+  if (!existsSync34(latestDir) || !statSync6(latestDir).isDirectory()) {
     structuredError({
       code: "latest_missing",
       message: `--latest directory not found: ${latestDir}`,
@@ -21419,7 +26277,7 @@ var run31 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const manifestResult = loadManifest(manifestPath);
+  const manifestResult = loadManifest2(manifestPath);
   if (!manifestResult.ok) {
     structuredError({
       code: "manifest_invalid",
@@ -21442,35 +26300,35 @@ var run31 = (argv, options = {}) => {
       message: error51 instanceof Error ? error51.message : String(error51),
       subcommand: "update merge"
     });
-    return UNEXPECTED_EXIT7;
+    return UNEXPECTED_EXIT15;
   }
   if (parsed.flags.json) {
     process.stdout.write(`${JSON.stringify(report)}
 `);
   } else {
-    printHuman3(report);
+    printHuman4(report);
   }
   return EXIT_CODES.OK;
 };
 
 // src/update/index.ts
-var HELP_TEXT20 = `Usage: gaia update <subcommand> [args]
+var HELP_TEXT30 = `Usage: gaia update <subcommand> [args]
 
   merge --baseline <dir> --latest <dir> --manifest <path> [--json]
                                               Three-way file compare per manifest class.
 `;
-var HELP_TOKENS18 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var SUBCOMMAND_HANDLERS3 = {
-  merge: run31
+var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS4 = {
+  merge: run41
 };
-var run32 = async (argv) => {
+var run42 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS18.has(subcommand)) {
-    process.stdout.write(HELP_TEXT20);
+  if (subcommand === void 0 || HELP_TOKENS28.has(subcommand)) {
+    process.stdout.write(HELP_TEXT30);
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS3[subcommand];
+  const handler = SUBCOMMAND_HANDLERS4[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -21483,185 +26341,32 @@ var run32 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-// src/wiki/util/git.ts
-import { execFileSync as execFileSync3 } from "node:child_process";
-var runGit = (args, options = {}) => {
-  const cwd = options.cwd ?? process.cwd();
-  const result = execFileSync3("git", args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-  return result.toString();
-};
-var tryRunGit = (args, options = {}) => {
-  try {
-    return runGit(args, options);
-  } catch {
-    return null;
-  }
-};
-var resolveRepoRoot3 = (cwd = process.cwd()) => runGit(["rev-parse", "--show-toplevel"], { cwd }).trim();
-var headSha = (cwd) => runGit(["rev-parse", "HEAD"], { cwd }).trim();
-var shortSha = (sha, cwd) => {
-  const result = tryRunGit(["rev-parse", "--short=7", sha], { cwd });
-  if (result === null) return sha.slice(0, 7);
-  return result.trim();
-};
-var isReachable = (sha, cwd) => {
-  try {
-    execFileSync3("git", ["merge-base", "--is-ancestor", sha, "HEAD"], {
-      cwd,
-      stdio: ["ignore", "ignore", "ignore"]
-    });
-    return true;
-  } catch {
-    return false;
-  }
-};
-var commitsAhead = (sha, cwd) => {
-  const result = tryRunGit(["rev-list", "--count", `${sha}..HEAD`], { cwd });
-  if (result === null) return 0;
-  const parsed = Number.parseInt(result.trim(), 10);
-  return Number.isNaN(parsed) ? 0 : parsed;
-};
-var recentCommits = (sinceSha, cwd, limit = 5) => {
-  const result = tryRunGit(
-    [
-      "log",
-      "--no-merges",
-      "--reverse",
-      "--format=%h%x09%s",
-      `${sinceSha}..HEAD`
-    ],
-    { cwd }
-  );
-  if (result === null) return [];
-  const lines = result.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
-  return lines.slice(-limit).map((line) => {
-    const tabIndex = line.indexOf("	");
-    const sha = tabIndex === -1 ? line : line.slice(0, tabIndex);
-    const subject = tabIndex === -1 ? "" : line.slice(tabIndex + 1);
-    return { sha, subject };
-  });
-};
-var parseShortStat = (stat3) => {
-  let filesChanged = 0;
-  let insertions = 0;
-  let deletions = 0;
-  const filesMatch = /(\d+)\s+files?\s+changed/u.exec(stat3);
-  if (filesMatch !== null) filesChanged = Number.parseInt(filesMatch[1], 10);
-  const insertMatch = /(\d+)\s+insertions?\(\+\)/u.exec(stat3);
-  if (insertMatch !== null) insertions = Number.parseInt(insertMatch[1], 10);
-  const deleteMatch = /(\d+)\s+deletions?\(-\)/u.exec(stat3);
-  if (deleteMatch !== null) deletions = Number.parseInt(deleteMatch[1], 10);
-  return { deletions, files_changed: filesChanged, insertions };
-};
-var fileListForCommit = (sha, cwd) => {
-  const result = tryRunGit(
-    ["diff-tree", "--no-commit-id", "--name-only", "-r", sha],
-    { cwd }
-  );
-  if (result === null) return [];
-  return result.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
-};
-var parseChunk = (chunk) => {
-  const trimmed = chunk.replace(/^[\s\n]+/u, "").replace(/[\s\n]+$/u, "");
-  if (trimmed === "") return { precedingStat: "", record: null };
-  const lines = trimmed.split("\n");
-  const commitLineIndex = lines.findIndex((line) => line.startsWith("COMMIT "));
-  if (commitLineIndex === -1) {
-    return { precedingStat: trimmed, record: null };
-  }
-  const statLines = lines.slice(0, commitLineIndex);
-  const precedingStat = statLines.find(
-    (line) => /\d+\s+files?\s+changed/u.test(line)
-  ) ?? "";
-  const commitBlock = lines.slice(commitLineIndex);
-  const sha = (commitBlock[0] ?? "").replace(/^COMMIT\s+/u, "").trim();
-  const subject = commitBlock[1] ?? "";
-  const bodyLines = commitBlock.slice(2);
-  while (bodyLines.length > 0 && (bodyLines.at(-1) ?? "").trim() === "") {
-    bodyLines.pop();
-  }
-  return {
-    precedingStat,
-    record: { body: bodyLines.join("\n"), sha, subject }
-  };
-};
-var commitDetails = (sinceSha, cwd) => {
-  const recordSeparator = "---END-COMMIT---";
-  const raw = tryRunGit(
-    [
-      "log",
-      "--no-merges",
-      "--reverse",
-      "--shortstat",
-      `--format=COMMIT %H%n%s%n%b%n${recordSeparator}`,
-      `${sinceSha}..HEAD`
-    ],
-    { cwd }
-  );
-  if (raw === null) return [];
-  const chunks = raw.split(recordSeparator);
-  const records = [];
-  const stats = [];
-  let pendingStat = null;
-  for (const chunk of chunks) {
-    const { precedingStat, record: record2 } = parseChunk(chunk);
-    if (record2 !== null) {
-      records.push(record2);
-      if (records.length > 1) stats.push(precedingStat);
-      pendingStat = null;
-    } else {
-      pendingStat = precedingStat;
-    }
-  }
-  if (records.length > 0) {
-    stats.push(pendingStat ?? "");
-  }
-  return records.map((record2, index) => {
-    const stat3 = stats[index] ?? "";
-    const parsed = parseShortStat(stat3);
-    const files = fileListForCommit(record2.sha, cwd);
-    return {
-      body: record2.body,
-      deletions: parsed.deletions,
-      files,
-      files_changed: parsed.files_changed,
-      insertions: parsed.insertions,
-      sha: record2.sha,
-      subject: record2.subject
-    };
-  });
-};
-
 // src/wiki/commit-classify.ts
-var HELP_TEXT21 = `Usage: gaia wiki commit-classify --since <sha> [--json]
+var HELP_TEXT31 = `Usage: gaia wiki commit-classify --since <sha> [--json]
 
   Emit a deterministic WORTHY/SKIP suggestion for every commit in
   <sha>..HEAD. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS19 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var takeValue8 = (argv, index, flag) => {
+var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var takeValue14 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) return { message: `${flag} requires a value`, ok: false };
   return { ok: true, value };
 };
-var parseFlags12 = (argv) => {
+var parseFlags20 = (argv) => {
   let since;
-  let json2 = false;
+  let json3 = false;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--since") {
-      const taken = takeValue8(argv, index + 1, "--since");
+      const taken = takeValue14(argv, index + 1, "--since");
       if (!taken.ok) return taken;
       since = taken.value;
       index += 1;
       continue;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     return { message: `unknown flag: ${token}`, ok: false };
@@ -21669,7 +26374,7 @@ var parseFlags12 = (argv) => {
   if (since === void 0) {
     return { message: "--since <sha> is required", ok: false };
   }
-  return { flags: { json: json2, since }, ok: true };
+  return { flags: { json: json3, since }, ok: true };
 };
 var ARCH_BODY_PATTERN = /BREAKING CHANGE|architecture|trade-?off|invariant|gotcha|workaround|decision/iu;
 var WIKI_HEAVY_DOMAINS = [
@@ -21786,7 +26491,7 @@ var classify = (commit) => {
     suggestion: "WORTHY"
   };
 };
-var printHuman4 = (classification) => {
+var printHuman5 = (classification) => {
   if (classification.commits.length === 0) {
     process.stdout.write("No commits to classify.\n");
     return;
@@ -21804,12 +26509,12 @@ var printHuman4 = (classification) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run33 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS19.has(argv[0])) {
-    process.stdout.write(HELP_TEXT21);
+var run43 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS29.has(argv[0])) {
+    process.stdout.write(HELP_TEXT31);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
-  const parsed = parseFlags12(argv);
+  const parsed = parseFlags20(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -21859,15 +26564,15 @@ var run33 = (argv, options = {}) => {
     process.stdout.write(`${JSON.stringify(classification)}
 `);
   } else {
-    printHuman4(classification);
+    printHuman5(classification);
   }
   return EXIT_CODES.OK;
 };
 
 // src/wiki/dead-paths.ts
-import { readdirSync as readdirSync6, readFileSync as readFileSync23, statSync as statSync4 } from "node:fs";
-import path28 from "node:path";
-var HELP_TEXT22 = `Usage: gaia wiki dead-paths [--json]
+import { readdirSync as readdirSync9, readFileSync as readFileSync31, statSync as statSync7 } from "node:fs";
+import path36 from "node:path";
+var HELP_TEXT32 = `Usage: gaia wiki dead-paths [--json]
 
   Scan wiki/**/*.md for backticked repo-relative paths under .claude/, .gaia/,
   app/, test/, wiki/ that no longer exist on disk, plus any reference to
@@ -21876,7 +26581,7 @@ var HELP_TEXT22 = `Usage: gaia wiki dead-paths [--json]
   and wiki/meta/** (audit artifacts that legitimately reference historical
   paths).
 `;
-var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TRACKED_PREFIXES = [".claude/", ".gaia/", "app/", "test/", "wiki/"];
 var SIBLING_REPO_PATTERN = /(?:^|\/)(studio|website)\//;
 var SKIP_PATH_FRAGMENTS = [
@@ -21884,7 +26589,7 @@ var SKIP_PATH_FRAGMENTS = [
   "wiki/meta/",
   "wiki/.state.json"
 ];
-var RUNTIME_PREFIXES = [".gaia/local/", ".gaia/cache/"];
+var RUNTIME_PREFIXES2 = [".gaia/local/", ".gaia/cache/"];
 var PATH_TOKEN_PATTERN = /`([^`\n]+?)`/g;
 var PLACEHOLDER_PATTERN = /[<>*${}]|N{3,}|X{3,}/;
 var HISTORICAL_BULLET_PATTERN = /^\s*-\s+\*\*(Removed|Deleted|Renamed|Migrated|Replaced)\*\*/i;
@@ -21892,38 +26597,38 @@ var isTrackedPath = (token) => {
   if (PLACEHOLDER_PATTERN.test(token)) return false;
   if (!token.includes("/")) return false;
   if (!/\.[a-z0-9]{1,8}$/i.test(token)) return false;
-  if (RUNTIME_PREFIXES.some((prefix) => token.startsWith(prefix))) return false;
+  if (RUNTIME_PREFIXES2.some((prefix) => token.startsWith(prefix))) return false;
   if (SIBLING_REPO_PATTERN.test(token)) return true;
   return TRACKED_PREFIXES.some((prefix) => token.startsWith(prefix));
 };
 var shouldSkipFile = (relPath) => SKIP_PATH_FRAGMENTS.some((fragment) => relPath.startsWith(fragment));
 var walkMarkdown = (root, dir) => {
-  const entries = readdirSync6(dir, { withFileTypes: true });
+  const entries = readdirSync9(dir, { withFileTypes: true });
   const out = [];
   for (const entry of entries) {
-    const full = path28.join(dir, entry.name);
+    const full = path36.join(dir, entry.name);
     if (entry.isDirectory()) {
       out.push(...walkMarkdown(root, full));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(path28.relative(root, full));
+      out.push(path36.relative(root, full));
     }
   }
   return out;
 };
 var pathExists = (root, candidate) => {
   try {
-    statSync4(path28.join(root, candidate));
+    statSync7(path36.join(root, candidate));
     return true;
   } catch {
     return false;
   }
 };
 var findDeadPaths = (cwd) => {
-  const wikiDir = path28.join(cwd, "wiki");
+  const wikiDir = path36.join(cwd, "wiki");
   try {
-    statSync4(wikiDir);
+    statSync7(wikiDir);
   } catch {
     return [];
   }
@@ -21931,7 +26636,7 @@ var findDeadPaths = (cwd) => {
   const files = walkMarkdown(cwd, wikiDir);
   for (const filePath of files) {
     if (shouldSkipFile(filePath)) continue;
-    const content = readFileSync23(path28.join(cwd, filePath), "utf8");
+    const content = readFileSync31(path36.join(cwd, filePath), "utf8");
     const lines = content.split("\n");
     for (const [index, line] of lines.entries()) {
       if (HISTORICAL_BULLET_PATTERN.test(line)) continue;
@@ -21951,15 +26656,15 @@ var findDeadPaths = (cwd) => {
   }
   return dead;
 };
-var run34 = (argv, options = {}) => {
-  let json2 = false;
+var run44 = (argv, options = {}) => {
+  let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS20.has(token)) {
-      process.stdout.write(HELP_TEXT22);
+    if (HELP_TOKENS30.has(token)) {
+      process.stdout.write(HELP_TEXT32);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     structuredError({
@@ -21972,7 +26677,7 @@ var run34 = (argv, options = {}) => {
   try {
     const cwd = options.cwd ?? process.cwd();
     const dead = findDeadPaths(cwd);
-    if (json2) {
+    if (json3) {
       process.stdout.write(`${JSON.stringify({ dead }, null, 2)}
 `);
       return EXIT_CODES.OK;
@@ -21995,44 +26700,44 @@ var run34 = (argv, options = {}) => {
 };
 
 // src/wiki/log-prepend.ts
-import { existsSync as existsSync29, readFileSync as readFileSync24, renameSync as renameSync8, writeFileSync as writeFileSync19 } from "node:fs";
-import path29 from "node:path";
-var HELP_TEXT23 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+import { existsSync as existsSync35, readFileSync as readFileSync32, renameSync as renameSync8, writeFileSync as writeFileSync25 } from "node:fs";
+import path37 from "node:path";
+var HELP_TEXT33 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS21 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS31 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
 var FRONTMATTER_FENCE = "---";
-var takeValue9 = (argv, index, flag) => {
+var takeValue15 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) {
     return { message: `${flag} requires a value`, ok: false };
   }
   return { ok: true, value };
 };
-var parseFlags13 = (argv) => {
+var parseFlags21 = (argv) => {
   let sha;
   let decision;
   let reason;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--sha") {
-      const taken = takeValue9(argv, index + 1, "--sha");
+      const taken = takeValue15(argv, index + 1, "--sha");
       if (!taken.ok) return taken;
       sha = taken.value;
       index += 1;
       continue;
     }
     if (token === "--decision") {
-      const taken = takeValue9(argv, index + 1, "--decision");
+      const taken = takeValue15(argv, index + 1, "--decision");
       if (!taken.ok) return taken;
       decision = taken.value;
       index += 1;
       continue;
     }
     if (token === "--reason") {
-      const taken = takeValue9(argv, index + 1, "--reason");
+      const taken = takeValue15(argv, index + 1, "--reason");
       if (!taken.ok) return taken;
       reason = taken.value;
       index += 1;
@@ -22051,7 +26756,7 @@ var parseFlags13 = (argv) => {
   }
   return { flags: { decision, reason, sha }, ok: true };
 };
-var todayUtc = () => {
+var todayUtc3 = () => {
   const now = /* @__PURE__ */ new Date();
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, "0");
@@ -22081,17 +26786,17 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run35 = (argv, options = {}) => {
+var run45 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT23);
+    process.stdout.write(HELP_TEXT33);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS21.has(first)) {
-    process.stdout.write(HELP_TEXT23);
+  if (HELP_TOKENS31.has(first)) {
+    process.stdout.write(HELP_TEXT33);
     return EXIT_CODES.OK;
   }
-  const parsed = parseFlags13(argv);
+  const parsed = parseFlags21(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -22111,8 +26816,8 @@ var run35 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const logPath = path29.join(repoRoot2, "wiki", "log.md");
-  if (!existsSync29(logPath)) {
+  const logPath = path37.join(repoRoot2, "wiki", "log.md");
+  if (!existsSync35(logPath)) {
     structuredError({
       code: "log_missing",
       message: "wiki/log.md does not exist",
@@ -22120,7 +26825,7 @@ var run35 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync24(logPath, "utf8");
+  const raw = readFileSync32(logPath, "utf8");
   const lines = raw.split("\n");
   const scan = scanFrontmatter(lines);
   if (scan.kind === "missing" || scan.kind === "malformed") {
@@ -22131,7 +26836,7 @@ var run35 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const date5 = options.today ?? todayUtc();
+  const date5 = options.today ?? todayUtc3();
   const newLine = `- ${date5} ${parsed.flags.sha} ${parsed.flags.decision} \u2014 ${parsed.flags.reason}`;
   const insertionIndex = findInsertionIndex(lines, scan.endLineIndex);
   const next = [
@@ -22140,22 +26845,22 @@ var run35 = (argv, options = {}) => {
     ...lines.slice(insertionIndex)
   ].join("\n");
   const tmpPath = `${logPath}.tmp`;
-  writeFileSync19(tmpPath, next, "utf8");
+  writeFileSync25(tmpPath, next, "utf8");
   renameSync8(tmpPath, logPath);
   return EXIT_CODES.OK;
 };
 
 // src/wiki/near-collisions.ts
-import { existsSync as existsSync30, readdirSync as readdirSync7, statSync as statSync5 } from "node:fs";
-import path30 from "node:path";
-var HELP_TEXT24 = `Usage: gaia wiki near-collisions [--max-distance 3]
+import { existsSync as existsSync36, readdirSync as readdirSync10, statSync as statSync8 } from "node:fs";
+import path38 from "node:path";
+var HELP_TEXT34 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS22 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS32 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
-var DOMAIN_DIRS = [
+var DOMAIN_DIRS2 = [
   "components",
   "concepts",
   "decisions",
@@ -22190,10 +26895,10 @@ var levenshtein = (a, b) => {
 };
 var collectDomainSlugs = (wikiRoot) => {
   const collected = [];
-  for (const domain2 of DOMAIN_DIRS) {
-    const domainDir = path30.join(wikiRoot, domain2);
-    if (!existsSync30(domainDir) || !statSync5(domainDir).isDirectory()) continue;
-    const entries = readdirSync7(domainDir, { withFileTypes: true });
+  for (const domain2 of DOMAIN_DIRS2) {
+    const domainDir = path38.join(wikiRoot, domain2);
+    if (!existsSync36(domainDir) || !statSync8(domainDir).isDirectory()) continue;
+    const entries = readdirSync10(domainDir, { withFileTypes: true });
     const slugs = [];
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -22232,17 +26937,17 @@ var findCollisions = (domainGroups, maxDistance) => {
   });
   return results;
 };
-var takeValue10 = (argv, index, flag) => {
+var takeValue16 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) return { message: `${flag} requires a value`, ok: false };
   return { ok: true, value };
 };
-var parseFlags14 = (argv) => {
+var parseFlags22 = (argv) => {
   let maxDistance = DEFAULT_MAX_DISTANCE;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--max-distance") {
-      const taken = takeValue10(argv, index + 1, "--max-distance");
+      const taken = takeValue16(argv, index + 1, "--max-distance");
       if (!taken.ok) return taken;
       const parsed = Number.parseInt(taken.value, 10);
       if (Number.isNaN(parsed) || parsed < 1) {
@@ -22259,12 +26964,12 @@ var parseFlags14 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run36 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS22.has(argv[0])) {
-    process.stdout.write(HELP_TEXT24);
+var run46 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS32.has(argv[0])) {
+    process.stdout.write(HELP_TEXT34);
     return EXIT_CODES.OK;
   }
-  const parsed = parseFlags14(argv);
+  const parsed = parseFlags22(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -22284,7 +26989,7 @@ var run36 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path30.join(repoRoot2, "wiki");
+  const wikiRoot = path38.join(repoRoot2, "wiki");
   const domainGroups = collectDomainSlugs(wikiRoot);
   const collisions = findCollisions(domainGroups, parsed.flags.maxDistance);
   if (collisions.length === 0) return EXIT_CODES.OK;
@@ -22297,8 +27002,8 @@ var run36 = (argv, options = {}) => {
 };
 
 // src/wiki/page-index.ts
-import { existsSync as existsSync31, readdirSync as readdirSync8, readFileSync as readFileSync25, statSync as statSync6 } from "node:fs";
-import path31 from "node:path";
+import { existsSync as existsSync37, readdirSync as readdirSync11, readFileSync as readFileSync33, statSync as statSync9 } from "node:fs";
+import path39 from "node:path";
 
 // src/wiki/util/frontmatter.ts
 var FRONTMATTER_FENCE2 = "---";
@@ -22374,13 +27079,13 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT25 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT35 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS23 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var DOMAIN_DIRS2 = [
+var HELP_TOKENS33 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var DOMAIN_DIRS3 = [
   "components",
   "concepts",
   "decisions",
@@ -22392,7 +27097,7 @@ var DOMAIN_DIRS2 = [
 ];
 var SKIPPED_FILES2 = /* @__PURE__ */ new Set(["_index.md", "README.md"]);
 var ROOT_LINK_SOURCES = ["index.md", "overview.md", "hot.md"];
-var slugFromPath = (filePath) => path31.basename(filePath, ".md");
+var slugFromPath = (filePath) => path39.basename(filePath, ".md");
 var extractTitle = (body, fallback) => {
   const lines = body.split("\n");
   for (const line of lines) {
@@ -22416,17 +27121,17 @@ var arrayOfStrings = (value) => {
 };
 var collectPages = (wikiRoot) => {
   const pages = [];
-  for (const domain2 of DOMAIN_DIRS2) {
-    const domainDir = path31.join(wikiRoot, domain2);
-    if (!existsSync31(domainDir) || !statSync6(domainDir).isDirectory()) continue;
-    const entries = readdirSync8(domainDir, { withFileTypes: true });
+  for (const domain2 of DOMAIN_DIRS3) {
+    const domainDir = path39.join(wikiRoot, domain2);
+    if (!existsSync37(domainDir) || !statSync9(domainDir).isDirectory()) continue;
+    const entries = readdirSync11(domainDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(".md")) continue;
       if (SKIPPED_FILES2.has(entry.name)) continue;
       if (entry.name.startsWith("_")) continue;
-      const absPath = path31.join(domainDir, entry.name);
-      const raw = readFileSync25(absPath, "utf8");
+      const absPath = path39.join(domainDir, entry.name);
+      const raw = readFileSync33(absPath, "utf8");
       const { body, frontmatter } = parseFrontmatter(raw);
       const slug = slugFromPath(entry.name);
       const title = extractTitle(body, slug);
@@ -22435,7 +27140,7 @@ var collectPages = (wikiRoot) => {
         body,
         domain: domain2,
         outboundTargets: targets,
-        relativePath: path31.posix.join("wiki", domain2, entry.name),
+        relativePath: path39.posix.join("wiki", domain2, entry.name),
         slug,
         status: stringValue(frontmatter.status),
         tags: arrayOfStrings(frontmatter.tags),
@@ -22449,9 +27154,9 @@ var collectPages = (wikiRoot) => {
 var collectRootLinkSources = (wikiRoot) => {
   const sources = [];
   for (const filename of ROOT_LINK_SOURCES) {
-    const absPath = path31.join(wikiRoot, filename);
-    if (!existsSync31(absPath)) continue;
-    const raw = readFileSync25(absPath, "utf8");
+    const absPath = path39.join(wikiRoot, filename);
+    if (!existsSync37(absPath)) continue;
+    const raw = readFileSync33(absPath, "utf8");
     const { body } = parseFrontmatter(raw);
     sources.push(extractWikilinks(body));
   }
@@ -22487,7 +27192,7 @@ var buildIndex = (pages, rootSources = []) => {
     }))
   };
 };
-var printHuman5 = (index) => {
+var printHuman6 = (index) => {
   if (index.pages.length === 0) {
     process.stdout.write("No wiki pages found.\n");
     return;
@@ -22503,20 +27208,20 @@ var printHuman5 = (index) => {
 };
 var computePageIndex = (cwd) => {
   const repoRoot2 = resolveRepoRoot3(cwd);
-  const wikiRoot = path31.join(repoRoot2, "wiki");
+  const wikiRoot = path39.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run37 = (argv, options = {}) => {
-  let json2 = false;
+var run47 = (argv, options = {}) => {
+  let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS23.has(token)) {
-      process.stdout.write(HELP_TEXT25);
+    if (HELP_TOKENS33.has(token)) {
+      process.stdout.write(HELP_TEXT35);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
-      json2 = true;
+      json3 = true;
       continue;
     }
     structuredError({
@@ -22537,30 +27242,30 @@ var run37 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path31.join(repoRoot2, "wiki");
+  const wikiRoot = path39.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   const index = buildIndex(pages, rootSources);
-  if (json2) {
+  if (json3) {
     process.stdout.write(`${JSON.stringify(index)}
 `);
   } else {
-    printHuman5(index);
+    printHuman6(index);
   }
   return EXIT_CODES.OK;
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT26 = `Usage: gaia wiki orphans
+var HELP_TEXT36 = `Usage: gaia wiki orphans
 
   Newline-separated list of wiki pages with zero inbound wikilinks.
 `;
-var HELP_TOKENS24 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var isMaintainerOnly = (path35) => path35.startsWith("wiki/meta/") || path35.startsWith("wiki/entities/");
-var run38 = (argv, options = {}) => {
+var HELP_TOKENS34 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var isMaintainerOnly = (path42) => path42.startsWith("wiki/meta/") || path42.startsWith("wiki/entities/");
+var run48 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS24.has(token)) {
-      process.stdout.write(HELP_TEXT26);
+    if (HELP_TOKENS34.has(token)) {
+      process.stdout.write(HELP_TEXT36);
       return EXIT_CODES.OK;
     }
     structuredError({
@@ -22590,147 +27295,16 @@ var run38 = (argv, options = {}) => {
   }
 };
 
-// src/wiki/state.ts
-import { existsSync as existsSync32, readdirSync as readdirSync9, readFileSync as readFileSync26, statSync as statSync7 } from "node:fs";
-import path32 from "node:path";
-var HELP_TEXT27 = `Usage: gaia wiki state [--json]
-`;
-var HELP_TOKENS25 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var classifySeverity = (commitCount) => {
-  if (commitCount <= 0) return "none";
-  if (commitCount <= 5) return "low";
-  if (commitCount <= 20) return "medium";
-  return "high";
-};
-var DOMAIN_DIRS3 = [
-  "components",
-  "concepts",
-  "decisions",
-  "dependencies",
-  "entities",
-  "flows",
-  "meta",
-  "modules"
-];
-var countDomainPages = (wikiRoot) => {
-  const counts = {};
-  for (const domain2 of DOMAIN_DIRS3) {
-    const domainDir = path32.join(wikiRoot, domain2);
-    if (!existsSync32(domainDir) || !statSync7(domainDir).isDirectory()) {
-      counts[domain2] = 0;
-      continue;
-    }
-    const entries = readdirSync9(domainDir, { withFileTypes: true });
-    let count = 0;
-    for (const entry of entries) {
-      if (!entry.isFile()) continue;
-      if (!entry.name.endsWith(".md")) continue;
-      if (entry.name === "_index.md") continue;
-      count += 1;
-    }
-    counts[domain2] = count;
-  }
-  return counts;
-};
-var readStateFile2 = (statePath) => {
-  if (!existsSync32(statePath)) return null;
-  const raw = readFileSync26(statePath, "utf8");
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
-};
-var printHuman6 = (state) => {
-  const lines = [
-    "Wiki state",
-    `  HEAD:           ${state.head_short}`,
-    `  Last evaluated: ${state.state_sha}`,
-    `  Reachable:      ${state.reachable ? "yes" : "no"}`,
-    `  Drift:          ${state.commits_ahead} commits (${state.drift_severity})`
-  ];
-  if (state.recent_commits.length > 0) {
-    lines.push("  Recent unsynced:");
-    for (const commit of state.recent_commits) {
-      lines.push(`    - ${commit.sha} ${commit.subject}`);
-    }
-  }
-  lines.push("  Per-domain pages:");
-  for (const [domain2, count] of Object.entries(state.per_domain_page_counts)) {
-    lines.push(`    ${domain2}: ${count}`);
-  }
-  process.stdout.write(`${lines.join("\n")}
-`);
-};
-var run39 = (argv, options = {}) => {
-  let json2 = false;
-  for (const token of argv) {
-    if (HELP_TOKENS25.has(token)) {
-      process.stdout.write(HELP_TEXT27);
-      return EXIT_CODES.OK;
-    }
-    if (token === "--json") {
-      json2 = true;
-      continue;
-    }
-    structuredError({
-      code: "invalid_arguments",
-      message: `unknown flag: ${token}`,
-      subcommand: "wiki state"
-    });
-    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-  }
-  let repoRoot2;
-  try {
-    repoRoot2 = resolveRepoRoot3(options.cwd ?? process.cwd());
-  } catch {
-    structuredError({
-      code: "not_a_git_repo",
-      message: "gaia wiki state must run inside a git repository",
-      subcommand: "wiki state"
-    });
-    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-  }
-  const wikiRoot = path32.join(repoRoot2, "wiki");
-  const statePath = path32.join(wikiRoot, ".state.json");
-  const stateFile = readStateFile2(statePath);
-  const stateSha = stateFile?.last_evaluated_sha ?? "";
-  const head = headSha(repoRoot2);
-  const headShort = shortSha(head, repoRoot2);
-  const stateShort = stateSha === "" ? "" : shortSha(stateSha, repoRoot2);
-  const reachable = stateSha !== "" && isReachable(stateSha, repoRoot2);
-  const ahead = stateSha === "" || !reachable ? 0 : commitsAhead(stateSha, repoRoot2);
-  const recent = stateSha === "" || !reachable ? [] : recentCommits(stateSha, repoRoot2, 5);
-  const severity = classifySeverity(ahead);
-  const counts = countDomainPages(wikiRoot);
-  const state = {
-    commits_ahead: ahead,
-    drift_severity: severity,
-    head_short: headShort,
-    per_domain_page_counts: counts,
-    reachable,
-    recent_commits: recent,
-    state_sha: stateShort
-  };
-  if (json2) {
-    process.stdout.write(`${JSON.stringify(state)}
-`);
-  } else {
-    printHuman6(state);
-  }
-  return EXIT_CODES.OK;
-};
-
 // src/wiki/state-bump.ts
-import { existsSync as existsSync33, readFileSync as readFileSync27, renameSync as renameSync9, writeFileSync as writeFileSync20 } from "node:fs";
-import path33 from "node:path";
-var HELP_TEXT28 = `Usage: gaia wiki state-bump <field> <value>
+import { existsSync as existsSync38, readFileSync as readFileSync34, renameSync as renameSync9, writeFileSync as writeFileSync26 } from "node:fs";
+import path40 from "node:path";
+var HELP_TEXT37 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS26 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS35 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson = (raw) => {
   try {
     return JSON.parse(raw);
@@ -22752,13 +27326,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run40 = (argv, options = {}) => {
+var run49 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT28);
+    process.stdout.write(HELP_TEXT37);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS26.has(argv[0])) {
-    process.stdout.write(HELP_TEXT28);
+  if (HELP_TOKENS35.has(argv[0])) {
+    process.stdout.write(HELP_TEXT37);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -22793,8 +27367,8 @@ var run40 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const statePath = path33.join(repoRoot2, "wiki", ".state.json");
-  if (!existsSync33(statePath)) {
+  const statePath = path40.join(repoRoot2, "wiki", ".state.json");
+  if (!existsSync38(statePath)) {
     structuredError({
       code: "state_missing",
       message: "wiki/.state.json does not exist",
@@ -22802,7 +27376,7 @@ var run40 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync27(statePath, "utf8");
+  const raw = readFileSync34(statePath, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -22827,16 +27401,16 @@ var run40 = (argv, options = {}) => {
   const trailingNewline = raw.endsWith("\n") ? "\n" : "";
   const serialized = `${JSON.stringify(next, null, 2)}${trailingNewline}`;
   const tmpPath = `${statePath}.tmp`;
-  writeFileSync20(tmpPath, serialized, "utf8");
+  writeFileSync26(tmpPath, serialized, "utf8");
   renameSync9(tmpPath, statePath);
   return EXIT_CODES.OK;
 };
 
 // src/wiki/state-init.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
-import { existsSync as existsSync34, mkdirSync as mkdirSync14, renameSync as renameSync10, writeFileSync as writeFileSync21 } from "node:fs";
-import path34 from "node:path";
-var HELP_TEXT29 = `Usage: gaia wiki state-init <sha>
+import { execFileSync as execFileSync5 } from "node:child_process";
+import { existsSync as existsSync39, mkdirSync as mkdirSync15, renameSync as renameSync10, writeFileSync as writeFileSync27 } from "node:fs";
+import path41 from "node:path";
+var HELP_TEXT38 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -22844,10 +27418,10 @@ var HELP_TEXT29 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag) \u2014 it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS27 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS36 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha = (ref, cwd) => {
   try {
-    const out = execFileSync4("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+    const out = execFileSync5("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -22857,13 +27431,13 @@ var resolveFullSha = (ref, cwd) => {
     return null;
   }
 };
-var run41 = (argv, options = {}) => {
+var run50 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT29);
+    process.stdout.write(HELP_TEXT38);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS27.has(argv[0])) {
-    process.stdout.write(HELP_TEXT29);
+  if (HELP_TOKENS36.has(argv[0])) {
+    process.stdout.write(HELP_TEXT38);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -22907,9 +27481,9 @@ var run41 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiDir = path34.join(repoRoot2, "wiki");
-  const statePath = path34.join(wikiDir, ".state.json");
-  if (existsSync34(statePath)) {
+  const wikiDir = path41.join(repoRoot2, "wiki");
+  const statePath = path41.join(wikiDir, ".state.json");
+  if (existsSync39(statePath)) {
     structuredError({
       code: "state_already_exists",
       message: "wiki/.state.json already exists \u2014 use `gaia wiki state-bump` to update fields",
@@ -22917,7 +27491,7 @@ var run41 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  mkdirSync14(wikiDir, { recursive: true });
+  mkdirSync15(wikiDir, { recursive: true });
   const nowDate = (options.now ?? (() => /* @__PURE__ */ new Date()))();
   const isoNow = nowDate.toISOString();
   const payload = {
@@ -22928,20 +27502,20 @@ var run41 = (argv, options = {}) => {
   const serialized = `${JSON.stringify(payload, null, 2)}
 `;
   const tmpPath = `${statePath}.tmp`;
-  writeFileSync21(tmpPath, serialized, "utf8");
+  writeFileSync27(tmpPath, serialized, "utf8");
   renameSync10(tmpPath, statePath);
   return EXIT_CODES.OK;
 };
 
 // src/wiki/util/branch.ts
-import { spawnSync as spawnSync2 } from "node:child_process";
-var defaultRunner = (command, args, options) => spawnSync2(command, args, {
+import { spawnSync as spawnSync6 } from "node:child_process";
+var defaultRunner5 = (command, args, options) => spawnSync6(command, args, {
   cwd: options.cwd,
   encoding: "utf8",
   stdio: ["ignore", "pipe", "pipe"]
 });
 var PROTECTED_BRANCHES = /* @__PURE__ */ new Set(["main", "master"]);
-var expectSuccess = (result, command, args) => {
+var expectSuccess3 = (result, command, args) => {
   if (result.error !== void 0) {
     throw new Error(
       `${command} ${args.join(" ")} failed: ${result.error.message}`
@@ -22955,15 +27529,15 @@ var expectSuccess = (result, command, args) => {
   }
   return result.stdout ?? "";
 };
-var currentBranch = (cwd, runner = defaultRunner) => {
+var currentBranch = (cwd, runner = defaultRunner5) => {
   const args = ["rev-parse", "--abbrev-ref", "HEAD"];
-  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
+  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
   return out.trim();
 };
 var isProtectedBranch = (branch) => PROTECTED_BRANCHES.has(branch);
-var inspectWorkingTree = (cwd, runner = defaultRunner) => {
+var inspectWorkingTree = (cwd, runner = defaultRunner5) => {
   const args = ["status", "--porcelain=v1", "-uall"];
-  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
+  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
   const paths = [];
   for (const rawLine of out.split("\n")) {
     const line = rawLine.replace(/\r$/u, "");
@@ -22990,7 +27564,7 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
 };
 
 // src/wiki/sync-land.ts
-var HELP_TEXT30 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT39 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -23001,9 +27575,9 @@ var HELP_TEXT30 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var UNEXPECTED_EXIT8 = 2;
-var parseFlags15 = (argv) => {
+var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var UNEXPECTED_EXIT16 = 2;
+var parseFlags23 = (argv) => {
   let branchAware = false;
   for (const token of argv) {
     if (token === "--branch-aware") {
@@ -23014,13 +27588,13 @@ var parseFlags15 = (argv) => {
   }
   return { flags: { branchAware }, ok: true };
 };
-var refuse = (message) => {
+var refuse2 = (message) => {
   process.stderr.write(`${message}
 `);
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 var runStep = (runner, step, cwd) => runner(step.command, step.args, { cwd });
-var passthroughFailure = (result, step) => {
+var passthroughFailure2 = (result, step) => {
   const stderr = (result.stderr ?? "").trim();
   const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
   const status = result.status ?? -1;
@@ -23032,9 +27606,9 @@ var passthroughFailure = (result, step) => {
     process.stderr.write(`${stderr}
 `);
   }
-  return UNEXPECTED_EXIT8;
+  return UNEXPECTED_EXIT16;
 };
-var stepSucceeded = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var stepSucceeded2 = (result) => result.error === void 0 && (result.status ?? -1) === 0;
 var inPlaceLanding = (ctx) => {
   const message = `wiki: sync through ${ctx.shortHead}`;
   const sequence = [
@@ -23043,7 +27617,7 @@ var inPlaceLanding = (ctx) => {
   ];
   for (const step of sequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
-    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+    if (!stepSucceeded2(result)) return passthroughFailure2(result, step);
   }
   process.stdout.write(
     `sync-land: landed via in-place commit ${ctx.shortHead}
@@ -23051,7 +27625,7 @@ var inPlaceLanding = (ctx) => {
   );
   return EXIT_CODES.OK;
 };
-var todayUtc2 = (now = /* @__PURE__ */ new Date()) => {
+var todayUtc4 = (now = /* @__PURE__ */ new Date()) => {
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, "0");
   const day = String(now.getUTCDate()).padStart(2, "0");
@@ -23072,7 +27646,7 @@ var protectedBranchLanding = (ctx, options) => {
   ];
   for (const step of sequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
-    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+    if (!stepSucceeded2(result)) return passthroughFailure2(result, step);
   }
   process.stdout.write(
     `sync-land: landed via branch-and-PR commit ${ctx.shortHead}
@@ -23080,12 +27654,12 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run42 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS28.has(argv[0])) {
-    process.stdout.write(HELP_TEXT30);
+var run51 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS37.has(argv[0])) {
+    process.stdout.write(HELP_TEXT39);
     return EXIT_CODES.OK;
   }
-  const parsed = parseFlags15(argv);
+  const parsed = parseFlags23(argv);
   if (!parsed.ok) {
     structuredError({
       code: "invalid_arguments",
@@ -23095,7 +27669,7 @@ var run42 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwdOption = options.cwd ?? process.cwd();
-  const runner = options.runner ?? defaultRunner;
+  const runner = options.runner ?? defaultRunner5;
   let repoRoot2;
   try {
     repoRoot2 = resolveRepoRoot3(cwdOption);
@@ -23117,18 +27691,18 @@ var run42 = (argv, options = {}) => {
       `sync-land: ${error51 instanceof Error ? error51.message : String(error51)}
 `
     );
-    return UNEXPECTED_EXIT8;
+    return UNEXPECTED_EXIT16;
   }
   if (workingTree.hasNonWikiChanges) {
-    return refuse(
+    return refuse2(
       "sync-land: working tree has non-wiki changes; aborting"
     );
   }
   if (!workingTree.hasWikiChanges) {
-    return refuse("sync-land: nothing to land");
+    return refuse2("sync-land: nothing to land");
   }
   if (isProtectedBranch(branch) && !parsed.flags.branchAware) {
-    return refuse(
+    return refuse2(
       "sync-land: refusing to land directly on main; pass --branch-aware or check out a feature branch"
     );
   }
@@ -23141,7 +27715,7 @@ var run42 = (argv, options = {}) => {
       `sync-land: ${error51 instanceof Error ? error51.message : String(error51)}
 `
     );
-    return UNEXPECTED_EXIT8;
+    return UNEXPECTED_EXIT16;
   }
   const ctx = {
     cwd: repoRoot2,
@@ -23149,7 +27723,7 @@ var run42 = (argv, options = {}) => {
     shortHead
   };
   if (isProtectedBranch(branch)) {
-    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc2() });
+    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc4() });
   }
   return inPlaceLanding(ctx);
 };
@@ -23168,7 +27742,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT31 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT40 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -23187,16 +27761,16 @@ var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS38 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS29.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS38.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run42(rest);
+    return run51(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -23205,26 +27779,26 @@ var runSync = async (args) => {
   });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-var SUBCOMMAND_HANDLERS4 = {
-  "commit-classify": run33,
-  "dead-paths": run34,
-  "log-prepend": run35,
-  "near-collisions": run36,
-  "orphans": run38,
-  "page-index": run37,
-  "state": run39,
-  "state-bump": run40,
-  "state-init": run41,
+var SUBCOMMAND_HANDLERS5 = {
+  "commit-classify": run43,
+  "dead-paths": run44,
+  "log-prepend": run45,
+  "near-collisions": run46,
+  "orphans": run48,
+  "page-index": run47,
+  "state": run24,
+  "state-bump": run49,
+  "state-init": run50,
   "sync": runSync
 };
-var run43 = async (argv) => {
+var run52 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS29.has(subcommand)) {
-    process.stdout.write(HELP_TEXT31);
+  if (subcommand === void 0 || HELP_TOKENS38.has(subcommand)) {
+    process.stdout.write(HELP_TEXT40);
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS4[subcommand];
+  const handler = SUBCOMMAND_HANDLERS5[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -23237,8 +27811,10 @@ var run43 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-// src/index.ts
-var HELP_TEXT32 = `Usage: gaia <subcommand> [args]
+// src/index.maintainer.ts
+var HELP_TEXT41 = `Usage: gaia-maintainer <subcommand> [args]
+
+Maintainer-only binary. Adopters use 'gaia' (no release namespace).
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -23247,33 +27823,35 @@ var HELP_TEXT32 = `Usage: gaia <subcommand> [args]
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
   update merge --baseline <dir> --latest <dir> --manifest <path>
+  release preflight|bump|changelog|scrub-wiki|manifest|scrub|runtime-deps|commit-and-tag
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT32);
+  process.stdout.write(HELP_TEXT41);
 };
-var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var SUBCOMMAND_HANDLERS5 = {
+var HELP_TOKENS39 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS6 = {
   init: run8,
   mentorship: run19,
-  scaffold: run24,
-  setup: run29,
-  telemetry: run30,
-  update: run32,
-  wiki: run43
+  release: run29,
+  scaffold: run34,
+  setup: run39,
+  telemetry: run40,
+  update: run42,
+  wiki: run52
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS30.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS39.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }
   if (subcommand === "_internal-fetch-coaching") {
     return run(rest);
   }
-  const handler = SUBCOMMAND_HANDLERS5[subcommand];
+  const handler = SUBCOMMAND_HANDLERS6[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -23290,3 +27868,8 @@ main().then((exitCode) => {
   });
   process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
 });
+/*! Bundled license information:
+
+js-yaml/dist/js-yaml.mjs:
+  (*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT *)
+*/

--- a/.gaia/cli/health/runbook.md
+++ b/.gaia/cli/health/runbook.md
@@ -148,8 +148,8 @@ awk '/^[[:space:]]*#/ {next} NF==0 {next} {print}' .gaia/release-exclude \
   > "$EXCLUDE_REGEX"
 grep -vE -f "$EXCLUDE_REGEX" "$ALL_TRACKED" > "$INCLUDE"
 rsync -a --files-from="$INCLUDE" . "$STAGING"/
-./.gaia/cli/gaia release scrub "$STAGING"
-./.gaia/cli/gaia release runtime-deps --staging "$STAGING"
+./.gaia/cli/gaia-maintainer release scrub "$STAGING"
+./.gaia/cli/gaia-maintainer release runtime-deps --staging "$STAGING"
 find "$STAGING" -name "*.md" -exec grep -l "gaia:maintainer-only" {} \;
 grep -rEn "\[\[(Release Workflow|Bundle-time Scrub|GAIA|Steven Sacks|dashboard|Entities|Meta)\]\]" "$STAGING/wiki/" || true
 ```

--- a/.gaia/cli/health/taxonomy.md
+++ b/.gaia/cli/health/taxonomy.md
@@ -114,7 +114,7 @@ Each entry: pattern, codified detection where one exists, prior occurrences (com
 ### Distribution boundary
 
 **Manifest stale relative to distributed file set.** Files added to the template don't auto-classify; manifest count diverges from `git ls-files | grep -v -f release-exclude`.
-- Detection: run `gaia release manifest` and `git diff .gaia/manifest.json` should be empty
+- Detection: run `gaia-maintainer release manifest` and `git diff .gaia/manifest.json` should be empty
 - Prior: 370 → 426 entry rebuild (ed94f49); 426 → 425 after `release.yml` excluded (98f7a62)
 
 **Maintainer-only files mis-classified as `shared` in manifest.** Files that don't ship should be in `release-exclude`, not in the manifest at all.
@@ -141,7 +141,7 @@ Each entry: pattern, codified detection where one exists, prior occurrences (com
 
 **Release-excluded runtime dependencies of shipped surfaces.** A shipped script, hook, statusline, or CLI binary calls into a path that is itself in `.gaia/release-exclude`. Adopters get the caller but not the callee — the surface silently degrades. Distinct from the prose-mention class above: this one has *runtime-behavior* consequences, not just documentation consequences. The bundle-time-scrub plan (post-#97) catches lexical leaks but does NOT catch this class — runtime references survive scrubbing.
 - Detection: enumerate every shell-callee path in shipped scripts (`bash <path>`, `source <path>`, `exec <path>`, explicit script-path constants) and cross-reference each against `.gaia/release-exclude`. A simpler heuristic: `grep -rEn '\.gaia/scripts/|\.gaia/cli/src/|\.specify/extensions/gaia/test/|\.gaia/tests/' .gaia/statusline/ .claude/hooks/ .gaia/cli/templates/` for path constants in shipped runtime surfaces. Every match where the cited path is release-excluded is a runtime leak.
-- Codification opportunity: a `gaia release runtime-deps` primitive could read every shipped `.sh`/`.ts` for explicit path constants and verify each is either in the manifest or a runtime-allocated path (`.gaia/local/`, `.gaia/cache/`).
+- Codification opportunity: a `gaia-maintainer release runtime-deps` primitive could read every shipped `.sh`/`.ts` for explicit path constants and verify each is either in the manifest or a runtime-allocated path (`.gaia/local/`, `.gaia/cache/`).
 - Prior: `.gaia/statusline/gaia-statusline.sh:26,108-110` invoked `.gaia/scripts/check-updates.sh` while the entire `.gaia/scripts/` directory was release-excluded (category 5, "legacy"); on adopter clones the statusline never refreshed its cache, so `Run /update-deps` and `Run /update-gaia` indicators never lit. Audit #13 fix: removed `.gaia/scripts` from release-exclude, updated `wiki/concepts/Release Workflow.md` framing (the directory is not legacy — `check-updates.sh` is actively shipped), regenerated manifest (420 → 421 entries, 322 → 323 owned).
 
 **Maintainer-monorepo path prefix in adopter-shipped files.** A path in a distributed file uses the maintainer's monorepo layout (`gaia/`, `studio/`, `website/` are siblings of the maintainer's clone). Adopter clones are single-repo; the prefix dangles.

--- a/.gaia/cli/package.json
+++ b/.gaia/cli/package.json
@@ -2,13 +2,16 @@
   "name": "@gaia-react/cli",
   "private": true,
   "type": "module",
-  "description": "GAIA CLI — telemetry emit primitive and mentorship subcommand surface. Maintainer source; ships to adopters as a single bundled binary at .gaia/cli/gaia.",
+  "description": "GAIA CLI — telemetry emit primitive, mentorship CLI, init/update/wiki/scaffold/setup subcommands. Maintainer source; ships to adopters as a single bundled binary at .gaia/cli/gaia. The maintainer binary at .gaia/cli/gaia-maintainer adds the release namespace and is excluded from the adopter tarball.",
   "scripts": {
-    "bundle": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --banner:js=$'#!/usr/bin/env node\\nimport { createRequire as __createRequire } from \"node:module\"; const require = __createRequire(import.meta.url);' --outfile=gaia && chmod +x gaia && rm -rf templates && cp -r src/scaffold/templates templates",
+    "bundle": "pnpm bundle:adopter && pnpm bundle:maintainer",
+    "bundle:adopter": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --banner:js=$'#!/usr/bin/env node\\nimport { createRequire as __createRequire } from \"node:module\"; const require = __createRequire(import.meta.url);' --outfile=gaia && chmod +x gaia && rm -rf templates && cp -r src/scaffold/templates templates",
+    "bundle:maintainer": "esbuild src/index.maintainer.ts --bundle --platform=node --target=node20 --format=esm --banner:js=$'#!/usr/bin/env node\\nimport { createRequire as __createRequire } from \"node:module\"; const require = __createRequire(import.meta.url);' --outfile=gaia-maintainer && chmod +x gaia-maintainer",
     "typecheck": "tsc -p ./tsconfig.json --noEmit",
     "test": "vitest --passWithNoTests",
     "fixtures:build": "tsx ./test-fixtures/profile/build.ts",
-    "gaia": "tsx ./src/index.ts"
+    "gaia": "tsx ./src/index.ts",
+    "gaia-maintainer": "tsx ./src/index.maintainer.ts"
   },
   "dependencies": {
     "js-yaml": "4.1.1",

--- a/.gaia/cli/src/index.maintainer.ts
+++ b/.gaia/cli/src/index.maintainer.ts
@@ -1,18 +1,23 @@
 /**
- * gaia CLI entrypoint (adopter binary).
+ * gaia-maintainer CLI entrypoint (maintainer-only binary).
  *
- * Top-level subcommand router. Maintainer-only namespaces (currently just
- * `release`) live in `index.maintainer.ts` and bundle to a separate
- * binary (`gaia-maintainer`) excluded from the adopter tarball by
- * `.gaia/release-exclude`. The adopter binary must not import any
- * maintainer-only handler, so esbuild tree-shakes their code out of this
- * bundle by construction.
+ * Adopter-binary surface plus the maintainer-only `release` namespace.
+ * Bundles to `.gaia/cli/gaia-maintainer`, which `.gaia/release-exclude`
+ * strips from the adopter tarball. Adopters never see this binary or
+ * any of its commands; only the GAIA template's own maintainer (and CI
+ * jobs running on the maintainer's clone) invokes it.
+ *
+ * Mirrors `index.ts` deliberately: the dispatch loop is short enough
+ * that a shared abstraction would obscure the contract more than it
+ * would save lines. Anything added to either binary's surface should be
+ * added here too unless it is intentionally adopter-only.
  */
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
 import {run as runFetchCoaching} from './adaptation/inject.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
+import {run as runRelease} from './release/index.js';
 import {run as runScaffold} from './scaffold/index.js';
 import {run as runSetup} from './setup/index.js';
 import {structuredError} from './stderr.js';
@@ -20,7 +25,9 @@ import {run as runTelemetry} from './telemetry/index.js';
 import {run as runUpdate} from './update/index.js';
 import {run as runWiki} from './wiki/index.js';
 
-const HELP_TEXT = `Usage: gaia <subcommand> [args]
+const HELP_TEXT = `Usage: gaia-maintainer <subcommand> [args]
+
+Maintainer-only binary. Adopters use 'gaia' (no release namespace).
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -29,6 +36,7 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
   update merge --baseline <dir> --latest <dir> --manifest <path>
+  release preflight|bump|changelog|scrub-wiki|manifest|scrub|runtime-deps|commit-and-tag
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
 `;
@@ -46,6 +54,7 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
   init: runInit,
   mentorship: runMentorship,
+  release: runRelease,
   scaffold: runScaffold,
   setup: runSetup,
   telemetry: runTelemetry,
@@ -54,9 +63,6 @@ const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> 
 };
 
 const main = async (): Promise<number> => {
-  // process.argv[2] is undefined when no subcommand is supplied. Node's
-  // typings model argv as `string[]` (no `noUncheckedIndexedAccess`),
-  // so we coerce through unknown to express the runtime reality.
   const subcommand = process.argv[2] as string | undefined;
   const rest = process.argv.slice(3);
 
@@ -66,12 +72,6 @@ const main = async (): Promise<number> => {
     return EXIT_CODES.OK;
   }
 
-  // Internal subcommand consumed by the `/gaia spec` skill (and future
-  // dispatch-time callers) to fetch profile-driven coaching text. Wired
-  // top-level rather than under `mentorship` because it's an
-  // implementation detail consumed by skill scaffolding, not a
-  // user-facing surface — kept out of the help text to match the
-  // `mentorship _internal-*` precedent.
   if (subcommand === '_internal-fetch-coaching') {
     return runFetchCoaching(rest);
   }

--- a/.gaia/cli/src/release/bump.test.ts
+++ b/.gaia/cli/src/release/bump.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release bump`.
+ * Tests for `gaia-maintainer release bump`.
  */
 import {execFileSync, type SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/release/bump.ts
+++ b/.gaia/cli/src/release/bump.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release bump [--auto]` handler.
+ * `gaia-maintainer release bump [--auto]` handler.
  *
  * Step 3 of the maintainer release runbook. Scans conventional-commit
  * subjects (and bodies) since the last tag, classifies the highest
@@ -28,7 +28,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release bump [--auto]
+const HELP_TEXT = `Usage: gaia-maintainer release bump [--auto]
 
   Compute the next semver bump from conventional-commit subjects since
   the last tag. Without --auto, prints the proposal. With --auto, writes

--- a/.gaia/cli/src/release/changelog.test.ts
+++ b/.gaia/cli/src/release/changelog.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release changelog`.
+ * Tests for `gaia-maintainer release changelog`.
  */
 import {execFileSync, type SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/release/changelog.ts
+++ b/.gaia/cli/src/release/changelog.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release changelog [--draft]` handler.
+ * `gaia-maintainer release changelog [--draft]` handler.
  *
  * Step 7 of the maintainer release runbook. Auto-drafts a Keep-a-Changelog
  * block from conventional-commit subjects since the last tag, mapping
@@ -21,7 +21,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release changelog [--draft] [--version <X.Y.Z>]
+const HELP_TEXT = `Usage: gaia-maintainer release changelog [--draft] [--version <X.Y.Z>]
 
   Render a Keep-a-Changelog block for the new version from
   conventional-commit subjects since the last tag.

--- a/.gaia/cli/src/release/commit-and-tag.test.ts
+++ b/.gaia/cli/src/release/commit-and-tag.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release commit-and-tag`.
+ * Tests for `gaia-maintainer release commit-and-tag`.
  *
  * Mixes a real-git temp-repo fixture (for the commit dance) with mocked
  * runners (for the tag-push path, where pushing to a remote isn't

--- a/.gaia/cli/src/release/commit-and-tag.ts
+++ b/.gaia/cli/src/release/commit-and-tag.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release commit-and-tag` handler.
+ * `gaia-maintainer release commit-and-tag` handler.
  *
  * Codifies Step 11 and Step 13 of the maintainer release runbook:
  *
@@ -25,7 +25,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release commit-and-tag (--commit | --tag) [--no-push]
+const HELP_TEXT = `Usage: gaia-maintainer release commit-and-tag (--commit | --tag) [--no-push]
 
   --commit      Stage release-related files and commit, then amend
                 wiki/.state.json with the new commit SHA.

--- a/.gaia/cli/src/release/index.ts
+++ b/.gaia/cli/src/release/index.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release` subcommand router.
+ * `gaia-maintainer release` subcommand router.
  *
  * Chains preflight → bump → quality gate → changelog → scrub-wiki →
  * manifest → commit-and-tag for `/gaia-release`. The slash command is a
@@ -19,7 +19,7 @@ import {run as runRuntimeDeps} from './runtime-deps.js';
 import {run as runScrub} from './scrub.js';
 import {run as runScrubWiki} from './scrub-wiki.js';
 
-const HELP_TEXT = `Usage: gaia release <subcommand> [args]
+const HELP_TEXT = `Usage: gaia-maintainer release <subcommand> [args]
 
   preflight [--branch <name>]                 Branch + working-tree + wiki state checks.
   bump [--auto]                               Conventional-commit semver bump.

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release manifest`.
+ * Tests for `gaia-maintainer release manifest`.
  *
  * Includes a byte-identity snapshot against the legacy
  * `.gaia/scripts/generate-manifest.mjs` script for the current repo

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release manifest` handler.
+ * `gaia-maintainer release manifest` handler.
  *
  * Walks `git ls-files`, subtracts paths matched by `.gaia/release-exclude`
  * and adopter-owned sentinels, classifies each remaining path, and
@@ -23,8 +23,8 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release manifest [--out <path>] [--stdout]
-       gaia release manifest --check [--json]
+const HELP_TEXT = `Usage: gaia-maintainer release manifest [--out <path>] [--stdout]
+       gaia-maintainer release manifest --check [--json]
 
   Regenerate .gaia/manifest.json. Walks git ls-files, subtracts
   release-exclude patterns and adopter-owned sentinels, classifies the
@@ -374,7 +374,7 @@ const runCheck = (
   if (!existsSync(manifestPath)) {
     structuredError({
       code: 'manifest_missing',
-      message: `committed manifest not found at ${manifestPath}; run \`gaia release manifest\` to generate it`,
+      message: `committed manifest not found at ${manifestPath}; run \`gaia-maintainer release manifest\` to generate it`,
       subcommand: 'release manifest',
     });
 

--- a/.gaia/cli/src/release/preflight.test.ts
+++ b/.gaia/cli/src/release/preflight.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release preflight`.
+ * Tests for `gaia-maintainer release preflight`.
  */
 import {execFileSync, type SpawnSyncReturns} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync} from 'node:fs';

--- a/.gaia/cli/src/release/preflight.ts
+++ b/.gaia/cli/src/release/preflight.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release preflight` handler.
+ * `gaia-maintainer release preflight` handler.
  *
  * Step 1 + Step 2 of the maintainer release runbook codified as exit codes:
  *
@@ -16,7 +16,7 @@ import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {run as runWikiState} from '../wiki/state.js';
 
-const HELP_TEXT = `Usage: gaia release preflight [--branch <name>]
+const HELP_TEXT = `Usage: gaia-maintainer release preflight [--branch <name>]
 
   Verify branch state, working tree, and wiki sync before cutting a release.
 

--- a/.gaia/cli/src/release/runtime-deps.test.ts
+++ b/.gaia/cli/src/release/runtime-deps.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release runtime-deps`.
+ * Tests for `gaia-maintainer release runtime-deps`.
  */
 import {
   mkdirSync,

--- a/.gaia/cli/src/release/runtime-deps.ts
+++ b/.gaia/cli/src/release/runtime-deps.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release runtime-deps` handler.
+ * `gaia-maintainer release runtime-deps` handler.
  *
  * Catches the class of leak that the bundle-time scrub cannot see:
  * runtime references in shipped scripts that resolve to release-excluded
@@ -34,7 +34,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
+const HELP_TEXT = `Usage: gaia-maintainer release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
 
   Scan shipped shell scripts for runtime path references that resolve to
   release-excluded files.

--- a/.gaia/cli/src/release/scrub-wiki.test.ts
+++ b/.gaia/cli/src/release/scrub-wiki.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release scrub-wiki`.
+ * Tests for `gaia-maintainer release scrub-wiki`.
  */
 import {
   mkdirSync,

--- a/.gaia/cli/src/release/scrub-wiki.ts
+++ b/.gaia/cli/src/release/scrub-wiki.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release scrub-wiki` handler.
+ * `gaia-maintainer release scrub-wiki` handler.
  *
  * Steps 8 + 9 of the maintainer release runbook. Overwrites
  * `wiki/hot.md` and `wiki/log.md` with release-clean content. The exact
@@ -13,7 +13,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release scrub-wiki [--version <X.Y.Z>] [--date <YYYY-MM-DD>]
+const HELP_TEXT = `Usage: gaia-maintainer release scrub-wiki [--version <X.Y.Z>] [--date <YYYY-MM-DD>]
 
   Overwrite wiki/hot.md and wiki/log.md with release-clean content
   (Step 8 + Step 9 of the runbook).

--- a/.gaia/cli/src/release/scrub.test.ts
+++ b/.gaia/cli/src/release/scrub.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `gaia release scrub`.
+ * Tests for `gaia-maintainer release scrub`.
  */
 import {
   mkdirSync,

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -1,5 +1,5 @@
 /**
- * `gaia release scrub` handler.
+ * `gaia-maintainer release scrub` handler.
  *
  * Bundle-time discipline for the GAIA release tarball. Runs inside
  * `release.yml` between the staging step (rsync from `git ls-files` minus
@@ -31,7 +31,7 @@ import {z} from 'zod';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
-const HELP_TEXT = `Usage: gaia release scrub <staging-dir> [--config <path>] [--json]
+const HELP_TEXT = `Usage: gaia-maintainer release scrub <staging-dir> [--config <path>] [--json]
 
   Apply bundle-time scrub transforms (marker-strip + leak-check) to a
   staging directory produced by release.yml. Writes in place inside

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -3,7 +3,7 @@
 # no business on an adopter's machine. Format is tar --exclude-from: one
 # path or glob per line, comments with `#` are honored.
 #
-# Anything excluded here is ALSO skipped by `gaia release manifest`, so the
+# Anything excluded here is ALSO skipped by `gaia-maintainer release manifest`, so the
 # adopter-facing manifest never references files an adopter cannot have.
 # Authoritative narrative of what's maintainer-only and why lives in
 # `wiki/concepts/Release Workflow.md` (Distribution Boundary section).
@@ -62,7 +62,7 @@ wiki/decisions/Forensics Triage Workflow.md
 
 # --- 5. Release-time maintainer tooling ---
 # This file itself — adopters don't run GAIA releases. The release-scrub
-# config drives `gaia release scrub` (bundle-time marker-strip + leak-check)
+# config drives `gaia-maintainer release scrub` (bundle-time marker-strip + leak-check)
 # and is consumed only by the maintainer's release.yml. Note:
 # `.gaia/scripts/` DOES ship: `check-updates.sh` is the background refresher
 # invoked by the adopter-facing statusline (writes the cache the statusline

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -36,11 +36,18 @@ wiki/decisions/Forensics Triage Workflow.md
 .claude/rules/_internal
 .specify/extensions/gaia/test
 
-# --- 4. CLI maintainer source ---
-# Adopters receive only the bundled binary at .gaia/cli/gaia (and the
-# templates at .gaia/cli/templates/). Source, tests, fixtures, and build
-# configs stay in the template repo so adopters can't accidentally rebuild
-# the binary out from under themselves.
+# --- 4. CLI maintainer source + maintainer binary ---
+# Adopters receive only the bundled adopter binary at .gaia/cli/gaia (and
+# the templates at .gaia/cli/templates/). Source, tests, fixtures, and
+# build configs stay in the template repo so adopters can't accidentally
+# rebuild the binary out from under themselves.
+#
+# .gaia/cli/gaia-maintainer is the second bundle produced by `pnpm bundle`
+# (entry: src/index.maintainer.ts). It carries the maintainer-only
+# `release` namespace and exists only on the GAIA team's clone — adopters
+# never see it. The adopter `gaia` binary's source (src/index.ts) does not
+# import any release code, so esbuild keeps the release surface out of the
+# adopter bundle by construction.
 .gaia/cli/src
 .gaia/cli/test-fixtures
 .gaia/cli/__tests__
@@ -51,6 +58,7 @@ wiki/decisions/Forensics Triage Workflow.md
 .gaia/cli/.gitignore
 .gaia/cli/node_modules
 .gaia/cli/dist
+.gaia/cli/gaia-maintainer
 
 # --- 5. Release-time maintainer tooling ---
 # This file itself — adopters don't run GAIA releases. The release-scrub

--- a/.gaia/release-scrub.yml
+++ b/.gaia/release-scrub.yml
@@ -1,4 +1,4 @@
-# Bundle-time scrub config. Consumed by `gaia release scrub <staging-dir>`
+# Bundle-time scrub config. Consumed by `gaia-maintainer release scrub <staging-dir>`
 # from inside `release.yml` between staging and tarball creation.
 #
 # Two transforms run in order against the staging tree:
@@ -15,7 +15,7 @@
 # repo-relative paths under the staging directory.
 #
 # This file is itself maintainer-only (release-exclude category 5).
-# Adopters never run `gaia release scrub`.
+# Adopters never run `gaia-maintainer release scrub`.
 
 transforms:
   - type: marker-strip
@@ -124,7 +124,7 @@ transforms:
           # Allowlisted by the audit taxonomy.
           - "wiki/concepts/Telemetry.md"
           # Adopter-owned sentinels that ship in the tarball but contain
-          # release-baseline content after `gaia release scrub-wiki`
+          # release-baseline content after `gaia-maintainer release scrub-wiki`
           # (Step 8 of `/gaia-release`). Local simulations against
           # mid-development hot/log content would otherwise false-positive.
           - "wiki/hot.md"
@@ -145,7 +145,7 @@ transforms:
           - ".specify/extensions/gaia/templates/**"
         path-allowlist:
           # Same hot/log carve-out as maintainer-paths — they get
-          # release-baseline content via `gaia release scrub-wiki`.
+          # release-baseline content via `gaia-maintainer release scrub-wiki`.
           - "wiki/hot.md"
           - "wiki/log.md"
 
@@ -182,7 +182,7 @@ transforms:
           - ".gaia/statusline/**"
         path-allowlist:
           # Adopter-owned sentinels carry release-baseline content after
-          # `gaia release scrub-wiki`; same carve-out as maintainer-paths.
+          # `gaia-maintainer release scrub-wiki`; same carve-out as maintainer-paths.
           - "wiki/hot.md"
           - "wiki/log.md"
 

--- a/.gaia/tests/distribution/01-files-present.sh
+++ b/.gaia/tests/distribution/01-files-present.sh
@@ -68,7 +68,8 @@ FILE_VER="$(tr -d '[:space:]' < "$STAGING/.gaia/VERSION")"
   || { fail ".gaia/VERSION ($FILE_VER) != package.json version ($PKG_VER)"; exit 1; }
 
 # wiki/hot.md and wiki/log.md should carry the release-marker strings
-# that `gaia release scrub-wiki` writes (Step 8 + 9 of `/gaia-release`).
+# that `gaia-maintainer release scrub-wiki` writes (Step 8 + 9 of
+# `/gaia-release`).
 # Asserting on the actual rendered content is stricter than a line-count
 # proxy — it catches "scrub-wiki didn't run" AND "scrub-wiki wrote the
 # wrong version". Marker shapes are pinned to scrub-wiki.ts:renderHotMd /

--- a/.gaia/tests/distribution/02-leak-replay.sh
+++ b/.gaia/tests/distribution/02-leak-replay.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # 02-leak-replay.sh
 #
-# Re-runs `gaia release scrub` on the staged tree as a defense-in-depth
-# check. The same scrub already ran during build-staging.sh; running it
-# twice on a clean tree must produce a clean result both times.
+# Re-runs `gaia-maintainer release scrub` on the staged tree as a
+# defense-in-depth check. The same scrub already ran during
+# build-staging.sh; running it twice on a clean tree must produce a clean
+# result both times.
 #
 # This catches:
 #   - non-idempotent scrub transforms (a regression class)
@@ -23,7 +24,7 @@ trap 'rm -rf "$STAGING"' EXIT
 # build-staging.sh; running again on a clean tree should be a no-op.
 SCRUB_OUTPUT="$(mktemp)"
 trap 'rm -rf "$STAGING" "$SCRUB_OUTPUT"' EXIT
-if ! "$PROJECT_ROOT/.gaia/cli/gaia" release scrub "$STAGING" --json > "$SCRUB_OUTPUT" 2>&1; then
+if ! "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release scrub "$STAGING" --json > "$SCRUB_OUTPUT" 2>&1; then
   log "Second scrub pass failed:"
   cat "$SCRUB_OUTPUT" >&2
   fail "scrub regression detected on second pass"

--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -28,10 +28,13 @@ if [ -n "$(ls -A "$OUTPUT_DIR" 2>/dev/null)" ]; then
   exit 1
 fi
 
-# Sanity: bundled CLI binary must exist. Maintainer runs
-# `pnpm -C .gaia/cli bundle` if stale; we don't rebuild here.
-if [ ! -x "$PROJECT_ROOT/.gaia/cli/gaia" ]; then
-  printf 'Bundled CLI binary missing or not executable: %s/.gaia/cli/gaia\n' "$PROJECT_ROOT" >&2
+# Sanity: maintainer CLI binary must exist. The release subcommands the
+# staging pipeline calls (scrub, scrub-wiki, runtime-deps) live only in
+# the maintainer binary; the adopter `gaia` binary intentionally has no
+# `release` namespace. Maintainer runs `pnpm -C .gaia/cli bundle` if
+# stale; we don't rebuild here.
+if [ ! -x "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" ]; then
+  printf 'Maintainer CLI binary missing or not executable: %s/.gaia/cli/gaia-maintainer\n' "$PROJECT_ROOT" >&2
   printf 'Run `pnpm -C .gaia/cli bundle` first.\n' >&2
   exit 1
 fi
@@ -59,7 +62,7 @@ fi
 rsync -a --files-from="$INCLUDE" "$PROJECT_ROOT/" "$OUTPUT_DIR/"
 
 # Phase 2 — Scrub. Same invocation as release.yml line 82.
-"$PROJECT_ROOT/.gaia/cli/gaia" release scrub "$OUTPUT_DIR"
+"$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release scrub "$OUTPUT_DIR"
 
 # Phase 2.5 — Scrub-wiki. Resets wiki/hot.md and wiki/log.md to release-
 # baseline state. release.yml does NOT do this — it runs in the local
@@ -67,7 +70,7 @@ rsync -a --files-from="$INCLUDE" "$PROJECT_ROOT/" "$OUTPUT_DIR/"
 # it against the staging tree so the harness mirrors what an adopter
 # receives in a published tarball, regardless of which source-commit
 # state we built from.
-( cd "$OUTPUT_DIR" && "$PROJECT_ROOT/.gaia/cli/gaia" release scrub-wiki )
+( cd "$OUTPUT_DIR" && "$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release scrub-wiki )
 
 # Phase 3 — Runtime-deps. Same invocation as release.yml line 87.
-"$PROJECT_ROOT/.gaia/cli/gaia" release runtime-deps --staging "$OUTPUT_DIR"
+"$PROJECT_ROOT/.gaia/cli/gaia-maintainer" release runtime-deps --staging "$OUTPUT_DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           echo "notes-path=release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Verify manifest is fresh
-        run: ./.gaia/cli/gaia release manifest --check
+        run: ./.gaia/cli/gaia-maintainer release manifest --check
 
       - name: Stage release tree
         run: |
@@ -79,12 +79,12 @@ jobs:
       - name: Bundle-time scrub (marker-strip + leak-check)
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          ./.gaia/cli/gaia release scrub "/tmp/gaia-${TAG}"
+          ./.gaia/cli/gaia-maintainer release scrub "/tmp/gaia-${TAG}"
 
       - name: Verify runtime dependencies
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          ./.gaia/cli/gaia release runtime-deps --staging "/tmp/gaia-${TAG}"
+          ./.gaia/cli/gaia-maintainer release runtime-deps --staging "/tmp/gaia-${TAG}"
 
       # Pre-publish distribution-test gate. Runs Layers 0+1+2 against an
       # independently-staged tree (build-staging.sh re-runs the same

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -21,7 +21,7 @@ How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/
 | `.gaia/VERSION`                       | Plain `X.Y.Z`. Single source of truth for the installed version. Survives `/gaia-init`.                       |
 | `.gaia/manifest.json`                 | Maps every GAIA-shipped file to a class (`owned` / `shared` / `wiki-owned`). Consumed by [[Update Workflow]]. |
 | `.gaia/release-exclude`               | Tar-exclude format. Paths listed here are stripped from the release tarball.                                  |
-| `gaia release manifest` (CLI)         | Maintainer-only. Walks `git ls-files` + classifier globs; writes `.gaia/manifest.json`.                       |
+| `gaia-maintainer release manifest` (CLI)         | Maintainer-only. Walks `git ls-files` + classifier globs; writes `.gaia/manifest.json`.                       |
 | `CHANGELOG.md`                        | Keep-a-Changelog format. `## [Unreleased]` at top; `/gaia-release` graduates it to a versioned section.       |
 | `.github/workflows/release.yml`       | Tag-triggered (`v*.*.*`). Builds scrubbed tarball, creates GitHub Release with CHANGELOG excerpt.             |
 
@@ -44,7 +44,7 @@ Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 7. Auto-draft CHANGELOG from `git log` since last release; present for approval; graduate to `## [vX.Y.Z] — YYYY-MM-DD` and seed a new empty `## [Unreleased]`.
 8. Overwrite `wiki/hot.md` with release-baseline content (so adopters clone a fresh slate).
 9. Overwrite `wiki/log.md` with a single release-milestone entry (dev history lives in git).
-10. Regenerate `.gaia/manifest.json` via `gaia release manifest`.
+10. Regenerate `.gaia/manifest.json` via `gaia-maintainer release manifest`.
 11. Commit on the release branch: `chore(release): vX.Y.Z`. The pre-commit dance updates `wiki/.state.json`'s `last_evaluated_sha` to the new commit's own SHA via amend, so adopters' state files match their release commit on first scaffold.
 12. Push branch, open PR via `gh`, merge inline via `gh pr merge --merge`. Release branches have no required checks, so the merge is immediate.
 13. Pull `main`, tag the merge commit (`v<NEW_VERSION>`), push the tag.
@@ -56,16 +56,16 @@ The tag push triggers [`release.yml`](../../.github/workflows/release.yml), whic
 `release.yml` builds the tarball in five phases:
 
 1. **Stage** — drive the file set from `git ls-files` (not a raw `tar .`) and subtract `.gaia/release-exclude` patterns. `git ls-files` already ignores anything in `.gitignore` (no `.DS_Store`, `node_modules`, build output, `.idea/`); `.gaia/release-exclude` strips the tracked-but-maintainer-only content. `rsync` materializes the include list into `/tmp/gaia-vX.Y.Z/`.
-2. **Bundle-time scrub** — `gaia release scrub /tmp/gaia-vX.Y.Z` applies the transforms in `.gaia/release-scrub.yml`: marker-delimited section strips and a leak-check pass that mirrors the `wiki-style.md` audit greps. Build fails closed on any leak. See [[Bundle-time Scrub]] for rationale.
-3. **Runtime-deps verification** — `gaia release runtime-deps --staging /tmp/gaia-vX.Y.Z` walks shipped shell scripts and verifies every explicit path constant resolves to a shipped path, an adopter-owned sentinel, or a runtime-allocated location. Catches the leak class scrubbing cannot see — runtime references survive lexical strip.
+2. **Bundle-time scrub** — `gaia-maintainer release scrub /tmp/gaia-vX.Y.Z` applies the transforms in `.gaia/release-scrub.yml`: marker-delimited section strips and a leak-check pass that mirrors the `wiki-style.md` audit greps. Build fails closed on any leak. See [[Bundle-time Scrub]] for rationale.
+3. **Runtime-deps verification** — `gaia-maintainer release runtime-deps --staging /tmp/gaia-vX.Y.Z` walks shipped shell scripts and verifies every explicit path constant resolves to a shipped path, an adopter-owned sentinel, or a runtime-allocated location. Catches the leak class scrubbing cannot see — runtime references survive lexical strip.
 4. **Distribution test gate** — `bash .gaia/tests/distribution/run-all.sh` runs Layers 0+1+2 against an independently-staged tree (`build-staging.sh` re-runs the same `git ls-files` + scrub + runtime-deps phases above). Layer 0 confirms an adopter scaffold typechecks, lints, tests, and builds; Layer 1 confirms the bootstrap path survives in a PATH-stripped subshell; Layer 2 builds a Claude-in-Docker image and probes OAuth auth. The gate's `CLAUDE_CODE_OAUTH_TOKEN` comes from GAIA's GitHub organization secrets; per-run cost is $0 on the maintainer's Claude Max subscription. If any scenario fails the release halts — the tarball is never built and `gh release create` never runs, so a broken release cannot publish.
-5. **Tar** — `tar -czf gaia-vX.Y.Z.tar.gz -C /tmp gaia-vX.Y.Z`. The same release-exclude list drives `gaia release manifest`, so the manifest never references files an adopter cannot have. The categories are spelled out in the next section.
+5. **Tar** — `tar -czf gaia-vX.Y.Z.tar.gz -C /tmp gaia-vX.Y.Z`. The same release-exclude list drives `gaia-maintainer release manifest`, so the manifest never references files an adopter cannot have. The categories are spelled out in the next section.
 
 The scrubbed `wiki/hot.md` + `wiki/log.md` contain only the release marker — none of GAIA's internal session cache.
 
 ### Bundle-time enforcement
 
-Marker-delimited maintainer-only blocks let the source repo carry content useful to maintainers (entity pages, internal cross-references, audit-decision rationale) without leaking into adopter scaffolds. Wrap a block in `<!-- gaia:maintainer-only:start -->` / `<!-- gaia:maintainer-only:end -->`; `gaia release scrub` strips the block before tar.
+Marker-delimited maintainer-only blocks let the source repo carry content useful to maintainers (entity pages, internal cross-references, audit-decision rationale) without leaking into adopter scaffolds. Wrap a block in `<!-- gaia:maintainer-only:start -->` / `<!-- gaia:maintainer-only:end -->`; `gaia-maintainer release scrub` strips the block before tar.
 
 The leak-check pass is the convergence mechanism the post-#97 audit trajectory predicted: free-form audits found roughly one novel issue class per round; codified detection patterns running against the staging tree close the loop. New leak patterns become explicit `.gaia/release-scrub.yml` entries — visible, reviewable, deterministic.
 
@@ -108,7 +108,7 @@ Excluding the source prevents adopters from accidentally rebuilding the binary o
 ### 5. Release-time maintainer tooling
 
 - `.gaia/release-exclude` — this exclusion file itself.
-- `.gaia/release-scrub.yml` — bundle-time scrub config consumed by `gaia release scrub`. Adopters never run releases.
+- `.gaia/release-scrub.yml` — bundle-time scrub config consumed by `gaia-maintainer release scrub`. Adopters never run releases.
 
 `.gaia/scripts/` ships to adopters: `check-updates.sh` is the background refresher the statusline invokes to populate `Run /update-deps` and `Run /update-gaia` indicators.
 

--- a/wiki/decisions/Bundle-time Scrub.md
+++ b/wiki/decisions/Bundle-time Scrub.md
@@ -25,7 +25,7 @@ Build-time enforcement closes the loop. The patterns the audit rounds surfaced b
 
 Two primitives, sequenced inside `release.yml` between rsync-staging and tar:
 
-### `gaia release scrub <staging-dir>`
+### `gaia-maintainer release scrub <staging-dir>`
 
 Reads `.gaia/release-scrub.yml`. Two transform types:
 
@@ -35,7 +35,7 @@ Reads `.gaia/release-scrub.yml`. Two transform types:
 
 Non-empty match in any check fails the build with a structured leak report.
 
-### `gaia release runtime-deps --staging <dir>`
+### `gaia-maintainer release runtime-deps --staging <dir>`
 
 Walks `.gaia/statusline/**/*.sh` and `.claude/hooks/**/*.sh` inside the staging tree, extracts repo-relative path constants, and verifies each is a shipped path (in `.gaia/manifest.json`), an adopter-owned sentinel (`wiki/hot.md`, `wiki/log.md`, `.gaia/VERSION`, `.gaia/manifest.json`), or a runtime-allocated path on adopter machines (`.gaia/local/`, `.gaia/cache/`, `.claude/handoff/`, `.claude/worktrees/`, `.claude/agent-memory/`, `.claude/audit/`, plus the per-session marker files).
 


### PR DESCRIPTION
## Summary

The adopter binary at `.gaia/cli/gaia` shipped with the entire `release` namespace baked in (`preflight`, `bump`, `changelog`, `scrub-wiki`, `manifest`, `scrub`, `runtime-deps`, `commit-and-tag`). `release-exclude` correctly stripped the source directory and the `/gaia-release` slash command, but the binary was built before staging, so every adopter clone shipped a CLI that advertised `release` in its help text and could execute its handlers. Release is maintainer-only — adopters never cut GAIA releases.

## Fix

Two-binary split:

- **`.gaia/cli/gaia`** (adopter; ships) — drops `release` import, handler, and help line from `src/index.ts`. esbuild tree-shakes the release source out of the bundle by construction. Binary size 984 KB → 829 KB.
- **`.gaia/cli/gaia-maintainer`** (NEW; excluded from tarball) — full adopter surface plus `release`. Built from a parallel entry at `.gaia/cli/src/index.maintainer.ts`. Carried by `release-exclude` category 4.

`pnpm bundle` now runs `bundle:adopter && bundle:maintainer`. Both binaries are tracked in git so CI on the maintainer's clone can use `gaia-maintainer`.

All call sites updated: `release.yml`, distribution-test scripts, the `/gaia-release` slash command, maintainer-only wiki pages (`Release Workflow`, `Bundle-time Scrub`), and `.gaia/cli/health/{runbook,taxonomy}.md`. The release subrouter's own help text and per-subcommand `Usage:` strings swap from `gaia release …` to `gaia-maintainer release …` so `gaia-maintainer release help` reads consistently.

`/gaia-release` gains a new Step 7b "Rebuild the bundled CLIs" to keep both binaries fresh through the release flow.

## Test plan

- [x] `pnpm --prefix .gaia/cli typecheck` — clean
- [x] `pnpm --prefix .gaia/cli test --run` — 664/664 pass
- [x] `gaia-maintainer release manifest --check --json` — `{drift: [], extra: [], missing: [], classifierOverlaps: []}`
- [x] Adopter `gaia release help` → `{"code":"unknown_subcommand","subcommand":"release"}`
- [x] `gaia-maintainer release help` → `Usage: gaia-maintainer release <subcommand>`
- [x] `grep -rEn "\bgaia release\b" .claude/ .specify/ wiki/ app/` (excluding maintainer-only files) — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)