### PR TITLE
feat: spec-001 slice 1 — smart-cron + per-tool state files

### DIFF
--- a/.claude/hooks/lib/gaia-ci-defer.sh
+++ b/.claude/hooks/lib/gaia-ci-defer.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# GAIA CI deferral helper. Source this from any local automatic wiki trigger.
+# When .gaia/automation.json says wiki.mode == "ci", emit a one-line log and
+# exit 0. Otherwise return without side effects so the caller continues.
+#
+# Usage (from a hook script):
+#   . .claude/hooks/lib/gaia-ci-defer.sh
+#   gaia_ci_defer_if_managed wiki   # exits 0 if managed; returns if not.
+#
+# Sourcing a function (rather than a top-level guard) lets the caller run its
+# own pre-flight (jq presence, .git presence, payload reads) before deciding
+# when to check deferral.
+
+gaia_ci_defer_if_managed() {
+  local tool="$1"
+  local config_path=".gaia/automation.json"
+
+  [ -f "$config_path" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local mode
+  mode=$(jq -r --arg t "$tool" '(.[$t].mode) // "local"' "$config_path" 2>/dev/null) || return 0
+
+  if [ "$mode" = "ci" ]; then
+    echo 'wiki is CI-managed; deferring'
+    exit 0
+  fi
+}

--- a/.claude/hooks/wiki-commit-nudge.sh
+++ b/.claude/hooks/wiki-commit-nudge.sh
@@ -23,6 +23,10 @@ grep -qE '(^|[^[:alnum:]_-])git[[:space:]]+commit([[:space:]]|$)' <<<"$cmd" || e
 # Skip --amend
 grep -qE -- '--amend([[:space:]]|=|$)' <<<"$cmd" && exit 0
 
+# GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
+# down so they don't collide with the cron-managed wiki run.
+. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+
 head_sha=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
 subject=$(git log -1 --format='%s' 2>/dev/null) || exit 0
 files_changed=$(git show --stat --format='' HEAD 2>/dev/null | tail -1 | grep -oE '[0-9]+ files? changed' | awk '{print $1}')

--- a/.claude/hooks/wiki-drift-check.sh
+++ b/.claude/hooks/wiki-drift-check.sh
@@ -24,6 +24,11 @@ if [ -f "$marker" ] && grep -q "^session_id=$session_id$" "$marker" 2>/dev/null;
   exit 0
 fi
 
+# GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
+# down so they don't collide with the cron-managed wiki run. The marker is
+# NOT advanced here so a future config change still gets the drift check.
+. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+
 state_sha=$(jq -r '.last_evaluated_sha // empty' wiki/.state.json 2>/dev/null || echo "")
 [ -n "$state_sha" ] || exit 0
 case "$state_sha" in

--- a/.claude/hooks/wiki-session-stop.sh
+++ b/.claude/hooks/wiki-session-stop.sh
@@ -22,6 +22,10 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 session_marker="$GIT_DIR/claude-session-start"
 [ -f "$session_marker" ] || exit 0
 
+# GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
+# down so they don't collide with the cron-managed wiki run.
+. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+
 start_sha=$(cat "$session_marker" 2>/dev/null) || exit 0
 [ -n "$start_sha" ] || exit 0
 head_sha=$(git rev-parse HEAD 2>/dev/null) || exit 0

--- a/.claude/skills/gaia/references/wiki.md
+++ b/.claude/skills/gaia/references/wiki.md
@@ -4,7 +4,9 @@ Wiki-maintenance router. Sub-commands run individually or chain end-to-end.
 
 ## Argument parsing
 
-Tokenize the first whitespace-separated word of `$ARGUMENTS`:
+Tokenize `$ARGUMENTS`. Detect a trailing `--force` token; if present, strip
+it and set `FORCE=true`. Then tokenize the first remaining whitespace-
+separated word.
 
 | First arg                         | Action                                                                      |
 | --------------------------------- | --------------------------------------------------------------------------- |
@@ -14,16 +16,63 @@ Tokenize the first whitespace-separated word of `$ARGUMENTS`:
 | (empty)                           | Full chain: sync → (gated) consolidate → lint. See "Full chain".            |
 | (anything else)                   | Print help.                                                                 |
 
+`--force` is positional-flexible but the contract is "trailing" — it must be
+the LAST argument so it doesn't shadow `sync` / `consolidate` / `lint`:
+
+- `/gaia wiki --force` (full chain, force)
+- `/gaia wiki sync --force` (sync only, force)
+
 Help message:
 
 ```
-Usage: /gaia wiki [sync|consolidate|lint]
+Usage: /gaia wiki [--force] [sync|consolidate|lint]
 
+  --force        Override GAIA CI deferral (no-op when wiki.mode != "ci")
   (no arg)       Full chain: sync, then consolidate if gate trips, then lint
   sync           Evaluate commits since last sync; update wiki where warranted
   consolidate    Cross-SPEC redundancy + contradiction audit; surfaces findings
   lint           Health check: orphans, dead links, drift, narrative-ref scrub
 ```
+
+## GAIA CI deferral check
+
+Before any sub-command dispatches (sync / consolidate / lint / full chain),
+the parent reads `.gaia/automation.json` to determine whether wiki updates
+are CI-managed.
+
+```
+STATUS=$(.gaia/cli/gaia automation read-config --json 2>/dev/null \
+         | jq -r '.wiki.mode // "local"') || STATUS=local
+```
+
+If the binary or config is missing the read fails; treat that as `local`
+and proceed.
+
+If `STATUS == "ci"` and `FORCE != "true"`, print this conflict-risk
+warning to stderr and exit 1 without dispatching anything:
+
+```
+GAIA CI manages /gaia wiki for this repo. Running it locally now risks colliding
+with the next scheduled run. To override, re-invoke with --force.
+```
+
+If `STATUS == "ci"` and `FORCE == "true"`, the chain runs as normal. After
+the chain commits its wiki edits, the parent ALSO calls:
+
+```
+.gaia/cli/gaia automation record-run wiki \
+  --sha "$(git rev-parse HEAD)" \
+  --trigger force \
+  --cost 0
+git add .gaia/automation.state-wiki.json
+git commit --amend --no-edit
+```
+
+The state changes commit in the same commit as the wiki content change.
+The dispatched sub-agent commits but does not push, so the amend is local
+only and the bundled commit is the one that hits the remote.
+
+If `STATUS != "ci"`, behave as before (no defer, no force, no record-run).
 
 ## Sync
 
@@ -40,7 +89,7 @@ Spawn:
 
 When the subagent returns, relay its final summary verbatim. Do not redo the work in the parent.
 
-If invoked as `/gaia wiki sync` (sub-arg form): stop after relaying the summary. Do **not** chain into consolidate or lint — that's only the no-arg form's job.
+If invoked as `/gaia wiki sync` (sub-arg form): stop after relaying the summary. Do **not** chain into consolidate or lint — that's only the no-arg form's job. The sub-arg form `/gaia wiki sync --force` is also valid; the same defer / force logic from "GAIA CI deferral check" applies.
 
 ## Consolidate
 

--- a/.gaia/cli/src/automation/__tests__/bump-state.test.ts
+++ b/.gaia/cli/src/automation/__tests__/bump-state.test.ts
@@ -1,0 +1,100 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {automationStatePath} from '../paths.js';
+import {run} from '../bump-state.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const silenceStdio = () => {
+  const errors: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+
+  return {
+    errors,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const baseState = (sha: string): AutomationStateFile => ({
+  cost_overage: false,
+  last_run_at: '2026-05-01T00:00:00Z',
+  last_run_cost: 0,
+  last_run_sha: sha,
+  last_run_trigger: 'cron',
+  skip_count: 2,
+  version: 1,
+});
+
+const readWiki = (root: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(automationStatePath(root, 'wiki'), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+
+describe('automation bump-state', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof silenceStdio>;
+
+  beforeEach(() => {
+    stdio = silenceStdio();
+    sandbox = setupSandbox('gaia-automation-bump-state-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('increments skip_count', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--field', 'skip_count', '--value', '3'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readWiki(sandbox.root).skip_count).toBe(3);
+  });
+
+  it('updates a string field', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--field', 'last_run_trigger', '--value', '"force"'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readWiki(sandbox.root).last_run_trigger).toBe('force');
+  });
+
+  it('treats unparseable JSON value as a raw string', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--field', 'last_run_trigger', '--value', 'force'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readWiki(sandbox.root).last_run_trigger).toBe('force');
+  });
+
+  it('rejects post-bump shape that violates schema', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--field', 'skip_count', '--value', '-5'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_malformed');
+  });
+
+  it('exits non-zero when state file missing', () => {
+    const exit = run(['wiki', '--field', 'skip_count', '--value', '3'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_missing');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/clear-overage.test.ts
+++ b/.gaia/cli/src/automation/__tests__/clear-overage.test.ts
@@ -1,0 +1,74 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {automationStatePath} from '../paths.js';
+import {run} from '../clear-overage.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const silenceStdio = () => {
+  const errors: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+
+  return {
+    errors,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const overageState = (sha: string): AutomationStateFile => ({
+  cost_overage: true,
+  last_run_at: '2026-05-01T00:00:00Z',
+  last_run_cost: 6.5,
+  last_run_sha: sha,
+  last_run_trigger: 'cron',
+  skip_count: 0,
+  version: 1,
+});
+
+describe('automation clear-overage', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof silenceStdio>;
+
+  beforeEach(() => {
+    stdio = silenceStdio();
+    sandbox = setupSandbox('gaia-automation-clear-overage-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('sets cost_overage=false while preserving siblings', () => {
+    sandbox.writeState('wiki', overageState(sandbox.headSha));
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(
+      readFileSync(automationStatePath(sandbox.root, 'wiki'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(parsed.cost_overage).toBe(false);
+    expect(parsed.last_run_cost).toBe(6.5);
+  });
+
+  it('is a silent OK when cost_overage already false', () => {
+    sandbox.writeState('wiki', {...overageState(sandbox.headSha), cost_overage: false});
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+  });
+
+  it('exits non-zero with state_missing when no state file', () => {
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_missing');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/cron-decide.test.ts
+++ b/.gaia/cli/src/automation/__tests__/cron-decide.test.ts
@@ -1,0 +1,297 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {automationStatePath} from '../paths.js';
+import {run as runCronDecide} from '../cron-decide.js';
+import {run as runRecordRun} from '../record-run.js';
+import {run as runRecordOverage} from '../record-overage.js';
+import {run as runClearOverage} from '../clear-overage.js';
+import {VALID_BASE_CONFIG, setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = () => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const decisionFromStdout = (out: string): {
+  decision: string;
+  reason: string;
+  skip_log_line: string | null;
+} => JSON.parse(out) as {decision: string; reason: string; skip_log_line: string | null};
+
+const validState = (sha: string, overrides: Partial<AutomationStateFile> = {}): AutomationStateFile => ({
+  cost_overage: false,
+  last_run_at: '2026-05-01T00:00:00Z',
+  last_run_cost: 0,
+  last_run_sha: sha,
+  last_run_trigger: 'cron',
+  skip_count: 0,
+  version: 1,
+  ...overrides,
+});
+
+describe('automation cron-decide', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+    sandbox = setupSandbox('gaia-automation-cron-decide-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('exits non-zero with config_missing when there is no config', () => {
+    const exit = runCronDecide(['wiki', '--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('config_missing');
+  });
+
+  it('skips with reason tool_off when wiki.mode is "off"', () => {
+    sandbox.writeConfig({...VALID_BASE_CONFIG, wiki: {mode: 'off'}});
+    const exit = runCronDecide(['wiki', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('tool_off');
+    expect(decision.skip_log_line).toBe('tool mode is off; skipping');
+  });
+
+  it('runs with reason first_run when state file is missing', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    const exit = runCronDecide(['wiki', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('run');
+    expect(decision.reason).toBe('first_run');
+    expect(decision.skip_log_line).toBeNull();
+  });
+
+  it('skips with reason cost_overage when state.cost_overage is true', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState('wiki', validState(sandbox.headSha, {cost_overage: true}));
+
+    const exit = runCronDecide(['wiki', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('cost_overage');
+    expect(decision.skip_log_line).toBe('cost overage; suppressed');
+  });
+
+  it('runs with reason ceiling_14d when last_run_at is older than 14 days', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {last_run_at: '2026-04-01T00:00:00Z'})
+    );
+
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-01T00:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('run');
+    expect(decision.reason).toBe('ceiling_14d');
+  });
+
+  it('runs with reason skip_safety_5 when skip_count > 5', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {
+        last_run_at: '2026-05-08T00:00:00Z',
+        skip_count: 6,
+      })
+    );
+
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-09T00:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('run');
+    expect(decision.reason).toBe('skip_safety_5');
+  });
+
+  it('skips with reason floor_24h when last_run_at < 24h ago', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {last_run_at: '2026-05-09T00:00:00Z'})
+    );
+
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-09T12:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('floor_24h');
+    expect(decision.skip_log_line).toBe('within 24h floor; skipping');
+  });
+
+  it('runs with reason app_changed when commits to app/** since last_run_sha', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {last_run_at: '2026-05-01T00:00:00Z'})
+    );
+    sandbox.commitFile('app/foo.ts', 'export const x = 1;\n');
+
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-05T00:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('run');
+    expect(decision.reason).toBe('app_changed');
+  });
+
+  it('skips with reason no_app_change when nothing in app/** since last_run_sha — UAT-001', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {last_run_at: '2026-05-01T00:00:00Z'})
+    );
+    // Commit OUTSIDE app/**
+    sandbox.commitFile('docs/CHANGELOG.md', 'changes\n');
+
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-05T00:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('no_app_change');
+    expect(decision.skip_log_line).toBe(
+      `skipped — no app/** changes since ${sandbox.headSha.slice(0, 7)}`
+    );
+  });
+
+  it('UAT-002: 15-day-old state forces a run regardless of app changes', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    sandbox.writeState(
+      'wiki',
+      validState(sandbox.headSha, {last_run_at: '2026-04-20T00:00:00Z'})
+    );
+    // No app/** changes — should still run because of ceiling.
+    const exit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-09T00:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('run');
+    expect(decision.reason).toBe('ceiling_14d');
+  });
+
+  it('UAT-005: after record-run --trigger force, next cron-decide returns floor_24h skip', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const recordExit = runRecordRun(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'force', '--cost', '0'],
+      {cwd: sandbox.root, now: () => new Date('2026-05-09T04:00:00Z')}
+    );
+    expect(recordExit).toBe(0);
+
+    const cronExit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-09T05:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(cronExit).toBe(0);
+
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('floor_24h');
+    expect(decision.skip_log_line).toBe('within 24h floor; skipping');
+
+    const stateFile = JSON.parse(
+      readFileSync(automationStatePath(sandbox.root, 'wiki'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(stateFile.last_run_trigger).toBe('force');
+    expect(stateFile.skip_count).toBe(0);
+  });
+
+  it('UAT-018: record-overage then cron-decide returns cost_overage skip; clear-overage restores natural decision', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    runRecordRun(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'cron', '--cost', '0'],
+      {cwd: sandbox.root, now: () => new Date('2026-05-09T04:00:00Z')}
+    );
+
+    const overageExit = runRecordOverage(['wiki', '--cost', '6.50'], {
+      cwd: sandbox.root,
+    });
+    expect(overageExit).toBe(0);
+
+    stdio.outputs.length = 0;
+    const cronExit = runCronDecide(
+      ['wiki', '--json', '--now', '2026-05-09T05:00:00Z'],
+      {cwd: sandbox.root}
+    );
+    expect(cronExit).toBe(0);
+    let decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.reason).toBe('cost_overage');
+
+    const clearExit = runClearOverage(['wiki'], {cwd: sandbox.root});
+    expect(clearExit).toBe(0);
+
+    stdio.outputs.length = 0;
+    runCronDecide(['wiki', '--json', '--now', '2026-05-09T05:00:00Z'], {
+      cwd: sandbox.root,
+    });
+    decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.reason).toBe('floor_24h');
+  });
+
+  it('non-wiki tools return tool_off-shaped placeholder', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    const exit = runCronDecide(['sharpen', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('tool_off');
+  });
+
+  it('non-wiki tool with mode != off still returns the placeholder', () => {
+    sandbox.writeConfig({
+      ...VALID_BASE_CONFIG,
+      stale_branches: {mode: 'ci', schedule: 'weekly'},
+    });
+    const exit = runCronDecide(['stale-branches', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const decision = decisionFromStdout(stdio.outputs.join(''));
+    expect(decision.decision).toBe('skip');
+    expect(decision.reason).toBe('tool_off');
+    expect(decision.skip_log_line).toContain('cron-decide not yet implemented');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/init-state.test.ts
+++ b/.gaia/cli/src/automation/__tests__/init-state.test.ts
@@ -1,0 +1,98 @@
+import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {automationStatePath} from '../paths.js';
+import {run} from '../init-state.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStderr = () => {
+  const errors: string[] = [];
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+  return {
+    errors,
+    restore: () => {
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    },
+  };
+};
+
+describe('automation init-state', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStderr>;
+
+  beforeEach(() => {
+    stdio = captureStderr();
+    sandbox = setupSandbox('gaia-automation-init-state-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a fresh state file with default fields', () => {
+    const fixedNow = new Date('2026-05-09T04:00:00.000Z');
+    const exit = run(['wiki', '--sha', 'HEAD'], {cwd: sandbox.root, now: () => fixedNow});
+    expect(exit).toBe(0);
+
+    const target = automationStatePath(sandbox.root, 'wiki');
+    expect(existsSync(target)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(target, 'utf8')) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      cost_overage: false,
+      last_run_at: '2026-05-09T04:00:00.000Z',
+      last_run_cost: 0,
+      last_run_sha: sandbox.headSha,
+      last_run_trigger: 'cron',
+      skip_count: 0,
+      version: 1,
+    });
+  });
+
+  it('refuses when the state file already exists', () => {
+    const target = automationStatePath(sandbox.root, 'wiki');
+    writeFileSync(target, '{}', 'utf8');
+
+    const exit = run(['wiki', '--sha', sandbox.headSha], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_already_exists');
+  });
+
+  it('refuses unknown tool', () => {
+    const exit = run(['nope', '--sha', sandbox.headSha], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('unknown tool');
+  });
+
+  it('rejects when --sha is missing', () => {
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('--sha');
+  });
+
+  it('rejects when --sha is unresolvable', () => {
+    const exit = run(['wiki', '--sha', 'not-a-real-ref'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('sha_unresolvable');
+  });
+
+  it('honors --at as the timestamp', () => {
+    const exit = run(['wiki', '--sha', sandbox.headSha, '--at', '2026-04-01T00:00:00Z'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(
+      readFileSync(automationStatePath(sandbox.root, 'wiki'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(parsed.last_run_at).toBe('2026-04-01T00:00:00Z');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/paths.test.ts
+++ b/.gaia/cli/src/automation/__tests__/paths.test.ts
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import {describe, expect, it} from 'vitest';
+import {
+  automationConfigPath,
+  automationStatePath,
+  localAutomationPath,
+} from '../paths.js';
+
+describe('automation/paths', () => {
+  describe('automationConfigPath', () => {
+    it('returns <repoRoot>/.gaia/automation.json', () => {
+      expect(automationConfigPath('/tmp/repo')).toBe(
+        path.join('/tmp/repo', '.gaia', 'automation.json')
+      );
+    });
+
+    it('handles a trailing slash via path.join semantics', () => {
+      expect(automationConfigPath('/tmp/repo/')).toBe(
+        path.join('/tmp/repo/', '.gaia', 'automation.json')
+      );
+    });
+  });
+
+  describe('automationStatePath', () => {
+    it('returns the correct path for each tool id', () => {
+      expect(automationStatePath('/r', 'wiki')).toBe(
+        path.join('/r', '.gaia', 'automation.state-wiki.json')
+      );
+      expect(automationStatePath('/r', 'sharpen')).toBe(
+        path.join('/r', '.gaia', 'automation.state-sharpen.json')
+      );
+      expect(automationStatePath('/r', 'pnpm-audit')).toBe(
+        path.join('/r', '.gaia', 'automation.state-pnpm-audit.json')
+      );
+      expect(automationStatePath('/r', 'stale-branches')).toBe(
+        path.join('/r', '.gaia', 'automation.state-stale-branches.json')
+      );
+    });
+
+    it('does not nest into a per-tool subdirectory', () => {
+      const result = automationStatePath('/r', 'wiki');
+      expect(result.includes(path.join('.gaia', 'wiki'))).toBe(false);
+    });
+  });
+
+  describe('localAutomationPath', () => {
+    it('returns <repoRoot>/.gaia/local/automation.json', () => {
+      expect(localAutomationPath('/tmp/repo')).toBe(
+        path.join('/tmp/repo', '.gaia', 'local', 'automation.json')
+      );
+    });
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/read-config.test.ts
+++ b/.gaia/cli/src/automation/__tests__/read-config.test.ts
@@ -1,0 +1,98 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../read-config.js';
+import {VALID_BASE_CONFIG, setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('automation read-config', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+    sandbox = setupSandbox('gaia-automation-read-config-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('emits JSON with --json', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const out = stdio.outputs.join('');
+    const parsed = JSON.parse(out) as Record<string, unknown>;
+    expect(parsed.version).toBe(1);
+    expect((parsed.wiki as Record<string, string>).mode).toBe('ci');
+  });
+
+  it('emits a human report without --json', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const out = stdio.outputs.join('');
+    expect(out).toContain('wiki: mode=ci');
+    expect(out).toContain('schedule=daily');
+  });
+
+  it('exits non-zero with config_missing when the file does not exist', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('config_missing');
+  });
+
+  it('exits non-zero with config_malformed for malformed JSON', () => {
+    sandbox.writeConfig({...VALID_BASE_CONFIG, version: 2 as unknown as 1});
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('config_malformed');
+  });
+
+  it('rejects unknown flags', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('unknown argument');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/read-state.test.ts
+++ b/.gaia/cli/src/automation/__tests__/read-state.test.ts
@@ -1,0 +1,87 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {run} from '../read-state.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = () => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const validState = (sha: string): AutomationStateFile => ({
+  cost_overage: false,
+  last_run_at: '2026-05-01T00:00:00Z',
+  last_run_cost: 0.42,
+  last_run_sha: sha,
+  last_run_trigger: 'cron',
+  skip_count: 0,
+  version: 1,
+});
+
+describe('automation read-state', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+    sandbox = setupSandbox('gaia-automation-read-state-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('emits JSON for an existing state', () => {
+    sandbox.writeState('wiki', validState(sandbox.headSha));
+    const exit = run(['wiki', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    const parsed = JSON.parse(stdio.outputs.join('')) as Record<string, unknown>;
+    expect(parsed.last_run_trigger).toBe('cron');
+  });
+
+  it('exits non-zero with state_missing when file is absent', () => {
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_missing');
+  });
+
+  it('rejects unknown tool', () => {
+    const exit = run(['unknown-tool'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('unknown tool');
+  });
+
+  it('rejects when no tool given', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.outputs.join('')).toContain('Usage:');
+  });
+
+  it('emits human report when --json absent', () => {
+    sandbox.writeState('wiki', validState(sandbox.headSha));
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('')).toContain('last_run_trigger: cron');
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/record-overage.test.ts
+++ b/.gaia/cli/src/automation/__tests__/record-overage.test.ts
@@ -1,0 +1,77 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {automationStatePath} from '../paths.js';
+import {run} from '../record-overage.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const silenceStdio = () => {
+  const errors: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  });
+
+  return {
+    errors,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const baseState = (sha: string): AutomationStateFile => ({
+  cost_overage: false,
+  last_run_at: '2026-05-01T00:00:00Z',
+  last_run_cost: 1.5,
+  last_run_sha: sha,
+  last_run_trigger: 'cron',
+  skip_count: 2,
+  version: 1,
+});
+
+describe('automation record-overage', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof silenceStdio>;
+
+  beforeEach(() => {
+    stdio = silenceStdio();
+    sandbox = setupSandbox('gaia-automation-record-overage-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('sets cost_overage and last_run_cost while preserving siblings', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--cost', '6.50'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(
+      readFileSync(automationStatePath(sandbox.root, 'wiki'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(parsed.cost_overage).toBe(true);
+    expect(parsed.last_run_cost).toBe(6.5);
+    // Other fields preserved.
+    expect(parsed.skip_count).toBe(2);
+    expect(parsed.last_run_trigger).toBe('cron');
+  });
+
+  it('exits non-zero with state_missing when no state file exists', () => {
+    const exit = run(['wiki', '--cost', '6.50'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_missing');
+  });
+
+  it('rejects negative cost', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--cost', '-1'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/record-run.test.ts
+++ b/.gaia/cli/src/automation/__tests__/record-run.test.ts
@@ -1,0 +1,109 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {automationStatePath} from '../paths.js';
+import {run} from '../record-run.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const silenceStdio = () => {
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+  return {
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const readWikiState = (sandbox: Sandbox): Record<string, unknown> =>
+  JSON.parse(readFileSync(automationStatePath(sandbox.root, 'wiki'), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+
+describe('automation record-run', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof silenceStdio>;
+
+  beforeEach(() => {
+    stdio = silenceStdio();
+    sandbox = setupSandbox('gaia-automation-record-run-');
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('writes a fresh state with skip_count reset to 0', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'cron', '--cost', '0.42'],
+      {cwd: sandbox.root, now: () => new Date('2026-05-09T04:00:00.000Z')}
+    );
+    expect(exit).toBe(0);
+
+    const parsed = readWikiState(sandbox);
+    expect(parsed).toEqual({
+      cost_overage: false,
+      last_run_at: '2026-05-09T04:00:00.000Z',
+      last_run_cost: 0.42,
+      last_run_sha: sandbox.headSha,
+      last_run_trigger: 'cron',
+      skip_count: 0,
+      version: 1,
+    });
+  });
+
+  it('sets cost_overage = true when cost > 5', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'cron', '--cost', '5.50'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    expect(readWikiState(sandbox).cost_overage).toBe(true);
+  });
+
+  it('sets cost_overage = false when cost == 5 (strict-greater-than)', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'cron', '--cost', '5.00'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    expect(readWikiState(sandbox).cost_overage).toBe(false);
+  });
+
+  it('records last_run_trigger=force', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'force', '--cost', '0'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    expect(readWikiState(sandbox).last_run_trigger).toBe('force');
+  });
+
+  it('rejects unknown trigger', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'rerun', '--cost', '0'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+  });
+
+  it('rejects negative cost', () => {
+    const exit = run(
+      ['wiki', '--sha', sandbox.headSha, '--trigger', 'cron', '--cost', '-1'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+  });
+
+  it('rejects bad sha (40-char regex)', () => {
+    const exit = run(
+      ['wiki', '--sha', 'short', '--trigger', 'cron', '--cost', '0'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+  });
+});

--- a/.gaia/cli/src/automation/__tests__/sandbox.ts
+++ b/.gaia/cli/src/automation/__tests__/sandbox.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared sandbox helpers for automation tests. Each sandbox is a tmp dir
+ * with `git init`, an initial commit, and a `.gaia/` directory ready for
+ * config and state files.
+ */
+import {execFileSync} from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import type {AutomationConfig} from '../../schemas/automation-config.js';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import {automationConfigPath, automationStatePath} from '../paths.js';
+import type {ToolId} from '../../schemas/automation-config.js';
+
+export type Sandbox = {
+  cleanup: () => void;
+  commitFile: (relPath: string, content: string) => string;
+  headSha: string;
+  root: string;
+  writeConfig: (config: AutomationConfig) => void;
+  writeState: (tool: ToolId, state: AutomationStateFile) => void;
+};
+
+export const VALID_BASE_CONFIG: AutomationConfig = {
+  pnpm_audit: {mode: 'local', schedule: 'weekly'},
+  setup_complete: true,
+  setup_opted_out: false,
+  sharpen: {mode: 'off'},
+  stale_branches: {mode: 'ci', schedule: 'weekly'},
+  update_gaia: {mode: 'local'},
+  version: 1,
+  wiki: {mode: 'ci', schedule: 'daily'},
+};
+
+export const setupSandbox = (prefix = 'gaia-automation-'): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {cwd: root});
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: root});
+  writeFileSync(path.join(root, 'README.md'), '# test\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], {cwd: root});
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], {cwd: root});
+  const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+    .toString()
+    .trim();
+
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  const commitFile = (relPath: string, content: string): string => {
+    const target = path.join(root, relPath);
+    mkdirSync(path.dirname(target), {recursive: true});
+    writeFileSync(target, content, 'utf8');
+    execFileSync('git', ['add', relPath], {cwd: root});
+    execFileSync('git', ['commit', '-q', '-m', `add ${relPath}`], {cwd: root});
+
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+    })
+      .toString()
+      .trim();
+  };
+
+  const writeConfig = (config: AutomationConfig): void => {
+    writeFileSync(automationConfigPath(root), JSON.stringify(config), 'utf8');
+  };
+
+  const writeState = (tool: ToolId, state: AutomationStateFile): void => {
+    writeFileSync(automationStatePath(root, tool), JSON.stringify(state), 'utf8');
+  };
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    commitFile,
+    headSha,
+    root,
+    writeConfig,
+    writeState,
+  };
+};

--- a/.gaia/cli/src/automation/bump-state.ts
+++ b/.gaia/cli/src/automation/bump-state.ts
@@ -1,0 +1,183 @@
+/**
+ * `gaia automation bump-state <tool> --field <name> --value <json>` handler.
+ *
+ * Generic field updater (parallel to `gaia wiki state-bump`). Reads the
+ * existing state, parses --value as JSON when possible (otherwise as a
+ * raw string), applies the bump, schema-validates the post-bump shape,
+ * and atomic-writes. Schema rejection on the post-bump shape exits
+ * non-zero with `state_malformed`.
+ *
+ * Slice-1 workflows use the higher-level record-run / record-overage /
+ * clear-overage primitives. bump-state is the low-level fallback used
+ * when the workflow needs to advance `skip_count` after a `floor_24h`
+ * skip.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
+import {
+  AutomationStateFileSchema,
+  readAutomationState,
+} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeStateFile} from './util/state-write.js';
+
+const HELP_TEXT = `Usage: gaia automation bump-state <tool> --field <name> --value <json>
+
+  Updates a single field in .gaia/automation.state-<tool>.json.
+  --value is parsed as JSON when it parses (numbers, booleans, null,
+  arrays, objects); otherwise treated as a raw string. The post-bump
+  shape is validated against the schema.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const tryParseJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+};
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let field: string | undefined;
+  let valueRaw: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--field') {
+      field = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--value') {
+      valueRaw = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation bump-state',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation bump-state',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation bump-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined || field === undefined || valueRaw === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'bump-state requires <tool> --field <name> --value <json>',
+      subcommand: 'automation bump-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation bump-state must run inside a git repository',
+      subcommand: 'automation bump-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationState(repoRoot, tool);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'state_missing',
+      message: `cannot bump: state file for "${tool}" does not exist`,
+      subcommand: 'automation bump-state',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'state_malformed',
+      message: result.error,
+      subcommand: 'automation bump-state',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const candidate: Record<string, unknown> = {
+    ...(result.state as unknown as Record<string, unknown>),
+    [field]: tryParseJson(valueRaw),
+  };
+
+  const validation = AutomationStateFileSchema.safeParse(candidate);
+
+  if (!validation.success) {
+    structuredError({
+      code: 'state_malformed',
+      message: validation.error.issues
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; '),
+      subcommand: 'automation bump-state',
+      tool,
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  writeStateFile(repoRoot, tool, validation.data);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/clear-overage.ts
+++ b/.gaia/cli/src/automation/clear-overage.ts
@@ -1,0 +1,133 @@
+/**
+ * `gaia automation clear-overage <tool>` handler.
+ *
+ * Human-intervention escape hatch (per SPEC: "until a human clears it").
+ * Sets `cost_overage = false` while preserving all other fields. State-
+ * missing is a hard error; clearing on a never-run tool is a workflow
+ * bug. Clearing when overage is already false is a silent OK.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
+import {readAutomationState} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeStateFile} from './util/state-write.js';
+
+const HELP_TEXT = `Usage: gaia automation clear-overage <tool>
+
+  Sets cost_overage = false on the per-tool state file. No-op when
+  cost_overage is already false. Refuses if the state file is missing.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+
+  for (const token of argv) {
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation clear-overage',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation clear-overage',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation clear-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'clear-overage requires <tool>',
+      subcommand: 'automation clear-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation clear-overage must run inside a git repository',
+      subcommand: 'automation clear-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationState(repoRoot, tool);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'state_missing',
+      message: `cannot clear overage: state file for "${tool}" does not exist`,
+      subcommand: 'automation clear-overage',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'state_malformed',
+      message: result.error,
+      subcommand: 'automation clear-overage',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (!result.state.cost_overage) {
+    return EXIT_CODES.OK;
+  }
+
+  writeStateFile(repoRoot, tool, {
+    ...result.state,
+    cost_overage: false,
+  });
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/cron-decide.ts
+++ b/.gaia/cli/src/automation/cron-decide.ts
@@ -1,0 +1,335 @@
+/**
+ * `gaia automation cron-decide <tool> [--json] [--now <iso>]` handler.
+ *
+ * The smart-cron decision primitive. Returns a deterministic
+ * `{decision, reason, skip_log_line}` triple per the SPEC's per-tool
+ * cron logic. Pure: never mutates state. Workflows inspect `decision`
+ * and act; `skip_count` advancement after a `floor_24h` skip is the
+ * caller's responsibility (via `bump-state`).
+ *
+ * Exit code 0 covers both `run` and `skip` decisions. Non-zero covers
+ * configuration errors (missing/malformed config or malformed state).
+ *
+ * `--now <iso>` is a hidden, tests-only flag that overrides `new Date()`.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  TOOL_IDS,
+  TOOL_ID_TO_CONFIG_KEY,
+  type AutomationConfig,
+  type ToolConfig,
+  type ToolId,
+} from '../schemas/automation-config.js';
+import {readAutomationConfig} from '../schemas/automation-config.js';
+import {readAutomationState} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {appChangedSince} from './util/source-changed.js';
+
+type CronReason =
+  | 'app_changed'
+  | 'ceiling_14d'
+  | 'cost_overage'
+  | 'first_run'
+  | 'floor_24h'
+  | 'no_app_change'
+  | 'skip_safety_5'
+  | 'tool_off';
+
+type CronDecision = {
+  decision: 'run' | 'skip';
+  reason: CronReason;
+  skip_log_line: string | null;
+};
+
+const HELP_TEXT = `Usage: gaia automation cron-decide <tool> [--json]
+
+  Smart-cron decision primitive. Reads .gaia/automation.json and the
+  per-tool state file, then emits {decision, reason, skip_log_line}.
+  Decision priority:
+    1. tool_off       (config.<tool>.mode == "off")
+    2. cost_overage   (state.cost_overage == true)
+    3. first_run      (state file missing)
+    4. ceiling_14d    (last_run_at > 14 days ago)
+    5. skip_safety_5  (skip_count > 5)
+    6. floor_24h      (last_run_at < 24 hours ago)
+    7. app_changed    (commits to app/** since last_run_sha) — wiki only
+    8. no_app_change  (otherwise) — wiki only
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const FLOOR_HOURS = 24;
+const CEILING_DAYS = 14;
+const SKIP_SAFETY_THRESHOLD = 5;
+
+const toolConfigFor = (config: AutomationConfig, tool: ToolId): ToolConfig => {
+  const key = TOOL_ID_TO_CONFIG_KEY[tool];
+  // `update_gaia` is not a ToolId so this cast is safe — TOOL_ID_TO_CONFIG_KEY
+  // is restricted to ToolId keys.
+  return config[key] as unknown as ToolConfig;
+};
+
+type RunOptions = {
+  cwd?: string;
+  now?: () => Date;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let json = false;
+  let nowOverride: Date | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--now') {
+      const value = argv[index + 1];
+
+      if (value === undefined) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: '--now requires an ISO timestamp',
+          subcommand: 'automation cron-decide',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+
+      const parsed = new Date(value);
+
+      if (Number.isNaN(parsed.getTime())) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `--now must be a parseable ISO timestamp; got: "${value}"`,
+          subcommand: 'automation cron-decide',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+
+      nowOverride = parsed;
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation cron-decide',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation cron-decide',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation cron-decide',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'cron-decide requires <tool>',
+      subcommand: 'automation cron-decide',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation cron-decide must run inside a git repository',
+      subcommand: 'automation cron-decide',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const configResult = readAutomationConfig(repoRoot);
+
+  if (configResult.status === 'missing') {
+    structuredError({
+      code: 'config_missing',
+      message:
+        'cron-decide requires .gaia/automation.json — running cron-decide on an unconfigured repo is a setup bug',
+      subcommand: 'automation cron-decide',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (configResult.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: configResult.error,
+      subcommand: 'automation cron-decide',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const toolConfig = toolConfigFor(configResult.config, tool);
+
+  const decision = decide({
+    appChangedSince: (sha) => appChangedSince(repoRoot, sha),
+    now: nowOverride ?? options.now?.() ?? new Date(),
+    repoRoot,
+    stateResult: readAutomationState(repoRoot, tool),
+    tool,
+    toolConfig,
+  });
+
+  if (decision === 'state_malformed') {
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(decision)}\n`);
+  } else {
+    process.stdout.write(
+      `decision: ${decision.decision}\n` +
+        `reason: ${decision.reason}\n` +
+        `skip_log_line: ${decision.skip_log_line ?? '(none)'}\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};
+
+type DecideArgs = {
+  appChangedSince: (sha: string) => boolean;
+  now: Date;
+  repoRoot: string;
+  stateResult: ReturnType<typeof readAutomationState>;
+  tool: ToolId;
+  toolConfig: ToolConfig;
+};
+
+const decide = (args: DecideArgs): CronDecision | 'state_malformed' => {
+  const {appChangedSince: appChanged, now, stateResult, tool, toolConfig} = args;
+
+  // 1. tool_off
+  if (toolConfig.mode === 'off') {
+    return {
+      decision: 'skip',
+      reason: 'tool_off',
+      skip_log_line: 'tool mode is off; skipping',
+    };
+  }
+
+  // Slice-1 limitation: cron-decide governs only the wiki tool. Non-wiki
+  // tools land in a future slice that adds per-tool source sets; for now,
+  // emit a clearly-tagged tool_off-shaped placeholder so the workflow can
+  // see the limitation and bail.
+  if (tool !== 'wiki') {
+    return {
+      decision: 'skip',
+      reason: 'tool_off',
+      skip_log_line: `cron-decide not yet implemented for ${tool}; skipping`,
+    };
+  }
+
+  // 2. cost_overage and 3. first_run / state_malformed
+  if (stateResult.status === 'malformed') {
+    structuredError({
+      code: 'state_malformed',
+      message: stateResult.error,
+      subcommand: 'automation cron-decide',
+    });
+
+    return 'state_malformed';
+  }
+
+  if (stateResult.status === 'missing') {
+    return {decision: 'run', reason: 'first_run', skip_log_line: null};
+  }
+
+  const state = stateResult.state;
+
+  if (state.cost_overage) {
+    return {
+      decision: 'skip',
+      reason: 'cost_overage',
+      skip_log_line: 'cost overage; suppressed',
+    };
+  }
+
+  // 4. ceiling_14d
+  const lastRunMs = new Date(state.last_run_at).getTime();
+  const ageMs = now.getTime() - lastRunMs;
+
+  if (ageMs > CEILING_DAYS * 24 * MS_PER_HOUR) {
+    return {decision: 'run', reason: 'ceiling_14d', skip_log_line: null};
+  }
+
+  // 5. skip_safety_5
+  if (state.skip_count > SKIP_SAFETY_THRESHOLD) {
+    return {decision: 'run', reason: 'skip_safety_5', skip_log_line: null};
+  }
+
+  // 6. floor_24h
+  if (ageMs < FLOOR_HOURS * MS_PER_HOUR) {
+    return {
+      decision: 'skip',
+      reason: 'floor_24h',
+      skip_log_line: 'within 24h floor; skipping',
+    };
+  }
+
+  // 7. app_changed (wiki only)
+  if (appChanged(state.last_run_sha)) {
+    return {decision: 'run', reason: 'app_changed', skip_log_line: null};
+  }
+
+  // 8. no_app_change (wiki only)
+  const shortSha = state.last_run_sha.slice(0, 7);
+
+  return {
+    decision: 'skip',
+    reason: 'no_app_change',
+    skip_log_line: `skipped — no app/** changes since ${shortSha}`,
+  };
+};

--- a/.gaia/cli/src/automation/index.ts
+++ b/.gaia/cli/src/automation/index.ts
@@ -1,0 +1,73 @@
+/**
+ * `gaia automation` subcommand router.
+ *
+ * The slice-1 surface for GAIA CI's local-side primitives. Mirrors the
+ * shape of `wiki/index.ts`: object-map dispatch (no `switch`), exported
+ * `run` returns `Promise<number>`, structured error on unknown subcommand.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {run as runBumpState} from './bump-state.js';
+import {run as runClearOverage} from './clear-overage.js';
+import {run as runCronDecide} from './cron-decide.js';
+import {run as runInitState} from './init-state.js';
+import {run as runReadConfig} from './read-config.js';
+import {run as runReadState} from './read-state.js';
+import {run as runRecordOverage} from './record-overage.js';
+import {run as runRecordRun} from './record-run.js';
+
+const HELP_TEXT = `Usage: gaia automation <subcommand> [args]
+
+  read-config [--json]
+  read-state <tool> [--json]
+  init-state <tool> --sha <sha> [--at <iso>]
+  bump-state <tool> --field <name> --value <json>
+  cron-decide <tool> [--json]
+  record-run <tool> --sha <sha> --trigger <cron|force|workflow_dispatch> --cost <dollars> [--at <iso>]
+  record-overage <tool> --cost <dollars>
+  clear-overage <tool>
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type SubcommandHandler = (
+  args: readonly string[]
+) => number | Promise<number>;
+
+const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
+  'bump-state': runBumpState,
+  'clear-overage': runClearOverage,
+  'cron-decide': runCronDecide,
+  'init-state': runInitState,
+  'read-config': runReadConfig,
+  'read-state': runReadState,
+  'record-overage': runRecordOverage,
+  'record-run': runRecordRun,
+};
+
+export const run = async (argv: readonly string[]): Promise<number> => {
+  const subcommand = argv[0] as string | undefined;
+  const rest = argv.slice(1);
+
+  if (subcommand === undefined || HELP_TOKENS.has(subcommand)) {
+    process.stdout.write(HELP_TEXT);
+
+    return EXIT_CODES.OK;
+  }
+
+  const handler = SUBCOMMAND_HANDLERS[subcommand];
+
+  if (handler !== undefined) {
+    const result = await handler(rest);
+
+    return typeof result === 'number' ? result : EXIT_CODES.OK;
+  }
+
+  structuredError({
+    code: 'unknown_subcommand',
+    message: `unknown automation subcommand: ${subcommand}`,
+    subcommand: `automation ${subcommand}`,
+  });
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};

--- a/.gaia/cli/src/automation/init-state.ts
+++ b/.gaia/cli/src/automation/init-state.ts
@@ -1,0 +1,186 @@
+/**
+ * `gaia automation init-state <tool> --sha <sha> [--at <iso>]` handler.
+ *
+ * Creates a fresh `.gaia/automation.state-<tool>.json` with the slice-1
+ * default shape. Refuses if the state file already exists (parallel to
+ * `gaia wiki state-init`). Workflows usually go straight to
+ * `record-run`; `init-state` exists for first-run bootstrapping.
+ */
+import {execFileSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {EXIT_CODES} from '../exit.js';
+import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
+import type {AutomationStateFile} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {automationStatePath} from './paths.js';
+import {writeStateFile} from './util/state-write.js';
+
+const HELP_TEXT = `Usage: gaia automation init-state <tool> --sha <sha> [--at <iso>]
+
+  Creates a fresh state file for <tool>. Refuses if it already exists.
+  <sha> may be any git ref; it is resolved to a full 40-char sha.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const resolveFullSha = (ref: string, cwd: string): string | null => {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    return out.trim();
+  } catch {
+    return null;
+  }
+};
+
+type RunOptions = {
+  cwd?: string;
+  now?: () => Date;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let sha: string | undefined;
+  let atIso: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--sha') {
+      sha = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--at') {
+      atIso = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation init-state',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation init-state',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'init-state requires <tool>',
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (sha === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'init-state requires --sha <sha>',
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation init-state must run inside a git repository',
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const fullSha = resolveFullSha(sha, repoRoot);
+
+  if (fullSha === null) {
+    structuredError({
+      code: 'sha_unresolvable',
+      message: `could not resolve --sha via git rev-parse: "${sha}"`,
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const targetPath = automationStatePath(repoRoot, tool);
+
+  if (existsSync(targetPath)) {
+    structuredError({
+      code: 'state_already_exists',
+      message: `${targetPath} already exists — use record-run, bump-state, or clear-overage`,
+      subcommand: 'automation init-state',
+      tool,
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const nowDate = (options.now ?? (() => new Date()))();
+  const isoNow = atIso ?? nowDate.toISOString();
+
+  const state: AutomationStateFile = {
+    cost_overage: false,
+    last_run_at: isoNow,
+    last_run_cost: 0,
+    last_run_sha: fullSha,
+    last_run_trigger: 'cron',
+    skip_count: 0,
+    version: 1,
+  };
+
+  writeStateFile(repoRoot, tool, state);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/paths.ts
+++ b/.gaia/cli/src/automation/paths.ts
@@ -1,0 +1,19 @@
+/**
+ * Path constants for GAIA CI configuration and per-tool state files.
+ *
+ * Every helper takes an explicit `repoRoot` argument — these primitives
+ * never call `process.cwd()` themselves. Callers resolve the root via
+ * `resolveRepoRoot` from `wiki/util/git.ts`, matching the wiki
+ * primitives' pattern.
+ */
+import path from 'node:path';
+import type {ToolId} from '../schemas/automation-config.js';
+
+export const automationConfigPath = (repoRoot: string): string =>
+  path.join(repoRoot, '.gaia', 'automation.json');
+
+export const automationStatePath = (repoRoot: string, tool: ToolId): string =>
+  path.join(repoRoot, '.gaia', `automation.state-${tool}.json`);
+
+export const localAutomationPath = (repoRoot: string): string =>
+  path.join(repoRoot, '.gaia', 'local', 'automation.json');

--- a/.gaia/cli/src/automation/read-config.ts
+++ b/.gaia/cli/src/automation/read-config.ts
@@ -1,0 +1,108 @@
+/**
+ * `gaia automation read-config [--json]` handler.
+ *
+ * Thin wrapper around `readAutomationConfig`. JSON output is the
+ * schema-typed object verbatim; human output is a few-line key:value
+ * summary. Exits non-zero with `config_missing` when the config file
+ * does not exist (the CLI is a primitive — callers handle missing
+ * configs explicitly).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {readAutomationConfig} from '../schemas/automation-config.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+
+const HELP_TEXT = `Usage: gaia automation read-config [--json]
+
+  Reads .gaia/automation.json and prints its content. Exits non-zero
+  with code "config_missing" when the file does not exist.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown argument: ${token}`,
+      subcommand: 'automation read-config',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation read-config must run inside a git repository',
+      subcommand: 'automation read-config',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationConfig(repoRoot);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'config_missing',
+      message: '.gaia/automation.json does not exist',
+      subcommand: 'automation read-config',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: result.error,
+      subcommand: 'automation read-config',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result.config)}\n`);
+  } else {
+    const c = result.config;
+    process.stdout.write(
+      `version: ${String(c.version)}\n` +
+        `setup_complete: ${String(c.setup_complete)}\n` +
+        `setup_opted_out: ${String(c.setup_opted_out)}\n` +
+        `wiki: mode=${c.wiki.mode}${c.wiki.schedule ? ` schedule=${c.wiki.schedule}` : ''}\n` +
+        `sharpen: mode=${c.sharpen.mode}${c.sharpen.schedule ? ` schedule=${c.sharpen.schedule}` : ''}\n` +
+        `pnpm_audit: mode=${c.pnpm_audit.mode}${c.pnpm_audit.schedule ? ` schedule=${c.pnpm_audit.schedule}` : ''}\n` +
+        `stale_branches: mode=${c.stale_branches.mode}${c.stale_branches.schedule ? ` schedule=${c.stale_branches.schedule}` : ''}\n` +
+        `update_gaia: mode=${c.update_gaia.mode}\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/read-state.ts
+++ b/.gaia/cli/src/automation/read-state.ts
@@ -1,0 +1,145 @@
+/**
+ * `gaia automation read-state <tool> [--json]` handler.
+ *
+ * Thin wrapper around `readAutomationState`. Exits non-zero with
+ * `state_missing` when the state file does not exist — the CLI is a
+ * primitive, not a fall-back-to-defaults abstraction. The workflow
+ * uses `cron-decide` to handle first-run, not this command.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
+import {readAutomationState} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+
+const HELP_TEXT = `Usage: gaia automation read-state <tool> [--json]
+
+  Reads .gaia/automation.state-<tool>.json and prints its content.
+  <tool> must be one of: ${TOOL_IDS.join(', ')}.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let json = false;
+
+  for (const token of argv) {
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation read-state',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token} (expected one of ${TOOL_IDS.join(', ')})`,
+          subcommand: 'automation read-state',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation read-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'read-state requires a <tool> argument',
+      subcommand: 'automation read-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation read-state must run inside a git repository',
+      subcommand: 'automation read-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationState(repoRoot, tool);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'state_missing',
+      message: `.gaia/automation.state-${tool}.json does not exist`,
+      subcommand: 'automation read-state',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'state_malformed',
+      message: result.error,
+      subcommand: 'automation read-state',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result.state)}\n`);
+  } else {
+    const s = result.state;
+    process.stdout.write(
+      `version: ${String(s.version)}\n` +
+        `last_run_at: ${s.last_run_at}\n` +
+        `last_run_sha: ${s.last_run_sha}\n` +
+        `last_run_trigger: ${s.last_run_trigger}\n` +
+        `skip_count: ${String(s.skip_count)}\n` +
+        `last_run_cost: ${String(s.last_run_cost)}\n` +
+        `cost_overage: ${String(s.cost_overage)}\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/record-overage.ts
+++ b/.gaia/cli/src/automation/record-overage.ts
@@ -1,0 +1,162 @@
+/**
+ * `gaia automation record-overage <tool> --cost <dollars>` handler.
+ *
+ * Post-run edit: only sets `cost_overage = true` and `last_run_cost`.
+ * All other fields are preserved. Exits non-zero with `state_missing`
+ * when the state file does not exist (calling record-overage without a
+ * prior run is a workflow bug).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
+import {readAutomationState} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeStateFile} from './util/state-write.js';
+
+const HELP_TEXT = `Usage: gaia automation record-overage <tool> --cost <dollars>
+
+  Marks the most recent run as a cost overage and records its actual cost.
+  Refuses if the state file is missing (record-overage is a post-run edit).
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let costStr: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--cost') {
+      costStr = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation record-overage',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation record-overage',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation record-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'record-overage requires <tool>',
+      subcommand: 'automation record-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (costStr === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'record-overage requires --cost <dollars>',
+      subcommand: 'automation record-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cost = Number.parseFloat(costStr);
+
+  if (!Number.isFinite(cost) || cost < 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `--cost must be a non-negative number; got: "${costStr}"`,
+      subcommand: 'automation record-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation record-overage must run inside a git repository',
+      subcommand: 'automation record-overage',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationState(repoRoot, tool);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'state_missing',
+      message: `cannot record overage: state file for "${tool}" does not exist`,
+      subcommand: 'automation record-overage',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'state_malformed',
+      message: result.error,
+      subcommand: 'automation record-overage',
+      tool,
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  writeStateFile(repoRoot, tool, {
+    ...result.state,
+    cost_overage: true,
+    last_run_cost: cost,
+  });
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/record-run.ts
+++ b/.gaia/cli/src/automation/record-run.ts
@@ -1,0 +1,208 @@
+/**
+ * `gaia automation record-run <tool> --sha <sha> --trigger <kind> --cost <dollars> [--at <iso>]` handler.
+ *
+ * Writes a fresh state-file shape after a real run. Resets `skip_count`
+ * to 0, sets `cost_overage = (cost > 5)` (strict-greater-than: equal-to-
+ * ceiling is NOT overage), and overwrites any existing state.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  TOOL_IDS,
+  type ToolId,
+} from '../schemas/automation-config.js';
+import type {AutomationStateFile, Trigger} from '../schemas/automation-state.js';
+import {AutomationStateFileSchema} from '../schemas/automation-state.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeStateFile} from './util/state-write.js';
+
+const COST_CEILING_DOLLARS = 5;
+
+const HELP_TEXT = `Usage: gaia automation record-run <tool> --sha <sha> --trigger <cron|force|workflow_dispatch> --cost <dollars> [--at <iso>]
+
+  Records a real run. Resets skip_count to 0; sets cost_overage = (cost > 5)
+  (strict-greater-than: cost == 5 is NOT overage).
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+const VALID_TRIGGERS: readonly Trigger[] = [
+  'cron',
+  'force',
+  'workflow_dispatch',
+];
+
+type RunOptions = {
+  cwd?: string;
+  now?: () => Date;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  let tool: ToolId | undefined;
+  let sha: string | undefined;
+  let trigger: Trigger | undefined;
+  let costStr: string | undefined;
+  let atIso: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--sha') {
+      sha = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--trigger') {
+      const value = argv[index + 1];
+
+      if (value === undefined || !(VALID_TRIGGERS as readonly string[]).includes(value)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `--trigger must be one of ${VALID_TRIGGERS.join(', ')}`,
+          subcommand: 'automation record-run',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+
+      trigger = value as Trigger;
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--cost') {
+      costStr = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--at') {
+      atIso = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'automation record-run',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (tool === undefined) {
+      if (!(TOOL_IDS as readonly string[]).includes(token)) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: `unknown tool: ${token}`,
+          subcommand: 'automation record-run',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      tool = token as ToolId;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (tool === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'record-run requires <tool>',
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (sha === undefined || trigger === undefined || costStr === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'record-run requires --sha, --trigger, --cost',
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cost = Number.parseFloat(costStr);
+
+  if (!Number.isFinite(cost) || cost < 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `--cost must be a non-negative number; got: "${costStr}"`,
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia automation record-run must run inside a git repository',
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const nowDate = (options.now ?? (() => new Date()))();
+  const isoNow = atIso ?? nowDate.toISOString();
+
+  const candidate: AutomationStateFile = {
+    cost_overage: cost > COST_CEILING_DOLLARS,
+    last_run_at: isoNow,
+    last_run_cost: cost,
+    last_run_sha: sha,
+    last_run_trigger: trigger,
+    skip_count: 0,
+    version: 1,
+  };
+
+  const validation = AutomationStateFileSchema.safeParse(candidate);
+
+  if (!validation.success) {
+    structuredError({
+      code: 'state_malformed',
+      message: validation.error.issues
+        .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+        .join('; '),
+      subcommand: 'automation record-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  writeStateFile(repoRoot, tool, validation.data);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/automation/util/__tests__/source-changed.test.ts
+++ b/.gaia/cli/src/automation/util/__tests__/source-changed.test.ts
@@ -1,0 +1,94 @@
+import {execFileSync} from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {appChangedSince} from '../source-changed.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  commit: (relPath: string, content: string) => string;
+  initialSha: string;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-source-changed-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {cwd: root});
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: root});
+  writeFileSync(path.join(root, 'README.md'), '# x\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], {cwd: root});
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], {cwd: root});
+  const initialSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+    .toString()
+    .trim();
+
+  const commit = (relPath: string, content: string): string => {
+    const target = path.join(root, relPath);
+    mkdirSync(path.dirname(target), {recursive: true});
+    writeFileSync(target, content, 'utf8');
+    execFileSync('git', ['add', relPath], {cwd: root});
+    execFileSync('git', ['commit', '-q', '-m', `add ${relPath}`], {cwd: root});
+
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+    })
+      .toString()
+      .trim();
+  };
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    commit,
+    initialSha,
+    root,
+  };
+};
+
+describe('appChangedSince', () => {
+  let sandbox: Sandbox;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  it('returns false when there are no commits since the sha', () => {
+    expect(appChangedSince(sandbox.root, sandbox.initialSha)).toBe(false);
+  });
+
+  it('returns false when commits touched files outside app/', () => {
+    sandbox.commit('docs/CHANGELOG.md', '# x\n');
+    expect(appChangedSince(sandbox.root, sandbox.initialSha)).toBe(false);
+  });
+
+  it('returns true when a commit touched app/**', () => {
+    sandbox.commit('app/foo.ts', 'export const x = 1;\n');
+    expect(appChangedSince(sandbox.root, sandbox.initialSha)).toBe(true);
+  });
+
+  it('returns true if any of multiple commits touched app/**', () => {
+    sandbox.commit('docs/CHANGELOG.md', '# x\n');
+    sandbox.commit('app/bar.ts', 'export const y = 1;\n');
+    expect(appChangedSince(sandbox.root, sandbox.initialSha)).toBe(true);
+  });
+
+  it('returns false when the sha is unreachable', () => {
+    expect(appChangedSince(sandbox.root, 'a'.repeat(40))).toBe(false);
+  });
+});

--- a/.gaia/cli/src/automation/util/source-changed.ts
+++ b/.gaia/cli/src/automation/util/source-changed.ts
@@ -1,0 +1,40 @@
+/**
+ * Source-change detection for the smart-cron decision tree.
+ *
+ * `appChangedSince(repoRoot, sha)` runs
+ * `git log <sha>..HEAD --name-only --pretty=format: -- app/` and returns
+ * `true` if any line is non-blank.
+ *
+ * If `<sha>` is unreachable (e.g. force-push rewrote history), git
+ * exits non-zero and this helper returns `false`. The workflow handles
+ * the unreachable-state branch separately in a future slice; slice 1
+ * documents the limitation here and treats unreachable as "no change".
+ */
+import {execFileSync} from 'node:child_process';
+
+export const appChangedSince = (repoRoot: string, sha: string): boolean => {
+  try {
+    const stdout = execFileSync(
+      'git',
+      [
+        'log',
+        `${sha}..HEAD`,
+        '--name-only',
+        '--pretty=format:',
+        '--',
+        'app/',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }
+    );
+
+    return stdout
+      .split('\n')
+      .some((line) => line.trim().length > 0);
+  } catch {
+    return false;
+  }
+};

--- a/.gaia/cli/src/automation/util/state-write.ts
+++ b/.gaia/cli/src/automation/util/state-write.ts
@@ -1,0 +1,31 @@
+/**
+ * Atomic-write helper for per-tool state files at
+ * `.gaia/automation.state-<tool>.json`.
+ *
+ * Tiny extraction of the `writeFileSync(tmp); renameSync(tmp, target)`
+ * idiom from `wiki/state-init.ts` and `wiki/state-bump.ts`. The wiki
+ * handlers continue to inline the idiom; refactoring them to use this
+ * helper is intentionally out of scope for slice 1 (surgical changes).
+ *
+ * Serializes with 2-space indentation + trailing newline to match the
+ * wiki state file format.
+ */
+import {mkdirSync, renameSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {automationStatePath} from '../paths.js';
+import type {AutomationStateFile} from '../../schemas/automation-state.js';
+import type {ToolId} from '../../schemas/automation-config.js';
+
+export const writeStateFile = (
+  repoRoot: string,
+  tool: ToolId,
+  state: AutomationStateFile
+): void => {
+  const target = automationStatePath(repoRoot, tool);
+  mkdirSync(path.dirname(target), {recursive: true});
+
+  const serialized = `${JSON.stringify(state, null, 2)}\n`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync(tmpPath, serialized, 'utf8');
+  renameSync(tmpPath, target);
+};

--- a/.gaia/cli/src/index.maintainer.ts
+++ b/.gaia/cli/src/index.maintainer.ts
@@ -14,6 +14,7 @@
  */
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
 import {run as runFetchCoaching} from './adaptation/inject.js';
+import {run as runAutomation} from './automation/index.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
@@ -35,6 +36,7 @@ Maintainer-only binary. Adopters use 'gaia' (no release namespace).
   mentorship analytics enable|disable|dry-run
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
+  automation read-config|read-state|init-state|bump-state|cron-decide|record-run|record-overage|clear-overage
   update merge --baseline <dir> --latest <dir> --manifest <path>
   release preflight|bump|changelog|scrub-wiki|manifest|scrub|runtime-deps|commit-and-tag
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
@@ -52,6 +54,7 @@ type SubcommandHandler = (
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
+  automation: runAutomation,
   init: runInit,
   mentorship: runMentorship,
   release: runRelease,

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -10,6 +10,7 @@
  */
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
 import {run as runFetchCoaching} from './adaptation/inject.js';
+import {run as runAutomation} from './automation/index.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
@@ -28,6 +29,7 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   mentorship analytics enable|disable|dry-run
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
+  automation read-config|read-state|init-state|bump-state|cron-decide|record-run|record-overage|clear-overage
   update merge --baseline <dir> --latest <dir> --manifest <path>
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
@@ -44,6 +46,7 @@ type SubcommandHandler = (
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
+  automation: runAutomation,
   init: runInit,
   mentorship: runMentorship,
   scaffold: runScaffold,

--- a/.gaia/cli/src/schemas/__tests__/automation-config.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/automation-config.test.ts
@@ -1,0 +1,164 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  AutomationConfigSchema,
+  CONFIG_KEY_TO_TOOL_ID,
+  TOOL_ID_TO_CONFIG_KEY,
+  TOOL_IDS,
+  parseAutomationConfig,
+  readAutomationConfig,
+} from '../automation-config.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  configDir: string;
+  configPath: string;
+  root: string;
+};
+
+const VALID_CONFIG = {
+  pnpm_audit: {mode: 'local', schedule: 'weekly'},
+  setup_complete: true,
+  setup_opted_out: false,
+  sharpen: {mode: 'off'},
+  stale_branches: {mode: 'ci', schedule: 'weekly'},
+  update_gaia: {mode: 'local'},
+  version: 1,
+  wiki: {mode: 'ci', schedule: 'daily'},
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-automation-config-'));
+  const configDir = path.join(root, '.gaia');
+  mkdirSync(configDir, {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    configDir,
+    configPath: path.join(configDir, 'automation.json'),
+    root,
+  };
+};
+
+describe('schemas/automation-config', () => {
+  describe('AutomationConfigSchema', () => {
+    it('parses a valid config', () => {
+      expect(() => parseAutomationConfig(VALID_CONFIG)).not.toThrow();
+    });
+
+    it('rejects version != 1', () => {
+      expect(() =>
+        AutomationConfigSchema.parse({...VALID_CONFIG, version: 2})
+      ).toThrow();
+    });
+
+    it('rejects unknown tool mode', () => {
+      expect(() =>
+        AutomationConfigSchema.parse({
+          ...VALID_CONFIG,
+          wiki: {mode: 'ci2'},
+        })
+      ).toThrow();
+    });
+
+    it('rejects missing wiki section', () => {
+      const {wiki: _wiki, ...rest} = VALID_CONFIG;
+      expect(() => AutomationConfigSchema.parse(rest)).toThrow();
+    });
+
+    it('accepts ToolConfig without schedule', () => {
+      expect(() =>
+        AutomationConfigSchema.parse({
+          ...VALID_CONFIG,
+          sharpen: {mode: 'off'},
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects update_gaia mode != "local"', () => {
+      expect(() =>
+        AutomationConfigSchema.parse({
+          ...VALID_CONFIG,
+          update_gaia: {mode: 'ci'},
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('TOOL_ID_TO_CONFIG_KEY <-> CONFIG_KEY_TO_TOOL_ID round-trip', () => {
+    for (const tool of TOOL_IDS) {
+      it(`round-trips for ${tool}`, () => {
+        const configKey = TOOL_ID_TO_CONFIG_KEY[tool];
+        expect(CONFIG_KEY_TO_TOOL_ID[configKey]).toBe(tool);
+      });
+    }
+  });
+
+  describe('readAutomationConfig', () => {
+    let sandbox: Sandbox;
+
+    beforeEach(() => {
+      sandbox = setupSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.cleanup();
+    });
+
+    it('returns {status: "missing"} when the file does not exist', () => {
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('missing');
+    });
+
+    it('returns {status: "ok", config} for valid JSON', () => {
+      writeFileSync(sandbox.configPath, JSON.stringify(VALID_CONFIG), 'utf8');
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('ok');
+
+      if (result.status === 'ok') {
+        expect(result.config.wiki.mode).toBe('ci');
+      }
+    });
+
+    it('returns {status: "malformed"} for invalid JSON', () => {
+      writeFileSync(sandbox.configPath, '{not json', 'utf8');
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('malformed');
+
+      if (result.status === 'malformed') {
+        expect(result.error).toContain('automation.json');
+        expect(result.error).toContain('invalid JSON');
+      }
+    });
+
+    it('returns {status: "malformed"} for schema-violating JSON', () => {
+      writeFileSync(
+        sandbox.configPath,
+        JSON.stringify({...VALID_CONFIG, wiki: {mode: 'wat'}}),
+        'utf8'
+      );
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('malformed');
+
+      if (result.status === 'malformed') {
+        expect(result.error).toContain('wiki.mode');
+      }
+    });
+
+    it('returns {status: "malformed"} when version is missing', () => {
+      const {version: _version, ...rest} = VALID_CONFIG;
+      writeFileSync(sandbox.configPath, JSON.stringify(rest), 'utf8');
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+  });
+});

--- a/.gaia/cli/src/schemas/__tests__/automation-state.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/automation-state.test.ts
@@ -1,0 +1,151 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  AutomationStateFileSchema,
+  parseAutomationState,
+  readAutomationState,
+} from '../automation-state.js';
+
+const VALID_STATE = {
+  cost_overage: false,
+  last_run_at: '2026-05-09T04:00:00Z',
+  last_run_cost: 0.42,
+  last_run_sha: 'a'.repeat(40),
+  last_run_trigger: 'cron',
+  skip_count: 0,
+  version: 1,
+};
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+  statePath: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-automation-state-'));
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+    statePath: path.join(root, '.gaia', 'automation.state-wiki.json'),
+  };
+};
+
+describe('schemas/automation-state', () => {
+  describe('AutomationStateFileSchema', () => {
+    it('parses a valid state', () => {
+      expect(() => parseAutomationState(VALID_STATE)).not.toThrow();
+    });
+
+    it('rejects a non-40-char sha', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({...VALID_STATE, last_run_sha: 'abc123'})
+      ).toThrow();
+    });
+
+    it('rejects an uppercase sha', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({
+          ...VALID_STATE,
+          last_run_sha: 'A'.repeat(40),
+        })
+      ).toThrow();
+    });
+
+    it('rejects a non-ISO last_run_at', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({
+          ...VALID_STATE,
+          last_run_at: 'yesterday',
+        })
+      ).toThrow();
+    });
+
+    it('rejects negative skip_count', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({...VALID_STATE, skip_count: -1})
+      ).toThrow();
+    });
+
+    it('rejects negative last_run_cost', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({...VALID_STATE, last_run_cost: -0.1})
+      ).toThrow();
+    });
+
+    it('rejects unknown trigger', () => {
+      expect(() =>
+        AutomationStateFileSchema.parse({...VALID_STATE, last_run_trigger: 'rerun'})
+      ).toThrow();
+    });
+  });
+
+  describe('readAutomationState', () => {
+    let sandbox: Sandbox;
+
+    beforeEach(() => {
+      sandbox = setupSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.cleanup();
+    });
+
+    it('returns {status: "missing"} when the file does not exist', () => {
+      const result = readAutomationState(sandbox.root, 'wiki');
+      expect(result.status).toBe('missing');
+    });
+
+    it('returns {status: "ok"} for valid JSON', () => {
+      writeFileSync(sandbox.statePath, JSON.stringify(VALID_STATE), 'utf8');
+      const result = readAutomationState(sandbox.root, 'wiki');
+      expect(result.status).toBe('ok');
+
+      if (result.status === 'ok') {
+        expect(result.state.last_run_trigger).toBe('cron');
+      }
+    });
+
+    it('returns {status: "malformed"} for invalid JSON', () => {
+      writeFileSync(sandbox.statePath, '{nope', 'utf8');
+      const result = readAutomationState(sandbox.root, 'wiki');
+      expect(result.status).toBe('malformed');
+    });
+
+    it('returns {status: "malformed"} for a bad sha', () => {
+      writeFileSync(
+        sandbox.statePath,
+        JSON.stringify({...VALID_STATE, last_run_sha: 'short'}),
+        'utf8'
+      );
+      const result = readAutomationState(sandbox.root, 'wiki');
+      expect(result.status).toBe('malformed');
+
+      if (result.status === 'malformed') {
+        expect(result.error).toContain('last_run_sha');
+      }
+    });
+
+    it('uses the kebab-case tool id in the path', () => {
+      const auditPath = path.join(
+        sandbox.root,
+        '.gaia',
+        'automation.state-pnpm-audit.json'
+      );
+      writeFileSync(auditPath, JSON.stringify(VALID_STATE), 'utf8');
+      const result = readAutomationState(sandbox.root, 'pnpm-audit');
+      expect(result.status).toBe('ok');
+    });
+  });
+});

--- a/.gaia/cli/src/schemas/__tests__/local-automation.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/local-automation.test.ts
@@ -1,0 +1,101 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  LocalAutomationSchema,
+  parseLocalAutomation,
+  readLocalAutomation,
+} from '../local-automation.js';
+
+const VALID_LOCAL = {
+  nudge_dismissed: false,
+  version: 1,
+};
+
+type Sandbox = {
+  cleanup: () => void;
+  localPath: string;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-local-automation-'));
+  mkdirSync(path.join(root, '.gaia', 'local'), {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    localPath: path.join(root, '.gaia', 'local', 'automation.json'),
+    root,
+  };
+};
+
+describe('schemas/local-automation', () => {
+  describe('LocalAutomationSchema', () => {
+    it('parses a valid local config', () => {
+      expect(() => parseLocalAutomation(VALID_LOCAL)).not.toThrow();
+    });
+
+    it('rejects version != 1', () => {
+      expect(() =>
+        LocalAutomationSchema.parse({...VALID_LOCAL, version: 2})
+      ).toThrow();
+    });
+
+    it('rejects a non-boolean nudge_dismissed', () => {
+      expect(() =>
+        LocalAutomationSchema.parse({...VALID_LOCAL, nudge_dismissed: 'no'})
+      ).toThrow();
+    });
+  });
+
+  describe('readLocalAutomation', () => {
+    let sandbox: Sandbox;
+
+    beforeEach(() => {
+      sandbox = setupSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.cleanup();
+    });
+
+    it('returns {status: "missing"} when the file does not exist', () => {
+      const result = readLocalAutomation(sandbox.root);
+      expect(result.status).toBe('missing');
+    });
+
+    it('returns {status: "ok"} for valid JSON', () => {
+      writeFileSync(sandbox.localPath, JSON.stringify(VALID_LOCAL), 'utf8');
+      const result = readLocalAutomation(sandbox.root);
+      expect(result.status).toBe('ok');
+
+      if (result.status === 'ok') {
+        expect(result.local.nudge_dismissed).toBe(false);
+      }
+    });
+
+    it('returns {status: "malformed"} for invalid JSON', () => {
+      writeFileSync(sandbox.localPath, '{nope', 'utf8');
+      const result = readLocalAutomation(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+
+    it('returns {status: "malformed"} for schema-violating JSON', () => {
+      writeFileSync(
+        sandbox.localPath,
+        JSON.stringify({...VALID_LOCAL, version: 99}),
+        'utf8'
+      );
+      const result = readLocalAutomation(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+  });
+});

--- a/.gaia/cli/src/schemas/automation-config.ts
+++ b/.gaia/cli/src/schemas/automation-config.ts
@@ -1,0 +1,122 @@
+/**
+ * Zod schema + read helpers for `.gaia/automation.json`, the committed
+ * GAIA CI configuration file.
+ *
+ * Per the SPEC-001 slice 1 contract: a missing config file means
+ * "GAIA CI not configured" — every defer / cron read returns a no-op
+ * result. The `read*` helpers therefore never throw; callers branch on
+ * the discriminated `status` field.
+ */
+import {existsSync, readFileSync} from 'node:fs';
+import {z} from 'zod';
+import {automationConfigPath} from '../automation/paths.js';
+
+export const TOOL_IDS = ['wiki', 'sharpen', 'pnpm-audit', 'stale-branches'] as const;
+export type ToolId = (typeof TOOL_IDS)[number];
+
+export const ToolModeSchema = z.enum(['ci', 'local', 'off']);
+export type ToolMode = z.infer<typeof ToolModeSchema>;
+
+export const ScheduleSchema = z.enum(['daily', 'weekly', 'monthly']);
+export type Schedule = z.infer<typeof ScheduleSchema>;
+
+export const ToolConfigSchema = z.object({
+  mode: ToolModeSchema,
+  schedule: ScheduleSchema.optional(),
+});
+export type ToolConfig = z.infer<typeof ToolConfigSchema>;
+
+export const UpdateGaiaConfigSchema = z.object({
+  mode: z.literal('local'),
+});
+export type UpdateGaiaConfig = z.infer<typeof UpdateGaiaConfigSchema>;
+
+export const AutomationConfigSchema = z.object({
+  version: z.literal(1),
+  setup_complete: z.boolean(),
+  setup_opted_out: z.boolean(),
+  wiki: ToolConfigSchema,
+  sharpen: ToolConfigSchema,
+  pnpm_audit: ToolConfigSchema,
+  stale_branches: ToolConfigSchema,
+  update_gaia: UpdateGaiaConfigSchema,
+});
+export type AutomationConfig = z.infer<typeof AutomationConfigSchema>;
+
+/**
+ * Map from kebab-case tool id (used in state file paths and CLI args)
+ * to the snake_case key used inside `.gaia/automation.json`.
+ *
+ * The split is intentional: the SPEC names the JSON keys snake_case
+ * (`pnpm_audit`, `stale_branches`) but workflow / state-file paths use
+ * kebab-case. Locking the mapping in one place keeps callers typesafe.
+ */
+export const TOOL_ID_TO_CONFIG_KEY: Readonly<Record<ToolId, keyof AutomationConfig>> = {
+  'pnpm-audit': 'pnpm_audit',
+  'sharpen': 'sharpen',
+  'stale-branches': 'stale_branches',
+  'wiki': 'wiki',
+};
+
+export const CONFIG_KEY_TO_TOOL_ID: Readonly<Record<string, ToolId>> = {
+  pnpm_audit: 'pnpm-audit',
+  sharpen: 'sharpen',
+  stale_branches: 'stale-branches',
+  wiki: 'wiki',
+};
+
+export const parseAutomationConfig = (raw: unknown): AutomationConfig =>
+  AutomationConfigSchema.parse(raw);
+
+export type ReadAutomationConfigResult =
+  | {config: AutomationConfig; status: 'ok'}
+  | {status: 'missing'}
+  | {error: string; status: 'malformed'};
+
+const summarizeZodError = (filePath: string, error: z.ZodError): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+
+    return `${pathStr}: ${issue.message}`;
+  });
+
+  return `${filePath}: ${lines.join('; ')}`;
+};
+
+export const readAutomationConfig = (
+  repoRoot: string
+): ReadAutomationConfigResult => {
+  const filePath = automationConfigPath(repoRoot);
+
+  if (!existsSync(filePath)) return {status: 'missing'};
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    return {
+      error: `${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      error: `${filePath}: invalid JSON — ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  const result = AutomationConfigSchema.safeParse(parsed);
+
+  if (!result.success) {
+    return {error: summarizeZodError(filePath, result.error), status: 'malformed'};
+  }
+
+  return {config: result.data, status: 'ok'};
+};

--- a/.gaia/cli/src/schemas/automation-state.ts
+++ b/.gaia/cli/src/schemas/automation-state.ts
@@ -1,0 +1,85 @@
+/**
+ * Zod schema + read helpers for `.gaia/automation.state-<tool>.json`,
+ * the per-tool state files driven by the smart-cron decision tree.
+ *
+ * A missing state file is treated by the SPEC as "no prior run, force a
+ * run" but that decision belongs in `cron-decide`. This module reports
+ * `{status: 'missing'}` and lets the caller decide.
+ */
+import {existsSync, readFileSync} from 'node:fs';
+import {z} from 'zod';
+import {automationStatePath} from '../automation/paths.js';
+import type {ToolId} from './automation-config.js';
+
+export const TriggerSchema = z.enum(['cron', 'force', 'workflow_dispatch']);
+export type Trigger = z.infer<typeof TriggerSchema>;
+
+const SHA_REGEX = /^[0-9a-f]{40}$/u;
+
+export const AutomationStateFileSchema = z.object({
+  version: z.literal(1),
+  last_run_at: z.iso.datetime({offset: false}),
+  last_run_sha: z.string().regex(SHA_REGEX, '40-char git sha'),
+  last_run_trigger: TriggerSchema,
+  skip_count: z.number().int().min(0),
+  last_run_cost: z.number().min(0),
+  cost_overage: z.boolean(),
+});
+export type AutomationStateFile = z.infer<typeof AutomationStateFileSchema>;
+
+export const parseAutomationState = (raw: unknown): AutomationStateFile =>
+  AutomationStateFileSchema.parse(raw);
+
+export type ReadAutomationStateResult =
+  | {state: AutomationStateFile; status: 'ok'}
+  | {status: 'missing'}
+  | {error: string; status: 'malformed'};
+
+const summarizeZodError = (filePath: string, error: z.ZodError): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+
+    return `${pathStr}: ${issue.message}`;
+  });
+
+  return `${filePath}: ${lines.join('; ')}`;
+};
+
+export const readAutomationState = (
+  repoRoot: string,
+  tool: ToolId
+): ReadAutomationStateResult => {
+  const filePath = automationStatePath(repoRoot, tool);
+
+  if (!existsSync(filePath)) return {status: 'missing'};
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    return {
+      error: `${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      error: `${filePath}: invalid JSON — ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  const result = AutomationStateFileSchema.safeParse(parsed);
+
+  if (!result.success) {
+    return {error: summarizeZodError(filePath, result.error), status: 'malformed'};
+  }
+
+  return {state: result.data, status: 'ok'};
+};

--- a/.gaia/cli/src/schemas/index.ts
+++ b/.gaia/cli/src/schemas/index.ts
@@ -2,9 +2,15 @@
 
 export * from './analytics-report.js';
 
+export * from './automation-config.js';
+
+export * from './automation-state.js';
+
 export * from './cloud-projection.js';
 
 export * from './envelope.js';
+
+export * from './local-automation.js';
 
 export * from './local-namespace.js';
 

--- a/.gaia/cli/src/schemas/local-automation.ts
+++ b/.gaia/cli/src/schemas/local-automation.ts
@@ -1,0 +1,73 @@
+/**
+ * Zod schema + read helpers for `.gaia/local/automation.json`, the
+ * gitignored personal nudge state.
+ *
+ * Slice 1 only reads this file; the dismissal write lands in
+ * `/setup-gaia-ci` (a later slice). The path constant + read helper
+ * exist now so all later slices share one canonical source.
+ */
+import {existsSync, readFileSync} from 'node:fs';
+import {z} from 'zod';
+import {localAutomationPath} from '../automation/paths.js';
+
+export const LocalAutomationSchema = z.object({
+  version: z.literal(1),
+  nudge_dismissed: z.boolean(),
+});
+export type LocalAutomation = z.infer<typeof LocalAutomationSchema>;
+
+export const parseLocalAutomation = (raw: unknown): LocalAutomation =>
+  LocalAutomationSchema.parse(raw);
+
+export type ReadLocalAutomationResult =
+  | {local: LocalAutomation; status: 'ok'}
+  | {status: 'missing'}
+  | {error: string; status: 'malformed'};
+
+const summarizeZodError = (filePath: string, error: z.ZodError): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+
+    return `${pathStr}: ${issue.message}`;
+  });
+
+  return `${filePath}: ${lines.join('; ')}`;
+};
+
+export const readLocalAutomation = (
+  repoRoot: string
+): ReadLocalAutomationResult => {
+  const filePath = localAutomationPath(repoRoot);
+
+  if (!existsSync(filePath)) return {status: 'missing'};
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    return {
+      error: `${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      error: `${filePath}: invalid JSON — ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  const result = LocalAutomationSchema.safeParse(parsed);
+
+  if (!result.success) {
+    return {error: summarizeZodError(filePath, result.error), status: 'malformed'};
+  }
+
+  return {local: result.data, status: 'ok'};
+};

--- a/.gaia/cli/test-fixtures/automation/README.md
+++ b/.gaia/cli/test-fixtures/automation/README.md
@@ -1,0 +1,32 @@
+# automation fixtures
+
+Example `.gaia/automation.json` and `.gaia/automation.state-<tool>.json`
+shapes for slice 1 of the GAIA CI configuration. **Slice 1 ships these
+fixtures but does not consume them in tests.** They exist for two reasons:
+
+1. **Living examples.** Adopters wiring up GAIA CI can read these files to
+   see what valid shapes look like end-to-end.
+2. **Slice 2 hooks.** The future workflow-generation slice exercises the
+   defer / cron-decide paths against these fixtures rather than inlining
+   JSON in test bodies.
+
+## Files
+
+| File                                  | Shape it demonstrates                                          |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `automation-config-wiki-ci.json`      | Wiki under CI control, daily schedule.                         |
+| `automation-config-wiki-local.json`   | Wiki under local control. Local hooks fire normally.           |
+| `automation-state-wiki-fresh.json`    | A run from the previous day; no overage, fresh `skip_count`.   |
+| `automation-state-wiki-stale.json`    | A run from > 14 days ago — triggers `ceiling_14d` decision.    |
+| `automation-state-wiki-overage.json`  | `cost_overage = true` — triggers `cost_overage` decision.      |
+
+## Validation
+
+Each fixture round-trips through the Phase 1 schemas. Slice 2 tests will
+parse and use them via:
+
+```ts
+import {parseAutomationConfig} from '../../src/schemas/automation-config.js';
+import fixture from '../../test-fixtures/automation/automation-config-wiki-ci.json';
+parseAutomationConfig(fixture);
+```

--- a/.gaia/cli/test-fixtures/automation/automation-config-wiki-ci.json
+++ b/.gaia/cli/test-fixtures/automation/automation-config-wiki-ci.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "setup_complete": true,
+  "setup_opted_out": false,
+  "wiki": {
+    "mode": "ci",
+    "schedule": "daily"
+  },
+  "sharpen": {
+    "mode": "off"
+  },
+  "pnpm_audit": {
+    "mode": "local",
+    "schedule": "weekly"
+  },
+  "stale_branches": {
+    "mode": "ci",
+    "schedule": "weekly"
+  },
+  "update_gaia": {
+    "mode": "local"
+  }
+}

--- a/.gaia/cli/test-fixtures/automation/automation-config-wiki-local.json
+++ b/.gaia/cli/test-fixtures/automation/automation-config-wiki-local.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "setup_complete": true,
+  "setup_opted_out": false,
+  "wiki": {
+    "mode": "local"
+  },
+  "sharpen": {
+    "mode": "off"
+  },
+  "pnpm_audit": {
+    "mode": "local",
+    "schedule": "weekly"
+  },
+  "stale_branches": {
+    "mode": "off"
+  },
+  "update_gaia": {
+    "mode": "local"
+  }
+}

--- a/.gaia/cli/test-fixtures/automation/automation-state-wiki-fresh.json
+++ b/.gaia/cli/test-fixtures/automation/automation-state-wiki-fresh.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "last_run_at": "2026-05-08T04:00:00Z",
+  "last_run_sha": "0123456789abcdef0123456789abcdef01234567",
+  "last_run_trigger": "cron",
+  "skip_count": 0,
+  "last_run_cost": 0.42,
+  "cost_overage": false
+}

--- a/.gaia/cli/test-fixtures/automation/automation-state-wiki-overage.json
+++ b/.gaia/cli/test-fixtures/automation/automation-state-wiki-overage.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "last_run_at": "2026-05-08T04:00:00Z",
+  "last_run_sha": "0123456789abcdef0123456789abcdef01234567",
+  "last_run_trigger": "cron",
+  "skip_count": 0,
+  "last_run_cost": 6.5,
+  "cost_overage": true
+}

--- a/.gaia/cli/test-fixtures/automation/automation-state-wiki-stale.json
+++ b/.gaia/cli/test-fixtures/automation/automation-state-wiki-stale.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "last_run_at": "2026-04-20T04:00:00Z",
+  "last_run_sha": "0123456789abcdef0123456789abcdef01234567",
+  "last_run_trigger": "cron",
+  "skip_count": 3,
+  "last_run_cost": 0.55,
+  "cost_overage": false
+}


### PR DESCRIPTION
## Summary

Phase 1 of three for SPEC-001 slice 1. Adds the foundational Zod schemas,
types, and read helpers for `.gaia/automation.json` (committed config),
`.gaia/automation.state-<tool>.json` (per-tool cron state), and
`.gaia/local/automation.json` (gitignored personal nudge state).

Subsequent phases:
- Phase 2 — `gaia automation` CLI subcommand surface (cron-decide, record-run, etc.)
- Phase 3 — local-detection wiring (hooks + /gaia wiki defer/--force).

## Test plan

- [ ] `pnpm typecheck && pnpm lint`
- [ ] `( cd .gaia/cli && pnpm typecheck && pnpm vitest --run )`
- [ ] Schemas reject malformed inputs (covered in Phase 1 unit tests).