### PR TITLE
docs: pre-launch gap fixes (CI opt-in, rollback, WSL stance)

### DIFF
--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -184,6 +184,67 @@ After install, `.specify/extensions/.registry` lists the `gaia` extension with a
 
 If any step fails, surface the error verbatim and halt — do not silently continue. The user can re-run the failing command manually and resume `/gaia-init` once spec-kit is in place.
 
+### Configure CI integrations
+
+Two GitHub Actions workflows ship with GAIA:
+
+- `.github/workflows/code-review-audit.yml` — pre-merge gate that runs the `code-review-audit` agent against every PR.
+- `.github/workflows/forensics-triage.yml` — autonomous triage for issues labeled `gaia-forensics`.
+
+Both invoke Claude via `claude-code-action` and require the repo secret `CLAUDE_CODE_OAUTH_TOKEN`. If the project isn't pushed to GitHub yet, or the maintainer doesn't want CI Claude billing yet, opt out — the workflow files move to `.gaia/templates/workflows/`, and `/update-gaia` respects the deletion as adopter intent (per the file-class decision table on the Update Workflow concept page).
+
+Use AskUserQuestion (in the user's language; this configuration block stays in English):
+
+> Enable GAIA's GitHub Actions workflows now?
+>
+> - **Yes — enable now** (Recommended). I'll print the `gh` commands you run yourself with maintainer credentials, and ensure the `gaia-forensics` issue label exists.
+> - **Skip — disable for now.** I'll move both workflow files to `.gaia/templates/workflows/`. Copy them back to `.github/workflows/` whenever you decide to enable.
+
+**On "Yes":**
+
+1. Verify gh CLI is authenticated:
+
+   ```bash
+   gh auth status
+   ```
+
+   If `gh auth status` exits non-zero, halt `/gaia-init` with: `GitHub CLI is not authenticated. Run 'gh auth login' and re-run /gaia-init.`
+
+2. Print the copy-pasteable enable recipe verbatim — the user runs these themselves on the maintainer's machine once the project is on GitHub:
+
+   ```bash
+   # 1. Mint an OAuth token from a Claude Code-authenticated machine, then store it as a repo secret.
+   claude setup-token
+   gh secret set CLAUDE_CODE_OAUTH_TOKEN
+
+   # 2. Make code-review-audit a required check on main (run after the workflow's first successful PR run).
+   gh api -X PUT "repos/{owner}/{repo}/branches/main/protection/required_status_checks" \
+     -f strict=true -f 'contexts[]=code-review-audit'
+   ```
+
+3. Ensure the `gaia-forensics` label exists, but only if the project already has a GitHub remote that gh can read:
+
+   ```bash
+   if gh repo view &>/dev/null && ! gh label list --limit 100 --json name 2>/dev/null \
+       | jq -e '.[] | select(.name == "gaia-forensics")' >/dev/null; then
+     gh label create gaia-forensics --color D93F0B --description "Triggers autonomous forensics triage"
+   fi
+   ```
+
+   If `gh repo view` returns non-zero (no remote configured yet), skip the label creation and tell the user: `Create the gaia-forensics label after pushing the project to GitHub: gh label create gaia-forensics --color D93F0B --description "Triggers autonomous forensics triage"`.
+
+**On "Skip":**
+
+```bash
+mkdir -p .gaia/templates/workflows
+git mv .github/workflows/code-review-audit.yml .gaia/templates/workflows/code-review-audit.yml 2>/dev/null \
+  || mv .github/workflows/code-review-audit.yml .gaia/templates/workflows/code-review-audit.yml
+git mv .github/workflows/forensics-triage.yml .gaia/templates/workflows/forensics-triage.yml 2>/dev/null \
+  || mv .github/workflows/forensics-triage.yml .gaia/templates/workflows/forensics-triage.yml
+```
+
+To re-enable later: `cp .gaia/templates/workflows/*.yml .github/workflows/`, then run the "Yes" recipe above. `/update-gaia` reads `.gaia/manifest.json` and treats deleted-from-adopter files as intentional, so the opt-out persists across updates.
+
 ### Make the statusline executable
 
 The CLI in Step 3 wired the statusline command into Claude settings; the wrapper still needs the executable bit:

--- a/.claude/commands/setup-gaia.md
+++ b/.claude/commands/setup-gaia.md
@@ -53,6 +53,25 @@ If `corepack` is available, run `corepack enable pnpm`. Otherwise `npm install -
 
 This step is NOT recorded in `setup-state.json` — pnpm + node_modules are baseline prerequisites; `pnpm install` is fast on a clean clone and fast-no-op when up to date.
 
+## Step 0.5: GitHub CLI prerequisites
+
+This step is NOT recorded in `setup-state.json` — it runs every invocation as a precondition. The check is advisory: warnings surface but do not halt setup, because a contributor may legitimately set up GAIA without gh wired up yet.
+
+```bash
+if ! command -v gh &>/dev/null; then
+  echo "Warning: GitHub CLI ('gh') is not installed. The PR merge gate, /gaia plan, and forensics workflows depend on it. Install: https://cli.github.com/" >&2
+elif ! gh auth status &>/dev/null; then
+  echo "Warning: GitHub CLI is not authenticated. Run: gh auth login" >&2
+elif [ -f .github/workflows/forensics-triage.yml ] && gh repo view &>/dev/null; then
+  if ! gh label list --limit 100 --json name 2>/dev/null \
+      | jq -e '.[] | select(.name == "gaia-forensics")' >/dev/null; then
+    echo "Warning: forensics-triage.yml is enabled but the 'gaia-forensics' label is missing on this repo. Ask a maintainer: gh label create gaia-forensics --color D93F0B --description 'Triggers autonomous forensics triage'" >&2
+  fi
+fi
+```
+
+Surface every warning to the user verbatim, then continue.
+
 ## Step 1: install-tools
 
 Skip if `install-tools` is in `completed_steps`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The React workflow that keeps Claude-shipped code production-grade as your team 
 
 ## Quick Start
 
+**Supported platforms:** macOS and Linux. Windows users should run GAIA inside [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) — the hooks and CLI rely on bash and POSIX file paths, and native Windows is not exercised in CI.
+
 Make sure you have [Node.js](https://nodejs.org/en/) >= 22.19.0 installed, preferably via [nvm](https://github.com/nvm-sh/nvm), and [uv](https://astral.sh/uv) (required for the Serena MCP server — install with `curl -LsSf https://astral.sh/uv/install.sh | sh`).
 
 ```bash

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -74,6 +74,29 @@ Files deleted upstream (in baseline, not in latest):
 - **Atomic version marker.** `.gaia/VERSION` flips to latest only after the full walk succeeds. Abort mid-walk → version stays at baseline, and a re-run resumes cleanly. Any already-overwritten files live in `.gaia-backup/`.
 - **No auto-commit.** `/update-gaia` leaves the working tree dirty; the adopter reviews + commits.
 
+## Rollback
+
+`/update-gaia` does not commit, so the rollback path depends on whether the adopter has already committed the merge.
+
+**Before commit** — discard the entire update:
+
+```bash
+git restore --staged --worktree .
+rm -rf .gaia-merge .gaia-backup
+```
+
+`git restore` reverts every overwritten file (including `.gaia/VERSION` and `.gaia/manifest.json`) to its committed baseline. The sidecar `.gaia-merge/` and `.gaia-backup/` directories are gitignored, so `git restore` does not touch them — the `rm -rf` is the cleanup pass.
+
+**After commit** — revert the commit:
+
+```bash
+git revert <update-commit-sha>
+```
+
+A single revert undoes the merge cleanly because `/update-gaia` lands its changes as ordinary edits, not a merge commit. The revert restores `.gaia/VERSION` and `.gaia/manifest.json` to baseline alongside everything else.
+
+In both cases the adopter is back at the prior baseline and can retry `/update-gaia` against the same release. Local customizations made AFTER the rollback point survive (`git restore` and `git revert` only undo the update walk's edits, not subsequent commits or unstaged changes touching files outside the manifest).
+
 ## When to run
 
 After a new GAIA release is announced (watch releases on `gaia-react/gaia`). Cadence is fully at the adopter's discretion — skipping versions is fine; the three-way diff works with any gap.


### PR DESCRIPTION
## Summary

Bundles five pre-launch audit findings into one branch:

- **T1.1 + T2.6 — CI integration during /gaia-init.** Step 8 gains a `Configure CI integrations` question. Opt-in prints copy-pasteable `gh secret set CLAUDE_CODE_OAUTH_TOKEN` + branch-protection recipe and bootstraps the `gaia-forensics` label (when a remote is configured). Opt-out moves both workflow files to `.gaia/templates/workflows/`, which `/update-gaia` respects as adopter intent. `/setup-gaia` gains an advisory `Step 0.5` precondition that warns (non-halting) when `gh` is missing, unauthenticated, or the forensics label is absent.
- **T1.2 — Update Workflow rollback.** New section documents the pre-commit (`git restore --staged --worktree . && rm -rf .gaia-merge .gaia-backup`) and post-commit (`git revert <sha>`) recovery paths.
- **T2.4 — Windows/WSL stance.** README Quick Start declares macOS + Linux as supported and points Windows users at WSL2.
- **T1.6 — GAIA-Audit trailer invalidation.** Tracked as #135.
- **T2.11 — Probe-after pass for /gaia-init Step 8.** Tracked as #136.

## Test plan

- [ ] Spot-read the four edited files and sanity-check rendered markdown
- [ ] Confirm `.gaia/templates/workflows/` opt-out path: `/update-gaia` decision table treats `Not in adopter, present in baseline` as `Adopter deleted — skip`, so opt-out persists across updates
- [ ] Verify the gh-bootstrap recipe prints correctly during a dry-run of `/gaia-init` Step 8 (no execution; the user runs `gh secret set` etc. themselves with maintainer credentials)
- [ ] Verify `/setup-gaia` Step 0.5 warnings fire and do NOT halt setup when `gh` is missing or unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)