### PR TITLE
feat: spec-001 slice 2 — auto-merge + auto-revert workflow shape

### DIFF
--- a/.gaia/cli/src/ci/__tests__/revert.test.ts
+++ b/.gaia/cli/src/ci/__tests__/revert.test.ts
@@ -1,0 +1,463 @@
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {RevertLedger} from '../../schemas/revert-ledger.js';
+import {run} from '../revert.js';
+import * as runProcess from '../util/run-process.js';
+import type {ProcessResult} from '../util/run-process.js';
+
+type RunFn = (
+  args: readonly string[],
+  options?: {cwd?: string; env?: NodeJS.ProcessEnv}
+) => ProcessResult;
+
+type Sandbox = {
+  cleanup: () => void;
+  ledgerPath: string;
+  root: string;
+  writeLedger: (ledger: RevertLedger) => void;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-ci-revert-'));
+  // The handler calls resolveRepoRoot, so we need a real git repo.
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {cwd: root});
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: root});
+  writeFileSync(path.join(root, 'README.md'), '# test\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], {cwd: root});
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], {cwd: root});
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  const ledgerPath = path.join(root, '.gaia', 'automation.state-revert-attempts.json');
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    ledgerPath,
+    root,
+    writeLedger: (ledger) => {
+      writeFileSync(ledgerPath, JSON.stringify(ledger), 'utf8');
+    },
+  };
+};
+
+const captureStdio = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const ghViewMerged = JSON.stringify({
+  baseRefName: 'main',
+  headRefName: 'gaia-ci/wiki/2026-05-09',
+  mergeCommit: {oid: '0123456789abcdef0123456789abcdef01234567'},
+  title: 'wiki: nightly run',
+});
+
+const ghCreateUrl = 'https://github.com/owner/repo/pull/137\n';
+
+describe('ci-revert', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let ghSpy: ReturnType<typeof vi.spyOn> & {
+    mock: {calls: Array<[readonly string[], unknown?]>};
+    mockImplementation: (impl: RunFn) => unknown;
+  };
+  let gitSpy: ReturnType<typeof vi.spyOn> & {
+    mock: {calls: Array<[readonly string[], unknown?]>};
+    mockImplementation: (impl: RunFn) => unknown;
+  };
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    stdio = captureStdio();
+
+    const ghImpl: RunFn = (args) => {
+      const [a, b] = args;
+
+      if (a === 'pr' && b === 'view') {
+        return {exitCode: 0, stderr: '', stdout: ghViewMerged};
+      }
+
+      if (a === 'pr' && b === 'create') {
+        return {exitCode: 0, stderr: '', stdout: ghCreateUrl};
+      }
+
+      if (a === 'pr' && b === 'merge') {
+        return {exitCode: 0, stderr: '', stdout: ''};
+      }
+
+      return {exitCode: 0, stderr: '', stdout: ''};
+    };
+
+    ghSpy = vi.spyOn(runProcess, 'runGh').mockImplementation(ghImpl) as typeof ghSpy;
+    gitSpy = vi
+      .spyOn(runProcess, 'runGit')
+      .mockReturnValue({exitCode: 0, stderr: '', stdout: ''}) as typeof gitSpy;
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('open', () => {
+    it('opens the revert PR and writes the ledger', () => {
+      const fixedNow = new Date('2026-05-09T05:00:00.000Z');
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root, now: () => fixedNow}
+      );
+      expect(exit).toBe(0);
+
+      const success = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(success.revert_pr).toBe(137);
+      expect(success.original_pr).toBe(99);
+      expect(success.revert_branch).toBe(
+        'gaia-ci/revert/gaia-ci/wiki/2026-05-09-0123456'
+      );
+
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']).toEqual({
+        opened_at: '2026-05-09T05:00:00.000Z',
+        original_pr: 99,
+        revert_pr: 137,
+        status: 'open',
+      });
+
+      // Verify all five external commands were called in order.
+      const ghArgsList = ghSpy.mock.calls.map((call: [readonly string[], unknown?]) => call[0]);
+      const gitArgsList = gitSpy.mock.calls.map((call: [readonly string[], unknown?]) => call[0]);
+
+      expect(ghArgsList[0]?.slice(0, 3)).toEqual(['pr', 'view', '99']);
+      expect(gitArgsList[0]).toEqual(['fetch', 'origin', 'main']);
+      expect(gitArgsList[1]?.[0]).toBe('checkout');
+      expect(gitArgsList[2]?.slice(0, 3)).toEqual([
+        'revert',
+        '--no-edit',
+        '0123456789abcdef0123456789abcdef01234567',
+      ]);
+      expect(gitArgsList[3]).toEqual([
+        'push',
+        '-u',
+        'origin',
+        'gaia-ci/revert/gaia-ci/wiki/2026-05-09-0123456',
+      ]);
+      expect(ghArgsList[1]?.slice(0, 2)).toEqual(['pr', 'create']);
+      expect(ghArgsList[2]).toEqual(['pr', 'merge', '137', '--auto', '--squash']);
+    });
+
+    it('refuses with revert_already_opened when an entry exists', () => {
+      sandbox.writeLedger({
+        attempts: {
+          '99': {
+            opened_at: '2026-05-08T00:00:00Z',
+            original_pr: 99,
+            revert_pr: 137,
+            status: 'open',
+          },
+        },
+        version: 1,
+      });
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      // Hard cap: zero gh / git invocations.
+      expect(ghSpy.mock.calls.length).toBe(0);
+      expect(gitSpy.mock.calls.length).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('revert_already_opened');
+      expect(printed.existing_revert_pr).toBe(137);
+
+      // Ledger byte-identical.
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']?.status).toBe('open');
+      expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    });
+
+    it('exits with pr_not_merged when mergeCommit is null', () => {
+      const impl: RunFn = (args) => {
+        if (args[0] === 'pr' && args[1] === 'view') {
+          return {
+            exitCode: 0,
+            stderr: '',
+            stdout: JSON.stringify({
+              baseRefName: 'main',
+              headRefName: 'gaia-ci/wiki',
+              mergeCommit: null,
+              title: 'open PR',
+            }),
+          };
+        }
+
+        return {exitCode: 0, stderr: '', stdout: ''};
+      };
+      ghSpy.mockImplementation(impl);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      // Only gh pr view was called; nothing else.
+      expect(ghSpy.mock.calls.length).toBe(1);
+      expect(gitSpy.mock.calls.length).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('pr_not_merged');
+
+      // Ledger never written.
+      expect(() => readFileSync(sandbox.ledgerPath, 'utf8')).toThrow();
+    });
+
+    it('rejects when --pr is missing', () => {
+      const exit = run(
+        ['open', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+      expect(stdio.err.join('')).toContain('--pr');
+    });
+
+    it('rejects when --label is missing', () => {
+      const exit = run(['open', '--pr', '99', '--json'], {cwd: sandbox.root});
+      expect(exit).not.toBe(0);
+      expect(stdio.err.join('')).toContain('--label');
+    });
+
+    it('emits revert_failed on git revert conflict', () => {
+      const impl: RunFn = (args) => {
+        if (args[0] === 'revert' && args[1] === '--no-edit') {
+          return {exitCode: 1, stderr: 'CONFLICT (content)', stdout: ''};
+        }
+
+        return {exitCode: 0, stderr: '', stdout: ''};
+      };
+      gitSpy.mockImplementation(impl);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('revert_failed');
+      expect(printed.step).toBe('git_revert');
+    });
+
+    it('parses the new PR number even with a banner line in stdout', () => {
+      const impl: RunFn = (args) => {
+        if (args[0] === 'pr' && args[1] === 'view') {
+          return {exitCode: 0, stderr: '', stdout: ghViewMerged};
+        }
+
+        if (args[0] === 'pr' && args[1] === 'create') {
+          return {
+            exitCode: 0,
+            stderr: '',
+            stdout: 'Creating pull request for ...\nhttps://github.com/owner/repo/pull/137\n',
+          };
+        }
+
+        return {exitCode: 0, stderr: '', stdout: ''};
+      };
+      ghSpy.mockImplementation(impl);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    });
+  });
+
+  describe('mark-failed', () => {
+    it('flips status to failed', () => {
+      sandbox.writeLedger({
+        attempts: {
+          '99': {
+            opened_at: '2026-05-08T00:00:00Z',
+            original_pr: 99,
+            revert_pr: 137,
+            status: 'open',
+          },
+        },
+        version: 1,
+      });
+
+      const exit = run(
+        ['mark-failed', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      // mark-failed never invokes gh / git.
+      expect(ghSpy.mock.calls.length).toBe(0);
+      expect(gitSpy.mock.calls.length).toBe(0);
+
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']?.status).toBe('failed');
+      expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    });
+
+    it('exits non-zero on missing attempt', () => {
+      const exit = run(
+        ['mark-failed', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('no_revert_attempt');
+    });
+
+    it('rejects when --pr is missing', () => {
+      const exit = run(['mark-failed'], {cwd: sandbox.root});
+      expect(exit).not.toBe(0);
+      expect(stdio.err.join('')).toContain('--pr');
+    });
+  });
+
+  describe('is-cap-reached', () => {
+    it('reports true for status: open', () => {
+      sandbox.writeLedger({
+        attempts: {
+          '99': {
+            opened_at: '2026-05-08T00:00:00Z',
+            original_pr: 99,
+            revert_pr: 137,
+            status: 'open',
+          },
+        },
+        version: 1,
+      });
+
+      const exit = run(
+        ['is-cap-reached', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.cap_reached).toBe(true);
+      expect(printed.status).toBe('open');
+    });
+
+    it('reports true for status: failed', () => {
+      sandbox.writeLedger({
+        attempts: {
+          '99': {
+            opened_at: '2026-05-08T00:00:00Z',
+            original_pr: 99,
+            revert_pr: 137,
+            status: 'failed',
+          },
+        },
+        version: 1,
+      });
+
+      const exit = run(
+        ['is-cap-reached', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.cap_reached).toBe(true);
+      expect(printed.status).toBe('failed');
+    });
+
+    it('reports false for status: merged', () => {
+      sandbox.writeLedger({
+        attempts: {
+          '99': {
+            opened_at: '2026-05-08T00:00:00Z',
+            original_pr: 99,
+            revert_pr: 137,
+            status: 'merged',
+          },
+        },
+        version: 1,
+      });
+
+      const exit = run(
+        ['is-cap-reached', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.cap_reached).toBe(false);
+      expect(printed.status).toBe('merged');
+    });
+
+    it('reports false on missing entry', () => {
+      const exit = run(
+        ['is-cap-reached', '--pr', '99', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.cap_reached).toBe(false);
+      expect(printed.status).toBeNull();
+    });
+  });
+
+  describe('help & dispatch', () => {
+    it('prints help on no args', () => {
+      const exit = run([], {cwd: sandbox.root});
+      expect(exit).not.toBe(0);
+      expect(stdio.out.join('')).toContain('Usage: gaia ci-revert');
+    });
+
+    it('prints help on --help and exits 0', () => {
+      const exit = run(['--help'], {cwd: sandbox.root});
+      expect(exit).toBe(0);
+      expect(stdio.out.join('')).toContain('Usage: gaia ci-revert');
+    });
+
+    it('exits non-zero on unknown subcommand', () => {
+      const exit = run(['unknown'], {cwd: sandbox.root});
+      expect(exit).not.toBe(0);
+      expect(stdio.err.join('')).toContain('unknown');
+    });
+  });
+});

--- a/.gaia/cli/src/ci/__tests__/stale-check.test.ts
+++ b/.gaia/cli/src/ci/__tests__/stale-check.test.ts
@@ -1,0 +1,211 @@
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../stale-check.js';
+import * as runProcess from '../util/run-process.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  // We don't need a real git repo for stale-check (it never calls
+  // resolveRepoRoot), but a tmp cwd keeps the test hermetic.
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-stale-check-'));
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+  };
+};
+
+const captureStdio = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('ci-stale-check', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('emits decision: "skip" when gh returns one entry', () => {
+    const ghSpy = vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: JSON.stringify([
+        {
+          createdAt: '2026-05-09T03:00:00Z',
+          headRefName: 'gaia-ci/wiki/2026-05-09',
+          number: 42,
+        },
+      ]),
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const lastCall = ghSpy.mock.calls.at(-1)?.[0] ?? [];
+    expect(lastCall).toContain('--label');
+    expect(lastCall).toContain('gaia-ci');
+    expect(lastCall).toContain('--author');
+    expect(lastCall).toContain('github-actions[bot]');
+    expect(lastCall).toContain('--base');
+    expect(lastCall).toContain('main');
+
+    const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(printed.decision).toBe('skip');
+    expect(printed.open_pr_number).toBe(42);
+    expect(printed.open_pr_branch).toBe('gaia-ci/wiki/2026-05-09');
+    expect(printed.skip_log_line).toBe(
+      'open gaia-ci PR #42 exists; skipping run'
+    );
+  });
+
+  it('emits decision: "proceed" when gh returns []', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: '[]',
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(printed.decision).toBe('proceed');
+    expect(printed.open_pr_number).toBeNull();
+    expect(printed.open_pr_branch).toBeNull();
+    expect(printed.skip_log_line).toBeNull();
+  });
+
+  it('exits non-zero with structured error when gh fails', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 4,
+      stderr: 'gh: not authenticated',
+      stdout: '',
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+
+    const errors = stdio.err.join('');
+    expect(errors).toContain('gh_invocation_failed');
+
+    const printed = stdio.out.join('').trim();
+    expect(printed).toContain('gh_invocation_failed');
+  });
+
+  it('passes both --label AND --author to gh pr list', () => {
+    const ghSpy = vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: '[]',
+    });
+
+    run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+
+    const args = ghSpy.mock.calls[0]?.[0] ?? [];
+    // Verbatim assertion: both predicates appear, exactly once each.
+    expect(args.filter((a) => a === '--label').length).toBe(1);
+    expect(args.filter((a) => a === '--author').length).toBe(1);
+    // And the values immediately follow the flags.
+    const labelIdx = args.indexOf('--label');
+    const authorIdx = args.indexOf('--author');
+    expect(args[labelIdx + 1]).toBe('gaia-ci');
+    expect(args[authorIdx + 1]).toBe('github-actions[bot]');
+  });
+
+  it('honors a custom --author', () => {
+    const ghSpy = vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 0,
+      stderr: '',
+      stdout: '[]',
+    });
+
+    run(
+      [
+        '--label',
+        'gaia-ci',
+        '--base',
+        'main',
+        '--author',
+        'someone-else',
+        '--json',
+      ],
+      {cwd: sandbox.root}
+    );
+
+    const args = ghSpy.mock.calls[0]?.[0] ?? [];
+    const authorIdx = args.indexOf('--author');
+    expect(args[authorIdx + 1]).toBe('someone-else');
+  });
+
+  it('rejects when --label is missing', () => {
+    const exit = run(['--base', 'main', '--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('--label');
+  });
+
+  it('rejects when --base is missing', () => {
+    const exit = run(['--label', 'gaia-ci', '--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('--base');
+  });
+
+  it('exits 0 with help on --help', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage: gaia ci-stale-check');
+  });
+
+});

--- a/.gaia/cli/src/ci/index.ts
+++ b/.gaia/cli/src/ci/index.ts
@@ -1,0 +1,10 @@
+/**
+ * `gaia ci-stale-check` and `gaia ci-revert` are registered at the
+ * top-level (`SUBCOMMAND_HANDLERS` in `index.ts`) per the SPEC-001
+ * slice 2 contract — `ci` is a namespace prefix, not a sub-router.
+ *
+ * This module re-exports the two `run` handlers so the entrypoint can
+ * import them with the existing `import {run as runCiX}` idiom.
+ */
+export {run as runCiRevert} from './revert.js';
+export {run as runCiStaleCheck} from './stale-check.js';

--- a/.gaia/cli/src/ci/paths.ts
+++ b/.gaia/cli/src/ci/paths.ts
@@ -1,0 +1,10 @@
+/**
+ * Path constants for GAIA CI revert-ledger state.
+ *
+ * Mirrors `automation/paths.ts`: every helper takes an explicit
+ * `repoRoot` argument; never calls `process.cwd()` directly.
+ */
+import path from 'node:path';
+
+export const revertLedgerPath = (repoRoot: string): string =>
+  path.join(repoRoot, '.gaia', 'automation.state-revert-attempts.json');

--- a/.gaia/cli/src/ci/revert.ts
+++ b/.gaia/cli/src/ci/revert.ts
@@ -1,0 +1,631 @@
+/**
+ * `gaia ci-revert {open|mark-failed|is-cap-reached}`
+ *
+ * Owner of the SPEC's hard-cap rule: one revert attempt per original PR
+ * (UAT-009/UAT-010). The CLI is the single enforcement surface — the
+ * Phase 2 composite action trusts the CLI's exit codes and never
+ * inspects the ledger directly.
+ *
+ * State file: `.gaia/automation.state-revert-attempts.json`
+ * (committed). Schema and atomic writer in `schemas/revert-ledger.ts`.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  emptyRevertLedger,
+  readRevertLedger,
+  writeRevertLedger,
+  type RevertLedger,
+} from '../schemas/revert-ledger.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {runGh, runGit, type ProcessResult} from './util/run-process.js';
+
+const HELP_TEXT = `Usage: gaia ci-revert <subcommand> [args]
+
+  open --pr <N> --label <name> [--reason <text>] [--json]
+    Open a single revert PR for the merged PR <N>. Refuses with
+    revert_already_opened if a ledger entry exists. Hard cap.
+
+  mark-failed --pr <N> [--json]
+    Flip attempts[<N>].status to "failed" (revert PR's CI also red).
+
+  is-cap-reached --pr <N> [--json]
+    Print {cap_reached, status} for the original PR.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+  now?: () => Date;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  const sub = argv[0] as string;
+  const rest = argv.slice(1);
+
+  if (sub === 'open') return handleOpen(rest, options);
+  if (sub === 'mark-failed') return handleMarkFailed(rest, options);
+  if (sub === 'is-cap-reached') return handleIsCapReached(rest, options);
+
+  structuredError({
+    code: 'unknown_subcommand',
+    message: `unknown ci-revert subcommand: ${sub}`,
+    subcommand: 'ci-revert',
+  });
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
+type CommonArgs = {
+  json: boolean;
+  pr: number | undefined;
+};
+
+const parsePrFlag = (value: string | undefined): number | undefined => {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) return undefined;
+
+  return parsed;
+};
+
+const resolveRoot = (
+  options: RunOptions,
+  subcommand: string
+): string | null => {
+  try {
+    return resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: `gaia ci-revert ${subcommand} must run inside a git repository`,
+      subcommand: `ci-revert ${subcommand}`,
+    });
+
+    return null;
+  }
+};
+
+const ensureLedger = (
+  repoRoot: string,
+  subcommand: string,
+  json: boolean
+): RevertLedger | null => {
+  const result = readRevertLedger(repoRoot);
+
+  if (result.status === 'malformed') {
+    const payload = {error: 'malformed_ledger', details: result.error};
+    structuredError({
+      code: 'malformed_ledger',
+      message: result.error,
+      subcommand: `ci-revert ${subcommand}`,
+    });
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(payload)}\n`);
+    }
+
+    return null;
+  }
+
+  if (result.status === 'missing') return emptyRevertLedger();
+
+  return result.ledger;
+};
+
+// --- open ----------------------------------------------------------------
+
+type OpenArgs = CommonArgs & {
+  label: string | undefined;
+  reason: string | undefined;
+};
+
+const parseOpenArgs = (argv: readonly string[]): OpenArgs | string => {
+  let pr: number | undefined;
+  let label: string | undefined;
+  let reason: string | undefined;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--pr') {
+      pr = parsePrFlag(argv[index + 1]);
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--label') {
+      label = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--reason') {
+      reason = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    return `unknown argument: ${token}`;
+  }
+
+  return {json, label, pr, reason};
+};
+
+const parsePrUrlNumber = (urlOrText: string): number | null => {
+  // gh pr create stdout is the URL; sometimes a banner line precedes it.
+  // We scan every whitespace-delimited token for the first one ending in
+  // /pull/<digits> or /<digits>.
+  const tokens = urlOrText.split(/\s+/u).filter((token) => token.length > 0);
+
+  for (let i = tokens.length - 1; i >= 0; i -= 1) {
+    const token = tokens[i] as string;
+    const pullMatch = /\/pull\/(\d+)$/u.exec(token);
+
+    if (pullMatch !== null) return Number.parseInt(pullMatch[1] as string, 10);
+
+    const trailingMatch = /\/(\d+)$/u.exec(token);
+
+    if (trailingMatch !== null) return Number.parseInt(trailingMatch[1] as string, 10);
+  }
+
+  return null;
+};
+
+const DEFAULT_REVERT_BODY = (originalPr: number): string =>
+  `Auto-revert of #${originalPr} opened by GAIA CI after post-merge CI failure.\n\n` +
+  `This PR will auto-merge on green CI. If its CI also fails, GAIA CI will\n` +
+  `stop automated activity on this change and open a \`priority:critical\`\n` +
+  `issue requesting human intervention.\n`;
+
+const surfaceRevertFailure = (
+  step: string,
+  result: ProcessResult,
+  json: boolean
+): number => {
+  const details = result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`;
+  const payload = {error: 'revert_failed', step, details};
+  structuredError({
+    code: 'revert_failed',
+    details,
+    message: `revert failed at step ${step}`,
+    step,
+    subcommand: 'ci-revert open',
+  });
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
+const handleOpen = (
+  argv: readonly string[],
+  options: RunOptions
+): number => {
+  const parsed = parseOpenArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'ci-revert open',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {json, label, pr, reason} = parsed;
+
+  if (pr === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-revert open requires --pr <N> (positive integer)',
+      subcommand: 'ci-revert open',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (label === undefined || label === '') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-revert open requires --label <name>',
+      subcommand: 'ci-revert open',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'open');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const ledger = ensureLedger(repoRoot, 'open', json);
+
+  if (ledger === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const key = String(pr);
+  const existing = ledger.attempts[key];
+
+  if (existing !== undefined) {
+    const payload = {
+      error: 'revert_already_opened',
+      existing_revert_pr: existing.revert_pr,
+    };
+    structuredError({
+      code: 'revert_already_opened',
+      existing_revert_pr: existing.revert_pr,
+      message: `revert already opened for PR #${pr} (revert PR #${existing.revert_pr})`,
+      subcommand: 'ci-revert open',
+    });
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(payload)}\n`);
+    }
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Step 4: gh pr view
+  const viewResult = runGh(
+    [
+      'pr',
+      'view',
+      String(pr),
+      '--json',
+      'mergeCommit,headRefName,baseRefName,title',
+    ],
+    {cwd: repoRoot}
+  );
+
+  if (viewResult.exitCode !== 0) {
+    return surfaceRevertFailure('gh_pr_view', viewResult, json);
+  }
+
+  let view: {
+    baseRefName?: unknown;
+    headRefName?: unknown;
+    mergeCommit?: unknown;
+    title?: unknown;
+  };
+
+  try {
+    view = JSON.parse(viewResult.stdout) as Record<string, unknown>;
+  } catch (error) {
+    return surfaceRevertFailure(
+      'gh_pr_view_parse',
+      {
+        exitCode: 1,
+        stderr: error instanceof Error ? error.message : String(error),
+        stdout: '',
+      },
+      json
+    );
+  }
+
+  const mergeCommit = view.mergeCommit;
+  const mergeSha =
+    typeof mergeCommit === 'object' &&
+    mergeCommit !== null &&
+    typeof (mergeCommit as Record<string, unknown>).oid === 'string'
+      ? ((mergeCommit as Record<string, unknown>).oid as string)
+      : null;
+
+  if (mergeSha === null) {
+    const payload = {error: 'pr_not_merged', pr};
+    structuredError({
+      code: 'pr_not_merged',
+      message: `PR #${pr} has no merge commit; cannot revert`,
+      pr,
+      subcommand: 'ci-revert open',
+    });
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(payload)}\n`);
+    }
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const headRefName = typeof view.headRefName === 'string' ? view.headRefName : null;
+  const baseRefName = typeof view.baseRefName === 'string' ? view.baseRefName : null;
+  const title = typeof view.title === 'string' ? view.title : `PR #${pr}`;
+
+  if (headRefName === null || baseRefName === null) {
+    return surfaceRevertFailure(
+      'gh_pr_view_parse',
+      {exitCode: 1, stderr: 'missing headRefName / baseRefName', stdout: ''},
+      json
+    );
+  }
+
+  const shortSha = mergeSha.slice(0, 7);
+  const revertBranch = `gaia-ci/revert/${headRefName}-${shortSha}`;
+
+  // Step 6: git fetch / checkout / revert / push
+  const fetchResult = runGit(['fetch', 'origin', baseRefName], {cwd: repoRoot});
+
+  if (fetchResult.exitCode !== 0) {
+    return surfaceRevertFailure('git_fetch', fetchResult, json);
+  }
+
+  const checkoutResult = runGit(
+    ['checkout', '-b', revertBranch, `origin/${baseRefName}`],
+    {cwd: repoRoot}
+  );
+
+  if (checkoutResult.exitCode !== 0) {
+    return surfaceRevertFailure('git_checkout', checkoutResult, json);
+  }
+
+  const revertResult = runGit(['revert', '--no-edit', mergeSha], {cwd: repoRoot});
+
+  if (revertResult.exitCode !== 0) {
+    // Best-effort cleanup so the working tree isn't left in a half-reverted
+    // state on the runner. Failure of --abort is non-fatal — the runner is
+    // ephemeral.
+    runGit(['revert', '--abort'], {cwd: repoRoot});
+
+    return surfaceRevertFailure('git_revert', revertResult, json);
+  }
+
+  const pushResult = runGit(['push', '-u', 'origin', revertBranch], {cwd: repoRoot});
+
+  if (pushResult.exitCode !== 0) {
+    return surfaceRevertFailure('git_push', pushResult, json);
+  }
+
+  const body = reason ?? DEFAULT_REVERT_BODY(pr);
+
+  const createResult = runGh(
+    [
+      'pr',
+      'create',
+      '--base',
+      baseRefName,
+      '--head',
+      revertBranch,
+      '--title',
+      `Revert: ${title}`,
+      '--body',
+      body,
+      '--label',
+      label,
+    ],
+    {cwd: repoRoot}
+  );
+
+  if (createResult.exitCode !== 0) {
+    return surfaceRevertFailure('gh_pr_create', createResult, json);
+  }
+
+  const newPr = parsePrUrlNumber(createResult.stdout);
+
+  if (newPr === null) {
+    return surfaceRevertFailure(
+      'gh_pr_create_parse',
+      {
+        exitCode: 1,
+        stderr: `unable to parse PR number from: ${createResult.stdout}`,
+        stdout: '',
+      },
+      json
+    );
+  }
+
+  const mergeAutoResult = runGh(
+    ['pr', 'merge', String(newPr), '--auto', '--squash'],
+    {cwd: repoRoot}
+  );
+
+  if (mergeAutoResult.exitCode !== 0) {
+    return surfaceRevertFailure('gh_pr_merge_auto', mergeAutoResult, json);
+  }
+
+  // Update the ledger.
+  const nowDate = (options.now ?? (() => new Date()))();
+  ledger.attempts[key] = {
+    opened_at: nowDate.toISOString(),
+    original_pr: pr,
+    revert_pr: newPr,
+    status: 'open',
+  };
+  writeRevertLedger(repoRoot, ledger);
+
+  const success = {
+    original_pr: pr,
+    revert_branch: revertBranch,
+    revert_pr: newPr,
+  };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(success)}\n`);
+  } else {
+    process.stdout.write(
+      `revert PR #${newPr} opened on branch ${revertBranch} for #${pr}\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};
+
+// --- mark-failed ---------------------------------------------------------
+
+const parseSimplePrArgs = (argv: readonly string[]): CommonArgs | string => {
+  let pr: number | undefined;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--pr') {
+      pr = parsePrFlag(argv[index + 1]);
+      index += 1;
+
+      continue;
+    }
+
+    return `unknown argument: ${token}`;
+  }
+
+  return {json, pr};
+};
+
+const handleMarkFailed = (
+  argv: readonly string[],
+  options: RunOptions
+): number => {
+  const parsed = parseSimplePrArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'ci-revert mark-failed',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {json, pr} = parsed;
+
+  if (pr === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-revert mark-failed requires --pr <N>',
+      subcommand: 'ci-revert mark-failed',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'mark-failed');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const ledger = ensureLedger(repoRoot, 'mark-failed', json);
+
+  if (ledger === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const key = String(pr);
+  const entry = ledger.attempts[key];
+
+  if (entry === undefined) {
+    const payload = {error: 'no_revert_attempt', pr};
+    structuredError({
+      code: 'no_revert_attempt',
+      message: `no revert attempt recorded for PR #${pr}`,
+      pr,
+      subcommand: 'ci-revert mark-failed',
+    });
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(payload)}\n`);
+    }
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  ledger.attempts[key] = {...entry, status: 'failed'};
+  writeRevertLedger(repoRoot, ledger);
+
+  const success = {
+    original_pr: entry.original_pr,
+    revert_pr: entry.revert_pr,
+    status: 'failed',
+  };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(success)}\n`);
+  } else {
+    process.stdout.write(
+      `marked revert attempt for PR #${pr} as failed (revert PR #${entry.revert_pr})\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};
+
+// --- is-cap-reached ------------------------------------------------------
+
+const handleIsCapReached = (
+  argv: readonly string[],
+  options: RunOptions
+): number => {
+  const parsed = parseSimplePrArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'ci-revert is-cap-reached',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {json, pr} = parsed;
+
+  if (pr === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-revert is-cap-reached requires --pr <N>',
+      subcommand: 'ci-revert is-cap-reached',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'is-cap-reached');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const ledger = ensureLedger(repoRoot, 'is-cap-reached', json);
+
+  if (ledger === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  const entry = ledger.attempts[String(pr)];
+  const status = entry?.status ?? null;
+  const capReached = status === 'open' || status === 'failed';
+
+  const payload = {cap_reached: capReached, status};
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else {
+    process.stdout.write(
+      `cap_reached: ${String(capReached)}\nstatus: ${status ?? '(none)'}\n`
+    );
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/ci/stale-check.ts
+++ b/.gaia/cli/src/ci/stale-check.ts
@@ -1,0 +1,235 @@
+/**
+ * `gaia ci-stale-check --label <name> --base <branch> [--author <login>] [--json]`
+ *
+ * The pre-run skip primitive consumed by `gaia-ci-stale-pr-skip`
+ * (Phase 2 composite action). UAT-019 requires both `--label` AND
+ * `--author` predicates to fire a skip — a label-only or author-only
+ * match must NOT skip. We delegate predicate evaluation to `gh pr list`
+ * (it does the filtering server-side); the CLI's only job is to ask the
+ * question with both predicates and report the answer.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {runGh} from './util/run-process.js';
+
+const HELP_TEXT = `Usage: gaia ci-stale-check --label <name> --base <branch> [--author <login>] [--json]
+
+  Decides whether a workflow run should skip because an existing GAIA CI
+  PR is already open. Both --label and --author are required predicates
+  (UAT-019); --author defaults to "github-actions[bot]".
+
+  Exit code 0 on either decision; non-zero only on gh invocation failure.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+const DEFAULT_AUTHOR = 'github-actions[bot]';
+
+type StaleCheckDecision = {
+  decision: 'proceed' | 'skip';
+  open_pr_branch: string | null;
+  open_pr_number: number | null;
+  reason: 'no_open_gaia_ci_pr' | 'open_gaia_ci_pr_exists';
+  skip_log_line: string | null;
+};
+
+const GhPrEntry = {
+  parse(value: unknown): {createdAt: string; headRefName: string; number: number} | null {
+    if (typeof value !== 'object' || value === null) return null;
+    const v = value as Record<string, unknown>;
+
+    if (typeof v.number !== 'number' || !Number.isFinite(v.number)) return null;
+    if (typeof v.headRefName !== 'string') return null;
+    if (typeof v.createdAt !== 'string') return null;
+
+    return {
+      createdAt: v.createdAt,
+      headRefName: v.headRefName,
+      number: v.number,
+    };
+  },
+};
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length > 0 && HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return EXIT_CODES.OK;
+  }
+
+  let label: string | undefined;
+  let base: string | undefined;
+  let author: string = DEFAULT_AUTHOR;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--label') {
+      label = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--base') {
+      base = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--author') {
+      const value = argv[index + 1];
+
+      if (value === undefined) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: '--author requires a value',
+          subcommand: 'ci-stale-check',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      author = value;
+      index += 1;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown argument: ${token}`,
+      subcommand: 'ci-stale-check',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (label === undefined || label === '') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-stale-check requires --label <name>',
+      subcommand: 'ci-stale-check',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (base === undefined || base === '') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'ci-stale-check requires --base <branch>',
+      subcommand: 'ci-stale-check',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Order matters for test verbatim-argv assertions — keep --label and
+  // --author together as the "predicates" pair, --base last.
+  const ghArgs = [
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--label',
+    label,
+    '--author',
+    author,
+    '--base',
+    base,
+    '--json',
+    'number,headRefName,createdAt',
+  ];
+
+  const result = runGh(ghArgs, {cwd: options.cwd});
+
+  if (result.exitCode !== 0) {
+    structuredError({
+      code: 'gh_invocation_failed',
+      exit_code: result.exitCode,
+      message: result.stderr.trim() || `gh pr list exited ${result.exitCode}`,
+      subcommand: 'ci-stale-check',
+    });
+
+    if (json) {
+      process.stdout.write(
+        `${JSON.stringify({error: 'gh_invocation_failed', exit_code: result.exitCode})}\n`
+      );
+    }
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (error) {
+    structuredError({
+      code: 'gh_response_unparseable',
+      message: error instanceof Error ? error.message : String(error),
+      subcommand: 'ci-stale-check',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (!Array.isArray(parsed)) {
+    structuredError({
+      code: 'gh_response_unparseable',
+      message: 'gh pr list did not return a JSON array',
+      subcommand: 'ci-stale-check',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const entries = parsed
+    .map((value) => GhPrEntry.parse(value))
+    .filter((value): value is {createdAt: string; headRefName: string; number: number} => value !== null);
+
+  let decision: StaleCheckDecision;
+
+  if (entries.length === 0) {
+    decision = {
+      decision: 'proceed',
+      open_pr_branch: null,
+      open_pr_number: null,
+      reason: 'no_open_gaia_ci_pr',
+      skip_log_line: null,
+    };
+  } else {
+    const first = entries[0] as {createdAt: string; headRefName: string; number: number};
+    decision = {
+      decision: 'skip',
+      open_pr_branch: first.headRefName,
+      open_pr_number: first.number,
+      reason: 'open_gaia_ci_pr_exists',
+      skip_log_line: `open ${label} PR #${first.number} exists; skipping run`,
+    };
+  }
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(decision)}\n`);
+  } else if (decision.decision === 'skip') {
+    process.stdout.write(`${decision.skip_log_line ?? ''}\n`);
+  } else {
+    process.stdout.write(`no open ${label} PR; proceeding\n`);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/ci/util/run-process.ts
+++ b/.gaia/cli/src/ci/util/run-process.ts
@@ -1,0 +1,61 @@
+/**
+ * Shell-out helpers for `gh` and `git` invocations from the `gaia ci`
+ * subcommand family.
+ *
+ * The two functions are the *only* points the rest of the `ci/` tree
+ * spawns external processes through. Tests intercept by stubbing the
+ * exported symbols (the fixture in `.gaia/cli/test-fixtures/ci-shape/`
+ * mocks `runGh` and `runGit` to verify argv verbatim and supply
+ * canned responses).
+ *
+ * Both helpers are synchronous (mirroring `wiki/util/git.ts`) and
+ * return a small `{exitCode, stdout, stderr}` shape. We never throw
+ * for non-zero exit codes — handlers branch on `exitCode` and emit
+ * structured errors themselves.
+ */
+import {spawnSync} from 'node:child_process';
+
+export type ProcessResult = {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+};
+
+type RunOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+const run = (
+  command: string,
+  args: readonly string[],
+  options: RunOptions = {}
+): ProcessResult => {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: 'utf8',
+    env: options.env ?? process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // spawnSync sets `status: null` on signal-terminated children; treat
+  // that as a non-zero exit so callers don't accidentally see it as
+  // success.
+  const exitCode = result.status ?? (result.signal === null ? 1 : 1);
+
+  return {
+    exitCode,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+  };
+};
+
+export const runGh = (
+  args: readonly string[],
+  options: RunOptions = {}
+): ProcessResult => run('gh', args, options);
+
+export const runGit = (
+  args: readonly string[],
+  options: RunOptions = {}
+): ProcessResult => run('git', args, options);

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -11,6 +11,7 @@
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
 import {run as runFetchCoaching} from './adaptation/inject.js';
 import {run as runAutomation} from './automation/index.js';
+import {runCiRevert, runCiStaleCheck} from './ci/index.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
@@ -30,6 +31,8 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
   automation read-config|read-state|init-state|bump-state|cron-decide|record-run|record-overage|clear-overage
+  ci-stale-check --label <name> --base <branch> [--author <login>] [--json]
+  ci-revert open|mark-failed|is-cap-reached
   update merge --baseline <dir> --latest <dir> --manifest <path>
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
@@ -47,6 +50,8 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
   automation: runAutomation,
+  'ci-revert': runCiRevert,
+  'ci-stale-check': runCiStaleCheck,
   init: runInit,
   mentorship: runMentorship,
   scaffold: runScaffold,

--- a/.gaia/cli/src/schemas/__tests__/revert-ledger.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/revert-ledger.test.ts
@@ -1,0 +1,210 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  emptyRevertLedger,
+  readRevertLedger,
+  RevertLedgerSchema,
+  writeRevertLedger,
+} from '../revert-ledger.js';
+
+import type {RevertLedger} from '../revert-ledger.js';
+
+const VALID_LEDGER: RevertLedger = {
+  attempts: {
+    '99': {
+      opened_at: '2026-05-09T04:00:00Z',
+      original_pr: 99,
+      revert_pr: 137,
+      status: 'open',
+    },
+  },
+  version: 1,
+};
+
+type Sandbox = {
+  cleanup: () => void;
+  ledgerPath: string;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-revert-ledger-'));
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    ledgerPath: path.join(root, '.gaia', 'automation.state-revert-attempts.json'),
+    root,
+  };
+};
+
+describe('schemas/revert-ledger', () => {
+  describe('RevertLedgerSchema', () => {
+    it('parses a valid ledger', () => {
+      expect(() => RevertLedgerSchema.parse(VALID_LEDGER)).not.toThrow();
+    });
+
+    it('rejects version: 2', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({...VALID_LEDGER, version: 2})
+      ).toThrow();
+    });
+
+    it('rejects attempts: null', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({...VALID_LEDGER, attempts: null})
+      ).toThrow();
+    });
+
+    it('rejects unknown status', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({
+          ...VALID_LEDGER,
+          attempts: {
+            '99': {...VALID_LEDGER.attempts['99'], status: 'wat'},
+          },
+        })
+      ).toThrow();
+    });
+
+    it('rejects negative original_pr', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({
+          ...VALID_LEDGER,
+          attempts: {
+            '99': {...VALID_LEDGER.attempts['99'], original_pr: -1},
+          },
+        })
+      ).toThrow();
+    });
+
+    it('rejects unparseable opened_at', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({
+          ...VALID_LEDGER,
+          attempts: {
+            '99': {...VALID_LEDGER.attempts['99'], opened_at: 'tomorrow'},
+          },
+        })
+      ).toThrow();
+    });
+
+    it('accepts merged status', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({
+          ...VALID_LEDGER,
+          attempts: {
+            '99': {...VALID_LEDGER.attempts['99'], status: 'merged'},
+          },
+        })
+      ).not.toThrow();
+    });
+
+    it('accepts failed status', () => {
+      expect(() =>
+        RevertLedgerSchema.parse({
+          ...VALID_LEDGER,
+          attempts: {
+            '99': {...VALID_LEDGER.attempts['99'], status: 'failed'},
+          },
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('emptyRevertLedger', () => {
+    it('returns a fresh empty ledger each call', () => {
+      const a = emptyRevertLedger();
+      const b = emptyRevertLedger();
+      a.attempts['1'] = {
+        opened_at: '2026-05-09T04:00:00Z',
+        original_pr: 1,
+        revert_pr: 2,
+        status: 'open',
+      };
+      expect(b.attempts).toEqual({});
+    });
+  });
+
+  describe('readRevertLedger', () => {
+    let sandbox: Sandbox;
+
+    beforeEach(() => {
+      sandbox = setupSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.cleanup();
+    });
+
+    it('returns {status: "missing"} when the file does not exist', () => {
+      const result = readRevertLedger(sandbox.root);
+      expect(result.status).toBe('missing');
+    });
+
+    it('returns {status: "ok"} for a valid ledger', () => {
+      writeFileSync(sandbox.ledgerPath, JSON.stringify(VALID_LEDGER), 'utf8');
+      const result = readRevertLedger(sandbox.root);
+      expect(result.status).toBe('ok');
+
+      if (result.status === 'ok') {
+        expect(result.ledger.attempts['99']?.revert_pr).toBe(137);
+      }
+    });
+
+    it('returns {status: "malformed"} for invalid JSON', () => {
+      writeFileSync(sandbox.ledgerPath, '{nope', 'utf8');
+      const result = readRevertLedger(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+
+    it('returns {status: "malformed"} for schema mismatch', () => {
+      writeFileSync(
+        sandbox.ledgerPath,
+        JSON.stringify({...VALID_LEDGER, version: 99}),
+        'utf8'
+      );
+      const result = readRevertLedger(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+  });
+
+  describe('writeRevertLedger', () => {
+    let sandbox: Sandbox;
+
+    beforeEach(() => {
+      sandbox = setupSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.cleanup();
+    });
+
+    it('writes a 2-space-indented file with trailing newline', () => {
+      writeRevertLedger(sandbox.root, VALID_LEDGER);
+      const text = readFileSync(sandbox.ledgerPath, 'utf8');
+      expect(text.endsWith('\n')).toBe(true);
+      expect(text).toContain('  "version": 1');
+    });
+
+    it('round-trips through readRevertLedger', () => {
+      writeRevertLedger(sandbox.root, VALID_LEDGER);
+      const result = readRevertLedger(sandbox.root);
+      expect(result.status).toBe('ok');
+
+      if (result.status === 'ok') {
+        expect(result.ledger).toEqual(VALID_LEDGER);
+      }
+    });
+  });
+});

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -15,7 +15,7 @@ import path from 'node:path';
 import {z} from 'zod';
 import {revertLedgerPath} from '../ci/paths.js';
 
-export const RevertAttemptStatusSchema = z.enum(['open', 'merged', 'failed']);
+export const RevertAttemptStatusSchema = z.literal(['failed', 'merged', 'open'] as const);
 export type RevertAttemptStatus = z.infer<typeof RevertAttemptStatusSchema>;
 
 export const RevertAttemptSchema = z.object({

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -1,0 +1,102 @@
+/**
+ * Zod schema + read/write helpers for the revert-attempt ledger.
+ *
+ * Mirrors the `automation-state` module: discriminated `read*` result,
+ * never throws, atomic writer using tmp-file + rename.
+ *
+ * The ledger file lives at `.gaia/automation.state-revert-attempts.json`.
+ * It is **the** source of truth for the SPEC's hard cap of one revert
+ * attempt per original PR (UAT-010). The CLI's `ci-revert open` handler
+ * consults `attempts[<original_pr>]` before doing any git/`gh` work and
+ * refuses to re-open if an entry already exists.
+ */
+import {existsSync, mkdirSync, readFileSync, renameSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {z} from 'zod';
+import {revertLedgerPath} from '../ci/paths.js';
+
+export const RevertAttemptStatusSchema = z.enum(['open', 'merged', 'failed']);
+export type RevertAttemptStatus = z.infer<typeof RevertAttemptStatusSchema>;
+
+export const RevertAttemptSchema = z.object({
+  opened_at: z.iso.datetime(),
+  original_pr: z.number().int().positive(),
+  revert_pr: z.number().int().positive(),
+  status: RevertAttemptStatusSchema,
+});
+export type RevertAttempt = z.infer<typeof RevertAttemptSchema>;
+
+export const RevertLedgerSchema = z.object({
+  attempts: z.record(z.string(), RevertAttemptSchema),
+  version: z.literal(1),
+});
+export type RevertLedger = z.infer<typeof RevertLedgerSchema>;
+
+export const emptyRevertLedger = (): RevertLedger => ({
+  attempts: {},
+  version: 1,
+});
+
+export type ReadRevertLedgerResult =
+  | {ledger: RevertLedger; status: 'ok'}
+  | {status: 'missing'}
+  | {error: string; status: 'malformed'};
+
+const summarizeZodError = (filePath: string, error: z.ZodError): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+
+    return `${pathStr}: ${issue.message}`;
+  });
+
+  return `${filePath}: ${lines.join('; ')}`;
+};
+
+export const readRevertLedger = (repoRoot: string): ReadRevertLedgerResult => {
+  const filePath = revertLedgerPath(repoRoot);
+
+  if (!existsSync(filePath)) return {status: 'missing'};
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    return {
+      error: `${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      error: `${filePath}: invalid JSON — ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  const result = RevertLedgerSchema.safeParse(parsed);
+
+  if (!result.success) {
+    return {error: summarizeZodError(filePath, result.error), status: 'malformed'};
+  }
+
+  return {ledger: result.data, status: 'ok'};
+};
+
+export const writeRevertLedger = (
+  repoRoot: string,
+  ledger: RevertLedger
+): void => {
+  const target = revertLedgerPath(repoRoot);
+  mkdirSync(path.dirname(target), {recursive: true});
+
+  const serialized = `${JSON.stringify(ledger, null, 2)}\n`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync(tmpPath, serialized, 'utf8');
+  renameSync(tmpPath, target);
+};

--- a/.gaia/cli/test-fixtures/ci-shape/README.md
+++ b/.gaia/cli/test-fixtures/ci-shape/README.md
@@ -1,0 +1,72 @@
+# ci-shape integration fixture
+
+The slice 2 acceptance fixture for SPEC-001. Exercises the
+`gaia ci-stale-check` and `gaia ci-revert` CLI primitives end-to-end
+against a mocked `gh` / `git` shell layer to verify UAT-009, UAT-010,
+and UAT-019 without spawning real processes.
+
+## What this fixture covers
+
+| UAT | Scenario | Test file |
+|---|---|---|
+| UAT-009 | revert opens, ledger records the entry | `revert-flow.test.ts` |
+| UAT-009 | hard cap: second `open` blocked, zero gh/git calls | `revert-flow.test.ts` |
+| UAT-009 | unmerged PR refused with `pr_not_merged` | `revert-flow.test.ts` |
+| UAT-010 | `mark-failed` flips ledger entry to `failed` | `revert-flow.test.ts` |
+| UAT-010 | `is-cap-reached` returns true after `failed` | `revert-flow.test.ts` |
+| UAT-010 | second `open` after `mark-failed` still blocked | `revert-flow.test.ts` |
+| UAT-019 | both predicates passed to `gh pr list` | `stale-check.test.ts` |
+| UAT-019 | `[]` response → `decision: "proceed"` | `stale-check.test.ts` |
+| UAT-019 | `gh` failure → exit non-zero | `stale-check.test.ts` |
+
+## How to run
+
+```bash
+# From the GAIA repo root:
+( cd .gaia/cli && pnpm test --run ci-shape )
+```
+
+The vitest config at `.gaia/cli/vitest.config.ts` includes
+`./test-fixtures/**/*.test.{ts,tsx}` so these tests run alongside the
+in-tree unit tests. The `ci-shape` filter narrows to this fixture.
+
+## How to run the opt-in shell smoke
+
+```bash
+GAIA_CI_SHAPE_E2E=1 bash .gaia/cli/test-fixtures/ci-shape/composite-actions.smoke.sh
+```
+
+The smoke runs `actionlint` on the two composite actions (wrapped in
+synthetic consumer workflows because actionlint cannot lint composite
+actions directly) and `shellcheck` on every `.sh` helper. It is **not**
+wired into `pnpm test --run` because `actionlint` and `shellcheck` are
+host tools (not pnpm dependencies); slice 3 will add a GH Actions
+workflow that runs them on every PR.
+
+## How to add a new scenario
+
+1. Pick the test file that owns the relevant UAT
+   (`revert-flow.test.ts` or `stale-check.test.ts`).
+2. Copy the closest existing `it('...', ...)` block.
+3. Change the discriminating fields:
+   - The mock responses in `installGhMock({...})`.
+   - The pre-populated ledger via `sandbox.writeLedger({...})` (if any).
+   - The CLI argv passed to `run([...])`.
+   - The expectations on `mock.ghCalls`, `mock.gitCalls`, and the
+     ledger after.
+4. Run `pnpm test --run ci-shape` to verify.
+
+The fixture deliberately uses inline assertions instead of snapshots —
+slice 2's invariants (the hard cap, the both-predicates rule) are too
+load-bearing for snapshot drift to silently absorb.
+
+## What this fixture does NOT cover
+
+- The composite-action YAML itself. The shell smoke checks the YAML
+  parses; the steps' bash logic is exercised on a real GH Actions
+  runner, not in vitest.
+- The polling helpers (`wait-for-merge.sh` / `wait-for-ci.sh`). They
+  are pure shell; `shellcheck` is the only static analysis applied to
+  them. Slice 3's per-tool workflows will exercise them on real PRs.
+- Time-related ledger fields beyond `opened_at` — slice 2 doesn't
+  introduce other timestamps.

--- a/.gaia/cli/test-fixtures/ci-shape/composite-actions.smoke.sh
+++ b/.gaia/cli/test-fixtures/ci-shape/composite-actions.smoke.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Opt-in shell smoke test for the slice 2 composite actions.
+#
+# Runs:
+#   - actionlint on the two action.yml files (note: actionlint v1.7
+#     does not natively lint composite actions in isolation; we wrap
+#     them in a synthetic workflow that uses each action so actionlint
+#     can validate the inputs/outputs surface).
+#   - shellcheck on every .sh helper under
+#     .github/actions/gaia-ci-merge-and-watch/lib/.
+#
+# Usage: GAIA_CI_SHAPE_E2E=1 bash .gaia/cli/test-fixtures/ci-shape/composite-actions.smoke.sh
+#
+# Skipped silently when GAIA_CI_SHAPE_E2E is unset — the default
+# `pnpm test --run` should not depend on these tools being installed.
+
+set -euo pipefail
+
+if [[ "${GAIA_CI_SHAPE_E2E:-}" != "1" ]]; then
+  echo "ci-shape smoke skipped (set GAIA_CI_SHAPE_E2E=1 to run)"
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ACTION_MAW="${REPO_ROOT}/.github/actions/gaia-ci-merge-and-watch/action.yml"
+ACTION_SPS="${REPO_ROOT}/.github/actions/gaia-ci-stale-pr-skip/action.yml"
+LIB_DIR="${REPO_ROOT}/.github/actions/gaia-ci-merge-and-watch/lib"
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "actionlint not installed; install via brew install actionlint"
+  exit 1
+fi
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "shellcheck not installed; install via brew install shellcheck"
+  exit 1
+fi
+
+# actionlint does not lint composite actions directly. We wrap each one
+# in a synthetic workflow that consumes it so actionlint can validate
+# the steps' YAML and bash-step expressions.
+TMP_WORKFLOW="$(mktemp -d)/smoke-workflows"
+mkdir -p "$TMP_WORKFLOW/.github/workflows"
+cat >"$TMP_WORKFLOW/.github/workflows/smoke-merge-watch.yml" <<'YAML'
+name: smoke-merge-watch
+on: workflow_dispatch
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/gaia-ci-merge-and-watch
+        with:
+          pr-number: '1'
+          label: gaia-ci
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+YAML
+
+cat >"$TMP_WORKFLOW/.github/workflows/smoke-stale-skip.yml" <<'YAML'
+name: smoke-stale-skip
+on: workflow_dispatch
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/gaia-ci-stale-pr-skip
+        with:
+          label: gaia-ci
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+YAML
+
+# Symlink the actions into the temp tree so `uses: ./...` resolves.
+ln -s "${REPO_ROOT}/.github/actions" "$TMP_WORKFLOW/.github/actions"
+
+(
+  cd "$TMP_WORKFLOW"
+  actionlint .github/workflows/smoke-merge-watch.yml .github/workflows/smoke-stale-skip.yml
+)
+
+# shellcheck the library scripts.
+shellcheck "${LIB_DIR}"/*.sh
+
+# Ensure the action.yml files exist and have the expected top-level
+# keys. (actionlint can't validate composite-action surfaces directly;
+# this is a minimal sanity check.)
+for action in "$ACTION_MAW" "$ACTION_SPS"; do
+  if ! grep -q '^name:' "$action"; then
+    echo "missing name in $action" >&2
+    exit 1
+  fi
+  if ! grep -q '^runs:' "$action"; then
+    echo "missing runs in $action" >&2
+    exit 1
+  fi
+  if ! grep -q "using: 'composite'" "$action"; then
+    echo "$action is not a composite action" >&2
+    exit 1
+  fi
+done
+
+echo "ci-shape smoke OK"

--- a/.gaia/cli/test-fixtures/ci-shape/gh-mock.ts
+++ b/.gaia/cli/test-fixtures/ci-shape/gh-mock.ts
@@ -1,0 +1,94 @@
+/**
+ * Vitest mock for the `runGh` / `runGit` helpers.
+ *
+ * The fixture intercepts at the CLI's helper layer
+ * (`src/ci/util/run-process.ts`) so the slice 2 handlers shell out
+ * "for real" and the mock returns scripted JSON / exit codes per a
+ * scenario object. This mirrors slice 1's pattern of testing CLI
+ * surfaces without spawning external processes.
+ */
+import {vi} from 'vitest';
+import * as runProcess from '../../src/ci/util/run-process.js';
+import type {ProcessResult} from '../../src/ci/util/run-process.js';
+
+export type GhCall = {
+  argv: readonly string[];
+  cwd?: string;
+};
+
+export type GhMockResponse = ProcessResult;
+
+export type ScenarioResponse = {
+  match: string | RegExp;
+  response: GhMockResponse;
+};
+
+export type GhMockScenario = {
+  gh?: ScenarioResponse[];
+  git?: ScenarioResponse[];
+};
+
+export type GhMock = {
+  ghCalls: GhCall[];
+  gitCalls: GhCall[];
+  reset: () => void;
+  restore: () => void;
+};
+
+const matches = (matcher: string | RegExp, joined: string): boolean => {
+  if (matcher instanceof RegExp) return matcher.test(joined);
+
+  return joined.includes(matcher);
+};
+
+const respond = (
+  responses: readonly ScenarioResponse[] | undefined,
+  argv: readonly string[]
+): GhMockResponse => {
+  const joined = argv.join(' ');
+  const match = (responses ?? []).find((entry) => matches(entry.match, joined));
+
+  if (match === undefined) {
+    return {
+      exitCode: 0,
+      stderr: '',
+      stdout: '',
+    };
+  }
+
+  return match.response;
+};
+
+export const installGhMock = (scenario: GhMockScenario): GhMock => {
+  const ghCalls: GhCall[] = [];
+  const gitCalls: GhCall[] = [];
+
+  const ghSpy = vi
+    .spyOn(runProcess, 'runGh')
+    .mockImplementation((argv: readonly string[], options) => {
+      ghCalls.push({argv, cwd: options?.cwd});
+
+      return respond(scenario.gh, argv);
+    });
+
+  const gitSpy = vi
+    .spyOn(runProcess, 'runGit')
+    .mockImplementation((argv: readonly string[], options) => {
+      gitCalls.push({argv, cwd: options?.cwd});
+
+      return respond(scenario.git, argv);
+    });
+
+  return {
+    ghCalls,
+    gitCalls,
+    reset: () => {
+      ghCalls.length = 0;
+      gitCalls.length = 0;
+    },
+    restore: () => {
+      ghSpy.mockRestore();
+      gitSpy.mockRestore();
+    },
+  };
+};

--- a/.gaia/cli/test-fixtures/ci-shape/revert-flow.test.ts
+++ b/.gaia/cli/test-fixtures/ci-shape/revert-flow.test.ts
@@ -1,0 +1,294 @@
+/**
+ * UAT-009 + UAT-010 integration scenarios.
+ *
+ * Each test sets up:
+ *   - a tmpdir sandbox with a real git repo (the revert handler calls
+ *     `git rev-parse` to resolve the repo root)
+ *   - the revert ledger pre-populated to a known state
+ *   - the gh/git mock with scripted responses
+ *
+ * Then runs the CLI and asserts the ledger state, stdio, and the
+ * exact argv the CLI shelled out with.
+ *
+ * Discriminating invariants:
+ *   - UAT-009 hard cap: a second `ci-revert open` for the same PR
+ *     exits 1 with `revert_already_opened` AND zero gh/git invocations.
+ *   - UAT-010 escalation: `mark-failed` flips status to `failed`;
+ *     `is-cap-reached` reports true; no second revert ever opens.
+ */
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../../src/ci/revert.js';
+import type {RevertLedger} from '../../src/schemas/revert-ledger.js';
+import {installGhMock, type GhMock} from './gh-mock.js';
+import {captureStdio, setupSandbox, type Sandbox} from './sandbox.js';
+
+const MERGE_SHA = '0123456789abcdef0123456789abcdef01234567';
+const ghViewMerged = JSON.stringify({
+  baseRefName: 'main',
+  headRefName: 'gaia-ci/wiki/2026-05-09',
+  mergeCommit: {oid: MERGE_SHA},
+  title: 'wiki: nightly run',
+});
+const ghViewUnmerged = JSON.stringify({
+  baseRefName: 'main',
+  headRefName: 'gaia-ci/wiki/2026-05-09',
+  mergeCommit: null,
+  title: 'wiki: pending',
+});
+const ghCreateUrlStandard = 'https://github.com/owner/repo/pull/137\n';
+const ghCreateUrlWithBanner =
+  'Creating pull request for revert -> main\nhttps://github.com/owner/repo/pull/137\n';
+
+describe('UAT-009 — auto-revert on post-merge failure', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let mock: GhMock;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    mock?.restore();
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('happy path: empty ledger → revert opens and ledger records the entry', () => {
+    mock = installGhMock({
+      gh: [
+        {match: 'pr view', response: {exitCode: 0, stderr: '', stdout: ghViewMerged}},
+        {match: 'pr create', response: {exitCode: 0, stderr: '', stdout: ghCreateUrlStandard}},
+        {match: 'pr merge', response: {exitCode: 0, stderr: '', stdout: ''}},
+      ],
+      git: [
+        // git revert returns 0 → success
+      ],
+    });
+
+    const fixedNow = new Date('2026-05-09T05:00:00.000Z');
+    const exit = run(
+      ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+      {cwd: sandbox.root, now: () => fixedNow}
+    );
+
+    expect(exit).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    expect(stdout).toMatch(/"revert_pr":\s*137/u);
+
+    const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+    expect(ledger.attempts['99']).toEqual({
+      opened_at: '2026-05-09T05:00:00.000Z',
+      original_pr: 99,
+      revert_pr: 137,
+      status: 'open',
+    });
+
+    // Verify the call sequence: gh pr view → git fetch/checkout/revert/push
+    // → gh pr create → gh pr merge --auto.
+    expect(mock.ghCalls.length).toBe(3);
+    expect(mock.gitCalls.length).toBe(4);
+    expect(mock.ghCalls[0]?.argv.slice(0, 3)).toEqual(['pr', 'view', '99']);
+    expect(mock.gitCalls[0]?.argv).toEqual(['fetch', 'origin', 'main']);
+    expect(mock.gitCalls[1]?.argv[0]).toBe('checkout');
+    expect(mock.gitCalls[2]?.argv).toEqual(['revert', '--no-edit', MERGE_SHA]);
+    expect(mock.gitCalls[3]?.argv).toEqual([
+      'push',
+      '-u',
+      'origin',
+      'gaia-ci/revert/gaia-ci/wiki/2026-05-09-0123456',
+    ]);
+    expect(mock.ghCalls[2]?.argv).toEqual(['pr', 'merge', '137', '--auto', '--squash']);
+  });
+
+  it('hard cap: ledger pre-populated → second open exits 1 with revert_already_opened and zero external calls', () => {
+    sandbox.writeLedger({
+      attempts: {
+        '99': {
+          opened_at: '2026-05-08T00:00:00Z',
+          original_pr: 99,
+          revert_pr: 137,
+          status: 'open',
+        },
+      },
+      version: 1,
+    });
+
+    mock = installGhMock({});
+
+    const exit = run(
+      ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).not.toBe(0);
+    expect(mock.ghCalls.length).toBe(0);
+    expect(mock.gitCalls.length).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.error).toBe('revert_already_opened');
+    expect(printed.existing_revert_pr).toBe(137);
+
+    // Ledger byte-identical: attempt remains as written.
+    const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+    expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    expect(ledger.attempts['99']?.status).toBe('open');
+  });
+
+  it('refuses to revert an unmerged PR', () => {
+    mock = installGhMock({
+      gh: [
+        {match: 'pr view', response: {exitCode: 0, stderr: '', stdout: ghViewUnmerged}},
+      ],
+    });
+
+    const exit = run(
+      ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).not.toBe(0);
+    expect(mock.ghCalls.length).toBe(1); // only `gh pr view`
+    expect(mock.gitCalls.length).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.error).toBe('pr_not_merged');
+
+    expect(() => readFileSync(sandbox.ledgerPath, 'utf8')).toThrow();
+  });
+
+  it('parses the new PR number even when stdout has a banner line', () => {
+    mock = installGhMock({
+      gh: [
+        {match: 'pr view', response: {exitCode: 0, stderr: '', stdout: ghViewMerged}},
+        {match: 'pr create', response: {exitCode: 0, stderr: '', stdout: ghCreateUrlWithBanner}},
+        {match: 'pr merge', response: {exitCode: 0, stderr: '', stdout: ''}},
+      ],
+    });
+
+    const exit = run(
+      ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+      {cwd: sandbox.root, now: () => new Date('2026-05-09T05:00:00Z')}
+    );
+    expect(exit).toBe(0);
+
+    const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+    expect(ledger.attempts['99']?.revert_pr).toBe(137);
+  });
+});
+
+describe('UAT-010 — hard-cap escalation', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let mock: GhMock;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    stdio = captureStdio();
+    mock = installGhMock({});
+  });
+
+  afterEach(() => {
+    mock.restore();
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('mark-failed flips status to failed and does no external work', () => {
+    sandbox.writeLedger({
+      attempts: {
+        '99': {
+          opened_at: '2026-05-08T00:00:00Z',
+          original_pr: 99,
+          revert_pr: 137,
+          status: 'open',
+        },
+      },
+      version: 1,
+    });
+
+    const exit = run(['mark-failed', '--pr', '99', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(mock.ghCalls.length).toBe(0);
+    expect(mock.gitCalls.length).toBe(0);
+
+    const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+    expect(ledger.attempts['99']?.status).toBe('failed');
+    expect(ledger.attempts['99']?.revert_pr).toBe(137);
+  });
+
+  it('is-cap-reached returns true after mark-failed', () => {
+    sandbox.writeLedger({
+      attempts: {
+        '99': {
+          opened_at: '2026-05-08T00:00:00Z',
+          original_pr: 99,
+          revert_pr: 137,
+          status: 'failed',
+        },
+      },
+      version: 1,
+    });
+
+    const exit = run(['is-cap-reached', '--pr', '99', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.cap_reached).toBe(true);
+    expect(printed.status).toBe('failed');
+  });
+
+  it('is-cap-reached returns false on missing entry', () => {
+    const exit = run(['is-cap-reached', '--pr', '99', '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.cap_reached).toBe(false);
+    expect(printed.status).toBeNull();
+  });
+
+  it('mark-failed on missing attempt exits non-zero', () => {
+    const exit = run(['mark-failed', '--pr', '99', '--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.error).toBe('no_revert_attempt');
+  });
+
+  it('after mark-failed, a second ci-revert open is still blocked (the cap is sealed)', () => {
+    sandbox.writeLedger({
+      attempts: {
+        '99': {
+          opened_at: '2026-05-08T00:00:00Z',
+          original_pr: 99,
+          revert_pr: 137,
+          status: 'failed',
+        },
+      },
+      version: 1,
+    });
+
+    const exit = run(
+      ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).not.toBe(0);
+    expect(mock.ghCalls.length).toBe(0);
+    expect(mock.gitCalls.length).toBe(0);
+
+    const stdout = stdio.out.join('').trim();
+    const printed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(printed.error).toBe('revert_already_opened');
+  });
+});

--- a/.gaia/cli/test-fixtures/ci-shape/sandbox.ts
+++ b/.gaia/cli/test-fixtures/ci-shape/sandbox.ts
@@ -1,0 +1,74 @@
+/**
+ * Tmpdir + git-init sandbox for the slice 2 fixture tests. Mirrors
+ * `src/automation/__tests__/sandbox.ts`, but ships the revert-ledger
+ * writer instead of automation-state writers.
+ */
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import type {RevertLedger} from '../../src/schemas/revert-ledger.js';
+
+export type Sandbox = {
+  cleanup: () => void;
+  ledgerPath: string;
+  root: string;
+  writeLedger: (ledger: RevertLedger) => void;
+};
+
+export const setupSandbox = (prefix = 'gaia-ci-shape-'): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {cwd: root});
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: root});
+  writeFileSync(path.join(root, 'README.md'), '# test\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], {cwd: root});
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], {cwd: root});
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  const ledgerPath = path.join(root, '.gaia', 'automation.state-revert-attempts.json');
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    ledgerPath,
+    root,
+    writeLedger: (ledger) => {
+      writeFileSync(ledgerPath, JSON.stringify(ledger), 'utf8');
+    },
+  };
+};
+
+export const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+
+  const stdoutSpy = process.stdout.write.bind(process.stdout);
+  const stderrSpy = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = ((chunk: unknown) => {
+    out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown) => {
+    err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+    return true;
+  }) as typeof process.stderr.write;
+
+  return {
+    err,
+    out,
+    restore: () => {
+      process.stdout.write = stdoutSpy;
+      process.stderr.write = stderrSpy;
+    },
+  };
+};

--- a/.gaia/cli/test-fixtures/ci-shape/stale-check.test.ts
+++ b/.gaia/cli/test-fixtures/ci-shape/stale-check.test.ts
@@ -1,0 +1,163 @@
+/**
+ * UAT-019 integration scenarios.
+ *
+ * The both-predicates rule (label `gaia-ci` AND author
+ * `github-actions[bot]`) is enforced server-side by the `gh pr list`
+ * filter; the CLI's job is to ALWAYS pass both predicates and surface
+ * the response. These tests verify:
+ *
+ *  1. argv to `gh pr list` always contains both `--label` and
+ *     `--author` (false-positive guard).
+ *  2. decision: "skip" only when the mocked response has an entry.
+ *  3. decision: "proceed" on `[]`.
+ *  4. exit non-zero on `gh` failure.
+ *  5. custom `--author` is passed through.
+ */
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../../src/ci/stale-check.js';
+import {installGhMock, type GhMock} from './gh-mock.js';
+import {captureStdio, setupSandbox, type Sandbox} from './sandbox.js';
+
+describe('UAT-019 — stale-PR pre-run skip', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let mock: GhMock;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-stale-check-fixture-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    mock?.restore();
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('decision: "skip" when both predicates match an open PR', () => {
+    mock = installGhMock({
+      gh: [
+        {
+          match: 'pr list',
+          response: {
+            exitCode: 0,
+            stderr: '',
+            stdout: JSON.stringify([
+              {
+                createdAt: '2026-05-09T03:00:00Z',
+                headRefName: 'gaia-ci/wiki/2026-05-09',
+                number: 42,
+              },
+            ]),
+          },
+        },
+      ],
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(printed.decision).toBe('skip');
+    expect(printed.open_pr_number).toBe(42);
+
+    const argv = mock.ghCalls[0]?.argv ?? [];
+    // Both predicates appear, exactly once each.
+    expect(argv.filter((a) => a === '--label').length).toBe(1);
+    expect(argv.filter((a) => a === '--author').length).toBe(1);
+    const labelIdx = argv.indexOf('--label');
+    const authorIdx = argv.indexOf('--author');
+    expect(argv[labelIdx + 1]).toBe('gaia-ci');
+    expect(argv[authorIdx + 1]).toBe('github-actions[bot]');
+  });
+
+  it('decision: "proceed" when gh returns []', () => {
+    mock = installGhMock({
+      gh: [{match: 'pr list', response: {exitCode: 0, stderr: '', stdout: '[]'}}],
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(printed.decision).toBe('proceed');
+    expect(printed.open_pr_number).toBeNull();
+    expect(printed.open_pr_branch).toBeNull();
+    expect(printed.skip_log_line).toBeNull();
+  });
+
+  it('explicit --author is passed through verbatim', () => {
+    mock = installGhMock({
+      gh: [{match: 'pr list', response: {exitCode: 0, stderr: '', stdout: '[]'}}],
+    });
+
+    run(
+      [
+        '--label',
+        'gaia-ci',
+        '--base',
+        'main',
+        '--author',
+        'someone-else',
+        '--json',
+      ],
+      {cwd: sandbox.root}
+    );
+
+    const argv = mock.ghCalls[0]?.argv ?? [];
+    const authorIdx = argv.indexOf('--author');
+    expect(argv[authorIdx + 1]).toBe('someone-else');
+  });
+
+  it('exits non-zero with structured error on gh failure', () => {
+    mock = installGhMock({
+      gh: [
+        {
+          match: 'pr list',
+          response: {exitCode: 4, stderr: 'gh: not authenticated', stdout: ''},
+        },
+      ],
+    });
+
+    const exit = run(
+      ['--label', 'gaia-ci', '--base', 'main', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+
+    const errors = stdio.err.join('');
+    expect(errors).toContain('gh_invocation_failed');
+
+    const stdout = stdio.out.join('').trim();
+    expect(stdout).toContain('gh_invocation_failed');
+  });
+
+  it('false-positive guard: even when only label "looks right", we ALWAYS pass both flags', () => {
+    // The "false-positive guard" the SPEC requires is that the CLI
+    // never tries to filter responses client-side; the predicates are
+    // server-side. So the only thing to assert here is that both flags
+    // appear in argv on every invocation. Already covered by the first
+    // test; this one re-confirms with a different label/base.
+    mock = installGhMock({
+      gh: [{match: 'pr list', response: {exitCode: 0, stderr: '', stdout: '[]'}}],
+    });
+
+    run(
+      ['--label', 'gaia-ci', '--base', 'master', '--json'],
+      {cwd: sandbox.root}
+    );
+
+    const argv = mock.ghCalls[0]?.argv ?? [];
+    expect(argv).toContain('--label');
+    expect(argv).toContain('--author');
+    expect(argv).toContain('--base');
+    expect(argv).toContain('master');
+  });
+});

--- a/.gaia/cli/test-fixtures/tsconfig.json
+++ b/.gaia/cli/test-fixtures/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".",
+    "rootDir": "..",
     "outDir": "./dist-fixtures"
   },
-  "include": ["./**/*.ts"],
-  "exclude": ["./dist-fixtures", "../node_modules"]
+  "include": ["./**/*.ts", "../src/**/*.ts"],
+  "exclude": ["./dist-fixtures", "../node_modules", "../src/**/__tests__/**"]
 }

--- a/.gaia/cli/vitest.config.ts
+++ b/.gaia/cli/vitest.config.ts
@@ -2,6 +2,9 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['./src/**/*.test.{ts,tsx}'],
+    include: [
+      './src/**/*.test.{ts,tsx}',
+      './test-fixtures/**/*.test.{ts,tsx}',
+    ],
   },
 });

--- a/.gaia/templates/ci-issues/priority-critical-revert-failed.md
+++ b/.gaia/templates/ci-issues/priority-critical-revert-failed.md
@@ -1,0 +1,26 @@
+GAIA CI auto-revert FAILED for PR #${ORIGINAL_PR}. The bot has stopped
+automated activity on this change and is asking for human intervention.
+
+A revert PR (#${REVERT_PR}) was opened to undo PR #${ORIGINAL_PR}, but the
+revert's own CI failed. Per the SPEC's hard-cap rule (one revert attempt per
+original PR), no second revert will be attempted automatically.
+
+Recovery options:
+1. Investigate the original failure on `${MERGE_SHA}` and fix forward in a
+   manual PR.
+2. Manually merge the revert PR after fixing whatever made the revert's CI red.
+3. Manually revert via `git revert ${MERGE_SHA}` on a local branch and open a
+   PR yourself.
+
+References:
+- Original PR: #${ORIGINAL_PR} (${ORIGINAL_TITLE})
+- Merge commit: ${MERGE_SHA}
+- Failed post-merge run: ${FAILED_RUN_URL}
+- Revert PR (failed): #${REVERT_PR}
+- Failed revert run: ${REVERT_FAILED_RUN_URL}
+- Workflow: ${WORKFLOW_NAME}
+
+Until this issue is closed, the GAIA CI cron schedule for `${WORKFLOW_NAME}` is
+not suppressed automatically — the next scheduled run will proceed normally on
+its next cycle. The hard-cap rule applies only to the specific original PR;
+unrelated runs continue.

--- a/.gaia/templates/ci-issues/priority-high-revert-opened.md
+++ b/.gaia/templates/ci-issues/priority-high-revert-opened.md
@@ -1,0 +1,17 @@
+GAIA CI auto-revert in progress for PR #${ORIGINAL_PR}.
+
+Post-merge CI on the merge commit `${MERGE_SHA}` failed. The bot has opened a
+revert PR (#${REVERT_PR}) and enabled auto-merge.
+
+If the revert's CI is also red, the bot will stop and escalate to a
+`priority:critical` issue. No second revert is attempted.
+
+- Original PR: #${ORIGINAL_PR} (${ORIGINAL_TITLE})
+- Merge commit: ${MERGE_SHA}
+- Failed run: ${FAILED_RUN_URL}
+- Revert PR: #${REVERT_PR}
+- Workflow: ${WORKFLOW_NAME}
+
+If you want to investigate before the revert merges, you can hold the revert PR
+by removing its `gaia-ci` label or closing it; the bot will treat that as a
+revert failure and escalate.

--- a/.github/actions/gaia-ci-merge-and-watch/action.yml
+++ b/.github/actions/gaia-ci-merge-and-watch/action.yml
@@ -1,0 +1,266 @@
+name: 'GAIA CI — Merge and Watch'
+description: |
+  Enables auto-merge on a GAIA CI PR, watches post-merge CI, and runs the
+  one-shot auto-revert + escalation pipeline on failure. Slice 2 of SPEC-001.
+inputs:
+  pr-number:
+    description: 'PR number to merge.'
+    required: true
+  label:
+    description: 'PR label predicate. v1 uses gaia-ci.'
+    required: true
+  merge-method:
+    description: 'squash | merge | rebase'
+    required: false
+    default: 'squash'
+  gh-token:
+    description: 'Token with pull-requests:write + contents:write + issues:write.'
+    required: true
+outputs:
+  merge-conclusion:
+    description: 'merged | closed_without_merge | revert_opened | revert_failed'
+    value: ${{ steps.summarize.outputs.conclusion }}
+  revert-pr:
+    description: 'Revert PR number on revert paths; empty otherwise.'
+    value: ${{ steps.summarize.outputs.revert_pr }}
+  revert-branch:
+    description: 'Revert branch name on revert paths; empty otherwise.'
+    value: ${{ steps.summarize.outputs.revert_branch }}
+  priority-high-issue:
+    description: 'Issue number opened on revert dispatch; empty otherwise.'
+    value: ${{ steps.summarize.outputs.high_issue }}
+  priority-critical-issue:
+    description: 'Issue number opened on revert failure; empty otherwise.'
+    value: ${{ steps.summarize.outputs.critical_issue }}
+runs:
+  using: 'composite'
+  steps:
+    - id: enable-auto-merge
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: |
+        set -euo pipefail
+        merge_output="$(gh pr merge "$PR_NUMBER" "--$MERGE_METHOD" --auto 2>&1)"
+        rc=$?
+        if [[ $rc -ne 0 ]]; then
+          if [[ "$merge_output" == *"is already used by worktree"* ]]; then
+            echo "::notice title=GAIA CI::PR #$PR_NUMBER auto-merge already enabled (worktree-conflict ignored per SPEC contract)"
+          else
+            echo "::error title=GAIA CI::failed to enable auto-merge for PR #$PR_NUMBER: $merge_output"
+            exit 1
+          fi
+        else
+          echo "::notice title=GAIA CI::auto-merge enabled for PR #$PR_NUMBER"
+        fi
+
+    - id: wait-for-merge
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        set -euo pipefail
+        result_json="$(${GITHUB_ACTION_PATH}/lib/wait-for-merge.sh "$PR_NUMBER")"
+        echo "result=$result_json" >> "$GITHUB_OUTPUT"
+        echo "merge_state=$(jq -r '.state' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+        echo "merge_sha=$(jq -r '.sha // ""' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+        echo "merge_title=$(jq -r '.title // ""' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+
+    - id: branch-on-merge-state
+      shell: bash
+      env:
+        MERGE_STATE: ${{ steps.wait-for-merge.outputs.merge_state }}
+      run: |
+        set -euo pipefail
+        if [[ "$MERGE_STATE" == "MERGED" ]]; then
+          echo "proceed_to_check=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "proceed_to_check=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: wait-for-ci
+      if: steps.branch-on-merge-state.outputs.proceed_to_check == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        MERGE_SHA: ${{ steps.wait-for-merge.outputs.merge_sha }}
+      run: |
+        set -euo pipefail
+        result_json="$(${GITHUB_ACTION_PATH}/lib/wait-for-ci.sh "$MERGE_SHA")"
+        echo "result=$result_json" >> "$GITHUB_OUTPUT"
+        echo "conclusion=$(jq -r '.conclusion' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+        echo "run_url=$(jq -r '.run_url // ""' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+
+    - id: branch-on-ci
+      shell: bash
+      env:
+        CI_CONCLUSION: ${{ steps.wait-for-ci.outputs.conclusion }}
+      run: |
+        set -euo pipefail
+        if [[ "$CI_CONCLUSION" == "failure" ]]; then
+          echo "proceed_to_revert=true" >> "$GITHUB_OUTPUT"
+          echo "done_clean=false" >> "$GITHUB_OUTPUT"
+        elif [[ "$CI_CONCLUSION" == "success" ]]; then
+          echo "proceed_to_revert=false" >> "$GITHUB_OUTPUT"
+          echo "done_clean=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "proceed_to_revert=false" >> "$GITHUB_OUTPUT"
+          echo "done_clean=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: open-revert
+      if: steps.branch-on-ci.outputs.proceed_to_revert == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        LABEL: ${{ inputs.label }}
+        MERGE_SHA: ${{ steps.wait-for-merge.outputs.merge_sha }}
+      run: |
+        set -euo pipefail
+        revert_json="$(gaia ci-revert open --pr "$PR_NUMBER" --label "$LABEL" --reason "post-merge CI failure on $MERGE_SHA" --json)"
+        rc=$?
+        if [[ $rc -ne 0 ]]; then
+          err_code="$(jq -r '.error // ""' <<<"$revert_json")"
+          if [[ "$err_code" == "revert_already_opened" ]]; then
+            existing="$(jq -r '.existing_revert_pr // ""' <<<"$revert_json")"
+            echo "::warning title=GAIA CI::revert already opened for PR #$PR_NUMBER (revert PR #$existing); reusing existing"
+            echo "revert_pr=$existing" >> "$GITHUB_OUTPUT"
+            echo "revert_branch=" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error title=GAIA CI::ci-revert open failed: $revert_json"
+            exit 1
+          fi
+        else
+          echo "revert_pr=$(jq -r '.revert_pr' <<<"$revert_json")" >> "$GITHUB_OUTPUT"
+          echo "revert_branch=$(jq -r '.revert_branch' <<<"$revert_json")" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: open-priority-high-issue
+      if: steps.open-revert.outcome == 'success' && steps.open-revert.conclusion == 'success'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        ORIGINAL_PR: ${{ inputs.pr-number }}
+        ORIGINAL_TITLE: ${{ steps.wait-for-merge.outputs.merge_title }}
+        REVERT_PR: ${{ steps.open-revert.outputs.revert_pr }}
+        MERGE_SHA: ${{ steps.wait-for-merge.outputs.merge_sha }}
+        FAILED_RUN_URL: ${{ steps.wait-for-ci.outputs.run_url }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+        REVERT_FAILED_RUN_URL: ''
+      run: |
+        set -euo pipefail
+        body="$(${GITHUB_ACTION_PATH}/lib/render-issue.sh "${GITHUB_WORKSPACE}/.gaia/templates/ci-issues/priority-high-revert-opened.md")"
+        issue_url="$(printf '%s\n' "$body" | gh issue create \
+          --title "GAIA CI: PR #${ORIGINAL_PR} reverted via PR #${REVERT_PR}" \
+          --label "priority:high" \
+          --label "gaia-ci" \
+          --body-file -)"
+        issue_number="${issue_url##*/}"
+        echo "high_issue=$issue_number" >> "$GITHUB_OUTPUT"
+        echo "::notice title=GAIA CI::PR #${ORIGINAL_PR} reverted via PR #${REVERT_PR} — see issue #${issue_number} (priority:high)"
+
+    - id: wait-for-revert-merge
+      if: steps.open-revert.outcome == 'success' && steps.open-revert.conclusion == 'success'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REVERT_PR: ${{ steps.open-revert.outputs.revert_pr }}
+      run: |
+        set -euo pipefail
+        result_json="$(${GITHUB_ACTION_PATH}/lib/wait-for-merge.sh "$REVERT_PR")"
+        echo "revert_merge_state=$(jq -r '.state' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+        echo "revert_merge_sha=$(jq -r '.sha // ""' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+
+    - id: wait-for-revert-ci
+      if: steps.wait-for-revert-merge.outputs.revert_merge_state == 'MERGED'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        REVERT_MERGE_SHA: ${{ steps.wait-for-revert-merge.outputs.revert_merge_sha }}
+      run: |
+        set -euo pipefail
+        result_json="$(${GITHUB_ACTION_PATH}/lib/wait-for-ci.sh "$REVERT_MERGE_SHA")"
+        echo "revert_conclusion=$(jq -r '.conclusion' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+        echo "revert_run_url=$(jq -r '.run_url // ""' <<<"$result_json")" >> "$GITHUB_OUTPUT"
+
+    - id: branch-on-revert-conclusion
+      if: steps.open-revert.outcome == 'success' && steps.open-revert.conclusion == 'success'
+      shell: bash
+      env:
+        REVERT_CONCLUSION: ${{ steps.wait-for-revert-ci.outputs.revert_conclusion }}
+        REVERT_MERGE_STATE: ${{ steps.wait-for-revert-merge.outputs.revert_merge_state }}
+      run: |
+        set -euo pipefail
+        if [[ "$REVERT_CONCLUSION" == "failure" ]] || [[ "$REVERT_MERGE_STATE" == "CLOSED" ]]; then
+          echo "revert_failed=true" >> "$GITHUB_OUTPUT"
+          echo "revert_clean=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "revert_failed=false" >> "$GITHUB_OUTPUT"
+          echo "revert_clean=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: mark-revert-failed-and-escalate
+      if: steps.branch-on-revert-conclusion.outputs.revert_failed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        ORIGINAL_PR: ${{ inputs.pr-number }}
+        ORIGINAL_TITLE: ${{ steps.wait-for-merge.outputs.merge_title }}
+        REVERT_PR: ${{ steps.open-revert.outputs.revert_pr }}
+        MERGE_SHA: ${{ steps.wait-for-merge.outputs.merge_sha }}
+        FAILED_RUN_URL: ${{ steps.wait-for-ci.outputs.run_url }}
+        REVERT_FAILED_RUN_URL: ${{ steps.wait-for-revert-ci.outputs.revert_run_url }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: |
+        set -euo pipefail
+        gaia ci-revert mark-failed --pr "$PR_NUMBER" --json >/dev/null
+        body="$(${GITHUB_ACTION_PATH}/lib/render-issue.sh "${GITHUB_WORKSPACE}/.gaia/templates/ci-issues/priority-critical-revert-failed.md")"
+        issue_url="$(printf '%s\n' "$body" | gh issue create \
+          --title "GAIA CI: revert of PR #${ORIGINAL_PR} also failed — bot stopped" \
+          --label "priority:critical" \
+          --label "gaia-ci" \
+          --body-file -)"
+        issue_number="${issue_url##*/}"
+        echo "critical_issue=$issue_number" >> "$GITHUB_OUTPUT"
+        echo "::error title=GAIA CI::revert PR #${REVERT_PR} failed CI; bot stopped — see issue #${issue_number} (priority:critical)"
+
+    - id: summarize
+      shell: bash
+      env:
+        DONE_CLEAN: ${{ steps.branch-on-ci.outputs.done_clean }}
+        MERGE_STATE: ${{ steps.wait-for-merge.outputs.merge_state }}
+        REVERT_FAILED: ${{ steps.branch-on-revert-conclusion.outputs.revert_failed }}
+        REVERT_CLEAN: ${{ steps.branch-on-revert-conclusion.outputs.revert_clean }}
+        REVERT_PR: ${{ steps.open-revert.outputs.revert_pr }}
+        REVERT_BRANCH: ${{ steps.open-revert.outputs.revert_branch }}
+        HIGH_ISSUE: ${{ steps.open-priority-high-issue.outputs.high_issue }}
+        CRITICAL_ISSUE: ${{ steps.mark-revert-failed-and-escalate.outputs.critical_issue }}
+        ORIGINAL_PR: ${{ inputs.pr-number }}
+      run: |
+        set -euo pipefail
+        if [[ "$REVERT_FAILED" == "true" ]]; then
+          conclusion="revert_failed"
+        elif [[ -n "$REVERT_PR" ]]; then
+          conclusion="revert_opened"
+        elif [[ "$MERGE_STATE" == "CLOSED" ]]; then
+          conclusion="closed_without_merge"
+        elif [[ "$DONE_CLEAN" == "true" ]]; then
+          conclusion="merged"
+        else
+          conclusion="unknown"
+        fi
+        echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+        echo "revert_pr=${REVERT_PR}" >> "$GITHUB_OUTPUT"
+        echo "revert_branch=${REVERT_BRANCH}" >> "$GITHUB_OUTPUT"
+        echo "high_issue=${HIGH_ISSUE}" >> "$GITHUB_OUTPUT"
+        echo "critical_issue=${CRITICAL_ISSUE}" >> "$GITHUB_OUTPUT"
+        if [[ "$conclusion" == "merged" ]]; then
+          echo "::notice title=GAIA CI::PR #${ORIGINAL_PR} merged green"
+        fi

--- a/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
+++ b/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
@@ -19,4 +19,6 @@ if [[ ! -f "$TEMPLATE" ]]; then
   exit 1
 fi
 
-envsubst < "$TEMPLATE"
+# Expand only the known set of variables to prevent accidental token injection
+# from variables in user-controlled fields (PR title, workflow name, etc).
+envsubst '${ORIGINAL_PR},${ORIGINAL_TITLE},${REVERT_PR},${MERGE_SHA},${FAILED_RUN_URL},${WORKFLOW_NAME},${REVERT_FAILED_RUN_URL}' < "$TEMPLATE"

--- a/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
+++ b/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Renders an issue body template by passing it through envsubst.
+# Required env vars (caller sets via composite-action `env:`):
+#   ORIGINAL_PR, ORIGINAL_TITLE, REVERT_PR, MERGE_SHA, FAILED_RUN_URL,
+#   WORKFLOW_NAME, REVERT_FAILED_RUN_URL (latter empty for priority:high).
+#
+# Args:
+#   $1 — path to the template (.md file using ${VAR} placeholders).
+#
+# stdout: rendered body. The composite action pipes it to
+#   `gh issue create --body-file -`.
+
+set -euo pipefail
+
+TEMPLATE="${1:?template path required}"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "render-issue: template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+envsubst < "$TEMPLATE"

--- a/.github/actions/gaia-ci-merge-and-watch/lib/wait-for-ci.sh
+++ b/.github/actions/gaia-ci-merge-and-watch/lib/wait-for-ci.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Polls post-merge CI conclusions on a commit SHA. Emits one-line JSON:
+#   {"conclusion":"success","run_url":"<url>"}
+#   {"conclusion":"failure","run_url":"<url>"}
+#   {"conclusion":"timeout","run_url":""}
+# Exit 0 on terminal (success | failure); exit 1 on timeout.
+#
+# Args:
+#   $1 — commit SHA to query.
+# Env (required):
+#   GITHUB_REPOSITORY — owner/repo (provided by Actions runner).
+#   DEFAULT_BRANCH — usually github.event.repository.default_branch.
+# Env overrides:
+#   TIMEOUT_SECONDS — defaults to 5400 (90 minutes)
+#   SLEEP_SECONDS — defaults to 30
+
+set -euo pipefail
+
+COMMIT_SHA="${1:?commit sha required}"
+DEADLINE=$(( SECONDS + ${TIMEOUT_SECONDS:-5400} ))
+SLEEP_SECONDS="${SLEEP_SECONDS:-30}"
+
+required_contexts=""
+required_status_json="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}/protection/required_status_checks" 2>/dev/null || true)"
+
+if [[ -n "$required_status_json" ]] && jq -e . >/dev/null 2>&1 <<<"$required_status_json"; then
+  required_contexts="$(jq -r '.contexts[]?' <<<"$required_status_json" 2>/dev/null || true)"
+fi
+
+# A terminal conclusion is one of: success failure cancelled timed_out
+# skipped neutral action_required stale. We treat anything other than
+# success / skipped / neutral as failure.
+
+while (( SECONDS < DEADLINE )); do
+  runs_json="$(gh run list --commit "$COMMIT_SHA" --json conclusion,status,name,url --limit 50 2>/dev/null || echo '[]')"
+
+  # Filter to required contexts when protection is configured. The branch
+  # protection API names are workflow contexts; gh run list .name is the
+  # workflow name. They line up for repos that use one workflow per
+  # required check. Adopters with finer-grained protection may need a
+  # different mapping; v1 keeps it simple.
+  if [[ -n "$required_contexts" ]]; then
+    matched_json="$(jq -c --argjson contexts "$(jq -R -s 'split("\n") | map(select(length > 0))' <<<"$required_contexts")" '[.[] | select(.name as $n | $contexts | index($n))]' <<<"$runs_json")"
+  else
+    matched_json="$runs_json"
+  fi
+
+  total="$(jq 'length' <<<"$matched_json")"
+
+  if [[ "$total" -eq 0 ]]; then
+    sleep "$SLEEP_SECONDS"
+    continue
+  fi
+
+  pending="$(jq '[.[] | select(.status != "completed")] | length' <<<"$matched_json")"
+
+  if [[ "$pending" -gt 0 ]]; then
+    sleep "$SLEEP_SECONDS"
+    continue
+  fi
+
+  # All runs terminal. Look for any non-success conclusion.
+  failed_run="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")] | first // empty' <<<"$matched_json")"
+
+  if [[ -n "$failed_run" && "$failed_run" != "null" ]]; then
+    run_url="$(jq -r '.url' <<<"$failed_run")"
+    jq -c -n --arg url "$run_url" '{conclusion: "failure", run_url: $url}'
+    exit 0
+  fi
+
+  jq -c -n '{conclusion: "success", run_url: ""}'
+  exit 0
+done
+
+echo '{"conclusion":"timeout","run_url":""}'
+exit 1

--- a/.github/actions/gaia-ci-merge-and-watch/lib/wait-for-merge.sh
+++ b/.github/actions/gaia-ci-merge-and-watch/lib/wait-for-merge.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Polls `gh pr view <N> --json state,mergeCommit,title` until the PR reaches
+# a terminal state (MERGED or CLOSED). Emits one-line JSON to stdout:
+#   {"state":"MERGED","sha":"<oid>","title":"<title>"}
+#   {"state":"CLOSED","sha":null,"title":null}
+#   {"state":"TIMEOUT","sha":null,"title":null}
+# Exit 0 on terminal state; exit 1 on timeout.
+#
+# Env overrides:
+#   TIMEOUT_SECONDS — defaults to 14400 (4 hours)
+#   SLEEP_SECONDS — defaults to 30
+
+set -euo pipefail
+
+PR_NUMBER="${1:?pr number required}"
+DEADLINE=$(( SECONDS + ${TIMEOUT_SECONDS:-14400} ))
+SLEEP_SECONDS="${SLEEP_SECONDS:-30}"
+
+while (( SECONDS < DEADLINE )); do
+  state_json="$(gh pr view "$PR_NUMBER" --json state,mergeCommit,title 2>/dev/null || true)"
+  state="$(jq -r '.state // ""' <<<"$state_json")"
+  case "$state" in
+    MERGED)
+      jq -c '{state, sha: (.mergeCommit.oid // null), title}' <<<"$state_json"
+      exit 0
+      ;;
+    CLOSED)
+      jq -c '{state, sha: null, title: null}' <<<"$state_json"
+      exit 0
+      ;;
+  esac
+  sleep "$SLEEP_SECONDS"
+done
+
+echo '{"state":"TIMEOUT","sha":null,"title":null}'
+exit 1

--- a/.github/actions/gaia-ci-stale-pr-skip/action.yml
+++ b/.github/actions/gaia-ci-stale-pr-skip/action.yml
@@ -1,0 +1,66 @@
+name: 'GAIA CI — Stale PR Skip'
+description: |
+  Pre-run check that skips opening a new GAIA CI PR when an existing
+  gaia-ci-labeled bot-authored PR is already open against the default
+  branch. Slice 2 of SPEC-001.
+inputs:
+  label:
+    description: 'PR label predicate. v1 uses gaia-ci.'
+    required: true
+  base:
+    description: 'Default branch predicate.'
+    required: false
+    default: ${{ github.event.repository.default_branch }}
+  author:
+    description: 'PR author predicate. Default is github-actions[bot].'
+    required: false
+    default: 'github-actions[bot]'
+  gh-token:
+    description: 'Token with pull-requests:read.'
+    required: true
+outputs:
+  skip:
+    description: "'true' if a blocking PR is open; 'false' otherwise."
+    value: ${{ steps.check.outputs.skip }}
+  open-pr-number:
+    description: 'Blocking PR number on skip; empty otherwise.'
+    value: ${{ steps.check.outputs.open_pr_number }}
+runs:
+  using: 'composite'
+  steps:
+    - id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        STALE_LABEL: ${{ inputs.label }}
+        STALE_BASE: ${{ inputs.base }}
+        STALE_AUTHOR: ${{ inputs.author }}
+      run: |
+        set -euo pipefail
+        result_json="$(gaia ci-stale-check \
+          --label "$STALE_LABEL" \
+          --base "$STALE_BASE" \
+          --author "$STALE_AUTHOR" \
+          --json)"
+        decision="$(jq -r '.decision' <<<"$result_json")"
+        case "$decision" in
+          skip)
+            log_line="$(jq -r '.skip_log_line' <<<"$result_json")"
+            pr_number="$(jq -r '.open_pr_number' <<<"$result_json")"
+            echo "::notice title=GAIA CI::${log_line}"
+            {
+              echo "skip=true"
+              echo "open_pr_number=${pr_number}"
+            } >> "$GITHUB_OUTPUT"
+            ;;
+          proceed)
+            {
+              echo "skip=false"
+              echo "open_pr_number="
+            } >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error title=GAIA CI::unexpected ci-stale-check decision: ${decision}"
+            exit 1
+            ;;
+        esac


### PR DESCRIPTION
## Summary

Phase 1 of three for SPEC-001 slice 2. Adds the foundational CLI primitives
the composite GitHub Actions in Phase 2 invoke: `gaia ci-stale-check` for
the pre-run skip (UAT-019) and `gaia ci-revert` for the one-shot revert
pipeline + hard cap (UAT-009, UAT-010).

The hard-cap enforcement lives in the CLI; the composite action trusts the
CLI's exit codes. Even if the action is invoked twice for the same PR, the
ledger entry blocks the second `open` call.

Subsequent phases:
- Phase 2 — composite GitHub Actions for merge-and-watch and stale-PR-skip,
  plus issue body templates.
- Phase 3 — integration fixture exercising the shape end-to-end against a
  mocked `gh` CLI.

## Test plan

- [ ] `pnpm typecheck && pnpm lint`
- [ ] `( cd .gaia/cli && pnpm typecheck && pnpm test --run )`
- [ ] Hard-cap verified: ledger pre-populated with an open attempt blocks
      a second `ci-revert open` with `revert_already_opened` and zero
      `gh`/`git` invocations.
- [ ] Stale-check both-predicates verified: argv to `gh pr list` always
      contains both `--label gaia-ci` and `--author github-actions[bot]`.
