### PR TITLE
docs: tighten adopter README template

### DIFF
--- a/.gaia/templates/README.md
+++ b/.gaia/templates/README.md
@@ -3,7 +3,6 @@
 ## Quick start
 
 ```bash
-pnpm install
 pnpm dev
 ```
 
@@ -11,26 +10,21 @@ The dev server runs on [http://localhost:3000](http://localhost:3000).
 
 ## Common scripts
 
-- `pnpm dev` — start the dev server
-- `pnpm build` — production build
-- `pnpm test` — run unit tests
-- `pnpm typecheck` — TypeScript type-check
-- `pnpm lint` — lint the codebase
+- `pnpm dev`: start the dev server
 
 ## Useful Claude commands
 
-This project ships with [GAIA](https://gaiareact.com/) — a workflow built on Claude Code with slash commands for common tasks:
+This project ships with [GAIA](https://gaiareact.com/). Run these slash commands from inside Claude Code:
 
-- `/gaia plan` — plan a feature as a graph of tasks and execute them via sub-agents
-- `/gaia handoff` — generate a session handoff document for the next developer (or next session)
-- `/gaia pickup` — restore context from a handoff document and continue work
-
-Run any of these from inside Claude Code.
+- `/gaia plan`: plan a feature as a graph of tasks and execute via subagents
+- `/gaia spec`: run Socratic discovery and produce an immutable SPEC artifact
+- `/gaia handoff` and `/gaia pickup`: clear context without losing state across sessions
+- `/gaia forensics`: file a redacted, classified report when GAIA itself misfires
 
 ## Knowledge base
 
-`wiki/` is an [Obsidian](https://obsidian.md/) vault. Open the folder in Obsidian for a graph view, backlinks, and canvas boards. Claude reads from it as the project's source of truth — architecture decisions, conventions, and "where we left off" all live here.
+`wiki/` is an [Obsidian](https://obsidian.md/) vault. Open the folder in Obsidian for a graph view, backlinks, and canvas boards. Claude reads from it as the project's source of truth. Architecture decisions, conventions, and "where we left off" all live here.
 
 ## Learn more
 
-- GAIA docs: [https://gaiareact.com/](https://gaiareact.com/)
+- GAIA docs: [https://docs.gaiareact.com/](https://docs.gaiareact.com/)


### PR DESCRIPTION
## Summary

Adopter README polish from the documentation agent:

- Drop `pnpm install` from the Quick Start (already auto-run by `/setup-gaia` and `/gaia-init`)
- Compress the scripts list to just `pnpm dev` (the rest are discoverable)
- Refresh the slash-command showcase: add `/gaia spec` and `/gaia forensics`, group `/gaia handoff` + `/gaia pickup`
- Point docs link at `docs.gaiareact.com` (the dedicated docs site)
- Style consistency: em-dash → colon in bullet lists

## Test plan

- [ ] Spot-read rendered README inside a fresh `npx create-gaia` scaffold
- [ ] Confirm docs link target resolves once the docs site ships content

🤖 Generated with [Claude Code](https://claude.com/claude-code)