### PR TITLE
wiki: sync through 804de97

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "9bf6ad4b2dd6d97ac80495c4452be7495e6b857d",
-  "last_evaluated_at": "2026-05-08T14:35:01Z",
+  "last_evaluated_sha": "804de979e8ddd3a391f00c01d483dd8ff4638e34",
+  "last_evaluated_at": "2026-05-08T15:19:52Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"
 }

--- a/wiki/decisions/CLI-Binary-Split.md
+++ b/wiki/decisions/CLI-Binary-Split.md
@@ -1,0 +1,47 @@
+---
+type: decision
+status: active
+priority: 1
+date: 2026-05-09
+created: 2026-05-09
+updated: 2026-05-09
+tags: [decision, distribution, maintainer, cli]
+---
+
+# CLI Binary Split
+
+> [!note] Audience
+> Maintainer-only. This page is excluded from adopter distribution by `.gaia/release-exclude`. Adopter-facing CLI documentation lives in public help text; this page documents the maintainer-only architecture choice.
+
+The `.gaia/cli/` directory ships two binaries:
+
+- **`gaia`** (adopter binary) — public CLI, no `release` namespace. Shipped in tarballs.
+- **`gaia-maintainer`** (maintainer-only binary) — includes `release` namespace. Excluded from tarballs by `.gaia/release-exclude`.
+
+## Why
+
+The adopter binary previously baked in the entire `release` namespace (preflight, bump, changelog, scrub-wiki, manifest, scrub, runtime-deps, commit-and-tag). Though `release-exclude` stripped the source directory and the `/gaia-release` slash command, the binary was built before staging, so adopters running `gaia --help` saw `release …` and could invoke release subcommands. Release is maintainer-only — adopters never cut GAIA releases.
+
+Tree-shaking via esbuild at build time requires two entry points:
+
+- `.gaia/cli/src/index.ts` — excludes release imports and handlers; builds the adopter binary (829KB).
+- `.gaia/cli/src/index.maintainer.ts` — includes release; builds the maintainer binary (984KB).
+
+`pnpm bundle` produces both. `release-exclude` marks the maintainer binary as `category: 4` so it's omitted from adopter tarballs.
+
+## Where it lives
+
+- Binaries: `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer`
+- Source: `.gaia/cli/src/`
+- Build driver: `.gaia/cli/package.json` (`bundle` script)
+- Release flow integration: `.claude/commands/gaia-release.md` (Step 7b rebuilds both binaries; Step 8 stages them manually if changed)
+- Release exclusions: `.gaia/release-exclude` (`category: 4` for `gaia-maintainer`)
+
+## Impact on the release flow
+
+The `/gaia-release` command invokes `gaia-maintainer release <subcommand>` (never `gaia release`). When bundling at release time, both binaries are rebuilt in Step 7b to ensure the new version's `--version` output stays current.
+
+## See also
+
+- [[Bundle-time Scrub]] — enforcement of the distribution boundary after binaries ship.
+- Related: `.gaia/release-exclude` (classification rules), `release.yml` (CI distribution gate).

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-08 804de97 WORTHY — CLI binary split (adopter vs maintainer) → wiki/decisions/CLI\ Binary\ Split.md
+- 2026-05-08 c08efa5 SKIP — wiki: self-referential
+- 2026-05-08 9ff3f34 SKIP — wiki: self-referential
 - 2026-05-08 9bf6ad4 SKIP — Serena handles hooks — audit-stamp-trailer.sh and code-review-audit.md updates
 - 2026-05-08 6c3c17d SKIP — chore(deps): version bump only
 - 2026-05-08 891f3ae WORTHY — updated forensics skill files and wiki/concepts/Forensics.md to remove studio/ references → wiki/concepts/Forensics.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 804de97.