### PR TITLE
feat(gaia-init): add probe-after verification pass to Step 8

### DIFF
--- a/.claude/commands/gaia-init.md
+++ b/.claude/commands/gaia-init.md
@@ -255,6 +255,29 @@ chmod +x .gaia/statusline/*.sh
 
 (Idempotent — safe to run regardless.)
 
+### Verify installs
+
+After all installs and plugin registrations above, run a probe-after pass to confirm each component landed. For each component below, run the probe and emit one line:
+
+| Component | Probe |
+|---|---|
+| React Doctor | `[ -d ~/.claude/skills/react-doctor ]` |
+| Playwright CLI | `command -v playwright-cli && playwright-cli --version >/dev/null 2>&1` |
+| Serena | `claude mcp list 2>/dev/null \| grep -q '^serena '` |
+| typescript-lsp | `claude plugin list 2>/dev/null \| grep -q 'typescript-lsp'` |
+| claude-obsidian | `claude plugin list 2>/dev/null \| grep -q 'claude-obsidian'` |
+| spec-kit | `[ -f .specify/integration.json ] && grep -q 'gaia' .specify/extensions/.registry 2>/dev/null && grep -q 'gaia' .specify/presets/.registry 2>/dev/null` |
+
+Emit one line per component: `[ok] <component>` if the probe exits 0, `[FAIL] <component>` if it exits non-zero.
+
+After all probes run: if any component shows `[FAIL]`, print the full table, then halt `/gaia-init` with:
+
+> "One or more components failed verification. Retry the failed install commands above, then resume with `.gaia/cli/gaia init resume`."
+
+If all probes pass, print the full table and continue to Step 9.
+
+The same probe set applies when setting up from an existing clone — `/setup-gaia` runs it after registering external tools.
+
 ## Step 9: Mentorship opt-in
 
 Tell the user (in their language): "GAIA includes an optional mentorship layer that learns how you work and adapts in-session — fully on your machine, never sent off it. Let's set the default."


### PR DESCRIPTION
## Summary

- Adds a `### Verify installs` section at the end of `/gaia-init` Step 8
- Runs six probes (React Doctor, Playwright CLI, Serena, typescript-lsp, claude-obsidian, spec-kit) after all installs complete
- Emits `[ok]` or `[FAIL]` per component; halts `/gaia-init` if any FAIL with a clear resume message
- Notes reusability in `/setup-gaia` for clone setups

## Why

Silent install failures currently surface only when the user invokes a missing skill. The probe pass costs ~10 lines of bash and surfaces failure at the moment it happens, while context is fresh.

## Test plan

- [ ] Run `/gaia-init` on a clean clone; verify all probes pass and Step 9 proceeds
- [ ] Simulate a failed install; verify the probe emits `[FAIL]` for that component and `/gaia-init` halts with the correct message

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)