### PR TITLE
feat: spec-001 slice 4 — /setup-gaia-ci slash command (Phase B)

### DIFF
--- a/.claude/commands/setup-gaia-ci.md
+++ b/.claude/commands/setup-gaia-ci.md
@@ -1,0 +1,350 @@
+---
+name: setup-gaia-ci
+description: Wire up GAIA CI workflows on GitHub. Run after first git push origin main. Idempotent — re-runs short-circuit; --reconfigure rotates tokens and re-selects tools.
+---
+
+Wire up GAIA CI on GitHub. Run this once after your first `git push origin main`. The command is idempotent — re-running on a configured repo prints `GAIA CI is already configured` and exits. Pass `--reconfigure` to rotate the bot token or re-select which tools run on cron.
+
+The flow:
+
+- Detect the repo's `origin` remote and confirm it's GitHub.
+- Warn if Dependabot or Renovate is configured (GAIA Sharpen overlaps).
+- Ask: enable now / not now / opt out for the team.
+- If admin: offer to enable `delete_branch_on_merge` (makes stale-branch cleanup redundant).
+- Accept your bot token (`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`) via stdin and pipe it directly to `gh secret set`.
+- Generate `.github/workflows/gaia-ci-*.yml` from `.gaia/automation.json`.
+- Trigger one `workflow_dispatch` run to verify the workflow boots.
+- On success, commit the workflow files plus a flip of `setup_complete: true` in a single commit.
+
+The slash command name intentionally does NOT start with `gaia-` so it does not pollute the `/gaia` autocomplete namespace (those are reserved for the four user-invoked GAIA workflows).
+
+## Step 0: Argument parse
+
+Parse `$ARGUMENTS` for the `--reconfigure` flag. Cache the boolean as `RECONFIGURE`.
+
+## Step 1: Detect Phase A
+
+```bash
+.gaia/cli/gaia setup-ci status --json
+```
+
+Read the JSON. If `configured: false`, print:
+
+```
+GAIA CI is not configured for this repo. Run /gaia-init first.
+.gaia/automation.json is missing.
+```
+
+Exit cleanly. Otherwise cache `setup_complete`, `setup_opted_out`, and `tools_enabled` for later steps.
+
+## Step 2: Idempotent short-circuit
+
+When `setup_complete: true` AND `RECONFIGURE` is NOT set, print exactly:
+
+```
+GAIA CI is already configured. Pass --reconfigure to rotate tokens or change tool selection.
+```
+
+Exit cleanly. Do not modify any file.
+
+When `setup_complete: false`, fall through to Step 3.
+
+When `setup_complete: true` AND `RECONFIGURE` IS set, fall through to Step 3 — the reconfigure path re-runs the rest of the flow. `--reconfigure` does NOT touch `setup_complete`; it stays true.
+
+## Step 3: Detect remote
+
+```bash
+.gaia/cli/gaia setup-ci detect-remote --json
+```
+
+Read the JSON. If `found: false`, print:
+
+```
+No `origin` remote found. Run `git remote add origin <url>` and `git push origin main` first, then re-run /setup-gaia-ci.
+```
+
+Exit cleanly.
+
+If `host != "github.com"`, print:
+
+```
+GAIA CI v1 supports GitHub Actions only. Detected host: <host>. Support for GitLab / Bitbucket / Circle is out of scope for this release.
+```
+
+Exit cleanly. Otherwise cache `owner` and `repo`.
+
+## Step 4: Warn about existing Dependabot / Renovate
+
+```bash
+.gaia/cli/gaia setup-ci warn-existing-tools --json
+```
+
+If `found` is non-empty, print the warning text (substituting the actual tools):
+
+```
+A {tool} configuration was detected in this repo. GAIA Sharpen covers the same ecosystems, and running both tools in parallel will open duplicate dependency PRs.
+
+Recommendation: disable {tool} for the ecosystems GAIA Sharpen covers (npm, pnpm) before continuing. /setup-gaia-ci will NOT auto-disable {tool}.
+```
+
+Then `AskUserQuestion`:
+
+> Continue with /setup-gaia-ci? You can disable {tool} now in another terminal and come back to confirm.
+>
+> - **Continue (I've decided how to handle the overlap)** (Recommended)
+> - **Cancel (I'll address {tool} first and re-run /setup-gaia-ci)**
+
+On Cancel, exit cleanly. On Continue, fall through.
+
+When `found` is empty, skip the warning and the question.
+
+## Step 5: Three-option enable / not now / opt out
+
+First, run the admin probe:
+
+```bash
+.gaia/cli/gaia setup-ci check-admin --owner <owner> --repo <repo> --json
+```
+
+Cache `admin` and `auth_status`. Treat `auth_status != "ok"` as personal-dismiss-only — never offer team opt-out unless `auth_status == "ok"`.
+
+If `RECONFIGURE` is set, skip this question entirely and use the reconfigure flow described in Step 11.
+
+Otherwise `AskUserQuestion` with these three options in this exact order:
+
+> Enable GAIA CI now? It runs four maintenance jobs on a smart cron (wiki sync, /sharpen, pnpm audit, stale branches), opens labeled PRs, and auto-merges them on green CI.
+>
+> - **Enable GAIA CI now** (Recommended)
+> - **Not now** (you can re-run /setup-gaia-ci anytime)
+> - **Don't ask the team again** (admin-only; skips this prompt for everyone)
+
+Branches:
+
+- **Enable now:** fall through to Step 6.
+- **Not now:**
+
+  ```bash
+  .gaia/cli/gaia setup-ci dismiss-personal
+  ```
+
+  Print `Personal dismissal recorded. Re-run /setup-gaia-ci anytime to enable.` and exit.
+
+- **Don't ask the team again:**
+  - If `admin: false` (or `auth_status != "ok"`): print
+
+    ```
+    "Don't ask the team again" requires repo admin permission. Your permission level is admin: <admin>, auth_status: <auth_status>. Falling back to personal dismissal.
+    ```
+
+    Then `AskUserQuestion`:
+
+    > Apply personal dismissal instead?
+    >
+    > - **Yes** (Recommended)
+    > - **No** (cancel — neither team opt-out nor personal dismissal is recorded)
+
+    On Yes: shell `gaia setup-ci dismiss-personal` and exit. On No: exit cleanly.
+
+  - If `admin: true`: shell
+
+    ```bash
+    .gaia/cli/gaia setup-ci opt-out-team
+    ```
+
+    Print `Team opt-out recorded in .gaia/automation.json (setup_opted_out=true). Commit and push to apply for the team.` and exit. The slash command does NOT auto-commit the team opt-out write — review the diff and commit yourself.
+
+## Step 6: Repo hygiene check
+
+Only reached when the user picked "Enable now" in Step 5 (or is in the reconfigure flow).
+
+Read the current `delete_branch_on_merge` setting:
+
+```bash
+gh api "repos/<owner>/<repo>" --jq .delete_branch_on_merge
+```
+
+Cache the boolean.
+
+If `false` AND `admin: true`, `AskUserQuestion`:
+
+> GitHub is set to NOT delete branches when PRs merge. GAIA's monthly stale-branch cron exists to clean those up. If we enable `delete_branch_on_merge` now, the cron becomes redundant and we'll mark `stale_branches.mode = "off"` in `.gaia/automation.json`.
+>
+> - **Enable delete_branch_on_merge** (Recommended; mark stale-branches off)
+> - **Skip** (keep stale-branch cleanup cron active)
+
+On Enable:
+
+```bash
+.gaia/cli/gaia setup-ci enable-delete-branch --owner <owner> --repo <repo>
+.gaia/cli/gaia setup-ci write-tool-mode stale-branches off
+```
+
+If `false` AND `admin: false`, skip the question and print:
+
+```
+Note: delete_branch_on_merge is disabled on the repo. An admin running /setup-gaia-ci can offer to enable it.
+```
+
+If already `true`, skip the question. Print:
+
+```
+delete_branch_on_merge is already enabled — stale-branches cron is redundant. Marking stale_branches.mode = "off".
+```
+
+Then shell the `bump-state` call directly:
+
+```bash
+.gaia/cli/gaia setup-ci write-tool-mode stale-branches off
+```
+
+## Step 7: Token type selection and entry
+
+`AskUserQuestion`:
+
+> Which bot token will GAIA CI use to authenticate workflow steps that hit the Anthropic API?
+>
+> - **CLAUDE_CODE_OAUTH_TOKEN** (default for Claude Code subscribers)
+> - **ANTHROPIC_API_KEY** (default for direct Anthropic API customers)
+> - **I don't know** (link to docs and exit)
+
+On "I don't know", print:
+
+```
+Open https://gaiareact.com/setup-gaia-ci to read the token-type section, then re-run /setup-gaia-ci.
+```
+
+Exit cleanly.
+
+On a token choice, prompt for the value:
+
+```
+Paste your <NAME> value below. The token is piped directly to `gh secret set <NAME>` and is never echoed, never logged, and never appears in the terminal scrollback.
+
+The agent reads your message and immediately invokes `gaia setup-ci set-secret <NAME>` with the token on stdin. Do not include any other text in your message — the agent will trim trailing whitespace defensively, but extra prose may corrupt the token.
+```
+
+When the user replies with their token, IMMEDIATELY invoke:
+
+```bash
+TOKEN='<paste-token-here>' && printf '%s' "$TOKEN" | .gaia/cli/gaia setup-ci set-secret <NAME> && unset TOKEN
+```
+
+(Construct the Bash tool call so the `$TOKEN` interpolation happens in the same shell as the `printf`+`gaia` pipeline. The Bash tool string contains the literal token; this is the unavoidable narrow window where the token is in the agent's process memory.)
+
+**Token-handling rules (non-negotiable):**
+
+- The agent MUST NOT write the token to ANY file (no scratch file, no cache, no log).
+- The agent MUST NOT echo the token in chat.
+- The agent MUST NOT include the token in any subsequent AskUserQuestion, Edit, or Write tool call.
+- The agent MUST NOT include the token in the final commit message.
+- The agent MUST scrub the token from working memory after `set-secret` returns (the `unset TOKEN` in the same Bash call is the scrub).
+
+If `set-secret` exits non-zero, print the structured error and exit cleanly. The user re-runs `/setup-gaia-ci` to retry.
+
+## Step 8: Generate workflow YAML
+
+Shell the workflow generator:
+
+```bash
+.gaia/cli/gaia automation render-workflows --out-dir .github/workflows
+```
+
+Capture the JSON list of written paths.
+
+If `render-workflows` reports no paths written (the config has `mode: "ci"` for zero tools), print:
+
+```
+No tools are configured for CI mode in .gaia/automation.json. Edit the file (set at least one tool's mode to "ci") and re-run /setup-gaia-ci.
+```
+
+Exit cleanly.
+
+## Step 9: Trigger verification run
+
+Pick the FIRST workflow file from the generated list (typically `.github/workflows/gaia-ci-wiki.yml`):
+
+```bash
+.gaia/cli/gaia setup-ci verify-run .github/workflows/gaia-ci-wiki.yml --json
+```
+
+Read the JSON.
+
+If `verified: true`, print `Verification run succeeded. Conclusion: success. URL: <url>.` and fall through to Step 10.
+
+If `verified: false`, surface the URL and `AskUserQuestion`:
+
+> Verification run did not succeed. Conclusion: <conclusion>. URL: <url>.
+>
+> - **Retry verification** (re-run gh workflow run on the same workflow)
+> - **Abandon** (delete the generated workflow files; commit nothing)
+> - **Commit without verification** (use only if you've already inspected the failed run and confirmed it's a transient infrastructure issue)
+
+On Retry: re-shell `verify-run`. (One retry permitted — second failure prompts the same three options again with Retry removed.)
+
+On Abandon: delete every file in the generated paths list, then exit. The `setup_complete` flag stays `false`.
+
+On Commit without verification: fall through to Step 10 with a flag that adds `(unverified)` to the commit message.
+
+## Step 10: Finalize and commit
+
+```bash
+.gaia/cli/gaia setup-ci finalize
+```
+
+Stage the generated workflow files plus `.gaia/automation.json`:
+
+```bash
+git add .github/workflows/gaia-ci-*.yml .gaia/automation.json
+```
+
+Commit with this exact message (when verified):
+
+```
+chore(gaia-ci): finalize Phase B setup — verified workflow_dispatch run
+
+Adds .github/workflows/gaia-ci-*.yml and flips
+.gaia/automation.json:setup_complete to true.
+```
+
+When the commit-without-verification flag is set, append `(unverified)` to the title and add a body line: `Verification run did not succeed; user opted to commit anyway.`
+
+Push:
+
+```bash
+git push origin <current-branch>
+```
+
+Print:
+
+```
+GAIA CI is configured. Workflows: <list>. Status: setup_complete=true. The first scheduled cron will fire at the times encoded in .github/workflows/gaia-ci-*.yml; you can run any workflow on demand via the Actions tab's "Run workflow" button or `gh workflow run <file>`.
+```
+
+## Step 11: --reconfigure flow
+
+When `RECONFIGURE` is set, the short-circuit at Step 2 is skipped and the flow re-runs Steps 3–10 with two differences:
+
+- **Step 5** is REPLACED with this two-option question:
+
+  > Re-select the tools running on cron. Current selections: <tools_enabled>.
+  >
+  > - **Re-prompt and rewrite .gaia/automation.json**
+  > - **Keep current selections** (only rotate the token)
+
+  On "Re-prompt", `AskUserQuestion` for each of `wiki`, `sharpen`, `pnpm-audit`, `stale-branches` with mode options `ci` / `local` / `off`. Apply each via `.gaia/cli/gaia setup-ci write-tool-mode <tool> <mode>`.
+
+- **Step 7** always asks for a fresh token (never reads the existing secret — `gh secret set` overwrites silently).
+- **Step 10's** commit message changes to:
+
+  ```
+  chore(gaia-ci): reconfigure — rotated tokens, regenerated workflows
+
+  Re-runs /setup-gaia-ci's verification flow. setup_complete remains
+  true.
+  ```
+
+  `setup_complete` is NOT touched on `--reconfigure` — it's already true.
+
+## On failure: re-run
+
+The CLI primitives are idempotent and safe to re-run on partial state. After fixing any failure cause (auth missing, network error, malformed config), simply re-run `/setup-gaia-ci` — the idempotent short-circuit in Step 2 catches the already-finalized case and the rest of the flow recovers naturally.

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -797,10 +797,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path41) {
-  if (!path41)
+function getElementAtPath(obj, path44) {
+  if (!path44)
     return obj;
-  return path41.reduce((acc, key) => acc?.[key], obj);
+  return path44.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -1209,11 +1209,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path41, issues) {
+function prefixIssues(path44, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path41);
+    iss.path.unshift(path44);
     return iss;
   });
 }
@@ -1360,16 +1360,16 @@ function flattenError(error51, mapper = (issue2) => issue2.message) {
 }
 function formatError(error51, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error52, path41 = []) => {
+  const processError = (error52, path44 = []) => {
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path41, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path44, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path41, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path44, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path41, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path44, ...issue2.path]);
       } else {
-        const fullpath = [...path41, ...issue2.path];
+        const fullpath = [...path44, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -1396,17 +1396,17 @@ function formatError(error51, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error51, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error52, path41 = []) => {
+  const processError = (error52, path44 = []) => {
     var _a3, _b;
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path41, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path44, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path41, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path44, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path41, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path44, ...issue2.path]);
       } else {
-        const fullpath = [...path41, ...issue2.path];
+        const fullpath = [...path44, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -1438,8 +1438,8 @@ function treeifyError(error51, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path41 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path41) {
+  const path44 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path44) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -14131,13 +14131,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path41 = ref.slice(1).split("/").filter(Boolean);
-  if (path41.length === 0) {
+  const path44 = ref.slice(1).split("/").filter(Boolean);
+  if (path44.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path41[0] === defsKey) {
-    const key = path41[1];
+  if (path44[0] === defsKey) {
+    const key = path44[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -15048,6 +15048,7 @@ import path5 from "node:path";
 import { fileURLToPath } from "node:url";
 var automationConfigPath = (repoRoot2) => path5.join(repoRoot2, ".gaia", "automation.json");
 var automationStatePath = (repoRoot2, tool) => path5.join(repoRoot2, ".gaia", `automation.state-${tool}.json`);
+var localAutomationPath = (repoRoot2) => path5.join(repoRoot2, ".gaia", "local", "automation.json");
 var TEMPLATES_RELATIVE_DIR = path5.join("templates", "workflows");
 var resolveTemplatesDirectory = () => {
   const here = fileURLToPath(import.meta.url);
@@ -21138,6 +21139,1231 @@ var run42 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
+// src/setup-ci/util/gh.ts
+import { spawn } from "node:child_process";
+var runGh2 = (options) => {
+  return new Promise((resolve) => {
+    const child = spawn("gh", [...options.args], {
+      cwd: options.cwd ?? process.cwd(),
+      env: options.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let settled = false;
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    child.stdout.on("data", (chunk) => {
+      stdoutBuf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderrBuf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+    child.on("error", (error51) => {
+      settle({
+        exitCode: -1,
+        ok: false,
+        stderr: error51.message
+      });
+    });
+    child.on("close", (code) => {
+      const exitCode = code ?? 1;
+      if (exitCode === 0) {
+        settle({ ok: true, stdout: stdoutBuf });
+        return;
+      }
+      settle({ exitCode, ok: false, stderr: stderrBuf });
+    });
+    if (options.stdin !== void 0) {
+      child.stdin.write(options.stdin);
+    }
+    child.stdin.end();
+  });
+};
+
+// src/setup-ci/check-admin.ts
+var HELP_TEXT30 = `Usage: gaia setup-ci check-admin --owner <o> --repo <r> [--json]
+
+  Probe repo admin permission via \`gh\`. Returns admin: false for any
+  non-ok auth status. Exits 0 in every branch.
+`;
+var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var printHuman3 = (output) => {
+  process.stdout.write(
+    `admin: ${String(output.admin)}
+auth_status: ${output.auth_status}
+`
+  );
+};
+var run43 = async (argv, options = {}) => {
+  let json2 = false;
+  let owner;
+  let repo;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (HELP_TOKENS28.has(token)) {
+      process.stdout.write(HELP_TEXT30);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    if (token === "--owner") {
+      owner = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--repo") {
+      repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "setup-ci check-admin"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (owner === void 0 || repo === void 0) {
+    structuredError({
+      code: "missing_required_arg",
+      message: "check-admin requires --owner <o> --repo <r>",
+      subcommand: "setup-ci check-admin"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const authResult = await runGh2({
+    args: ["auth", "status"],
+    cwd: options.cwd ?? process.cwd()
+  });
+  if (!authResult.ok) {
+    const output2 = {
+      admin: false,
+      auth_status: "unauthenticated"
+    };
+    if (json2) {
+      process.stdout.write(`${JSON.stringify(output2)}
+`);
+    } else {
+      printHuman3(output2);
+    }
+    return EXIT_CODES.OK;
+  }
+  const apiResult = await runGh2({
+    args: ["api", `repos/${owner}/${repo}`, "--jq", ".permissions.admin"],
+    cwd: options.cwd ?? process.cwd()
+  });
+  if (!apiResult.ok) {
+    const output2 = {
+      admin: false,
+      auth_status: "api_error",
+      error: apiResult.stderr.trim()
+    };
+    if (json2) {
+      process.stdout.write(`${JSON.stringify(output2)}
+`);
+    } else {
+      printHuman3(output2);
+    }
+    return EXIT_CODES.OK;
+  }
+  const trimmed = apiResult.stdout.trim();
+  const admin = trimmed === "true";
+  const output = { admin, auth_status: "ok" };
+  if (json2) {
+    process.stdout.write(`${JSON.stringify(output)}
+`);
+  } else {
+    printHuman3(output);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/detect-remote.ts
+import { execFileSync as execFileSync6 } from "node:child_process";
+
+// src/setup-ci/util/parse-remote-url.ts
+var stripGitSuffix = (value) => value.endsWith(".git") ? value.slice(0, -4) : value;
+var isValidSegment = (value) => value.length > 0 && !value.includes("/");
+var SCP_SSH_RE = /^([^@]+)@([^:]+):(.+)$/u;
+var HTTPS_RE = /^https?:\/\/([^/]+)\/(.+)$/u;
+var SSH_PROTO_RE = /^ssh:\/\/[^/]+\/(.+)$/u;
+var SSH_PROTO_HOST_RE = /^ssh:\/\/(?:[^@/]+@)?([^/]+)\//u;
+var parseTwoSegments = (url2, host, rest) => {
+  const trimmedRest = stripGitSuffix(rest).replace(/\/+$/u, "");
+  const segments = trimmedRest.split("/");
+  if (segments.length !== 2) return null;
+  const [owner, repo] = segments;
+  if (owner === void 0 || repo === void 0 || !isValidSegment(owner) || !isValidSegment(repo)) {
+    return null;
+  }
+  return { host, owner, repo, url: url2 };
+};
+var parseRemoteUrl = (url2) => {
+  if (typeof url2 !== "string" || url2.trim() === "") return null;
+  const trimmed = url2.trim();
+  if (trimmed.startsWith("ssh://")) {
+    const hostMatch = SSH_PROTO_HOST_RE.exec(trimmed);
+    const restMatch = SSH_PROTO_RE.exec(trimmed);
+    if (hostMatch === null || restMatch === null) return null;
+    return parseTwoSegments(trimmed, hostMatch[1], restMatch[1]);
+  }
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    const match = HTTPS_RE.exec(trimmed);
+    if (match === null) return null;
+    return parseTwoSegments(trimmed, match[1], match[2]);
+  }
+  const scpMatch = SCP_SSH_RE.exec(trimmed);
+  if (scpMatch !== null) {
+    const host = scpMatch[2];
+    const rest = scpMatch[3];
+    return parseTwoSegments(trimmed, host, rest);
+  }
+  return null;
+};
+
+// src/setup-ci/detect-remote.ts
+var HELP_TEXT31 = `Usage: gaia setup-ci detect-remote [--json]
+
+  Read \`git remote get-url origin\` and parse it. Returns parsed
+  owner/repo/host on success; \`found: false\` on missing remote.
+`;
+var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var tryGitRemoteUrl = (cwd) => {
+  try {
+    const result = execFileSync6("git", ["remote", "get-url", "origin"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    return result.toString().trim();
+  } catch {
+    return null;
+  }
+};
+var printHuman4 = (output) => {
+  if (!output.found) {
+    process.stdout.write("No origin remote configured.\n");
+    return;
+  }
+  process.stdout.write(
+    `url: ${String(output.url)}
+host: ${String(output.host)}
+owner: ${String(output.owner)}
+repo: ${String(output.repo)}
+`
+  );
+};
+var run44 = (argv, options = {}) => {
+  let json2 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS29.has(token)) {
+      process.stdout.write(HELP_TEXT31);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "setup-ci detect-remote"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci detect-remote must run inside a git repository",
+      subcommand: "setup-ci detect-remote"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const url2 = tryGitRemoteUrl(repoRoot2);
+  if (url2 === null) {
+    const output2 = {
+      found: false,
+      host: null,
+      owner: null,
+      repo: null,
+      url: null
+    };
+    if (json2) {
+      process.stdout.write(`${JSON.stringify(output2)}
+`);
+    } else {
+      printHuman4(output2);
+    }
+    return EXIT_CODES.OK;
+  }
+  const parsed = parseRemoteUrl(url2);
+  const output = parsed === null ? { found: false, host: null, owner: null, repo: null, url: url2 } : {
+    found: true,
+    host: parsed.host,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    url: parsed.url
+  };
+  if (json2) {
+    process.stdout.write(`${JSON.stringify(output)}
+`);
+  } else {
+    printHuman4(output);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/schemas/local-automation.ts
+import { existsSync as existsSync27, readFileSync as readFileSync23 } from "node:fs";
+var LocalAutomationSchema = external_exports.object({
+  version: external_exports.literal(1),
+  nudge_dismissed: external_exports.boolean()
+});
+var summarizeZodError4 = (filePath, error51) => {
+  const lines = error51.issues.map((issue2) => {
+    const pathStr = issue2.path.length === 0 ? "<root>" : issue2.path.join(".");
+    return `${pathStr}: ${issue2.message}`;
+  });
+  return `${filePath}: ${lines.join("; ")}`;
+};
+var readLocalAutomation = (repoRoot2) => {
+  const filePath = localAutomationPath(repoRoot2);
+  if (!existsSync27(filePath)) return { status: "missing" };
+  let raw;
+  try {
+    raw = readFileSync23(filePath, "utf8");
+  } catch (error51) {
+    return {
+      error: `${filePath}: ${error51 instanceof Error ? error51.message : String(error51)}`,
+      status: "malformed"
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error51) {
+    return {
+      error: `${filePath}: invalid JSON \u2014 ${error51 instanceof Error ? error51.message : String(error51)}`,
+      status: "malformed"
+    };
+  }
+  const result = LocalAutomationSchema.safeParse(parsed);
+  if (!result.success) {
+    return { error: summarizeZodError4(filePath, result.error), status: "malformed" };
+  }
+  return { local: result.data, status: "ok" };
+};
+
+// src/setup-ci/util/local-automation-write.ts
+import { mkdirSync as mkdirSync15, renameSync as renameSync9, writeFileSync as writeFileSync19 } from "node:fs";
+import path28 from "node:path";
+var writeLocalAutomation = (repoRoot2, payload) => {
+  LocalAutomationSchema.parse(payload);
+  const target = localAutomationPath(repoRoot2);
+  mkdirSync15(path28.dirname(target), { recursive: true });
+  const serialized = `${JSON.stringify(payload, null, 2)}
+`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync19(tmpPath, serialized, "utf8");
+  renameSync9(tmpPath, target);
+};
+
+// src/setup-ci/dismiss-personal.ts
+var HELP_TEXT32 = `Usage: gaia setup-ci dismiss-personal
+
+  Write nudge_dismissed=true to .gaia/local/automation.json (gitignored).
+`;
+var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run45 = (argv, options = {}) => {
+  for (const token of argv) {
+    if (HELP_TOKENS30.has(token)) {
+      process.stdout.write(HELP_TEXT32);
+      return EXIT_CODES.OK;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${token}`,
+      subcommand: "setup-ci dismiss-personal"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci dismiss-personal must run inside a git repository",
+      subcommand: "setup-ci dismiss-personal"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const existing = readLocalAutomation(repoRoot2);
+  if (existing.status === "malformed") {
+    structuredError({
+      code: "local_malformed",
+      message: existing.error,
+      subcommand: "setup-ci dismiss-personal"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  const merged = existing.status === "ok" ? { ...existing.local, nudge_dismissed: true } : { nudge_dismissed: true, version: 1 };
+  writeLocalAutomation(repoRoot2, merged);
+  process.stdout.write(`${JSON.stringify({ dismissed: true })}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/enable-delete-branch.ts
+var HELP_TEXT33 = `Usage: gaia setup-ci enable-delete-branch --owner <o> --repo <r>
+
+  PATCH repos/<owner>/<repo> -f delete_branch_on_merge=true via gh.
+`;
+var HELP_TOKENS31 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run46 = async (argv, options = {}) => {
+  let owner;
+  let repo;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (HELP_TOKENS31.has(token)) {
+      process.stdout.write(HELP_TEXT33);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--owner") {
+      owner = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--repo") {
+      repo = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "setup-ci enable-delete-branch"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (owner === void 0 || repo === void 0) {
+    structuredError({
+      code: "missing_required_arg",
+      message: "enable-delete-branch requires --owner <o> --repo <r>",
+      subcommand: "setup-ci enable-delete-branch"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const result = await runGh2({
+    args: [
+      "api",
+      "-X",
+      "PATCH",
+      `repos/${owner}/${repo}`,
+      "-f",
+      "delete_branch_on_merge=true"
+    ],
+    cwd: options.cwd ?? process.cwd()
+  });
+  if (!result.ok) {
+    process.stdout.write(
+      `${JSON.stringify({ applied: false, error: result.stderr.trim() })}
+`
+    );
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  process.stdout.write(`${JSON.stringify({ applied: true })}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/util/automation-write.ts
+import { mkdirSync as mkdirSync16, renameSync as renameSync10, writeFileSync as writeFileSync20 } from "node:fs";
+import path29 from "node:path";
+var writeAutomationConfig = (repoRoot2, payload) => {
+  AutomationConfigSchema.parse(payload);
+  const target = automationConfigPath(repoRoot2);
+  mkdirSync16(path29.dirname(target), { recursive: true });
+  const serialized = `${JSON.stringify(payload, null, 2)}
+`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync20(tmpPath, serialized, "utf8");
+  renameSync10(tmpPath, target);
+};
+
+// src/setup-ci/finalize.ts
+var HELP_TEXT34 = `Usage: gaia setup-ci finalize
+
+  Flip setup_complete=true in .gaia/automation.json. Idempotent.
+`;
+var HELP_TOKENS32 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run47 = (argv, options = {}) => {
+  for (const token of argv) {
+    if (HELP_TOKENS32.has(token)) {
+      process.stdout.write(HELP_TEXT34);
+      return EXIT_CODES.OK;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${token}`,
+      subcommand: "setup-ci finalize"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci finalize must run inside a git repository",
+      subcommand: "setup-ci finalize"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const result = readAutomationConfig(repoRoot2);
+  if (result.status === "missing") {
+    structuredError({
+      code: "config_missing",
+      message: ".gaia/automation.json does not exist",
+      subcommand: "setup-ci finalize"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  if (result.status === "malformed") {
+    structuredError({
+      code: "config_malformed",
+      message: result.error,
+      subcommand: "setup-ci finalize"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  const alreadyFinalized = result.config.setup_complete;
+  writeAutomationConfig(repoRoot2, {
+    ...result.config,
+    setup_complete: true
+  });
+  process.stdout.write(
+    `${JSON.stringify({ already_finalized: alreadyFinalized, finalized: true })}
+`
+  );
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/opt-out-team.ts
+var HELP_TEXT35 = `Usage: gaia setup-ci opt-out-team
+
+  Write setup_opted_out=true to .gaia/automation.json (committed).
+  Refuses if the config is missing or malformed.
+`;
+var HELP_TOKENS33 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run48 = (argv, options = {}) => {
+  for (const token of argv) {
+    if (HELP_TOKENS33.has(token)) {
+      process.stdout.write(HELP_TEXT35);
+      return EXIT_CODES.OK;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${token}`,
+      subcommand: "setup-ci opt-out-team"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci opt-out-team must run inside a git repository",
+      subcommand: "setup-ci opt-out-team"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const result = readAutomationConfig(repoRoot2);
+  if (result.status === "missing") {
+    structuredError({
+      code: "config_missing",
+      message: ".gaia/automation.json does not exist",
+      subcommand: "setup-ci opt-out-team"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  if (result.status === "malformed") {
+    structuredError({
+      code: "config_malformed",
+      message: result.error,
+      subcommand: "setup-ci opt-out-team"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  writeAutomationConfig(repoRoot2, {
+    ...result.config,
+    setup_opted_out: true
+  });
+  process.stdout.write(`${JSON.stringify({ opted_out: true })}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/set-secret.ts
+var HELP_TEXT36 = `Usage: gaia setup-ci set-secret <name>
+
+  Read a secret value from stdin and pipe it into \`gh secret set <name>\`.
+  The token is never echoed, logged, or passed on the command line.
+
+  <name> must be one of: CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY.
+`;
+var HELP_TOKENS34 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUPPORTED_SECRET_NAMES = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY"
+];
+var readStdinToBuffer = (stream) => {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (chunk) => {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk);
+    });
+    stream.on("end", () => {
+      resolve(Buffer.concat(chunks));
+    });
+    stream.on("error", (error51) => {
+      reject(error51);
+    });
+  });
+};
+var trimTrailingWhitespace = (buf) => {
+  let end = buf.length;
+  while (end > 0) {
+    const byte = buf[end - 1];
+    if (byte === 10 || byte === 13) {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return buf.subarray(0, end);
+};
+var run49 = async (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS34.has(argv[0])) {
+    process.stdout.write(HELP_TEXT36);
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+  const name = argv[0];
+  const rest = argv.slice(1);
+  if (rest.length > 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${rest[0]}`,
+      subcommand: "setup-ci set-secret"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (!SUPPORTED_SECRET_NAMES.includes(name)) {
+    structuredError({
+      code: "unknown_secret_name",
+      message: `unsupported secret name: ${name}. Supported: ${SUPPORTED_SECRET_NAMES.join(", ")}`,
+      subcommand: "setup-ci set-secret"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const validatedName = name;
+  const stream = options.stdin ?? process.stdin;
+  let stdinBuffer;
+  try {
+    stdinBuffer = await readStdinToBuffer(stream);
+  } catch {
+    structuredError({
+      code: "stdin_read_error",
+      message: "failed to read secret from stdin",
+      subcommand: "setup-ci set-secret"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const trimmed = trimTrailingWhitespace(stdinBuffer);
+  if (trimmed.length === 0) {
+    structuredError({
+      code: "empty_secret",
+      message: "no secret value provided on stdin",
+      subcommand: "setup-ci set-secret"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const result = await runGh2({
+    args: ["secret", "set", validatedName],
+    cwd: options.cwd ?? process.cwd(),
+    stdin: trimmed
+  });
+  if (!result.ok) {
+    process.stdout.write(
+      `${JSON.stringify({ error: "gh_failure", name: validatedName, set: false })}
+`
+    );
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  process.stdout.write(
+    `${JSON.stringify({ name: validatedName, set: true })}
+`
+  );
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/status.ts
+var HELP_TEXT37 = `Usage: gaia setup-ci status [--json]
+
+  Print whether Phase B (GAIA CI remote integration) is configured.
+  Exits 0 in every state \u2014 branch on the JSON output.
+`;
+var HELP_TOKENS35 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var enabledTools = (config2) => {
+  const result = [];
+  for (const tool of TOOL_IDS) {
+    const key = TOOL_ID_TO_CONFIG_KEY[tool];
+    const slot = config2[key];
+    if (slot !== void 0 && slot.mode === "ci") {
+      result.push(tool);
+    }
+  }
+  return result;
+};
+var printHuman5 = (output) => {
+  if (!output.configured) {
+    process.stdout.write(
+      "GAIA CI is not configured for this repo. .gaia/automation.json is missing.\n"
+    );
+    return;
+  }
+  process.stdout.write(
+    `configured: true
+setup_complete: ${String(output.setup_complete)}
+setup_opted_out: ${String(output.setup_opted_out)}
+nudge_dismissed: ${String(output.nudge_dismissed)}
+tools_enabled: ${output.tools_enabled.join(", ") || "(none)"}
+`
+  );
+};
+var run50 = (argv, options = {}) => {
+  let json2 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS35.has(token)) {
+      process.stdout.write(HELP_TEXT37);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "setup-ci status"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci status must run inside a git repository",
+      subcommand: "setup-ci status"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const configRead = readAutomationConfig(repoRoot2);
+  if (configRead.status === "malformed") {
+    structuredError({
+      code: "config_malformed",
+      message: configRead.error,
+      subcommand: "setup-ci status"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  const localRead = readLocalAutomation(repoRoot2);
+  if (localRead.status === "malformed") {
+    structuredError({
+      code: "local_malformed",
+      message: localRead.error,
+      subcommand: "setup-ci status"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  const output = configRead.status === "ok" ? {
+    configured: true,
+    nudge_dismissed: localRead.status === "ok" ? localRead.local.nudge_dismissed : false,
+    setup_complete: configRead.config.setup_complete,
+    setup_opted_out: configRead.config.setup_opted_out,
+    tools_enabled: enabledTools(configRead.config)
+  } : {
+    configured: false,
+    nudge_dismissed: localRead.status === "ok" ? localRead.local.nudge_dismissed : false,
+    setup_complete: false,
+    setup_opted_out: false,
+    tools_enabled: []
+  };
+  if (json2) {
+    process.stdout.write(`${JSON.stringify(output)}
+`);
+  } else {
+    printHuman5(output);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/verify-run.ts
+var HELP_TEXT38 = `Usage: gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]
+
+  Trigger a workflow_dispatch run and watch the run to completion.
+  Default timeout: 600s. Default poll interval: 10s (override with
+  --poll-interval-ms <ms>; intended for tests).
+`;
+var HELP_TOKENS36 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var DEFAULT_TIMEOUT_SECONDS = 600;
+var DEFAULT_POLL_INTERVAL_MS = 1e4;
+var sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+var printHuman6 = (output) => {
+  process.stdout.write(
+    `verified: ${String(output.verified)}
+run_id: ${output.run_id ?? "(none)"}
+conclusion: ${output.conclusion ?? "(none)"}
+url: ${output.url ?? "(none)"}
+`
+  );
+};
+var run51 = async (argv, options = {}) => {
+  let json2 = false;
+  let workflowFile;
+  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (HELP_TOKENS36.has(token)) {
+      process.stdout.write(HELP_TEXT38);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    if (token === "--timeout-seconds") {
+      const value = argv[index + 1];
+      if (value === void 0) {
+        structuredError({
+          code: "invalid_arguments",
+          message: "--timeout-seconds requires a value",
+          subcommand: "setup-ci verify-run"
+        });
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      timeoutSeconds = Number.parseInt(value, 10);
+      index += 1;
+      continue;
+    }
+    if (token === "--poll-interval-ms") {
+      const value = argv[index + 1];
+      if (value === void 0) {
+        structuredError({
+          code: "invalid_arguments",
+          message: "--poll-interval-ms requires a value",
+          subcommand: "setup-ci verify-run"
+        });
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      pollIntervalMs = Number.parseInt(value, 10);
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      structuredError({
+        code: "invalid_arguments",
+        message: `unknown flag: ${token}`,
+        subcommand: "setup-ci verify-run"
+      });
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+    if (workflowFile === void 0) {
+      workflowFile = token;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${token}`,
+      subcommand: "setup-ci verify-run"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (workflowFile === void 0) {
+    structuredError({
+      code: "missing_required_arg",
+      message: "verify-run requires <workflow-file>",
+      subcommand: "setup-ci verify-run"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (Number.isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: "--timeout-seconds must be a positive integer",
+      subcommand: "setup-ci verify-run"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (Number.isNaN(pollIntervalMs) || pollIntervalMs <= 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: "--poll-interval-ms must be a positive integer",
+      subcommand: "setup-ci verify-run"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const triggerResult = await runGh2({
+    args: ["workflow", "run", workflowFile, "--ref", "main"],
+    cwd
+  });
+  if (!triggerResult.ok) {
+    structuredError({
+      code: "workflow_run_failed",
+      message: triggerResult.stderr.trim(),
+      subcommand: "setup-ci verify-run",
+      workflow: workflowFile
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const listResult = await runGh2({
+    args: [
+      "run",
+      "list",
+      `--workflow=${workflowFile}`,
+      "--limit",
+      "1",
+      "--json",
+      "databaseId,createdAt"
+    ],
+    cwd
+  });
+  if (!listResult.ok) {
+    structuredError({
+      code: "run_list_failed",
+      message: listResult.stderr.trim(),
+      subcommand: "setup-ci verify-run",
+      workflow: workflowFile
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let runId;
+  try {
+    const parsed = JSON.parse(listResult.stdout);
+    const first = parsed[0];
+    if (first === void 0) {
+      structuredError({
+        code: "run_list_empty",
+        message: `gh run list returned no runs for ${workflowFile}`,
+        subcommand: "setup-ci verify-run",
+        workflow: workflowFile
+      });
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+    runId = String(first.databaseId);
+  } catch (error51) {
+    structuredError({
+      code: "run_list_malformed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "setup-ci verify-run"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const deadline = Date.now() + timeoutSeconds * 1e3;
+  let conclusion = null;
+  let url2 = null;
+  let timedOut = false;
+  while (true) {
+    const view = await runGh2({
+      args: [
+        "run",
+        "view",
+        runId,
+        "--json",
+        "status,conclusion,url"
+      ],
+      cwd
+    });
+    if (!view.ok) {
+      structuredError({
+        code: "run_view_failed",
+        message: view.stderr.trim(),
+        run_id: runId,
+        subcommand: "setup-ci verify-run"
+      });
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+    let payload;
+    try {
+      payload = JSON.parse(view.stdout);
+    } catch (error51) {
+      structuredError({
+        code: "run_view_malformed",
+        message: error51 instanceof Error ? error51.message : String(error51),
+        run_id: runId,
+        subcommand: "setup-ci verify-run"
+      });
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+    url2 = payload.url ?? url2;
+    if (payload.status === "completed") {
+      conclusion = payload.conclusion ?? null;
+      break;
+    }
+    if (Date.now() >= deadline) {
+      timedOut = true;
+      break;
+    }
+    await sleep(pollIntervalMs);
+  }
+  const output = {
+    conclusion: timedOut ? "polling_timeout" : conclusion,
+    run_id: runId,
+    url: url2,
+    verified: !timedOut && conclusion === "success"
+  };
+  if (json2) {
+    process.stdout.write(`${JSON.stringify(output)}
+`);
+  } else {
+    printHuman6(output);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/warn-existing-tools.ts
+import { existsSync as existsSync28 } from "node:fs";
+import path30 from "node:path";
+var HELP_TEXT39 = `Usage: gaia setup-ci warn-existing-tools [--json]
+
+  Detect Dependabot or Renovate config files in the repo. Read-only.
+`;
+var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var DEPENDABOT_PATHS = [
+  [".github", "dependabot.yml"],
+  [".github", "dependabot.yaml"]
+];
+var RENOVATE_PATHS = [
+  ["renovate.json"],
+  [".renovaterc.json"],
+  [".github", "renovate.json"]
+];
+var printHuman7 = (found) => {
+  if (found.length === 0) {
+    process.stdout.write("No competing dependency-bot configs detected.\n");
+    return;
+  }
+  process.stdout.write(`detected: ${found.join(", ")}
+`);
+};
+var run52 = (argv, options = {}) => {
+  let json2 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS37.has(token)) {
+      process.stdout.write(HELP_TEXT39);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "setup-ci warn-existing-tools"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci warn-existing-tools must run inside a git repository",
+      subcommand: "setup-ci warn-existing-tools"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const found = [];
+  const hasDependabot = DEPENDABOT_PATHS.some(
+    (segments) => existsSync28(path30.join(repoRoot2, ...segments))
+  );
+  if (hasDependabot) found.push("dependabot");
+  const hasRenovate = RENOVATE_PATHS.some(
+    (segments) => existsSync28(path30.join(repoRoot2, ...segments))
+  );
+  if (hasRenovate) found.push("renovate");
+  if (json2) {
+    process.stdout.write(`${JSON.stringify({ found })}
+`);
+  } else {
+    printHuman7(found);
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/write-tool-mode.ts
+var HELP_TEXT40 = `Usage: gaia setup-ci write-tool-mode <tool> <mode>
+
+  Set a tool's mode in .gaia/automation.json.
+  <tool> must be one of: ${TOOL_IDS.join(", ")}.
+  <mode> must be one of: ci, local, off.
+`;
+var HELP_TOKENS38 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run53 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS38.has(argv[0])) {
+    process.stdout.write(HELP_TEXT40);
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+  const toolToken = argv[0];
+  const modeToken = argv[1];
+  const rest = argv.slice(2);
+  if (rest.length > 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unexpected argument: ${rest[0]}`,
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (!TOOL_IDS.includes(toolToken)) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown tool: ${toolToken}. Supported: ${TOOL_IDS.join(", ")}`,
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (modeToken === void 0) {
+    structuredError({
+      code: "missing_required_arg",
+      message: "write-tool-mode requires <mode>",
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const modeResult = ToolModeSchema.safeParse(modeToken);
+  if (!modeResult.success) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `invalid mode: ${modeToken}. Supported: ci, local, off`,
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const tool = toolToken;
+  const mode = modeResult.data;
+  let repoRoot2;
+  try {
+    repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia setup-ci write-tool-mode must run inside a git repository",
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const result = readAutomationConfig(repoRoot2);
+  if (result.status === "missing") {
+    structuredError({
+      code: "config_missing",
+      message: ".gaia/automation.json does not exist",
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  if (result.status === "malformed") {
+    structuredError({
+      code: "config_malformed",
+      message: result.error,
+      subcommand: "setup-ci write-tool-mode"
+    });
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+  const key = TOOL_ID_TO_CONFIG_KEY[tool];
+  const existing = result.config[key];
+  const nextSlot = existing.schedule === void 0 ? { mode } : { mode, schedule: existing.schedule };
+  writeAutomationConfig(repoRoot2, {
+    ...result.config,
+    [key]: nextSlot
+  });
+  process.stdout.write(`${JSON.stringify({ mode, tool })}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/setup-ci/index.ts
+var HELP_TEXT41 = `Usage: gaia setup-ci <subcommand> [args]
+
+  status [--json]                          Print Phase B configuration status.
+  detect-remote [--json]                   Read git remote get-url origin.
+  warn-existing-tools [--json]             Detect Dependabot / Renovate configs.
+  check-admin --owner <o> --repo <r> [--json]
+                                           Probe repo admin permission via gh.
+  dismiss-personal                         Write nudge_dismissed=true (per-machine).
+  opt-out-team                             Write setup_opted_out=true (committed).
+  enable-delete-branch --owner <o> --repo <r>
+                                           PATCH delete_branch_on_merge=true.
+  set-secret <name>                        Pipe stdin into gh secret set <name>.
+  verify-run <workflow-file> [--timeout-seconds N] [--json]
+                                           Trigger workflow_dispatch and watch run.
+  finalize                                 Flip setup_complete=true.
+  write-tool-mode <tool> <mode>            Set a tool's mode in .gaia/automation.json.
+`;
+var HELP_TOKENS39 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS4 = {
+  "check-admin": run43,
+  "detect-remote": run44,
+  "dismiss-personal": run45,
+  "enable-delete-branch": run46,
+  finalize: run47,
+  "opt-out-team": run48,
+  "set-secret": run49,
+  status: run50,
+  "verify-run": run51,
+  "warn-existing-tools": run52,
+  "write-tool-mode": run53
+};
+var run54 = async (argv) => {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
+  if (subcommand === void 0 || HELP_TOKENS39.has(subcommand)) {
+    process.stdout.write(HELP_TEXT41);
+    return EXIT_CODES.OK;
+  }
+  const handler = SUBCOMMAND_HANDLERS4[subcommand];
+  if (handler !== void 0) {
+    const result = await handler(rest);
+    return typeof result === "number" ? result : EXIT_CODES.OK;
+  }
+  structuredError({
+    code: "unknown_subcommand",
+    message: `unknown setup-ci subcommand: ${subcommand}`,
+    subcommand: `setup-ci ${subcommand}`
+  });
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
 // src/analytics/audit-attest.ts
 var EVENT_DATA_KEYS = /* @__PURE__ */ new Set([
   "_local",
@@ -21246,8 +22472,8 @@ var computeAuditBlock = (report) => {
 };
 
 // src/analytics/generator.ts
-import { existsSync as existsSync27, readdirSync as readdirSync4, readFileSync as readFileSync23 } from "node:fs";
-import path28 from "node:path";
+import { existsSync as existsSync29, readdirSync as readdirSync4, readFileSync as readFileSync24 } from "node:fs";
+import path31 from "node:path";
 var REPORT_WINDOW_DAYS = 30;
 var MS_PER_DAY = 864e5;
 var MS_PER_WEEK = MS_PER_DAY * 7;
@@ -21259,13 +22485,13 @@ var isoDateUtc = (date5) => {
   return `${year}-${month}-${day}`;
 };
 var readGaiaVersion = (roots) => {
-  const repoRoot2 = path28.dirname(
-    path28.dirname(path28.dirname(roots.projectIdPath))
+  const repoRoot2 = path31.dirname(
+    path31.dirname(path31.dirname(roots.projectIdPath))
   );
-  const packagePath = path28.join(repoRoot2, "package.json");
-  if (!existsSync27(packagePath)) return "unknown";
+  const packagePath = path31.join(repoRoot2, "package.json");
+  if (!existsSync29(packagePath)) return "unknown";
   try {
-    const raw = readFileSync23(packagePath, "utf8");
+    const raw = readFileSync24(packagePath, "utf8");
     const parsed = JSON.parse(raw);
     return typeof parsed.version === "string" ? parsed.version : "unknown";
   } catch {
@@ -21325,7 +22551,7 @@ var accumulateEvent = (line, bounds, counts) => {
 var consumeFile = (filePath, bounds, counts) => {
   let raw;
   try {
-    raw = readFileSync23(filePath, "utf8");
+    raw = readFileSync24(filePath, "utf8");
   } catch {
     return;
   }
@@ -21335,7 +22561,7 @@ var consumeFile = (filePath, bounds, counts) => {
 };
 var readMentorshipEngagement = (roots, bounds) => {
   const counts = newEngagementCounts();
-  if (!existsSync27(roots.mentorshipDir)) return counts;
+  if (!existsSync29(roots.mentorshipDir)) return counts;
   let entries;
   try {
     entries = readdirSync4(roots.mentorshipDir);
@@ -21347,7 +22573,7 @@ var readMentorshipEngagement = (roots, bounds) => {
     const match = MENTORSHIP_FILENAME_REGEX.exec(entry);
     const fileDate = match?.[1];
     if (fileDate !== void 0 && fileDate >= startDate) {
-      consumeFile(path28.join(roots.mentorshipDir, entry), bounds, counts);
+      consumeFile(path31.join(roots.mentorshipDir, entry), bounds, counts);
     }
   }
   return counts;
@@ -21394,17 +22620,17 @@ var generateAnalyticsReport = async (args) => {
 };
 
 // src/analytics/writer.ts
-import { existsSync as existsSync28, mkdirSync as mkdirSync15, renameSync as renameSync9, writeFileSync as writeFileSync19 } from "node:fs";
-import path29 from "node:path";
+import { existsSync as existsSync30, mkdirSync as mkdirSync17, renameSync as renameSync11, writeFileSync as writeFileSync21 } from "node:fs";
+import path32 from "node:path";
 var ANALYTICS_DIR_MODE = 493;
 var REPORT_FILE_MODE = 420;
 var writeAnalyticsReport = async (args) => {
   const { report, roots } = args;
   const generatedAt = args.generatedAt ?? /* @__PURE__ */ new Date();
   const dateSegment = isoDateUtc(generatedAt);
-  const filePath = path29.join(roots.analyticsDir, `report-${dateSegment}.json`);
-  if (!existsSync28(roots.analyticsDir)) {
-    mkdirSync15(roots.analyticsDir, {
+  const filePath = path32.join(roots.analyticsDir, `report-${dateSegment}.json`);
+  if (!existsSync30(roots.analyticsDir)) {
+    mkdirSync17(roots.analyticsDir, {
       mode: ANALYTICS_DIR_MODE,
       recursive: true
     });
@@ -21412,8 +22638,8 @@ var writeAnalyticsReport = async (args) => {
   const contents = `${JSON.stringify(report, null, 2)}
 `;
   const temporaryPath = `${filePath}.tmp-${process.pid}-${process.hrtime.bigint().toString()}`;
-  writeFileSync19(temporaryPath, contents, { mode: REPORT_FILE_MODE });
-  renameSync9(temporaryPath, filePath);
+  writeFileSync21(temporaryPath, contents, { mode: REPORT_FILE_MODE });
+  renameSync11(temporaryPath, filePath);
   return { filePath };
 };
 
@@ -21669,7 +22895,7 @@ var runAllPatternDetectors = (args) => {
 
 // src/profile/reader.ts
 import { readFile } from "node:fs/promises";
-import path30 from "node:path";
+import path33 from "node:path";
 
 // src/schemas/mentorship-payloads.ts
 var SPEC_ID_REGEX = /^SPEC-\d{3,}$/;
@@ -21853,7 +23079,7 @@ var readMentorshipEvents = async (args) => {
   const dates = enumerateWindowDates(now, windowDays);
   const events = [];
   for (const date5 of dates) {
-    const filePath = path30.join(roots.mentorshipDir, `events-${date5}.jsonl`);
+    const filePath = path33.join(roots.mentorshipDir, `events-${date5}.jsonl`);
     const raw = await readFileIfExists(filePath);
     if (raw !== null) events.push(...parseFileLines(raw, filePath));
   }
@@ -22156,7 +23382,7 @@ var computeProfile = async (options = {}) => {
 
 // src/telemetry/emit.ts
 import { createHash as createHash3 } from "node:crypto";
-import path31 from "node:path";
+import path34 from "node:path";
 
 // src/telemetry/envelope.ts
 import { createHash as createHash2 } from "node:crypto";
@@ -22234,13 +23460,13 @@ var buildEnvelope = (args) => {
 };
 
 // src/telemetry/ndjson-writer.ts
-import { existsSync as existsSync29, readFileSync as readFileSync24 } from "node:fs";
+import { existsSync as existsSync31, readFileSync as readFileSync25 } from "node:fs";
 import { appendFile, chmod as chmod2, stat as stat2 } from "node:fs/promises";
 var appendIdempotent = async (args) => {
   const { eventId, fileMode, filePath, line } = args;
   const dedupNeedle = `"event_id":"${eventId}"`;
-  if (existsSync29(filePath)) {
-    const existing = readFileSync24(filePath, "utf8");
+  if (existsSync31(filePath)) {
+    const existing = readFileSync25(filePath, "utf8");
     if (existing.includes(dedupNeedle)) {
       return { written: false };
     }
@@ -22339,12 +23565,6 @@ var FORBIDDEN_CLOUD_KEYS = [
   "git_author_email",
   "_local"
 ];
-
-// src/schemas/local-automation.ts
-var LocalAutomationSchema = external_exports.object({
-  version: external_exports.literal(1),
-  nudge_dismissed: external_exports.boolean()
-});
 
 // src/schemas/local-namespace.ts
 var LocalNamespaceSchema = external_exports.looseObject({
@@ -22645,7 +23865,7 @@ var writeCloud = async (envelope, roots, now) => {
       ok: false
     };
   }
-  const cloudPath = path31.join(
+  const cloudPath = path34.join(
     roots.cloudDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -22659,7 +23879,7 @@ var writeCloud = async (envelope, roots, now) => {
 };
 var writeMentorship = async (envelope, roots, now) => {
   const mentorshipLine = JSON.stringify(envelope);
-  const mentorshipPath = path31.join(
+  const mentorshipPath = path34.join(
     roots.mentorshipDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -23081,19 +24301,19 @@ var handleParseStdin = async () => {
 };
 
 // src/telemetry/index.ts
-var HELP_TEXT30 = `Usage: gaia telemetry <subcommand> [args]
+var HELP_TEXT42 = `Usage: gaia telemetry <subcommand> [args]
 
   emit <event_type> [--field value ...]   Emit one telemetry event.
   compute-profile                          Regenerate profile.md from events.
   parse-stdin                              Read PostToolUse hook JSON on stdin,
                                            dispatch emits from trailer YAML.
 `;
-var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run43 = async (argv) => {
+var HELP_TOKENS40 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run55 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS28.has(subcommand)) {
-    process.stdout.write(HELP_TEXT30);
+  if (subcommand === void 0 || HELP_TOKENS40.has(subcommand)) {
+    process.stdout.write(HELP_TEXT42);
     return EXIT_CODES.OK;
   }
   if (subcommand === "emit") {
@@ -23114,16 +24334,16 @@ var run43 = async (argv) => {
 
 // src/update/merge.ts
 import {
-  existsSync as existsSync32,
-  mkdirSync as mkdirSync16,
+  existsSync as existsSync34,
+  mkdirSync as mkdirSync18,
   readdirSync as readdirSync5,
   statSync as statSync3,
-  writeFileSync as writeFileSync21
+  writeFileSync as writeFileSync23
 } from "node:fs";
-import path33 from "node:path";
+import path36 from "node:path";
 
 // src/update/util/manifest.ts
-import { existsSync as existsSync30, readFileSync as readFileSync25 } from "node:fs";
+import { existsSync as existsSync32, readFileSync as readFileSync26 } from "node:fs";
 var VALID_RAW_CLASSES = /* @__PURE__ */ new Set(["owned", "shared", "wiki-owned"]);
 var normalizeClass = (rawClass) => {
   if (rawClass === "owned") return "owned";
@@ -23131,7 +24351,7 @@ var normalizeClass = (rawClass) => {
 };
 var isObject2 = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
 var loadManifest = (manifestPath) => {
-  if (!existsSync30(manifestPath)) {
+  if (!existsSync32(manifestPath)) {
     return {
       ok: false,
       message: `manifest not found: ${manifestPath}`
@@ -23139,7 +24359,7 @@ var loadManifest = (manifestPath) => {
   }
   let raw;
   try {
-    raw = readFileSync25(manifestPath, "utf8");
+    raw = readFileSync26(manifestPath, "utf8");
   } catch (error51) {
     return {
       ok: false,
@@ -23163,21 +24383,21 @@ var loadManifest = (manifestPath) => {
     return { ok: false, message: "manifest.files is missing or not an object" };
   }
   const files = /* @__PURE__ */ new Map();
-  for (const [path41, value] of Object.entries(shape.files)) {
+  for (const [path44, value] of Object.entries(shape.files)) {
     if (typeof value !== "string") {
       return {
         ok: false,
-        message: `manifest.files["${path41}"] is not a string`
+        message: `manifest.files["${path44}"] is not a string`
       };
     }
     if (!VALID_RAW_CLASSES.has(value)) {
       return {
         ok: false,
-        message: `manifest.files["${path41}"] has unknown class: "${value}"`
+        message: `manifest.files["${path44}"] has unknown class: "${value}"`
       };
     }
     const rawClass = value;
-    files.set(path41, {
+    files.set(path44, {
       normalizedClass: normalizeClass(rawClass),
       rawClass
     });
@@ -23192,21 +24412,21 @@ var loadManifest = (manifestPath) => {
 // src/update/util/three-way.ts
 import { spawnSync as spawnSync2 } from "node:child_process";
 import {
-  existsSync as existsSync31,
+  existsSync as existsSync33,
   mkdtempSync,
-  readFileSync as readFileSync26,
+  readFileSync as readFileSync27,
   rmSync as rmSync4,
-  writeFileSync as writeFileSync20
+  writeFileSync as writeFileSync22
 } from "node:fs";
 import { tmpdir } from "node:os";
-import path32 from "node:path";
+import path35 from "node:path";
 var snapshot = (absPath) => {
-  if (!existsSync31(absPath)) {
+  if (!existsSync33(absPath)) {
     return { absPath, bytes: null, exists: false };
   }
   let bytes;
   try {
-    bytes = readFileSync26(absPath);
+    bytes = readFileSync27(absPath);
   } catch {
     return { absPath, bytes: null, exists: false };
   }
@@ -23219,14 +24439,14 @@ var bytesEqual = (a, b) => {
   return a.equals(b);
 };
 var cleanMerge = (current, baseline, latest) => {
-  const dir = mkdtempSync(path32.join(tmpdir(), "gaia-merge-"));
-  const currentPath = path32.join(dir, "current");
-  const baselinePath = path32.join(dir, "baseline");
-  const latestPath = path32.join(dir, "latest");
+  const dir = mkdtempSync(path35.join(tmpdir(), "gaia-merge-"));
+  const currentPath = path35.join(dir, "current");
+  const baselinePath = path35.join(dir, "baseline");
+  const latestPath = path35.join(dir, "latest");
   try {
-    writeFileSync20(currentPath, current);
-    writeFileSync20(baselinePath, baseline);
-    writeFileSync20(latestPath, latest);
+    writeFileSync22(currentPath, current);
+    writeFileSync22(baselinePath, baseline);
+    writeFileSync22(latestPath, latest);
     const result = spawnSync2(
       "git",
       ["merge-file", "--stdout", currentPath, baselinePath, latestPath],
@@ -23409,7 +24629,7 @@ var buildUnifiedDiff = (fromText, toText, options) => {
 };
 
 // src/update/merge.ts
-var HELP_TEXT31 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
+var HELP_TEXT43 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
 
   Three-way file compare across baseline and latest tarball trees,
   classified by .gaia/manifest.json. Replaces the prose Step 7 of the
@@ -23423,7 +24643,7 @@ var HELP_TEXT31 = `Usage: gaia update merge --baseline <dir> --latest <dir> --ma
     1  user-correctable error (missing dir, malformed manifest)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT7 = 2;
 var MERGE_DIR = ".gaia-merge";
 var takeValue7 = (argv, index, flag) => {
@@ -23473,7 +24693,7 @@ var parseFlags11 = (argv) => {
 var walkRelative = (rootDir) => {
   const out = [];
   const visit = (relative) => {
-    const absolute = path33.join(rootDir, relative);
+    const absolute = path36.join(rootDir, relative);
     let names;
     try {
       names = readdirSync5(absolute);
@@ -23481,8 +24701,8 @@ var walkRelative = (rootDir) => {
       return;
     }
     for (const name of names) {
-      const child = relative === "" ? name : path33.join(relative, name);
-      const childAbs = path33.join(rootDir, child);
+      const child = relative === "" ? name : path36.join(relative, name);
+      const childAbs = path36.join(rootDir, child);
       let info;
       try {
         info = statSync3(childAbs);
@@ -23496,29 +24716,29 @@ var walkRelative = (rootDir) => {
       if (info.isFile()) out.push(child);
     }
   };
-  if (!existsSync32(rootDir) || !statSync3(rootDir).isDirectory()) return out;
+  if (!existsSync34(rootDir) || !statSync3(rootDir).isDirectory()) return out;
   visit("");
   return out.sort();
 };
 var ensureDir2 = (absDir) => {
-  mkdirSync16(absDir, { recursive: true });
+  mkdirSync18(absDir, { recursive: true });
 };
 var writePatch = (ctx, relativePath, patch) => {
-  const mergeRoot = path33.join(ctx.cwd, MERGE_DIR);
-  const patchAbs = path33.join(mergeRoot, `${relativePath}.patch`);
-  ensureDir2(path33.dirname(patchAbs));
-  writeFileSync21(patchAbs, patch, "utf8");
-  return path33.relative(ctx.cwd, patchAbs);
+  const mergeRoot = path36.join(ctx.cwd, MERGE_DIR);
+  const patchAbs = path36.join(mergeRoot, `${relativePath}.patch`);
+  ensureDir2(path36.dirname(patchAbs));
+  writeFileSync23(patchAbs, patch, "utf8");
+  return path36.relative(ctx.cwd, patchAbs);
 };
 var writeWorkingTree = (ctx, relativePath, bytes) => {
-  const target = path33.join(ctx.cwd, relativePath);
-  ensureDir2(path33.dirname(target));
-  writeFileSync21(target, bytes);
+  const target = path36.join(ctx.cwd, relativePath);
+  ensureDir2(path36.dirname(target));
+  writeFileSync23(target, bytes);
 };
 var handleManifestPath = (ctx, relativePath, klass) => {
-  const baselineSnap = snapshot(path33.join(ctx.baselineDir, relativePath));
-  const latestSnap = snapshot(path33.join(ctx.latestDir, relativePath));
-  const currentSnap = snapshot(path33.join(ctx.cwd, relativePath));
+  const baselineSnap = snapshot(path36.join(ctx.baselineDir, relativePath));
+  const latestSnap = snapshot(path36.join(ctx.latestDir, relativePath));
+  const currentSnap = snapshot(path36.join(ctx.cwd, relativePath));
   if (!latestSnap.exists) return null;
   if (!currentSnap.exists) {
     if (!baselineSnap.exists) {
@@ -23612,16 +24832,16 @@ var computeReport = (ctx) => {
   }
   for (const relativePath of [...latestPaths].sort()) {
     if (manifestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path33.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path36.join(ctx.cwd, relativePath));
     if (currentSnap.exists) continue;
-    const latestSnap = snapshot(path33.join(ctx.latestDir, relativePath));
+    const latestSnap = snapshot(path36.join(ctx.latestDir, relativePath));
     if (!latestSnap.exists) continue;
     writeWorkingTree(ctx, relativePath, latestSnap.bytes);
     add.push(relativePath);
   }
   for (const relativePath of [...baselinePaths].sort()) {
     if (latestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path33.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path36.join(ctx.cwd, relativePath));
     if (!currentSnap.exists) continue;
     deleteList.push(relativePath);
   }
@@ -23634,7 +24854,7 @@ var computeReport = (ctx) => {
     skip: skip.sort()
   };
 };
-var printHuman3 = (report) => {
+var printHuman8 = (report) => {
   const lines = [
     "gaia update merge",
     `  Overwrite: ${report.overwrite.length}`,
@@ -23665,9 +24885,9 @@ var printHuman3 = (report) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run44 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS29.has(argv[0])) {
-    process.stdout.write(HELP_TEXT31);
+var run56 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS41.has(argv[0])) {
+    process.stdout.write(HELP_TEXT43);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags11(argv);
@@ -23680,10 +24900,10 @@ var run44 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwd = options.cwd ?? process.cwd();
-  const baselineDir = path33.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path33.join(cwd, parsed.flags.baseline);
-  const latestDir = path33.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path33.join(cwd, parsed.flags.latest);
-  const manifestPath = path33.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path33.join(cwd, parsed.flags.manifest);
-  if (!existsSync32(baselineDir) || !statSync3(baselineDir).isDirectory()) {
+  const baselineDir = path36.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path36.join(cwd, parsed.flags.baseline);
+  const latestDir = path36.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path36.join(cwd, parsed.flags.latest);
+  const manifestPath = path36.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path36.join(cwd, parsed.flags.manifest);
+  if (!existsSync34(baselineDir) || !statSync3(baselineDir).isDirectory()) {
     structuredError({
       code: "baseline_missing",
       message: `--baseline directory not found: ${baselineDir}`,
@@ -23691,7 +24911,7 @@ var run44 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (!existsSync32(latestDir) || !statSync3(latestDir).isDirectory()) {
+  if (!existsSync34(latestDir) || !statSync3(latestDir).isDirectory()) {
     structuredError({
       code: "latest_missing",
       message: `--latest directory not found: ${latestDir}`,
@@ -23728,29 +24948,29 @@ var run44 = (argv, options = {}) => {
     process.stdout.write(`${JSON.stringify(report)}
 `);
   } else {
-    printHuman3(report);
+    printHuman8(report);
   }
   return EXIT_CODES.OK;
 };
 
 // src/update/index.ts
-var HELP_TEXT32 = `Usage: gaia update <subcommand> [args]
+var HELP_TEXT44 = `Usage: gaia update <subcommand> [args]
 
   merge --baseline <dir> --latest <dir> --manifest <path> [--json]
                                               Three-way file compare per manifest class.
 `;
-var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var SUBCOMMAND_HANDLERS4 = {
-  merge: run44
+var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS5 = {
+  merge: run56
 };
-var run45 = async (argv) => {
+var run57 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS30.has(subcommand)) {
-    process.stdout.write(HELP_TEXT32);
+  if (subcommand === void 0 || HELP_TOKENS42.has(subcommand)) {
+    process.stdout.write(HELP_TEXT44);
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS4[subcommand];
+  const handler = SUBCOMMAND_HANDLERS5[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -23764,12 +24984,12 @@ var run45 = async (argv) => {
 };
 
 // src/wiki/commit-classify.ts
-var HELP_TEXT33 = `Usage: gaia wiki commit-classify --since <sha> [--json]
+var HELP_TEXT45 = `Usage: gaia wiki commit-classify --since <sha> [--json]
 
   Emit a deterministic WORTHY/SKIP suggestion for every commit in
   <sha>..HEAD. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS31 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS43 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var takeValue8 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) return { message: `${flag} requires a value`, ok: false };
@@ -23913,7 +25133,7 @@ var classify = (commit) => {
     suggestion: "WORTHY"
   };
 };
-var printHuman4 = (classification) => {
+var printHuman9 = (classification) => {
   if (classification.commits.length === 0) {
     process.stdout.write("No commits to classify.\n");
     return;
@@ -23931,9 +25151,9 @@ var printHuman4 = (classification) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run46 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS31.has(argv[0])) {
-    process.stdout.write(HELP_TEXT33);
+var run58 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS43.has(argv[0])) {
+    process.stdout.write(HELP_TEXT45);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const parsed = parseFlags12(argv);
@@ -23986,15 +25206,15 @@ var run46 = (argv, options = {}) => {
     process.stdout.write(`${JSON.stringify(classification)}
 `);
   } else {
-    printHuman4(classification);
+    printHuman9(classification);
   }
   return EXIT_CODES.OK;
 };
 
 // src/wiki/dead-paths.ts
-import { readdirSync as readdirSync6, readFileSync as readFileSync27, statSync as statSync4 } from "node:fs";
-import path34 from "node:path";
-var HELP_TEXT34 = `Usage: gaia wiki dead-paths [--json]
+import { readdirSync as readdirSync6, readFileSync as readFileSync28, statSync as statSync4 } from "node:fs";
+import path37 from "node:path";
+var HELP_TEXT46 = `Usage: gaia wiki dead-paths [--json]
 
   Scan wiki/**/*.md for backticked repo-relative paths under .claude/, .gaia/,
   app/, test/, wiki/ that no longer exist on disk, plus any reference to
@@ -24003,7 +25223,7 @@ var HELP_TEXT34 = `Usage: gaia wiki dead-paths [--json]
   and wiki/meta/** (audit artifacts that legitimately reference historical
   paths).
 `;
-var HELP_TOKENS32 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS44 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TRACKED_PREFIXES = [".claude/", ".gaia/", "app/", "test/", "wiki/"];
 var SIBLING_REPO_PATTERN = /(?:^|\/)(studio|website)\//;
 var SKIP_PATH_FRAGMENTS = [
@@ -24028,27 +25248,27 @@ var walkMarkdown = (root, dir) => {
   const entries = readdirSync6(dir, { withFileTypes: true });
   const out = [];
   for (const entry of entries) {
-    const full = path34.join(dir, entry.name);
+    const full = path37.join(dir, entry.name);
     if (entry.isDirectory()) {
       out.push(...walkMarkdown(root, full));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(path34.relative(root, full));
+      out.push(path37.relative(root, full));
     }
   }
   return out;
 };
 var pathExists = (root, candidate) => {
   try {
-    statSync4(path34.join(root, candidate));
+    statSync4(path37.join(root, candidate));
     return true;
   } catch {
     return false;
   }
 };
 var findDeadPaths = (cwd) => {
-  const wikiDir = path34.join(cwd, "wiki");
+  const wikiDir = path37.join(cwd, "wiki");
   try {
     statSync4(wikiDir);
   } catch {
@@ -24058,7 +25278,7 @@ var findDeadPaths = (cwd) => {
   const files = walkMarkdown(cwd, wikiDir);
   for (const filePath of files) {
     if (shouldSkipFile(filePath)) continue;
-    const content = readFileSync27(path34.join(cwd, filePath), "utf8");
+    const content = readFileSync28(path37.join(cwd, filePath), "utf8");
     const lines = content.split("\n");
     for (const [index, line] of lines.entries()) {
       if (HISTORICAL_BULLET_PATTERN.test(line)) continue;
@@ -24078,11 +25298,11 @@ var findDeadPaths = (cwd) => {
   }
   return dead;
 };
-var run47 = (argv, options = {}) => {
+var run59 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS32.has(token)) {
-      process.stdout.write(HELP_TEXT34);
+    if (HELP_TOKENS44.has(token)) {
+      process.stdout.write(HELP_TEXT46);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -24122,13 +25342,13 @@ var run47 = (argv, options = {}) => {
 };
 
 // src/wiki/log-prepend.ts
-import { existsSync as existsSync33, readFileSync as readFileSync28, renameSync as renameSync10, writeFileSync as writeFileSync22 } from "node:fs";
-import path35 from "node:path";
-var HELP_TEXT35 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+import { existsSync as existsSync35, readFileSync as readFileSync29, renameSync as renameSync12, writeFileSync as writeFileSync24 } from "node:fs";
+import path38 from "node:path";
+var HELP_TEXT47 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS33 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS45 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
 var FRONTMATTER_FENCE = "---";
 var takeValue9 = (argv, index, flag) => {
@@ -24208,14 +25428,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run48 = (argv, options = {}) => {
+var run60 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT35);
+    process.stdout.write(HELP_TEXT47);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS33.has(first)) {
-    process.stdout.write(HELP_TEXT35);
+  if (HELP_TOKENS45.has(first)) {
+    process.stdout.write(HELP_TEXT47);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags13(argv);
@@ -24238,8 +25458,8 @@ var run48 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const logPath = path35.join(repoRoot2, "wiki", "log.md");
-  if (!existsSync33(logPath)) {
+  const logPath = path38.join(repoRoot2, "wiki", "log.md");
+  if (!existsSync35(logPath)) {
     structuredError({
       code: "log_missing",
       message: "wiki/log.md does not exist",
@@ -24247,7 +25467,7 @@ var run48 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync28(logPath, "utf8");
+  const raw = readFileSync29(logPath, "utf8");
   const lines = raw.split("\n");
   const scan = scanFrontmatter(lines);
   if (scan.kind === "missing" || scan.kind === "malformed") {
@@ -24267,20 +25487,20 @@ var run48 = (argv, options = {}) => {
     ...lines.slice(insertionIndex)
   ].join("\n");
   const tmpPath = `${logPath}.tmp`;
-  writeFileSync22(tmpPath, next, "utf8");
-  renameSync10(tmpPath, logPath);
+  writeFileSync24(tmpPath, next, "utf8");
+  renameSync12(tmpPath, logPath);
   return EXIT_CODES.OK;
 };
 
 // src/wiki/near-collisions.ts
-import { existsSync as existsSync34, readdirSync as readdirSync7, statSync as statSync5 } from "node:fs";
-import path36 from "node:path";
-var HELP_TEXT36 = `Usage: gaia wiki near-collisions [--max-distance 3]
+import { existsSync as existsSync36, readdirSync as readdirSync7, statSync as statSync5 } from "node:fs";
+import path39 from "node:path";
+var HELP_TEXT48 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS34 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS46 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS = [
   "components",
@@ -24318,8 +25538,8 @@ var levenshtein = (a, b) => {
 var collectDomainSlugs = (wikiRoot) => {
   const collected = [];
   for (const domain2 of DOMAIN_DIRS) {
-    const domainDir = path36.join(wikiRoot, domain2);
-    if (!existsSync34(domainDir) || !statSync5(domainDir).isDirectory()) continue;
+    const domainDir = path39.join(wikiRoot, domain2);
+    if (!existsSync36(domainDir) || !statSync5(domainDir).isDirectory()) continue;
     const entries = readdirSync7(domainDir, { withFileTypes: true });
     const slugs = [];
     for (const entry of entries) {
@@ -24386,9 +25606,9 @@ var parseFlags14 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run49 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS34.has(argv[0])) {
-    process.stdout.write(HELP_TEXT36);
+var run61 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS46.has(argv[0])) {
+    process.stdout.write(HELP_TEXT48);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags14(argv);
@@ -24411,7 +25631,7 @@ var run49 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path36.join(repoRoot2, "wiki");
+  const wikiRoot = path39.join(repoRoot2, "wiki");
   const domainGroups = collectDomainSlugs(wikiRoot);
   const collisions = findCollisions(domainGroups, parsed.flags.maxDistance);
   if (collisions.length === 0) return EXIT_CODES.OK;
@@ -24424,8 +25644,8 @@ var run49 = (argv, options = {}) => {
 };
 
 // src/wiki/page-index.ts
-import { existsSync as existsSync35, readdirSync as readdirSync8, readFileSync as readFileSync29, statSync as statSync6 } from "node:fs";
-import path37 from "node:path";
+import { existsSync as existsSync37, readdirSync as readdirSync8, readFileSync as readFileSync30, statSync as statSync6 } from "node:fs";
+import path40 from "node:path";
 
 // src/wiki/util/frontmatter.ts
 var FRONTMATTER_FENCE2 = "---";
@@ -24501,12 +25721,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT37 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT49 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS35 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS2 = [
   "components",
   "concepts",
@@ -24519,7 +25739,7 @@ var DOMAIN_DIRS2 = [
 ];
 var SKIPPED_FILES2 = /* @__PURE__ */ new Set(["_index.md", "README.md"]);
 var ROOT_LINK_SOURCES = ["index.md", "overview.md", "hot.md"];
-var slugFromPath = (filePath) => path37.basename(filePath, ".md");
+var slugFromPath = (filePath) => path40.basename(filePath, ".md");
 var extractTitle = (body, fallback) => {
   const lines = body.split("\n");
   for (const line of lines) {
@@ -24544,16 +25764,16 @@ var arrayOfStrings = (value) => {
 var collectPages = (wikiRoot) => {
   const pages = [];
   for (const domain2 of DOMAIN_DIRS2) {
-    const domainDir = path37.join(wikiRoot, domain2);
-    if (!existsSync35(domainDir) || !statSync6(domainDir).isDirectory()) continue;
+    const domainDir = path40.join(wikiRoot, domain2);
+    if (!existsSync37(domainDir) || !statSync6(domainDir).isDirectory()) continue;
     const entries = readdirSync8(domainDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(".md")) continue;
       if (SKIPPED_FILES2.has(entry.name)) continue;
       if (entry.name.startsWith("_")) continue;
-      const absPath = path37.join(domainDir, entry.name);
-      const raw = readFileSync29(absPath, "utf8");
+      const absPath = path40.join(domainDir, entry.name);
+      const raw = readFileSync30(absPath, "utf8");
       const { body, frontmatter } = parseFrontmatter(raw);
       const slug = slugFromPath(entry.name);
       const title = extractTitle(body, slug);
@@ -24562,7 +25782,7 @@ var collectPages = (wikiRoot) => {
         body,
         domain: domain2,
         outboundTargets: targets,
-        relativePath: path37.posix.join("wiki", domain2, entry.name),
+        relativePath: path40.posix.join("wiki", domain2, entry.name),
         slug,
         status: stringValue(frontmatter.status),
         tags: arrayOfStrings(frontmatter.tags),
@@ -24576,9 +25796,9 @@ var collectPages = (wikiRoot) => {
 var collectRootLinkSources = (wikiRoot) => {
   const sources = [];
   for (const filename of ROOT_LINK_SOURCES) {
-    const absPath = path37.join(wikiRoot, filename);
-    if (!existsSync35(absPath)) continue;
-    const raw = readFileSync29(absPath, "utf8");
+    const absPath = path40.join(wikiRoot, filename);
+    if (!existsSync37(absPath)) continue;
+    const raw = readFileSync30(absPath, "utf8");
     const { body } = parseFrontmatter(raw);
     sources.push(extractWikilinks(body));
   }
@@ -24614,7 +25834,7 @@ var buildIndex = (pages, rootSources = []) => {
     }))
   };
 };
-var printHuman5 = (index) => {
+var printHuman10 = (index) => {
   if (index.pages.length === 0) {
     process.stdout.write("No wiki pages found.\n");
     return;
@@ -24630,16 +25850,16 @@ var printHuman5 = (index) => {
 };
 var computePageIndex = (cwd) => {
   const repoRoot2 = resolveRepoRoot2(cwd);
-  const wikiRoot = path37.join(repoRoot2, "wiki");
+  const wikiRoot = path40.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run50 = (argv, options = {}) => {
+var run62 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS35.has(token)) {
-      process.stdout.write(HELP_TEXT37);
+    if (HELP_TOKENS47.has(token)) {
+      process.stdout.write(HELP_TEXT49);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -24664,7 +25884,7 @@ var run50 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path37.join(repoRoot2, "wiki");
+  const wikiRoot = path40.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   const index = buildIndex(pages, rootSources);
@@ -24672,22 +25892,22 @@ var run50 = (argv, options = {}) => {
     process.stdout.write(`${JSON.stringify(index)}
 `);
   } else {
-    printHuman5(index);
+    printHuman10(index);
   }
   return EXIT_CODES.OK;
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT38 = `Usage: gaia wiki orphans
+var HELP_TEXT50 = `Usage: gaia wiki orphans
 
   Newline-separated list of wiki pages with zero inbound wikilinks.
 `;
-var HELP_TOKENS36 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var isMaintainerOnly = (path41) => path41.startsWith("wiki/meta/") || path41.startsWith("wiki/entities/");
-var run51 = (argv, options = {}) => {
+var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var isMaintainerOnly = (path44) => path44.startsWith("wiki/meta/") || path44.startsWith("wiki/entities/");
+var run63 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS36.has(token)) {
-      process.stdout.write(HELP_TEXT38);
+    if (HELP_TOKENS48.has(token)) {
+      process.stdout.write(HELP_TEXT50);
       return EXIT_CODES.OK;
     }
     structuredError({
@@ -24718,11 +25938,11 @@ var run51 = (argv, options = {}) => {
 };
 
 // src/wiki/state.ts
-import { existsSync as existsSync36, readdirSync as readdirSync9, readFileSync as readFileSync30, statSync as statSync7 } from "node:fs";
-import path38 from "node:path";
-var HELP_TEXT39 = `Usage: gaia wiki state [--json]
+import { existsSync as existsSync38, readdirSync as readdirSync9, readFileSync as readFileSync31, statSync as statSync7 } from "node:fs";
+import path41 from "node:path";
+var HELP_TEXT51 = `Usage: gaia wiki state [--json]
 `;
-var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var classifySeverity = (commitCount) => {
   if (commitCount <= 0) return "none";
   if (commitCount <= 5) return "low";
@@ -24742,8 +25962,8 @@ var DOMAIN_DIRS3 = [
 var countDomainPages = (wikiRoot) => {
   const counts = {};
   for (const domain2 of DOMAIN_DIRS3) {
-    const domainDir = path38.join(wikiRoot, domain2);
-    if (!existsSync36(domainDir) || !statSync7(domainDir).isDirectory()) {
+    const domainDir = path41.join(wikiRoot, domain2);
+    if (!existsSync38(domainDir) || !statSync7(domainDir).isDirectory()) {
       counts[domain2] = 0;
       continue;
     }
@@ -24760,15 +25980,15 @@ var countDomainPages = (wikiRoot) => {
   return counts;
 };
 var readStateFile2 = (statePath) => {
-  if (!existsSync36(statePath)) return null;
-  const raw = readFileSync30(statePath, "utf8");
+  if (!existsSync38(statePath)) return null;
+  const raw = readFileSync31(statePath, "utf8");
   try {
     return JSON.parse(raw);
   } catch {
     return null;
   }
 };
-var printHuman6 = (state) => {
+var printHuman11 = (state) => {
   const lines = [
     "Wiki state",
     `  HEAD:           ${state.head_short}`,
@@ -24789,11 +26009,11 @@ var printHuman6 = (state) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run52 = (argv, options = {}) => {
+var run64 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS37.has(token)) {
-      process.stdout.write(HELP_TEXT39);
+    if (HELP_TOKENS49.has(token)) {
+      process.stdout.write(HELP_TEXT51);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -24818,8 +26038,8 @@ var run52 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path38.join(repoRoot2, "wiki");
-  const statePath = path38.join(wikiRoot, ".state.json");
+  const wikiRoot = path41.join(repoRoot2, "wiki");
+  const statePath = path41.join(wikiRoot, ".state.json");
   const stateFile = readStateFile2(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? "";
   const head = headSha(repoRoot2);
@@ -24843,21 +26063,21 @@ var run52 = (argv, options = {}) => {
     process.stdout.write(`${JSON.stringify(state)}
 `);
   } else {
-    printHuman6(state);
+    printHuman11(state);
   }
   return EXIT_CODES.OK;
 };
 
 // src/wiki/state-bump.ts
-import { existsSync as existsSync37, readFileSync as readFileSync31, renameSync as renameSync11, writeFileSync as writeFileSync23 } from "node:fs";
-import path39 from "node:path";
-var HELP_TEXT40 = `Usage: gaia wiki state-bump <field> <value>
+import { existsSync as existsSync39, readFileSync as readFileSync32, renameSync as renameSync13, writeFileSync as writeFileSync25 } from "node:fs";
+import path42 from "node:path";
+var HELP_TEXT52 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS38 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson2 = (raw) => {
   try {
     return JSON.parse(raw);
@@ -24879,13 +26099,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run53 = (argv, options = {}) => {
+var run65 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT40);
+    process.stdout.write(HELP_TEXT52);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS38.has(argv[0])) {
-    process.stdout.write(HELP_TEXT40);
+  if (HELP_TOKENS50.has(argv[0])) {
+    process.stdout.write(HELP_TEXT52);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -24920,8 +26140,8 @@ var run53 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const statePath = path39.join(repoRoot2, "wiki", ".state.json");
-  if (!existsSync37(statePath)) {
+  const statePath = path42.join(repoRoot2, "wiki", ".state.json");
+  if (!existsSync39(statePath)) {
     structuredError({
       code: "state_missing",
       message: "wiki/.state.json does not exist",
@@ -24929,7 +26149,7 @@ var run53 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync31(statePath, "utf8");
+  const raw = readFileSync32(statePath, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -24954,16 +26174,16 @@ var run53 = (argv, options = {}) => {
   const trailingNewline = raw.endsWith("\n") ? "\n" : "";
   const serialized = `${JSON.stringify(next, null, 2)}${trailingNewline}`;
   const tmpPath = `${statePath}.tmp`;
-  writeFileSync23(tmpPath, serialized, "utf8");
-  renameSync11(tmpPath, statePath);
+  writeFileSync25(tmpPath, serialized, "utf8");
+  renameSync13(tmpPath, statePath);
   return EXIT_CODES.OK;
 };
 
 // src/wiki/state-init.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
-import { existsSync as existsSync38, mkdirSync as mkdirSync17, renameSync as renameSync12, writeFileSync as writeFileSync24 } from "node:fs";
-import path40 from "node:path";
-var HELP_TEXT41 = `Usage: gaia wiki state-init <sha>
+import { execFileSync as execFileSync7 } from "node:child_process";
+import { existsSync as existsSync40, mkdirSync as mkdirSync19, renameSync as renameSync14, writeFileSync as writeFileSync26 } from "node:fs";
+import path43 from "node:path";
+var HELP_TEXT53 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -24971,10 +26191,10 @@ var HELP_TEXT41 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag) \u2014 it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS39 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha2 = (ref, cwd) => {
   try {
-    const out = execFileSync6("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+    const out = execFileSync7("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
       cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -24984,13 +26204,13 @@ var resolveFullSha2 = (ref, cwd) => {
     return null;
   }
 };
-var run54 = (argv, options = {}) => {
+var run66 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT41);
+    process.stdout.write(HELP_TEXT53);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS39.has(argv[0])) {
-    process.stdout.write(HELP_TEXT41);
+  if (HELP_TOKENS51.has(argv[0])) {
+    process.stdout.write(HELP_TEXT53);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -25034,9 +26254,9 @@ var run54 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiDir = path40.join(repoRoot2, "wiki");
-  const statePath = path40.join(wikiDir, ".state.json");
-  if (existsSync38(statePath)) {
+  const wikiDir = path43.join(repoRoot2, "wiki");
+  const statePath = path43.join(wikiDir, ".state.json");
+  if (existsSync40(statePath)) {
     structuredError({
       code: "state_already_exists",
       message: "wiki/.state.json already exists \u2014 use `gaia wiki state-bump` to update fields",
@@ -25044,7 +26264,7 @@ var run54 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  mkdirSync17(wikiDir, { recursive: true });
+  mkdirSync19(wikiDir, { recursive: true });
   const nowDate = (options.now ?? (() => /* @__PURE__ */ new Date()))();
   const isoNow = nowDate.toISOString();
   const payload = {
@@ -25055,8 +26275,8 @@ var run54 = (argv, options = {}) => {
   const serialized = `${JSON.stringify(payload, null, 2)}
 `;
   const tmpPath = `${statePath}.tmp`;
-  writeFileSync24(tmpPath, serialized, "utf8");
-  renameSync12(tmpPath, statePath);
+  writeFileSync26(tmpPath, serialized, "utf8");
+  renameSync14(tmpPath, statePath);
   return EXIT_CODES.OK;
 };
 
@@ -25117,7 +26337,7 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
 };
 
 // src/wiki/sync-land.ts
-var HELP_TEXT42 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT54 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -25128,7 +26348,7 @@ var HELP_TEXT42 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS40 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT8 = 2;
 var parseFlags15 = (argv) => {
   let branchAware = false;
@@ -25207,9 +26427,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run55 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS40.has(argv[0])) {
-    process.stdout.write(HELP_TEXT42);
+var run67 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS52.has(argv[0])) {
+    process.stdout.write(HELP_TEXT54);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags15(argv);
@@ -25295,7 +26515,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT43 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT55 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -25314,16 +26534,16 @@ var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS41.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS53.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run55(rest);
+    return run67(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -25332,26 +26552,26 @@ var runSync = async (args) => {
   });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-var SUBCOMMAND_HANDLERS5 = {
-  "commit-classify": run46,
-  "dead-paths": run47,
-  "log-prepend": run48,
-  "near-collisions": run49,
-  "orphans": run51,
-  "page-index": run50,
-  "state": run52,
-  "state-bump": run53,
-  "state-init": run54,
+var SUBCOMMAND_HANDLERS6 = {
+  "commit-classify": run58,
+  "dead-paths": run59,
+  "log-prepend": run60,
+  "near-collisions": run61,
+  "orphans": run63,
+  "page-index": run62,
+  "state": run64,
+  "state-bump": run65,
+  "state-init": run66,
   "sync": runSync
 };
-var run56 = async (argv) => {
+var run68 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS41.has(subcommand)) {
-    process.stdout.write(HELP_TEXT43);
+  if (subcommand === void 0 || HELP_TOKENS53.has(subcommand)) {
+    process.stdout.write(HELP_TEXT55);
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS5[subcommand];
+  const handler = SUBCOMMAND_HANDLERS6[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -25365,7 +26585,7 @@ var run56 = async (argv) => {
 };
 
 // src/index.ts
-var HELP_TEXT44 = `Usage: gaia <subcommand> [args]
+var HELP_TEXT56 = `Usage: gaia <subcommand> [args]
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -25379,12 +26599,13 @@ var HELP_TEXT44 = `Usage: gaia <subcommand> [args]
   update merge --baseline <dir> --latest <dir> --manifest <path>
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
+  setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize|write-tool-mode
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT44);
+  process.stdout.write(HELP_TEXT56);
 };
-var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var SUBCOMMAND_HANDLERS6 = {
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SUBCOMMAND_HANDLERS7 = {
   automation: run11,
   "ci-revert": run13,
   "ci-stale-check": run14,
@@ -25392,21 +26613,22 @@ var SUBCOMMAND_HANDLERS6 = {
   mentorship: run32,
   scaffold: run37,
   setup: run42,
-  telemetry: run43,
-  update: run45,
-  wiki: run56
+  "setup-ci": run54,
+  telemetry: run55,
+  update: run57,
+  wiki: run68
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS42.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }
   if (subcommand === "_internal-fetch-coaching") {
     return run(rest);
   }
-  const handler = SUBCOMMAND_HANDLERS6[subcommand];
+  const handler = SUBCOMMAND_HANDLERS7[subcommand];
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -37,7 +37,7 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   update merge --baseline <dir> --latest <dir> --manifest <path>
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
-  setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize
+  setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize|write-tool-mode
 `;
 
 const printHelp = (): void => {

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -17,6 +17,7 @@ import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
 import {run as runScaffold} from './scaffold/index.js';
 import {run as runSetup} from './setup/index.js';
+import {run as runSetupCi} from './setup-ci/index.js';
 import {structuredError} from './stderr.js';
 import {run as runTelemetry} from './telemetry/index.js';
 import {run as runUpdate} from './update/index.js';
@@ -36,6 +37,7 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   update merge --baseline <dir> --latest <dir> --manifest <path>
   init strip-branding|configure-i18n|rename|wire-statusline|finalize|resume
   setup status|mark-step|finalize|link-worktree
+  setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize
 `;
 
 const printHelp = (): void => {
@@ -56,6 +58,7 @@ const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> 
   mentorship: runMentorship,
   scaffold: runScaffold,
   setup: runSetup,
+  'setup-ci': runSetupCi,
   telemetry: runTelemetry,
   update: runUpdate,
   wiki: runWiki,

--- a/.gaia/cli/src/setup-ci/__tests__/check-admin.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/check-admin.test.ts
@@ -1,0 +1,154 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../check-admin.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci check-admin', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let restore: (() => void) | undefined;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-check-admin-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns admin: true, auth_status: ok when gh auth ok and api returns true', async () => {
+    // First call: `gh auth status` (exits 0 with no stdout). Second
+    // call: `gh api ...` returns "true\n".
+    const handle = sandbox.installGhShim({
+      exitCode: 0,
+      stdoutQueue: ['', 'true\n'],
+    });
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.admin).toBe(true);
+    expect(parsed.auth_status).toBe('ok');
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    expect(recorded[0]).toEqual(['auth', 'status']);
+    expect(recorded[1]).toEqual([
+      'api',
+      'repos/foo/bar',
+      '--jq',
+      '.permissions.admin',
+    ]);
+  });
+
+  it('returns admin: false, auth_status: ok when api returns false', async () => {
+    const handle = sandbox.installGhShim({
+      exitCode: 0,
+      stdoutQueue: ['', 'false\n'],
+    });
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.admin).toBe(false);
+    expect(parsed.auth_status).toBe('ok');
+  });
+
+  it('returns admin: false, auth_status: unauthenticated when gh auth fails', async () => {
+    // gh auth status fails -> exit code != 0.
+    const handle = sandbox.installGhShim({exitCode: 1});
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    // Critical contract: never false-positive admin.
+    expect(parsed.admin).toBe(false);
+    expect(parsed.auth_status).toBe('unauthenticated');
+  });
+
+  it('returns admin: false, auth_status: api_error when api call fails', async () => {
+    // First gh call (auth status) succeeds; second (api) fails.
+    const handle = sandbox.installGhShim({
+      exitCodeQueue: [0, 1],
+      stdoutQueue: ['', ''],
+    });
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.admin).toBe(false);
+    expect(parsed.auth_status).toBe('api_error');
+  });
+
+  it('exits non-zero when --owner missing', async () => {
+    const exit = await run(['--repo', 'bar', '--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('missing_required_arg');
+  });
+
+  it('rejects unknown flags', async () => {
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--bogus'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown flag');
+  });
+
+  it('--help exits 0', async () => {
+    const exit = await run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/detect-remote.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/detect-remote.test.ts
@@ -1,0 +1,119 @@
+import {execFileSync} from 'node:child_process';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../detect-remote.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci detect-remote', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-detect-remote-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed fields when origin is configured', () => {
+    execFileSync(
+      'git',
+      ['remote', 'add', 'origin', 'git@github.com:foo/bar.git'],
+      {cwd: sandbox.root}
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toBe(true);
+    expect(parsed.host).toBe('github.com');
+    expect(parsed.owner).toBe('foo');
+    expect(parsed.repo).toBe('bar');
+  });
+
+  it('returns found: false when origin is missing', () => {
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toBe(false);
+    expect(parsed.url).toBeNull();
+    expect(parsed.host).toBeNull();
+  });
+
+  it('returns found: false when remote URL is unparseable', () => {
+    execFileSync(
+      'git',
+      ['remote', 'add', 'origin', 'https://gitlab.com/foo/bar/baz.git'],
+      {cwd: sandbox.root}
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toBe(false);
+    // The URL itself is preserved for diagnostics.
+    expect(parsed.url).toBe('https://gitlab.com/foo/bar/baz.git');
+  });
+
+  it('emits a human report without --json', () => {
+    execFileSync(
+      'git',
+      ['remote', 'add', 'origin', 'https://github.com/foo/bar'],
+      {cwd: sandbox.root}
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('host: github.com');
+  });
+
+  it('rejects unknown flags', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown flag');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/dismiss-personal.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/dismiss-personal.test.ts
@@ -1,0 +1,138 @@
+import {mkdirSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {localAutomationPath} from '../../automation/paths.js';
+import {readLocalAutomation} from '../../schemas/local-automation.js';
+import {run} from '../dismiss-personal.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci dismiss-personal', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-dismiss-personal-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('creates the local file when missing', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readLocalAutomation(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.local.nudge_dismissed).toBe(true);
+    }
+  });
+
+  it('flips nudge_dismissed when existing local has it false', () => {
+    mkdirSync(path.dirname(localAutomationPath(sandbox.root)), {recursive: true});
+    writeFileSync(
+      localAutomationPath(sandbox.root),
+      JSON.stringify({nudge_dismissed: false, version: 1}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readLocalAutomation(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.local.nudge_dismissed).toBe(true);
+    }
+  });
+
+  it('is idempotent (final state unchanged when already dismissed)', () => {
+    mkdirSync(path.dirname(localAutomationPath(sandbox.root)), {recursive: true});
+    writeFileSync(
+      localAutomationPath(sandbox.root),
+      JSON.stringify({nudge_dismissed: true, version: 1}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readLocalAutomation(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.local.nudge_dismissed).toBe(true);
+    }
+  });
+
+  it('refuses with local_malformed when existing local is malformed', () => {
+    mkdirSync(path.dirname(localAutomationPath(sandbox.root)), {recursive: true});
+    writeFileSync(
+      localAutomationPath(sandbox.root),
+      JSON.stringify({nudge_dismissed: 'yes', version: 1}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('local_malformed');
+  });
+
+  it('emits dismissed: true JSON on success', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.dismissed).toBe(true);
+  });
+
+  it('rejects unexpected arguments', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unexpected argument');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/enable-delete-branch.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/enable-delete-branch.test.ts
@@ -1,0 +1,107 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../enable-delete-branch.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci enable-delete-branch', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let restore: (() => void) | undefined;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-enable-delete-branch-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes delete_branch_on_merge=true on success', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    expect(recorded[0]).toEqual([
+      'api',
+      '-X',
+      'PATCH',
+      'repos/foo/bar',
+      '-f',
+      'delete_branch_on_merge=true',
+    ]);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.applied).toBe(true);
+  });
+
+  it('returns applied: false with error on gh failure', async () => {
+    const handle = sandbox.installGhShim({exitCode: 1});
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.applied).toBe(false);
+  });
+
+  it('exits non-zero when --owner missing', async () => {
+    const exit = await run(['--repo', 'bar'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('missing_required_arg');
+  });
+
+  it('rejects unknown flags', async () => {
+    const exit = await run(['--owner', 'foo', '--repo', 'bar', '--bogus'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown flag');
+  });
+
+  it('--help exits 0', async () => {
+    const exit = await run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
@@ -1,0 +1,119 @@
+import {writeFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {automationConfigPath} from '../../automation/paths.js';
+import {readAutomationConfig} from '../../schemas/automation-config.js';
+import {run} from '../finalize.js';
+import {
+  setupSandbox,
+  VALID_BASE_CONFIG,
+  type Sandbox,
+} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci finalize', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-finalize-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('flips setup_complete=true on a pending config', () => {
+    sandbox.writeConfig({...VALID_BASE_CONFIG, setup_complete: false});
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.config.setup_complete).toBe(true);
+    }
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.finalized).toBe(true);
+    expect(parsed.already_finalized).toBe(false);
+  });
+
+  it('returns already_finalized: true when config is already finalized', () => {
+    sandbox.writeConfig({...VALID_BASE_CONFIG, setup_complete: true});
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.finalized).toBe(true);
+    expect(parsed.already_finalized).toBe(true);
+  });
+
+  it('exits config_missing when config is absent', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_missing');
+  });
+
+  it('exits config_malformed for malformed config', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_malformed');
+  });
+
+  it('rejects unexpected arguments', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unexpected argument');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
@@ -1,0 +1,117 @@
+import {writeFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {automationConfigPath} from '../../automation/paths.js';
+import {readAutomationConfig} from '../../schemas/automation-config.js';
+import {run} from '../opt-out-team.js';
+import {
+  setupSandbox,
+  VALID_BASE_CONFIG,
+  type Sandbox,
+} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci opt-out-team', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-opt-out-team-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('flips setup_opted_out=true preserving other fields', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.config.setup_opted_out).toBe(true);
+      // Other fields preserved.
+      expect(result.config.wiki.mode).toBe('ci');
+      expect(result.config.update_gaia.mode).toBe('local');
+    }
+  });
+
+  it('exits config_missing when .gaia/automation.json is absent', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_missing');
+  });
+
+  it('exits config_malformed when config fails schema validation', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_malformed');
+  });
+
+  it('emits opted_out: true JSON on success', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.opted_out).toBe(true);
+  });
+
+  it('rejects unexpected arguments', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unexpected argument');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/sandbox.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/sandbox.ts
@@ -25,11 +25,13 @@ export type Sandbox = {
   cleanup: () => void;
   ghArgvPath: string;
   ghExitCodeQueuePath: string;
+  ghStderrQueuePath: string;
   ghStdinPath: string;
   ghStdoutQueuePath: string;
   installGhShim: (options?: {
     exitCode?: number;
     exitCodeQueue?: number[];
+    stderrQueue?: string[];
     stdoutQueue?: string[];
   }) => {pathOverride: string; restore: () => void};
   root: string;
@@ -54,6 +56,7 @@ import {appendFileSync, readFileSync, writeFileSync, existsSync} from 'node:fs';
 const argvFile = process.env.GH_SHIM_ARGV_FILE;
 const stdinFile = process.env.GH_SHIM_STDIN_FILE;
 const stdoutQueueFile = process.env.GH_SHIM_STDOUT_QUEUE_FILE;
+const stderrQueueFile = process.env.GH_SHIM_STDERR_QUEUE_FILE;
 const exitCodeQueueFile = process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
 const fallbackExitCode = Number.parseInt(process.env.GH_SHIM_EXIT_CODE ?? '0', 10);
 const args = process.argv.slice(2);
@@ -81,6 +84,15 @@ process.stdin.on('end', () => {
     writeFileSync(stdoutQueueFile, JSON.stringify(queue), 'utf8');
     if (typeof next === 'string') {
       process.stdout.write(next);
+    }
+  }
+  if (stderrQueueFile && existsSync(stderrQueueFile)) {
+    let queue = [];
+    try { queue = JSON.parse(readFileSync(stderrQueueFile, 'utf8')); } catch { queue = []; }
+    const next = queue.shift();
+    writeFileSync(stderrQueueFile, JSON.stringify(queue), 'utf8');
+    if (typeof next === 'string') {
+      process.stderr.write(next);
     }
   }
   let exitCode = fallbackExitCode;
@@ -113,6 +125,7 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
   const ghArgvPath = path.join(root, 'gh-argv.json');
   const ghStdinPath = path.join(root, 'gh-stdin.bin');
   const ghStdoutQueuePath = path.join(root, 'gh-stdout-queue.json');
+  const ghStderrQueuePath = path.join(root, 'gh-stderr-queue.json');
   const ghExitCodeQueuePath = path.join(root, 'gh-exit-code-queue.json');
 
   const writeConfig = (config: AutomationConfig): void => {
@@ -122,6 +135,7 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
   const installGhShim = (options: {
     exitCode?: number;
     exitCodeQueue?: number[];
+    stderrQueue?: string[];
     stdoutQueue?: string[];
   } = {}): {pathOverride: string; restore: () => void} => {
     const shimPath = path.join(binDir, 'gh');
@@ -130,6 +144,11 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
     writeFileSync(
       ghStdoutQueuePath,
       JSON.stringify(options.stdoutQueue ?? []),
+      'utf8'
+    );
+    writeFileSync(
+      ghStderrQueuePath,
+      JSON.stringify(options.stderrQueue ?? []),
       'utf8'
     );
     writeFileSync(
@@ -142,6 +161,7 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
     const previousArgv = process.env.GH_SHIM_ARGV_FILE;
     const previousStdin = process.env.GH_SHIM_STDIN_FILE;
     const previousQueue = process.env.GH_SHIM_STDOUT_QUEUE_FILE;
+    const previousStderrQueue = process.env.GH_SHIM_STDERR_QUEUE_FILE;
     const previousExitQueue = process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
     const previousExitCode = process.env.GH_SHIM_EXIT_CODE;
 
@@ -149,6 +169,7 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
     process.env.GH_SHIM_ARGV_FILE = ghArgvPath;
     process.env.GH_SHIM_STDIN_FILE = ghStdinPath;
     process.env.GH_SHIM_STDOUT_QUEUE_FILE = ghStdoutQueuePath;
+    process.env.GH_SHIM_STDERR_QUEUE_FILE = ghStderrQueuePath;
     process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE = ghExitCodeQueuePath;
     process.env.GH_SHIM_EXIT_CODE = String(options.exitCode ?? 0);
 
@@ -175,6 +196,11 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
         } else {
           process.env.GH_SHIM_STDOUT_QUEUE_FILE = previousQueue;
         }
+        if (previousStderrQueue === undefined) {
+          delete process.env.GH_SHIM_STDERR_QUEUE_FILE;
+        } else {
+          process.env.GH_SHIM_STDERR_QUEUE_FILE = previousStderrQueue;
+        }
         if (previousExitQueue === undefined) {
           delete process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
         } else {
@@ -196,6 +222,7 @@ export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
     },
     ghArgvPath,
     ghExitCodeQueuePath,
+    ghStderrQueuePath,
     ghStdinPath,
     ghStdoutQueuePath,
     installGhShim,

--- a/.gaia/cli/src/setup-ci/__tests__/sandbox.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/sandbox.ts
@@ -1,0 +1,206 @@
+/**
+ * Shared sandbox helpers for setup-ci tests.
+ *
+ * Two scopes overlap here:
+ *
+ * 1. Filesystem sandbox — `setupSandbox` creates a tmp dir with
+ *    `git init` + an initial commit + `.gaia/` ready for config files.
+ *    Mirror's slice 1's `automation/__tests__/sandbox.ts` shape.
+ *
+ * 2. `gh` shim — `installGhShim` writes a tiny Node script to
+ *    `<sandbox>/bin/gh` that records argv + stdin to sandbox files
+ *    and emits scripted stdout / exit code. Tests that assert the
+ *    secret never appears on argv use this shim end-to-end (PATH
+ *    override) rather than spying on `runGh` directly.
+ */
+import {execFileSync} from 'node:child_process';
+import {chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {automationConfigPath} from '../../automation/paths.js';
+import type {AutomationConfig} from '../../schemas/automation-config.js';
+
+export type Sandbox = {
+  binDir: string;
+  cleanup: () => void;
+  ghArgvPath: string;
+  ghExitCodeQueuePath: string;
+  ghStdinPath: string;
+  ghStdoutQueuePath: string;
+  installGhShim: (options?: {
+    exitCode?: number;
+    exitCodeQueue?: number[];
+    stdoutQueue?: string[];
+  }) => {pathOverride: string; restore: () => void};
+  root: string;
+  writeConfig: (config: AutomationConfig) => void;
+};
+
+export const VALID_BASE_CONFIG: AutomationConfig = {
+  pnpm_audit: {mode: 'ci', schedule: 'weekly'},
+  setup_complete: false,
+  setup_opted_out: false,
+  sharpen: {mode: 'ci', schedule: 'weekly'},
+  stale_branches: {mode: 'ci', schedule: 'monthly'},
+  update_gaia: {mode: 'local'},
+  version: 1,
+  wiki: {mode: 'ci', schedule: 'daily'},
+};
+
+const SHIM_NODE_SOURCE = `#!/usr/bin/env node
+// Sandbox \`gh\` shim. Records argv + stdin and emits scripted output.
+import {appendFileSync, readFileSync, writeFileSync, existsSync} from 'node:fs';
+
+const argvFile = process.env.GH_SHIM_ARGV_FILE;
+const stdinFile = process.env.GH_SHIM_STDIN_FILE;
+const stdoutQueueFile = process.env.GH_SHIM_STDOUT_QUEUE_FILE;
+const exitCodeQueueFile = process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
+const fallbackExitCode = Number.parseInt(process.env.GH_SHIM_EXIT_CODE ?? '0', 10);
+const args = process.argv.slice(2);
+
+if (argvFile) {
+  let lines = [];
+  if (existsSync(argvFile)) {
+    try { lines = JSON.parse(readFileSync(argvFile, 'utf8')); } catch { lines = []; }
+  }
+  lines.push(args);
+  writeFileSync(argvFile, JSON.stringify(lines), 'utf8');
+}
+
+const chunks = [];
+process.stdin.on('data', (chunk) => chunks.push(chunk));
+process.stdin.on('end', () => {
+  const buf = Buffer.concat(chunks);
+  if (stdinFile) {
+    appendFileSync(stdinFile, buf);
+  }
+  if (stdoutQueueFile && existsSync(stdoutQueueFile)) {
+    let queue = [];
+    try { queue = JSON.parse(readFileSync(stdoutQueueFile, 'utf8')); } catch { queue = []; }
+    const next = queue.shift();
+    writeFileSync(stdoutQueueFile, JSON.stringify(queue), 'utf8');
+    if (typeof next === 'string') {
+      process.stdout.write(next);
+    }
+  }
+  let exitCode = fallbackExitCode;
+  if (exitCodeQueueFile && existsSync(exitCodeQueueFile)) {
+    let q = [];
+    try { q = JSON.parse(readFileSync(exitCodeQueueFile, 'utf8')); } catch { q = []; }
+    if (q.length > 0) {
+      exitCode = q.shift();
+      writeFileSync(exitCodeQueueFile, JSON.stringify(q), 'utf8');
+    }
+  }
+  process.exit(exitCode);
+});
+`;
+
+export const setupSandbox = (prefix = 'gaia-setup-ci-'): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], {cwd: root});
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: root});
+  writeFileSync(path.join(root, 'README.md'), '# test\n', 'utf8');
+  execFileSync('git', ['add', 'README.md'], {cwd: root});
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], {cwd: root});
+
+  mkdirSync(path.join(root, '.gaia'), {recursive: true});
+
+  const binDir = path.join(root, 'bin');
+  mkdirSync(binDir, {recursive: true});
+
+  const ghArgvPath = path.join(root, 'gh-argv.json');
+  const ghStdinPath = path.join(root, 'gh-stdin.bin');
+  const ghStdoutQueuePath = path.join(root, 'gh-stdout-queue.json');
+  const ghExitCodeQueuePath = path.join(root, 'gh-exit-code-queue.json');
+
+  const writeConfig = (config: AutomationConfig): void => {
+    writeFileSync(automationConfigPath(root), JSON.stringify(config), 'utf8');
+  };
+
+  const installGhShim = (options: {
+    exitCode?: number;
+    exitCodeQueue?: number[];
+    stdoutQueue?: string[];
+  } = {}): {pathOverride: string; restore: () => void} => {
+    const shimPath = path.join(binDir, 'gh');
+    writeFileSync(shimPath, SHIM_NODE_SOURCE, 'utf8');
+    chmodSync(shimPath, 0o755);
+    writeFileSync(
+      ghStdoutQueuePath,
+      JSON.stringify(options.stdoutQueue ?? []),
+      'utf8'
+    );
+    writeFileSync(
+      ghExitCodeQueuePath,
+      JSON.stringify(options.exitCodeQueue ?? []),
+      'utf8'
+    );
+
+    const previousPath = process.env.PATH;
+    const previousArgv = process.env.GH_SHIM_ARGV_FILE;
+    const previousStdin = process.env.GH_SHIM_STDIN_FILE;
+    const previousQueue = process.env.GH_SHIM_STDOUT_QUEUE_FILE;
+    const previousExitQueue = process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
+    const previousExitCode = process.env.GH_SHIM_EXIT_CODE;
+
+    process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ''}`;
+    process.env.GH_SHIM_ARGV_FILE = ghArgvPath;
+    process.env.GH_SHIM_STDIN_FILE = ghStdinPath;
+    process.env.GH_SHIM_STDOUT_QUEUE_FILE = ghStdoutQueuePath;
+    process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE = ghExitCodeQueuePath;
+    process.env.GH_SHIM_EXIT_CODE = String(options.exitCode ?? 0);
+
+    return {
+      pathOverride: process.env.PATH,
+      restore: () => {
+        if (previousPath === undefined) {
+          delete process.env.PATH;
+        } else {
+          process.env.PATH = previousPath;
+        }
+        if (previousArgv === undefined) {
+          delete process.env.GH_SHIM_ARGV_FILE;
+        } else {
+          process.env.GH_SHIM_ARGV_FILE = previousArgv;
+        }
+        if (previousStdin === undefined) {
+          delete process.env.GH_SHIM_STDIN_FILE;
+        } else {
+          process.env.GH_SHIM_STDIN_FILE = previousStdin;
+        }
+        if (previousQueue === undefined) {
+          delete process.env.GH_SHIM_STDOUT_QUEUE_FILE;
+        } else {
+          process.env.GH_SHIM_STDOUT_QUEUE_FILE = previousQueue;
+        }
+        if (previousExitQueue === undefined) {
+          delete process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE;
+        } else {
+          process.env.GH_SHIM_EXIT_CODE_QUEUE_FILE = previousExitQueue;
+        }
+        if (previousExitCode === undefined) {
+          delete process.env.GH_SHIM_EXIT_CODE;
+        } else {
+          process.env.GH_SHIM_EXIT_CODE = previousExitCode;
+        }
+      },
+    };
+  };
+
+  return {
+    binDir,
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    ghArgvPath,
+    ghExitCodeQueuePath,
+    ghStdinPath,
+    ghStdoutQueuePath,
+    installGhShim,
+    root,
+    writeConfig,
+  };
+};
+

--- a/.gaia/cli/src/setup-ci/__tests__/set-secret.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/set-secret.test.ts
@@ -1,0 +1,193 @@
+import {Readable} from 'node:stream';
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../set-secret.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const SECRET_VALUE = 'sk-this-is-the-secret-payload-do-not-leak-12345';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const stdinFromString = (value: string): NodeJS.ReadableStream =>
+  Readable.from([Buffer.from(value, 'utf8')]);
+
+describe('setup-ci set-secret', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let restore: (() => void) | undefined;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-set-secret-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('passes the secret name on argv but never the secret value', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+    expect(exit).toBe(0);
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    expect(recorded[0]).toEqual(['secret', 'set', 'CLAUDE_CODE_OAUTH_TOKEN']);
+
+    // Critical: the secret VALUE never appears anywhere in argv.
+    expect(JSON.stringify(recorded)).not.toContain(SECRET_VALUE);
+  });
+
+  it('pipes the secret to gh stdin', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+    expect(exit).toBe(0);
+
+    const stdinBytes = readFileSync(sandbox.ghStdinPath, 'utf8');
+    expect(stdinBytes).toBe(SECRET_VALUE);
+  });
+
+  it('trims trailing newlines defensively', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(`${SECRET_VALUE}\n`)}
+    );
+
+    const stdinBytes = readFileSync(sandbox.ghStdinPath, 'utf8');
+    expect(stdinBytes).toBe(SECRET_VALUE);
+  });
+
+  it('does NOT echo the secret to stdout or stderr on happy path', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+
+    expect(stdio.out.join('')).not.toContain(SECRET_VALUE);
+    expect(stdio.err.join('')).not.toContain(SECRET_VALUE);
+  });
+
+  it('does NOT echo the secret on gh failure path', async () => {
+    const handle = sandbox.installGhShim({exitCode: 1});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+    expect(exit).not.toBe(0);
+
+    const allOutput = stdio.out.join('') + stdio.err.join('');
+    expect(allOutput).not.toContain(SECRET_VALUE);
+
+    // The structured error/payload must use a generic message.
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.set).toBe(false);
+    expect(parsed.error).toBe('gh_failure');
+  });
+
+  it('exits unknown_secret_name on unsupported names', async () => {
+    const exit = await run(
+      ['NOT_A_REAL_SECRET'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown_secret_name');
+  });
+
+  it('exits empty_secret on empty stdin', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString('')}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('empty_secret');
+  });
+
+  it('exits empty_secret when stdin is only newlines', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString('\n\n')}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('empty_secret');
+  });
+
+  it('accepts ANTHROPIC_API_KEY as a supported name', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['ANTHROPIC_API_KEY'],
+      {cwd: sandbox.root, stdin: stdinFromString('sk-ant-12345')}
+    );
+    expect(exit).toBe(0);
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    expect(recorded[0]).toEqual(['secret', 'set', 'ANTHROPIC_API_KEY']);
+  });
+
+  it('--help exits 0', async () => {
+    const exit = await run(['--help'], {
+      cwd: sandbox.root,
+      stdin: stdinFromString(''),
+    });
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/set-secret.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/set-secret.test.ts
@@ -135,6 +135,30 @@ describe('setup-ci set-secret', () => {
     expect(parsed.error).toBe('gh_failure');
   });
 
+  it('does NOT echo the secret when gh emits it in its own stderr', async () => {
+    // Defense-in-depth: even if a future `gh` build leaks the captured
+    // secret to its own stderr, the handler must suppress it and emit a
+    // generic `gh_failure` instead of forwarding the raw stderr.
+    const handle = sandbox.installGhShim({
+      exitCode: 1,
+      stderrQueue: [`gh: api error: token=${SECRET_VALUE} rejected`],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      ['CLAUDE_CODE_OAUTH_TOKEN'],
+      {cwd: sandbox.root, stdin: stdinFromString(SECRET_VALUE)}
+    );
+    expect(exit).not.toBe(0);
+
+    const allOutput = stdio.out.join('') + stdio.err.join('');
+    expect(allOutput).not.toContain(SECRET_VALUE);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.set).toBe(false);
+    expect(parsed.error).toBe('gh_failure');
+  });
+
   it('exits unknown_secret_name on unsupported names', async () => {
     const exit = await run(
       ['NOT_A_REAL_SECRET'],

--- a/.gaia/cli/src/setup-ci/__tests__/status.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/status.test.ts
@@ -1,0 +1,156 @@
+import {mkdirSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {localAutomationPath} from '../../automation/paths.js';
+import {run} from '../status.js';
+import {
+  setupSandbox,
+  VALID_BASE_CONFIG,
+  type Sandbox,
+} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci status', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-status-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns configured: false when .gaia/automation.json is missing', () => {
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.configured).toBe(false);
+    expect(parsed.tools_enabled).toEqual([]);
+  });
+
+  it('returns configured: true with full report when config is present', () => {
+    sandbox.writeConfig({
+      ...VALID_BASE_CONFIG,
+      pnpm_audit: {mode: 'local', schedule: 'weekly'},
+      setup_complete: false,
+    });
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.configured).toBe(true);
+    expect(parsed.setup_complete).toBe(false);
+    expect(parsed.setup_opted_out).toBe(false);
+    // `pnpm_audit` is local, so only the other three are CI-mode.
+    expect(parsed.tools_enabled).toEqual(['wiki', 'sharpen', 'stale-branches']);
+  });
+
+  it('reports nudge_dismissed from .gaia/local/automation.json when present', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    mkdirSync(path.dirname(localAutomationPath(sandbox.root)), {recursive: true});
+    writeFileSync(
+      localAutomationPath(sandbox.root),
+      JSON.stringify({nudge_dismissed: true, version: 1}),
+      'utf8'
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.nudge_dismissed).toBe(true);
+  });
+
+  it('exits non-zero when local file is malformed', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+    mkdirSync(path.dirname(localAutomationPath(sandbox.root)), {recursive: true});
+    writeFileSync(
+      localAutomationPath(sandbox.root),
+      JSON.stringify({nudge_dismissed: 'yes', version: 1}),
+      'utf8'
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('local_malformed');
+  });
+
+  it('exits non-zero when committed config is malformed', () => {
+    sandbox.writeConfig({
+      ...VALID_BASE_CONFIG,
+      version: 99 as unknown as 1,
+    });
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_malformed');
+  });
+
+  it('emits a human report without --json', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const out = stdio.out.join('');
+    expect(out).toContain('configured: true');
+    expect(out).toContain('tools_enabled:');
+  });
+
+  it('emits a missing-config human message when .gaia/automation.json absent', () => {
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    expect(stdio.out.join('')).toContain('not configured');
+  });
+
+  it('rejects unknown flags', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown flag');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/verify-run.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/verify-run.test.ts
@@ -1,0 +1,219 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../verify-run.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const completedSuccess = JSON.stringify({
+  conclusion: 'success',
+  status: 'completed',
+  url: 'https://github.com/foo/bar/actions/runs/12345',
+});
+
+const completedFailure = JSON.stringify({
+  conclusion: 'failure',
+  status: 'completed',
+  url: 'https://github.com/foo/bar/actions/runs/12345',
+});
+
+const inProgress = JSON.stringify({
+  conclusion: null,
+  status: 'in_progress',
+  url: 'https://github.com/foo/bar/actions/runs/12345',
+});
+
+const runListPayload = JSON.stringify([
+  {createdAt: '2026-05-09T05:00:00.000Z', databaseId: 12_345},
+]);
+
+describe('setup-ci verify-run', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+  let restore: (() => void) | undefined;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-verify-run-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns verified: true on completed/success', async () => {
+    // Sequence: workflow run, run list, run view (completed success).
+    const handle = sandbox.installGhShim({
+      stdoutQueue: ['', runListPayload, completedSuccess],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.verified).toBe(true);
+    expect(parsed.conclusion).toBe('success');
+    expect(parsed.run_id).toBe('12345');
+  });
+
+  it('returns verified: false on completed/failure', async () => {
+    const handle = sandbox.installGhShim({
+      stdoutQueue: ['', runListPayload, completedFailure],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.verified).toBe(false);
+    expect(parsed.conclusion).toBe('failure');
+  });
+
+  it('polls until completed when status starts in_progress', async () => {
+    // 5 calls: workflow run, run list, view in_progress, view in_progress, view completed.
+    const handle = sandbox.installGhShim({
+      stdoutQueue: ['', runListPayload, inProgress, inProgress, completedSuccess],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      [
+        '.github/workflows/gaia-ci-wiki.yml',
+        '--json',
+        '--poll-interval-ms',
+        '5',
+        '--timeout-seconds',
+        '30',
+      ],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.verified).toBe(true);
+
+    // Three view calls were made.
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    const viewCalls = recorded.filter(
+      (args) => args[0] === 'run' && args[1] === 'view'
+    );
+    expect(viewCalls.length).toBe(3);
+  });
+
+  it('returns conclusion: polling_timeout on hard timeout', async () => {
+    // Endless in_progress responses -> the handler should hit the
+    // timeout and emit polling_timeout.
+    const queue: string[] = ['', runListPayload];
+
+    for (let i = 0; i < 50; i += 1) queue.push(inProgress);
+
+    const handle = sandbox.installGhShim({stdoutQueue: queue});
+    restore = handle.restore;
+
+    const exit = await run(
+      [
+        '.github/workflows/gaia-ci-wiki.yml',
+        '--json',
+        '--poll-interval-ms',
+        '5',
+        '--timeout-seconds',
+        '1',
+      ],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.verified).toBe(false);
+    expect(parsed.conclusion).toBe('polling_timeout');
+  });
+
+  it('exits non-zero when gh workflow run fails', async () => {
+    const handle = sandbox.installGhShim({exitCode: 1});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('workflow_run_failed');
+  });
+
+  it('exits non-zero when gh run list returns no runs', async () => {
+    const handle = sandbox.installGhShim({
+      stdoutQueue: ['', '[]'],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('run_list_empty');
+  });
+
+  it('exits non-zero when --timeout-seconds is invalid', async () => {
+    const exit = await run(
+      ['.github/workflows/foo.yml', '--timeout-seconds', '0'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('invalid_arguments');
+  });
+
+  it('exits non-zero when workflow file argument is missing', async () => {
+    const exit = await run(['--json'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('missing_required_arg');
+  });
+
+  it('--help exits 0', async () => {
+    const exit = await run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/warn-existing-tools.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/warn-existing-tools.test.ts
@@ -1,0 +1,150 @@
+import {mkdirSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {run} from '../warn-existing-tools.js';
+import {setupSandbox, type Sandbox} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const writeFileAt = (root: string, relPath: string, content: string): void => {
+  const target = path.join(root, relPath);
+  mkdirSync(path.dirname(target), {recursive: true});
+  writeFileSync(target, content, 'utf8');
+};
+
+describe('setup-ci warn-existing-tools', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-warn-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array on a clean repo', () => {
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual([]);
+  });
+
+  it('detects .github/dependabot.yml', () => {
+    writeFileAt(sandbox.root, '.github/dependabot.yml', 'version: 2\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['dependabot']);
+  });
+
+  it('detects .github/dependabot.yaml', () => {
+    writeFileAt(sandbox.root, '.github/dependabot.yaml', 'version: 2\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['dependabot']);
+  });
+
+  it('detects renovate.json', () => {
+    writeFileAt(sandbox.root, 'renovate.json', '{}\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['renovate']);
+  });
+
+  it('detects .renovaterc.json and .github/renovate.json under same name', () => {
+    writeFileAt(sandbox.root, '.renovaterc.json', '{}\n');
+    writeFileAt(sandbox.root, '.github/renovate.json', '{}\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['renovate']);
+  });
+
+  it('reports both when both exist', () => {
+    writeFileAt(sandbox.root, '.github/dependabot.yml', 'version: 2\n');
+    writeFileAt(sandbox.root, 'renovate.json', '{}\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['dependabot', 'renovate']);
+  });
+
+  it('deduplicates when both .yml and .yaml exist', () => {
+    writeFileAt(sandbox.root, '.github/dependabot.yml', 'version: 2\n');
+    writeFileAt(sandbox.root, '.github/dependabot.yaml', 'version: 2\n');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.found).toEqual(['dependabot']);
+  });
+
+  it('emits a human report without --json', () => {
+    writeFileAt(sandbox.root, '.github/dependabot.yml', 'version: 2\n');
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('detected: dependabot');
+  });
+
+  it('rejects unknown flags', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown flag');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
@@ -1,0 +1,151 @@
+import {writeFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {automationConfigPath} from '../../automation/paths.js';
+import {readAutomationConfig} from '../../schemas/automation-config.js';
+import {run} from '../write-tool-mode.js';
+import {
+  setupSandbox,
+  VALID_BASE_CONFIG,
+  type Sandbox,
+} from './sandbox.js';
+
+const captureStdio = (): {
+  err: string[];
+  out: string[];
+  restore: () => void;
+} => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('setup-ci write-tool-mode', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-write-tool-mode-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('flips a tool mode to off and preserves schedule', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['stale-branches', 'off'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.config.stale_branches.mode).toBe('off');
+      // Schedule preserved.
+      expect(result.config.stale_branches.schedule).toBe('monthly');
+    }
+  });
+
+  it('writes mode without schedule when existing slot has none', () => {
+    sandbox.writeConfig({
+      ...VALID_BASE_CONFIG,
+      sharpen: {mode: 'ci'},
+    });
+
+    const exit = run(['sharpen', 'local'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.config.sharpen.mode).toBe('local');
+      expect(result.config.sharpen.schedule).toBeUndefined();
+    }
+  });
+
+  it('emits {tool, mode} JSON on success', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['wiki', 'local'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+    expect(parsed.tool).toBe('wiki');
+    expect(parsed.mode).toBe('local');
+  });
+
+  it('exits invalid_arguments on unknown tool', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['bogus-tool', 'off'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('unknown tool');
+  });
+
+  it('exits invalid_arguments on unknown mode', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['wiki', 'bogus'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('invalid mode');
+  });
+
+  it('exits config_missing when config absent', () => {
+    const exit = run(['wiki', 'off'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_missing');
+  });
+
+  it('exits config_malformed when config fails schema', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      'utf8'
+    );
+
+    const exit = run(['wiki', 'off'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('config_malformed');
+  });
+
+  it('exits missing_required_arg when mode missing', () => {
+    sandbox.writeConfig(VALID_BASE_CONFIG);
+
+    const exit = run(['wiki'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('missing_required_arg');
+  });
+
+  it('--help exits 0', () => {
+    const exit = run(['--help'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('Usage:');
+  });
+});

--- a/.gaia/cli/src/setup-ci/check-admin.ts
+++ b/.gaia/cli/src/setup-ci/check-admin.ts
@@ -1,0 +1,157 @@
+/**
+ * `gaia setup-ci check-admin --owner <o> --repo <r> [--json]` handler.
+ *
+ * Probes whether the authenticated user has admin permission on the
+ * target repo. Returns a strict three-way `auth_status` enum so the
+ * slash command can branch:
+ *
+ *   - `ok`               — gh auth + API both succeeded.
+ *   - `unauthenticated`  — gh auth status failed.
+ *   - `api_error`        — auth ok but the repos API call failed.
+ *
+ * Contract: `admin: false` whenever `auth_status != "ok"`. Never
+ * false-positive admin. Exits 0 in every branch — `check-admin` is a
+ * query, not a gate.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {runGh} from './util/gh.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci check-admin --owner <o> --repo <r> [--json]
+
+  Probe repo admin permission via \`gh\`. Returns admin: false for any
+  non-ok auth status. Exits 0 in every branch.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+type AuthStatus = 'api_error' | 'ok' | 'unauthenticated';
+
+type CheckAdminOutput = {
+  admin: boolean;
+  auth_status: AuthStatus;
+  error?: string;
+};
+
+const printHuman = (output: CheckAdminOutput): void => {
+  process.stdout.write(
+    `admin: ${String(output.admin)}\nauth_status: ${output.auth_status}\n`
+  );
+};
+
+export const run = async (
+  argv: readonly string[],
+  options: RunOptions = {}
+): Promise<number> => {
+  let json = false;
+  let owner: string | undefined;
+  let repo: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--owner') {
+      owner = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--repo') {
+      repo = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'setup-ci check-admin',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (owner === undefined || repo === undefined) {
+    structuredError({
+      code: 'missing_required_arg',
+      message: 'check-admin requires --owner <o> --repo <r>',
+      subcommand: 'setup-ci check-admin',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Step 1: gh auth status.
+  const authResult = await runGh({
+    args: ['auth', 'status'],
+    cwd: options.cwd ?? process.cwd(),
+  });
+
+  if (!authResult.ok) {
+    const output: CheckAdminOutput = {
+      admin: false,
+      auth_status: 'unauthenticated',
+    };
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(output)}\n`);
+    } else {
+      printHuman(output);
+    }
+
+    return EXIT_CODES.OK;
+  }
+
+  // Step 2: gh api repos/<owner>/<repo> --jq .permissions.admin.
+  const apiResult = await runGh({
+    args: ['api', `repos/${owner}/${repo}`, '--jq', '.permissions.admin'],
+    cwd: options.cwd ?? process.cwd(),
+  });
+
+  if (!apiResult.ok) {
+    const output: CheckAdminOutput = {
+      admin: false,
+      auth_status: 'api_error',
+      error: apiResult.stderr.trim(),
+    };
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(output)}\n`);
+    } else {
+      printHuman(output);
+    }
+
+    return EXIT_CODES.OK;
+  }
+
+  const trimmed = apiResult.stdout.trim();
+  const admin = trimmed === 'true';
+
+  const output: CheckAdminOutput = {admin, auth_status: 'ok'};
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    printHuman(output);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/detect-remote.ts
+++ b/.gaia/cli/src/setup-ci/detect-remote.ts
@@ -1,0 +1,147 @@
+/**
+ * `gaia setup-ci detect-remote [--json]` handler.
+ *
+ * Shells `git remote get-url origin` and parses the result via
+ * `parseRemoteUrl`. Returns the four parsed fields on success; returns
+ * `{ found: false, ... }` on missing remote.
+ *
+ * Exits 0 in every branch where the working directory is a git repo —
+ * `detect-remote` is a query. Exits non-zero only for `not_a_git_repo`.
+ */
+import {execFileSync} from 'node:child_process';
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {parseRemoteUrl} from './util/parse-remote-url.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci detect-remote [--json]
+
+  Read \`git remote get-url origin\` and parse it. Returns parsed
+  owner/repo/host on success; \`found: false\` on missing remote.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+type DetectOutput = {
+  found: boolean;
+  host: null | string;
+  owner: null | string;
+  repo: null | string;
+  url: null | string;
+};
+
+const tryGitRemoteUrl = (cwd: string): null | string => {
+  try {
+    const result = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    return result.toString().trim();
+  } catch {
+    return null;
+  }
+};
+
+const printHuman = (output: DetectOutput): void => {
+  if (!output.found) {
+    process.stdout.write('No origin remote configured.\n');
+
+    return;
+  }
+
+  process.stdout.write(
+    `url: ${String(output.url)}\n`
+      + `host: ${String(output.host)}\n`
+      + `owner: ${String(output.owner)}\n`
+      + `repo: ${String(output.repo)}\n`
+  );
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'setup-ci detect-remote',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia setup-ci detect-remote must run inside a git repository',
+      subcommand: 'setup-ci detect-remote',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const url = tryGitRemoteUrl(repoRoot);
+
+  if (url === null) {
+    const output: DetectOutput = {
+      found: false,
+      host: null,
+      owner: null,
+      repo: null,
+      url: null,
+    };
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(output)}\n`);
+    } else {
+      printHuman(output);
+    }
+
+    return EXIT_CODES.OK;
+  }
+
+  const parsed = parseRemoteUrl(url);
+
+  const output: DetectOutput = parsed === null
+    ? {found: false, host: null, owner: null, repo: null, url}
+    : {
+      found: true,
+      host: parsed.host,
+      owner: parsed.owner,
+      repo: parsed.repo,
+      url: parsed.url,
+    };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    printHuman(output);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/dismiss-personal.ts
+++ b/.gaia/cli/src/setup-ci/dismiss-personal.ts
@@ -1,0 +1,90 @@
+/**
+ * `gaia setup-ci dismiss-personal` handler.
+ *
+ * Writes `.gaia/local/automation.json` with `nudge_dismissed: true`.
+ * The file is gitignored — this is the per-machine "stop nudging me"
+ * record. Idempotent: re-running on an already-dismissed local writes
+ * the same shape; the result is unchanged.
+ *
+ * If the existing local file is malformed, the handler refuses with
+ * `local_malformed` rather than overwriting (slice 1's read helper
+ * detects malformed shapes).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {readLocalAutomation} from '../schemas/local-automation.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeLocalAutomation} from './util/local-automation-write.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci dismiss-personal
+
+  Write nudge_dismissed=true to .gaia/local/automation.json (gitignored).
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'setup-ci dismiss-personal',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message:
+        'gaia setup-ci dismiss-personal must run inside a git repository',
+      subcommand: 'setup-ci dismiss-personal',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const existing = readLocalAutomation(repoRoot);
+
+  if (existing.status === 'malformed') {
+    structuredError({
+      code: 'local_malformed',
+      message: existing.error,
+      subcommand: 'setup-ci dismiss-personal',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  // Read-then-merge: preserve any future fields slice 1's schema may
+  // grow without a slice-4 update. The only field this primitive sets
+  // is `nudge_dismissed`.
+  const merged
+    = existing.status === 'ok'
+      ? {...existing.local, nudge_dismissed: true}
+      : {nudge_dismissed: true, version: 1 as const};
+
+  writeLocalAutomation(repoRoot, merged);
+
+  process.stdout.write(`${JSON.stringify({dismissed: true})}\n`);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/enable-delete-branch.ts
+++ b/.gaia/cli/src/setup-ci/enable-delete-branch.ts
@@ -1,0 +1,102 @@
+/**
+ * `gaia setup-ci enable-delete-branch --owner <o> --repo <r>` handler.
+ *
+ * Runs `gh api -X PATCH repos/<owner>/<repo> -f delete_branch_on_merge=true`.
+ * The slash command has already verified admin permission via
+ * `check-admin` before invoking this primitive.
+ *
+ * Output JSON:
+ *   `{ "applied": true }` on success.
+ *   `{ "applied": false, "error": "<gh stderr>" }` on failure.
+ *
+ * Exits 0 on success, non-zero on failure (so callers can branch on
+ * exit code AND inspect the JSON for the error message).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {runGh} from './util/gh.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci enable-delete-branch --owner <o> --repo <r>
+
+  PATCH repos/<owner>/<repo> -f delete_branch_on_merge=true via gh.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = async (
+  argv: readonly string[],
+  options: RunOptions = {}
+): Promise<number> => {
+  let owner: string | undefined;
+  let repo: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--owner') {
+      owner = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--repo') {
+      repo = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'setup-ci enable-delete-branch',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (owner === undefined || repo === undefined) {
+    structuredError({
+      code: 'missing_required_arg',
+      message: 'enable-delete-branch requires --owner <o> --repo <r>',
+      subcommand: 'setup-ci enable-delete-branch',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = await runGh({
+    args: [
+      'api',
+      '-X',
+      'PATCH',
+      `repos/${owner}/${repo}`,
+      '-f',
+      'delete_branch_on_merge=true',
+    ],
+    cwd: options.cwd ?? process.cwd(),
+  });
+
+  if (!result.ok) {
+    process.stdout.write(
+      `${JSON.stringify({applied: false, error: result.stderr.trim()})}\n`
+    );
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  process.stdout.write(`${JSON.stringify({applied: true})}\n`);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/finalize.ts
+++ b/.gaia/cli/src/setup-ci/finalize.ts
@@ -1,0 +1,95 @@
+/**
+ * `gaia setup-ci finalize` handler.
+ *
+ * Sets `setup_complete: true` in `.gaia/automation.json` via the
+ * schema-typed write helper. The only primitive that flips
+ * `setup_complete`. Idempotent — re-running on an already-finalized
+ * config returns `already_finalized: true` without changing the
+ * file's content (the write itself runs and is a no-op shape-wise).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {readAutomationConfig} from '../schemas/automation-config.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeAutomationConfig} from './util/automation-write.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci finalize
+
+  Flip setup_complete=true in .gaia/automation.json. Idempotent.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'setup-ci finalize',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia setup-ci finalize must run inside a git repository',
+      subcommand: 'setup-ci finalize',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationConfig(repoRoot);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'config_missing',
+      message: '.gaia/automation.json does not exist',
+      subcommand: 'setup-ci finalize',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: result.error,
+      subcommand: 'setup-ci finalize',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const alreadyFinalized = result.config.setup_complete;
+
+  writeAutomationConfig(repoRoot, {
+    ...result.config,
+    setup_complete: true,
+  });
+
+  process.stdout.write(
+    `${JSON.stringify({already_finalized: alreadyFinalized, finalized: true})}\n`
+  );
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/index.ts
+++ b/.gaia/cli/src/setup-ci/index.ts
@@ -1,0 +1,88 @@
+/**
+ * `gaia setup-ci` subcommand router.
+ *
+ * The Phase B remote-integration surface for GAIA CI. Every primitive
+ * the `/setup-gaia-ci` slash command shells out to lives under this
+ * namespace — remote detection, admin permission probe, token
+ * piping (stdin only), workflow_dispatch verification, and the
+ * `setup_complete` flip.
+ *
+ * Object-map dispatch (no `switch`) per the project's typescript
+ * conventions; mirrors the shape of `setup/index.ts` and
+ * `automation/index.ts`.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {run as runCheckAdmin} from './check-admin.js';
+import {run as runDetectRemote} from './detect-remote.js';
+import {run as runDismissPersonal} from './dismiss-personal.js';
+import {run as runEnableDeleteBranch} from './enable-delete-branch.js';
+import {run as runFinalize} from './finalize.js';
+import {run as runOptOutTeam} from './opt-out-team.js';
+import {run as runSetSecret} from './set-secret.js';
+import {run as runStatus} from './status.js';
+import {run as runVerifyRun} from './verify-run.js';
+import {run as runWarnExistingTools} from './warn-existing-tools.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci <subcommand> [args]
+
+  status [--json]                          Print Phase B configuration status.
+  detect-remote [--json]                   Read git remote get-url origin.
+  warn-existing-tools [--json]             Detect Dependabot / Renovate configs.
+  check-admin --owner <o> --repo <r> [--json]
+                                           Probe repo admin permission via gh.
+  dismiss-personal                         Write nudge_dismissed=true (per-machine).
+  opt-out-team                             Write setup_opted_out=true (committed).
+  enable-delete-branch --owner <o> --repo <r>
+                                           PATCH delete_branch_on_merge=true.
+  set-secret <name>                        Pipe stdin into gh secret set <name>.
+  verify-run <workflow-file> [--timeout-seconds N] [--json]
+                                           Trigger workflow_dispatch and watch run.
+  finalize                                 Flip setup_complete=true.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type SubcommandHandler = (
+  args: readonly string[]
+) => number | Promise<number>;
+
+const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> = {
+  'check-admin': runCheckAdmin,
+  'detect-remote': runDetectRemote,
+  'dismiss-personal': runDismissPersonal,
+  'enable-delete-branch': runEnableDeleteBranch,
+  finalize: runFinalize,
+  'opt-out-team': runOptOutTeam,
+  'set-secret': runSetSecret,
+  status: runStatus,
+  'verify-run': runVerifyRun,
+  'warn-existing-tools': runWarnExistingTools,
+};
+
+export const run = async (argv: readonly string[]): Promise<number> => {
+  const subcommand = argv[0] as string | undefined;
+  const rest = argv.slice(1);
+
+  if (subcommand === undefined || HELP_TOKENS.has(subcommand)) {
+    process.stdout.write(HELP_TEXT);
+
+    return EXIT_CODES.OK;
+  }
+
+  const handler = SUBCOMMAND_HANDLERS[subcommand];
+
+  if (handler !== undefined) {
+    const result = await handler(rest);
+
+    return typeof result === 'number' ? result : EXIT_CODES.OK;
+  }
+
+  structuredError({
+    code: 'unknown_subcommand',
+    message: `unknown setup-ci subcommand: ${subcommand}`,
+    subcommand: `setup-ci ${subcommand}`,
+  });
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};

--- a/.gaia/cli/src/setup-ci/index.ts
+++ b/.gaia/cli/src/setup-ci/index.ts
@@ -23,6 +23,7 @@ import {run as runSetSecret} from './set-secret.js';
 import {run as runStatus} from './status.js';
 import {run as runVerifyRun} from './verify-run.js';
 import {run as runWarnExistingTools} from './warn-existing-tools.js';
+import {run as runWriteToolMode} from './write-tool-mode.js';
 
 const HELP_TEXT = `Usage: gaia setup-ci <subcommand> [args]
 
@@ -39,6 +40,7 @@ const HELP_TEXT = `Usage: gaia setup-ci <subcommand> [args]
   verify-run <workflow-file> [--timeout-seconds N] [--json]
                                            Trigger workflow_dispatch and watch run.
   finalize                                 Flip setup_complete=true.
+  write-tool-mode <tool> <mode>            Set a tool's mode in .gaia/automation.json.
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
@@ -58,6 +60,7 @@ const SUBCOMMAND_HANDLERS: Readonly<Partial<Record<string, SubcommandHandler>>> 
   status: runStatus,
   'verify-run': runVerifyRun,
   'warn-existing-tools': runWarnExistingTools,
+  'write-tool-mode': runWriteToolMode,
 };
 
 export const run = async (argv: readonly string[]): Promise<number> => {

--- a/.gaia/cli/src/setup-ci/opt-out-team.ts
+++ b/.gaia/cli/src/setup-ci/opt-out-team.ts
@@ -1,0 +1,94 @@
+/**
+ * `gaia setup-ci opt-out-team` handler.
+ *
+ * Writes `setup_opted_out: true` to `.gaia/automation.json` (the
+ * committed config). The CLI does NOT check admin permission — that's
+ * the slash command's responsibility. By the time this primitive is
+ * called, `check-admin` has already returned `admin: true`.
+ *
+ * Refuses (non-zero) when the config is missing or malformed —
+ * fail-closed, no destructive write on a broken state.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {readAutomationConfig} from '../schemas/automation-config.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeAutomationConfig} from './util/automation-write.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci opt-out-team
+
+  Write setup_opted_out=true to .gaia/automation.json (committed).
+  Refuses if the config is missing or malformed.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'setup-ci opt-out-team',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia setup-ci opt-out-team must run inside a git repository',
+      subcommand: 'setup-ci opt-out-team',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationConfig(repoRoot);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'config_missing',
+      message: '.gaia/automation.json does not exist',
+      subcommand: 'setup-ci opt-out-team',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: result.error,
+      subcommand: 'setup-ci opt-out-team',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  writeAutomationConfig(repoRoot, {
+    ...result.config,
+    setup_opted_out: true,
+  });
+
+  process.stdout.write(`${JSON.stringify({opted_out: true})}\n`);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/set-secret.ts
+++ b/.gaia/cli/src/setup-ci/set-secret.ts
@@ -1,0 +1,173 @@
+/**
+ * `gaia setup-ci set-secret <name>` handler.
+ *
+ * Reads the token from `process.stdin` and pipes it directly to
+ * `gh secret set <name>` via the child's stdin. The implementation
+ * is designed to never leak the secret on any code path:
+ *
+ *   - The token is NEVER appended to argv. The `gh` invocation always
+ *     receives the literal `['secret', 'set', <name>]`.
+ *   - The token is NEVER written to a file.
+ *   - The token is NEVER echoed to stdout or stderr.
+ *   - On any failure (including `gh` non-zero, gh missing from PATH,
+ *     stdin empty, unknown name, etc.), the structured-error / JSON
+ *     payload contains a generic message — never the captured `gh`
+ *     stdout/stderr verbatim.
+ *
+ * If `gh` writes the secret to its OWN stderr (which it should not,
+ * but defense in depth), the wrapper captures the stderr but this
+ * handler reports a generic `gh_failure` message rather than echoing
+ * the captured stderr in the structured error. This is the only place
+ * in the codebase that intentionally suppresses stderr propagation —
+ * the trade-off is an opaque error message in exchange for a strict
+ * no-leak guarantee.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {runGh} from './util/gh.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci set-secret <name>
+
+  Read a secret value from stdin and pipe it into \`gh secret set <name>\`.
+  The token is never echoed, logged, or passed on the command line.
+
+  <name> must be one of: CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const SUPPORTED_SECRET_NAMES = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+] as const;
+
+type SupportedSecretName = (typeof SUPPORTED_SECRET_NAMES)[number];
+
+type RunOptions = {
+  cwd?: string;
+  stdin?: NodeJS.ReadableStream;
+};
+
+const readStdinToBuffer = (
+  stream: NodeJS.ReadableStream
+): Promise<Buffer> => {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    stream.on('data', (chunk: Buffer | string) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+    });
+
+    stream.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+
+    stream.on('error', (error: Error) => {
+      reject(error);
+    });
+  });
+};
+
+const trimTrailingWhitespace = (buf: Buffer): Buffer => {
+  let end = buf.length;
+
+  while (end > 0) {
+    const byte = buf[end - 1];
+
+    if (byte === 0x0a /* \n */ || byte === 0x0d /* \r */) {
+      end -= 1;
+
+      continue;
+    }
+    break;
+  }
+
+  return buf.subarray(0, end);
+};
+
+export const run = async (
+  argv: readonly string[],
+  options: RunOptions = {}
+): Promise<number> => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  const name = argv[0] as string;
+  const rest = argv.slice(1);
+
+  if (rest.length > 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${rest[0] as string}`,
+      subcommand: 'setup-ci set-secret',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (!(SUPPORTED_SECRET_NAMES as readonly string[]).includes(name)) {
+    structuredError({
+      code: 'unknown_secret_name',
+      message: `unsupported secret name: ${name}. Supported: ${SUPPORTED_SECRET_NAMES.join(', ')}`,
+      subcommand: 'setup-ci set-secret',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const validatedName = name as SupportedSecretName;
+
+  const stream = options.stdin ?? process.stdin;
+  let stdinBuffer: Buffer;
+
+  try {
+    stdinBuffer = await readStdinToBuffer(stream);
+  } catch {
+    structuredError({
+      code: 'stdin_read_error',
+      message: 'failed to read secret from stdin',
+      subcommand: 'setup-ci set-secret',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const trimmed = trimTrailingWhitespace(stdinBuffer);
+
+  if (trimmed.length === 0) {
+    structuredError({
+      code: 'empty_secret',
+      message: 'no secret value provided on stdin',
+      subcommand: 'setup-ci set-secret',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = await runGh({
+    args: ['secret', 'set', validatedName],
+    cwd: options.cwd ?? process.cwd(),
+    stdin: trimmed,
+  });
+
+  if (!result.ok) {
+    // Defensive no-leak: never include `result.stderr` (which `gh`
+    // populated) in any user-visible payload. The captured stderr
+    // could in principle echo the secret if `gh` misbehaves; we report
+    // a generic failure marker instead.
+    process.stdout.write(
+      `${JSON.stringify({error: 'gh_failure', name: validatedName, set: false})}\n`
+    );
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  process.stdout.write(
+    `${JSON.stringify({name: validatedName, set: true})}\n`
+  );
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/status.ts
+++ b/.gaia/cli/src/setup-ci/status.ts
@@ -1,0 +1,178 @@
+/**
+ * `gaia setup-ci status [--json]` handler.
+ *
+ * Reads `.gaia/automation.json` and `.gaia/local/automation.json` and
+ * prints a Phase-B-readiness summary. The `/setup-gaia-ci` slash
+ * command's first step is `status --json`; it bails when
+ * `configured: false` (Phase A has not run).
+ *
+ * JSON shape (the canonical contract):
+ *
+ *   {
+ *     "configured": boolean,
+ *     "setup_complete": boolean,
+ *     "setup_opted_out": boolean,
+ *     "nudge_dismissed": boolean,
+ *     "tools_enabled": ToolId[]
+ *   }
+ *
+ * `tools_enabled` lists every tool whose `.mode == "ci"`. The handler
+ * exits 0 in every branch — `status` is a query, not a gate.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  TOOL_ID_TO_CONFIG_KEY,
+  TOOL_IDS,
+  readAutomationConfig,
+  type AutomationConfig,
+  type ToolId,
+} from '../schemas/automation-config.js';
+import {readLocalAutomation} from '../schemas/local-automation.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci status [--json]
+
+  Print whether Phase B (GAIA CI remote integration) is configured.
+  Exits 0 in every state — branch on the JSON output.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+type StatusOutput = {
+  configured: boolean;
+  nudge_dismissed: boolean;
+  setup_complete: boolean;
+  setup_opted_out: boolean;
+  tools_enabled: ToolId[];
+};
+
+const enabledTools = (config: AutomationConfig): ToolId[] => {
+  const result: ToolId[] = [];
+
+  for (const tool of TOOL_IDS) {
+    const key = TOOL_ID_TO_CONFIG_KEY[tool];
+    const slot = config[key] as {mode: string} | undefined;
+
+    if (slot !== undefined && slot.mode === 'ci') {
+      result.push(tool);
+    }
+  }
+
+  return result;
+};
+
+const printHuman = (output: StatusOutput): void => {
+  if (!output.configured) {
+    process.stdout.write(
+      'GAIA CI is not configured for this repo. .gaia/automation.json is missing.\n'
+    );
+
+    return;
+  }
+
+  process.stdout.write(
+    `configured: true\n`
+      + `setup_complete: ${String(output.setup_complete)}\n`
+      + `setup_opted_out: ${String(output.setup_opted_out)}\n`
+      + `nudge_dismissed: ${String(output.nudge_dismissed)}\n`
+      + `tools_enabled: ${output.tools_enabled.join(', ') || '(none)'}\n`
+  );
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'setup-ci status',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia setup-ci status must run inside a git repository',
+      subcommand: 'setup-ci status',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const configRead = readAutomationConfig(repoRoot);
+
+  if (configRead.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: configRead.error,
+      subcommand: 'setup-ci status',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const localRead = readLocalAutomation(repoRoot);
+
+  if (localRead.status === 'malformed') {
+    structuredError({
+      code: 'local_malformed',
+      message: localRead.error,
+      subcommand: 'setup-ci status',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const output: StatusOutput = configRead.status === 'ok'
+    ? {
+      configured: true,
+      nudge_dismissed:
+        localRead.status === 'ok' ? localRead.local.nudge_dismissed : false,
+      setup_complete: configRead.config.setup_complete,
+      setup_opted_out: configRead.config.setup_opted_out,
+      tools_enabled: enabledTools(configRead.config),
+    }
+    : {
+      configured: false,
+      nudge_dismissed:
+        localRead.status === 'ok' ? localRead.local.nudge_dismissed : false,
+      setup_complete: false,
+      setup_opted_out: false,
+      tools_enabled: [],
+    };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    printHuman(output);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/util/__tests__/automation-write.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/automation-write.test.ts
@@ -1,0 +1,55 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {automationConfigPath} from '../../../automation/paths.js';
+import {readAutomationConfig} from '../../../schemas/automation-config.js';
+import {
+  setupSandbox,
+  VALID_BASE_CONFIG,
+  type Sandbox,
+} from '../../__tests__/sandbox.js';
+import {writeAutomationConfig} from '../automation-write.js';
+
+describe('writeAutomationConfig', () => {
+  let sandbox: Sandbox;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-config-write-');
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  it('writes the committed file with 2-space indentation and trailing newline', () => {
+    writeAutomationConfig(sandbox.root, VALID_BASE_CONFIG);
+
+    const filePath = automationConfigPath(sandbox.root);
+    const raw = readFileSync(filePath, 'utf8');
+
+    expect(raw).toContain('  "version": 1');
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+
+  it('round-trips through readAutomationConfig', () => {
+    writeAutomationConfig(sandbox.root, {
+      ...VALID_BASE_CONFIG,
+      setup_complete: true,
+    });
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.config.setup_complete).toBe(true);
+    }
+  });
+
+  it('throws on schema-invalid payloads', () => {
+    expect(() =>
+      writeAutomationConfig(sandbox.root, {
+        ...VALID_BASE_CONFIG,
+        version: 99 as unknown as 1,
+      })
+    ).toThrow();
+  });
+});

--- a/.gaia/cli/src/setup-ci/util/__tests__/gh.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/gh.test.ts
@@ -1,0 +1,74 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {setupSandbox, type Sandbox} from '../../__tests__/sandbox.js';
+import {runGh} from '../gh.js';
+
+describe('runGh wrapper', () => {
+  let sandbox: Sandbox;
+  let restore: (() => void) | undefined;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-gh-');
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    sandbox.cleanup();
+  });
+
+  it('spawns gh and resolves stdout on exit code 0', async () => {
+    const handle = sandbox.installGhShim({
+      exitCode: 0,
+      stdoutQueue: ['hello world\n'],
+    });
+    restore = handle.restore;
+
+    const result = await runGh({args: ['version']});
+    expect(result.ok).toBe(true);
+
+    if (result.ok) {
+      expect(result.stdout).toBe('hello world\n');
+    }
+  });
+
+  it('records argv exactly without appending stdin to args', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    await runGh({
+      args: ['secret', 'set', 'TOKEN_NAME'],
+      stdin: 'super-secret-payload-12345',
+    });
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toEqual(['secret', 'set', 'TOKEN_NAME']);
+
+    // The secret MUST NOT appear anywhere in argv.
+    const flat = JSON.stringify(recorded);
+    expect(flat).not.toContain('super-secret-payload-12345');
+  });
+
+  it('pipes stdin to the child process', async () => {
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    await runGh({args: ['secret', 'set', 'NAME'], stdin: 'piped-value'});
+
+    const stdinBytes = readFileSync(sandbox.ghStdinPath, 'utf8');
+    expect(stdinBytes).toBe('piped-value');
+  });
+
+  it('returns ok: false with stderr on non-zero exit', async () => {
+    const handle = sandbox.installGhShim({exitCode: 7});
+    restore = handle.restore;
+
+    const result = await runGh({args: ['version']});
+    expect(result.ok).toBe(false);
+
+    if (!result.ok) {
+      expect(result.exitCode).toBe(7);
+    }
+  });
+});

--- a/.gaia/cli/src/setup-ci/util/__tests__/local-automation-write.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/local-automation-write.test.ts
@@ -1,0 +1,48 @@
+import {readFileSync} from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {localAutomationPath} from '../../../automation/paths.js';
+import {readLocalAutomation} from '../../../schemas/local-automation.js';
+import {setupSandbox, type Sandbox} from '../../__tests__/sandbox.js';
+import {writeLocalAutomation} from '../local-automation-write.js';
+
+describe('writeLocalAutomation', () => {
+  let sandbox: Sandbox;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-local-write-');
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  it('writes the gitignored file with 2-space indentation and trailing newline', () => {
+    writeLocalAutomation(sandbox.root, {nudge_dismissed: true, version: 1});
+
+    const filePath = localAutomationPath(sandbox.root);
+    const raw = readFileSync(filePath, 'utf8');
+
+    expect(raw).toContain('  "nudge_dismissed": true');
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+
+  it('round-trips through the read helper', () => {
+    writeLocalAutomation(sandbox.root, {nudge_dismissed: true, version: 1});
+
+    const result = readLocalAutomation(sandbox.root);
+    expect(result.status).toBe('ok');
+
+    if (result.status === 'ok') {
+      expect(result.local.nudge_dismissed).toBe(true);
+    }
+  });
+
+  it('throws on schema-invalid payloads', () => {
+    expect(() =>
+      writeLocalAutomation(sandbox.root, {
+        nudge_dismissed: 'yes' as unknown as boolean,
+        version: 1,
+      })
+    ).toThrow();
+  });
+});

--- a/.gaia/cli/src/setup-ci/util/__tests__/parse-remote-url.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/parse-remote-url.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it} from 'vitest';
+import {parseRemoteUrl} from '../parse-remote-url.js';
+
+describe('parseRemoteUrl', () => {
+  describe('accepted forms', () => {
+    it('parses scp-style SSH with .git', () => {
+      expect(parseRemoteUrl('git@github.com:owner/repo.git')).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repo: 'repo',
+        url: 'git@github.com:owner/repo.git',
+      });
+    });
+
+    it('parses scp-style SSH without .git', () => {
+      expect(parseRemoteUrl('git@github.com:owner/repo')).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repo: 'repo',
+        url: 'git@github.com:owner/repo',
+      });
+    });
+
+    it('parses HTTPS with .git', () => {
+      expect(parseRemoteUrl('https://github.com/owner/repo.git')).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repo: 'repo',
+        url: 'https://github.com/owner/repo.git',
+      });
+    });
+
+    it('parses HTTPS without .git', () => {
+      expect(parseRemoteUrl('https://github.com/owner/repo')).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repo: 'repo',
+        url: 'https://github.com/owner/repo',
+      });
+    });
+
+    it('parses ssh:// protocol with .git', () => {
+      expect(parseRemoteUrl('ssh://git@github.com/owner/repo.git')).toEqual({
+        host: 'github.com',
+        owner: 'owner',
+        repo: 'repo',
+        url: 'ssh://git@github.com/owner/repo.git',
+      });
+    });
+
+    it('preserves non-github host (caller branches on host)', () => {
+      const result = parseRemoteUrl('https://gitlab.com/owner/repo.git');
+      expect(result?.host).toBe('gitlab.com');
+      expect(result?.owner).toBe('owner');
+      expect(result?.repo).toBe('repo');
+    });
+
+    it('preserves non-github host on scp-style', () => {
+      const result = parseRemoteUrl('git@bitbucket.org:owner/repo.git');
+      expect(result?.host).toBe('bitbucket.org');
+    });
+  });
+
+  describe('rejection cases', () => {
+    it('returns null for empty string', () => {
+      expect(parseRemoteUrl('')).toBeNull();
+    });
+
+    it('returns null for whitespace', () => {
+      expect(parseRemoteUrl('   ')).toBeNull();
+    });
+
+    it('returns null for malformed URL', () => {
+      expect(parseRemoteUrl('not a url')).toBeNull();
+    });
+
+    it('returns null for HTTPS with subgroups (3 path segments)', () => {
+      expect(parseRemoteUrl('https://gitlab.com/foo/bar/baz.git')).toBeNull();
+    });
+
+    it('returns null for SSH with subgroups', () => {
+      expect(parseRemoteUrl('git@gitlab.com:group/subgroup/repo.git')).toBeNull();
+    });
+
+    it('returns null for missing repo', () => {
+      expect(parseRemoteUrl('https://github.com/owner')).toBeNull();
+    });
+
+    it('returns null for trailing-slash-only URL', () => {
+      expect(parseRemoteUrl('https://github.com/')).toBeNull();
+    });
+
+    it('returns null for ssh:// missing path', () => {
+      expect(parseRemoteUrl('ssh://git@github.com/')).toBeNull();
+    });
+  });
+});

--- a/.gaia/cli/src/setup-ci/util/automation-write.ts
+++ b/.gaia/cli/src/setup-ci/util/automation-write.ts
@@ -1,0 +1,32 @@
+/**
+ * Atomic-write helper for `.gaia/automation.json` (the committed GAIA
+ * CI configuration).
+ *
+ * Used by the `opt-out-team` and `finalize` primitives. Mirrors the
+ * `writeFileSync(tmp); renameSync(tmp, target)` idiom from
+ * `automation/util/state-write.ts`. Validates the payload against
+ * `AutomationConfigSchema` before any I/O so callers cannot persist a
+ * malformed shape.
+ */
+import {mkdirSync, renameSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {automationConfigPath} from '../../automation/paths.js';
+import {
+  AutomationConfigSchema,
+  type AutomationConfig,
+} from '../../schemas/automation-config.js';
+
+export const writeAutomationConfig = (
+  repoRoot: string,
+  payload: AutomationConfig
+): void => {
+  const validated = AutomationConfigSchema.parse(payload);
+
+  const target = automationConfigPath(repoRoot);
+  mkdirSync(path.dirname(target), {recursive: true});
+
+  const serialized = `${JSON.stringify(validated, null, 2)}\n`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync(tmpPath, serialized, 'utf8');
+  renameSync(tmpPath, target);
+};

--- a/.gaia/cli/src/setup-ci/util/automation-write.ts
+++ b/.gaia/cli/src/setup-ci/util/automation-write.ts
@@ -20,12 +20,17 @@ export const writeAutomationConfig = (
   repoRoot: string,
   payload: AutomationConfig
 ): void => {
-  const validated = AutomationConfigSchema.parse(payload);
+  // Validate the shape (throws on malformed input). Serialize the raw
+  // payload — not the parsed output — so unknown fields a future slice
+  // adds to `.gaia/automation.json` survive a round-trip through this
+  // helper instead of being silently stripped by Zod's default
+  // `.strip()` behaviour.
+  AutomationConfigSchema.parse(payload);
 
   const target = automationConfigPath(repoRoot);
   mkdirSync(path.dirname(target), {recursive: true});
 
-  const serialized = `${JSON.stringify(validated, null, 2)}\n`;
+  const serialized = `${JSON.stringify(payload, null, 2)}\n`;
   const tmpPath = `${target}.tmp`;
   writeFileSync(tmpPath, serialized, 'utf8');
   renameSync(tmpPath, target);

--- a/.gaia/cli/src/setup-ci/util/gh.ts
+++ b/.gaia/cli/src/setup-ci/util/gh.ts
@@ -1,0 +1,95 @@
+/**
+ * Thin wrapper around `gh` invocations used by `gaia setup-ci`.
+ *
+ * Spawns child processes via `child_process.spawn` (NOT `execSync`) so
+ * stdin can be piped into `gh secret set`. Returns a discriminated
+ * `{ ok: true, stdout }` / `{ ok: false, exitCode, stderr }` shape.
+ *
+ * Critical security contract for `set-secret`:
+ *
+ * - The wrapper NEVER appends `stdin` content to `args`.
+ * - The wrapper NEVER logs or echoes `stdin` content.
+ * - On wrapper-internal errors (e.g. `gh` not on PATH), the wrapper
+ *   returns a structured failure WITHOUT including `stdin` content
+ *   in any error field.
+ *
+ * Tests assert these guarantees by inspecting a sandbox `gh` shim's
+ * recorded argv + stdin files.
+ */
+import {spawn} from 'node:child_process';
+
+export type GhSuccess = {
+  ok: true;
+  stdout: string;
+};
+
+export type GhFailure = {
+  exitCode: number;
+  ok: false;
+  stderr: string;
+};
+
+export type GhResult = GhFailure | GhSuccess;
+
+export type GhOptions = {
+  args: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdin?: Buffer | string;
+};
+
+export const runGh = (options: GhOptions): Promise<GhResult> => {
+  return new Promise((resolve) => {
+    const child = spawn('gh', [...options.args], {
+      cwd: options.cwd ?? process.cwd(),
+      env: options.env ?? process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    let settled = false;
+
+    const settle = (result: GhResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    });
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      stderrBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    });
+
+    child.on('error', (error: Error) => {
+      // Wrapper-internal failure (gh not on PATH, ENOENT, etc). The
+      // stdin payload is intentionally NOT included in the surfaced
+      // stderr — secret callers depend on this guarantee.
+      settle({
+        exitCode: -1,
+        ok: false,
+        stderr: error.message,
+      });
+    });
+
+    child.on('close', (code: null | number) => {
+      const exitCode = code ?? 1;
+
+      if (exitCode === 0) {
+        settle({ok: true, stdout: stdoutBuf});
+
+        return;
+      }
+
+      settle({exitCode, ok: false, stderr: stderrBuf});
+    });
+
+    if (options.stdin !== undefined) {
+      child.stdin.write(options.stdin);
+    }
+    child.stdin.end();
+  });
+};

--- a/.gaia/cli/src/setup-ci/util/local-automation-write.ts
+++ b/.gaia/cli/src/setup-ci/util/local-automation-write.ts
@@ -22,13 +22,16 @@ export const writeLocalAutomation = (
   repoRoot: string,
   payload: LocalAutomation
 ): void => {
-  // Validate before any I/O.
-  const validated = LocalAutomationSchema.parse(payload);
+  // Validate the shape (throws on malformed input). Serialize the raw
+  // payload — not the parsed output — so unknown fields land
+  // round-trip-safe instead of being silently stripped by Zod's default
+  // `.strip()` behaviour.
+  LocalAutomationSchema.parse(payload);
 
   const target = localAutomationPath(repoRoot);
   mkdirSync(path.dirname(target), {recursive: true});
 
-  const serialized = `${JSON.stringify(validated, null, 2)}\n`;
+  const serialized = `${JSON.stringify(payload, null, 2)}\n`;
   const tmpPath = `${target}.tmp`;
   writeFileSync(tmpPath, serialized, 'utf8');
   renameSync(tmpPath, target);

--- a/.gaia/cli/src/setup-ci/util/local-automation-write.ts
+++ b/.gaia/cli/src/setup-ci/util/local-automation-write.ts
@@ -1,0 +1,35 @@
+/**
+ * Atomic-write helper for `.gaia/local/automation.json` (the gitignored
+ * personal nudge state).
+ *
+ * Slice 1 ships only the read; slice 4 adds the write (per Phase B's
+ * personal-dismiss flow). Mirrors the `writeFileSync(tmp);
+ * renameSync(tmp, target)` idiom used by `automation/util/state-write.ts`
+ * and the wiki state writers.
+ *
+ * Validates against `LocalAutomationSchema` before writing — no caller
+ * can persist a malformed shape.
+ */
+import {mkdirSync, renameSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {localAutomationPath} from '../../automation/paths.js';
+import {
+  LocalAutomationSchema,
+  type LocalAutomation,
+} from '../../schemas/local-automation.js';
+
+export const writeLocalAutomation = (
+  repoRoot: string,
+  payload: LocalAutomation
+): void => {
+  // Validate before any I/O.
+  const validated = LocalAutomationSchema.parse(payload);
+
+  const target = localAutomationPath(repoRoot);
+  mkdirSync(path.dirname(target), {recursive: true});
+
+  const serialized = `${JSON.stringify(validated, null, 2)}\n`;
+  const tmpPath = `${target}.tmp`;
+  writeFileSync(tmpPath, serialized, 'utf8');
+  renameSync(tmpPath, target);
+};

--- a/.gaia/cli/src/setup-ci/util/parse-remote-url.ts
+++ b/.gaia/cli/src/setup-ci/util/parse-remote-url.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helper for parsing GitHub remote URLs.
+ *
+ * Supports the five forms `git remote get-url origin` produces in the
+ * wild. Returns `null` for any other shape — callers surface the
+ * "no GitHub origin" message themselves.
+ *
+ * Accepted forms:
+ *   git@github.com:owner/repo.git
+ *   git@github.com:owner/repo
+ *   https://github.com/owner/repo.git
+ *   https://github.com/owner/repo
+ *   ssh://git@github.com/owner/repo.git
+ *
+ * Rejection behaviour: any URL with extra path segments (e.g. GitLab
+ * subgroups), missing owner/repo, or a non-host-and-path shape parses
+ * to `null`. The host field is preserved as-is so the caller can
+ * branch on `host !== "github.com"` for the "GitHub-only v1" guard.
+ */
+
+export type ParsedRemote = {
+  host: string;
+  owner: string;
+  repo: string;
+  url: string;
+};
+
+const stripGitSuffix = (value: string): string =>
+  value.endsWith('.git') ? value.slice(0, -4) : value;
+
+const isValidSegment = (value: string): boolean =>
+  value.length > 0 && !value.includes('/');
+
+// SSH "scp-style" form: git@host:owner/repo[.git]
+const SCP_SSH_RE = /^([^@]+)@([^:]+):(.+)$/u;
+
+// HTTPS form: https://host/owner/repo[.git]
+const HTTPS_RE = /^https?:\/\/([^/]+)\/(.+)$/u;
+
+// SSH protocol form: ssh://git@host/owner/repo[.git]
+const SSH_PROTO_RE = /^ssh:\/\/[^/]+\/(.+)$/u;
+const SSH_PROTO_HOST_RE = /^ssh:\/\/(?:[^@/]+@)?([^/]+)\//u;
+
+const parseTwoSegments = (
+  url: string,
+  host: string,
+  rest: string
+): ParsedRemote | null => {
+  const trimmedRest = stripGitSuffix(rest).replace(/\/+$/u, '');
+  const segments = trimmedRest.split('/');
+
+  if (segments.length !== 2) return null;
+
+  const [owner, repo] = segments;
+
+  if (
+    owner === undefined
+    || repo === undefined
+    || !isValidSegment(owner)
+    || !isValidSegment(repo)
+  ) {
+    return null;
+  }
+
+  return {host, owner, repo, url};
+};
+
+export const parseRemoteUrl = (url: string): ParsedRemote | null => {
+  if (typeof url !== 'string' || url.trim() === '') return null;
+
+  const trimmed = url.trim();
+
+  if (trimmed.startsWith('ssh://')) {
+    const hostMatch = SSH_PROTO_HOST_RE.exec(trimmed);
+    const restMatch = SSH_PROTO_RE.exec(trimmed);
+
+    if (hostMatch === null || restMatch === null) return null;
+
+    return parseTwoSegments(trimmed, hostMatch[1] as string, restMatch[1] as string);
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    const match = HTTPS_RE.exec(trimmed);
+
+    if (match === null) return null;
+
+    return parseTwoSegments(trimmed, match[1] as string, match[2] as string);
+  }
+
+  const scpMatch = SCP_SSH_RE.exec(trimmed);
+
+  if (scpMatch !== null) {
+    const host = scpMatch[2] as string;
+    const rest = scpMatch[3] as string;
+
+    return parseTwoSegments(trimmed, host, rest);
+  }
+
+  return null;
+};

--- a/.gaia/cli/src/setup-ci/verify-run.ts
+++ b/.gaia/cli/src/setup-ci/verify-run.ts
@@ -1,0 +1,335 @@
+/**
+ * `gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]` handler.
+ *
+ * Triggers a `workflow_dispatch` run via `gh workflow run <file> --ref main`,
+ * captures the run id, and polls `gh run view <id>` until the run
+ * completes or the timeout fires.
+ *
+ * Output JSON:
+ *
+ *   {
+ *     "verified": boolean,
+ *     "run_id": string | null,
+ *     "conclusion": string | null,
+ *     "url": string | null
+ *   }
+ *
+ * `verified: true` iff `conclusion == "success"`. On polling timeout,
+ * `conclusion: "polling_timeout"` and `verified: false`. Race-window
+ * note: step 3 picks the most recent run for the workflow file. If
+ * the user triggered a manual run between step 2 and step 3, the
+ * latest one could be theirs. v1 accepts this risk.
+ *
+ * The handler exits 0 regardless of `verified` — the slash command
+ * branches on the JSON. Exits non-zero only on hard `gh` errors (e.g.
+ * `gh workflow run` failed entirely).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {runGh} from './util/gh.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]
+
+  Trigger a workflow_dispatch run and watch the run to completion.
+  Default timeout: 600s. Default poll interval: 10s (override with
+  --poll-interval-ms <ms>; intended for tests).
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const DEFAULT_TIMEOUT_SECONDS = 600;
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+
+type RunOptions = {
+  cwd?: string;
+};
+
+type VerifyOutput = {
+  conclusion: null | string;
+  run_id: null | string;
+  url: null | string;
+  verified: boolean;
+};
+
+type RunListEntry = {createdAt?: string; databaseId: number | string};
+
+type RunViewPayload = {conclusion?: null | string; status?: string; url?: string};
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const printHuman = (output: VerifyOutput): void => {
+  process.stdout.write(
+    `verified: ${String(output.verified)}\n`
+      + `run_id: ${output.run_id ?? '(none)'}\n`
+      + `conclusion: ${output.conclusion ?? '(none)'}\n`
+      + `url: ${output.url ?? '(none)'}\n`
+  );
+};
+
+export const run = async (
+  argv: readonly string[],
+  options: RunOptions = {}
+): Promise<number> => {
+  let json = false;
+  let workflowFile: string | undefined;
+  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    if (token === '--timeout-seconds') {
+      const value = argv[index + 1];
+
+      if (value === undefined) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: '--timeout-seconds requires a value',
+          subcommand: 'setup-ci verify-run',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      timeoutSeconds = Number.parseInt(value, 10);
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--poll-interval-ms') {
+      const value = argv[index + 1];
+
+      if (value === undefined) {
+        structuredError({
+          code: 'invalid_arguments',
+          message: '--poll-interval-ms requires a value',
+          subcommand: 'setup-ci verify-run',
+        });
+
+        return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+      }
+      pollIntervalMs = Number.parseInt(value, 10);
+      index += 1;
+
+      continue;
+    }
+
+    if (token.startsWith('--')) {
+      structuredError({
+        code: 'invalid_arguments',
+        message: `unknown flag: ${token}`,
+        subcommand: 'setup-ci verify-run',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    if (workflowFile === undefined) {
+      workflowFile = token;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${token}`,
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (workflowFile === undefined) {
+    structuredError({
+      code: 'missing_required_arg',
+      message: 'verify-run requires <workflow-file>',
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (Number.isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: '--timeout-seconds must be a positive integer',
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (Number.isNaN(pollIntervalMs) || pollIntervalMs <= 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: '--poll-interval-ms must be a positive integer',
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+
+  // Step 1: trigger the run.
+  const triggerResult = await runGh({
+    args: ['workflow', 'run', workflowFile, '--ref', 'main'],
+    cwd,
+  });
+
+  if (!triggerResult.ok) {
+    structuredError({
+      code: 'workflow_run_failed',
+      message: triggerResult.stderr.trim(),
+      subcommand: 'setup-ci verify-run',
+      workflow: workflowFile,
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Step 2: capture the most recent run id for the workflow.
+  const listResult = await runGh({
+    args: [
+      'run',
+      'list',
+      `--workflow=${workflowFile}`,
+      '--limit',
+      '1',
+      '--json',
+      'databaseId,createdAt',
+    ],
+    cwd,
+  });
+
+  if (!listResult.ok) {
+    structuredError({
+      code: 'run_list_failed',
+      message: listResult.stderr.trim(),
+      subcommand: 'setup-ci verify-run',
+      workflow: workflowFile,
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let runId: string;
+
+  try {
+    const parsed = JSON.parse(listResult.stdout) as RunListEntry[];
+    const first = parsed[0];
+
+    if (first === undefined) {
+      structuredError({
+        code: 'run_list_empty',
+        message: `gh run list returned no runs for ${workflowFile}`,
+        subcommand: 'setup-ci verify-run',
+        workflow: workflowFile,
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+    runId = String(first.databaseId);
+  } catch (error) {
+    structuredError({
+      code: 'run_list_malformed',
+      message: error instanceof Error ? error.message : String(error),
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Step 3: poll until completed or timeout.
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let conclusion: null | string = null;
+  let url: null | string = null;
+  let timedOut = false;
+
+  // First call before any sleep so a fast-completing run resolves
+  // immediately in tests.
+  while (true) {
+    const view = await runGh({
+      args: [
+        'run',
+        'view',
+        runId,
+        '--json',
+        'status,conclusion,url',
+      ],
+      cwd,
+    });
+
+    if (!view.ok) {
+      // Surface the underlying gh error rather than retrying — gh
+      // would have surfaced a transient retry on its own.
+      structuredError({
+        code: 'run_view_failed',
+        message: view.stderr.trim(),
+        run_id: runId,
+        subcommand: 'setup-ci verify-run',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    let payload: RunViewPayload;
+
+    try {
+      payload = JSON.parse(view.stdout) as RunViewPayload;
+    } catch (error) {
+      structuredError({
+        code: 'run_view_malformed',
+        message: error instanceof Error ? error.message : String(error),
+        run_id: runId,
+        subcommand: 'setup-ci verify-run',
+      });
+
+      return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+    }
+
+    url = payload.url ?? url;
+
+    if (payload.status === 'completed') {
+      conclusion = payload.conclusion ?? null;
+      break;
+    }
+
+    if (Date.now() >= deadline) {
+      timedOut = true;
+      break;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  const output: VerifyOutput = {
+    conclusion: timedOut ? 'polling_timeout' : conclusion,
+    run_id: runId,
+    url,
+    verified: !timedOut && conclusion === 'success',
+  };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } else {
+    printHuman(output);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/warn-existing-tools.ts
+++ b/.gaia/cli/src/setup-ci/warn-existing-tools.ts
@@ -1,0 +1,124 @@
+/**
+ * `gaia setup-ci warn-existing-tools [--json]` handler.
+ *
+ * Detects pre-existing dependency-bot configurations that would
+ * collide with GAIA Sharpen. Read-only by design — never auto-disables
+ * either tool. The `/setup-gaia-ci` slash command surfaces the warning
+ * text and asks the user to confirm before continuing.
+ *
+ * Detected files:
+ *   - .github/dependabot.yml
+ *   - .github/dependabot.yaml
+ *   - renovate.json
+ *   - .renovaterc.json
+ *   - .github/renovate.json
+ *
+ * Output JSON: `{ "found": [...] }`. The `found` array deduplicates by
+ * tool name (so `["dependabot"]` even when both `.yml` and `.yaml`
+ * exist).
+ */
+import {existsSync} from 'node:fs';
+import path from 'node:path';
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci warn-existing-tools [--json]
+
+  Detect Dependabot or Renovate config files in the repo. Read-only.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+type ToolName = 'dependabot' | 'renovate';
+
+const DEPENDABOT_PATHS = [
+  ['.github', 'dependabot.yml'],
+  ['.github', 'dependabot.yaml'],
+] as const;
+
+const RENOVATE_PATHS = [
+  ['renovate.json'],
+  ['.renovaterc.json'],
+  ['.github', 'renovate.json'],
+] as const;
+
+const printHuman = (found: ToolName[]): void => {
+  if (found.length === 0) {
+    process.stdout.write('No competing dependency-bot configs detected.\n');
+
+    return;
+  }
+
+  process.stdout.write(`detected: ${found.join(', ')}\n`);
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+
+      continue;
+    }
+
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'setup-ci warn-existing-tools',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message:
+        'gaia setup-ci warn-existing-tools must run inside a git repository',
+      subcommand: 'setup-ci warn-existing-tools',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const found: ToolName[] = [];
+
+  const hasDependabot = DEPENDABOT_PATHS.some((segments) =>
+    existsSync(path.join(repoRoot, ...segments))
+  );
+
+  if (hasDependabot) found.push('dependabot');
+
+  const hasRenovate = RENOVATE_PATHS.some((segments) =>
+    existsSync(path.join(repoRoot, ...segments))
+  );
+
+  if (hasRenovate) found.push('renovate');
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify({found})}\n`);
+  } else {
+    printHuman(found);
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/setup-ci/write-tool-mode.ts
+++ b/.gaia/cli/src/setup-ci/write-tool-mode.ts
@@ -1,0 +1,155 @@
+/**
+ * `gaia setup-ci write-tool-mode <tool> <mode>` handler.
+ *
+ * Updates a single tool's `mode` field in `.gaia/automation.json`.
+ * Slice 1 ships `bump-state` for the per-tool state files but the
+ * tool's `mode` lives in the committed config — a different file with
+ * a different schema. This primitive bridges that gap so the slash
+ * command (and `--reconfigure` flow) can flip a tool's mode without
+ * editing the config by hand.
+ *
+ * Refuses when the config is missing or malformed (fail-closed).
+ *
+ * Output JSON: `{ "tool": "<tool>", "mode": "<mode>" }`.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  TOOL_ID_TO_CONFIG_KEY,
+  TOOL_IDS,
+  ToolModeSchema,
+  readAutomationConfig,
+  type ToolConfig,
+  type ToolId,
+  type ToolMode,
+} from '../schemas/automation-config.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+import {writeAutomationConfig} from './util/automation-write.js';
+
+const HELP_TEXT = `Usage: gaia setup-ci write-tool-mode <tool> <mode>
+
+  Set a tool's mode in .gaia/automation.json.
+  <tool> must be one of: ${TOOL_IDS.join(', ')}.
+  <mode> must be one of: ci, local, off.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+type RunOptions = {
+  cwd?: string;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  const toolToken = argv[0] as string;
+  const modeToken = argv[1] as string | undefined;
+  const rest = argv.slice(2);
+
+  if (rest.length > 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unexpected argument: ${rest[0] as string}`,
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (!(TOOL_IDS as readonly string[]).includes(toolToken)) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown tool: ${toolToken}. Supported: ${TOOL_IDS.join(', ')}`,
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (modeToken === undefined) {
+    structuredError({
+      code: 'missing_required_arg',
+      message: 'write-tool-mode requires <mode>',
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const modeResult = ToolModeSchema.safeParse(modeToken);
+
+  if (!modeResult.success) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `invalid mode: ${modeToken}. Supported: ci, local, off`,
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const tool = toolToken as ToolId;
+  const mode: ToolMode = modeResult.data;
+
+  let repoRoot: string;
+
+  try {
+    repoRoot = resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message:
+        'gaia setup-ci write-tool-mode must run inside a git repository',
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const result = readAutomationConfig(repoRoot);
+
+  if (result.status === 'missing') {
+    structuredError({
+      code: 'config_missing',
+      message: '.gaia/automation.json does not exist',
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'config_malformed',
+      message: result.error,
+      subcommand: 'setup-ci write-tool-mode',
+    });
+
+    return EXIT_CODES.CONFIG_INVALID;
+  }
+
+  const key = TOOL_ID_TO_CONFIG_KEY[tool];
+  // The config slot is `ToolConfig` (mode + optional schedule) for the
+  // four tool keys. Preserve `schedule` when present.
+  const existing = result.config[key] as ToolConfig;
+  const nextSlot: ToolConfig =
+    existing.schedule === undefined
+      ? {mode}
+      : {mode, schedule: existing.schedule};
+
+  writeAutomationConfig(repoRoot, {
+    ...result.config,
+    [key]: nextSlot,
+  });
+
+  process.stdout.write(`${JSON.stringify({mode, tool})}\n`);
+
+  return EXIT_CODES.OK;
+};


### PR DESCRIPTION
## Summary

Phase 1 of two for SPEC-001 slice 4. Adds the `gaia setup-ci` CLI
surface — deterministic primitives the /setup-gaia-ci slash command
shells out to: remote detection, admin permission probe, token
piping (stdin only, never on argv), workflow_dispatch verification,
and the setup_complete flip.

Subsequent phase:
- Phase 2 — .claude/commands/setup-gaia-ci.md (the conversational runbook).

## Test plan

- [ ] `pnpm typecheck && pnpm lint`
- [ ] `( cd .gaia/cli && pnpm typecheck && pnpm test --run )`
- [ ] Token never appears in stdout, stderr, or `gh` argv (covered in
      Phase 1 set-secret tests via the gh-shim PATH override).
- [ ] check-admin never false-positives admin (covered in Phase 1
      tests with shimmed gh auth status failures).