### PR TITLE
chore: spec-001 follow-up cleanup (8 audit deferrals)

### DIFF
--- a/.claude/hooks/lib/gaia-ci-defer.sh
+++ b/.claude/hooks/lib/gaia-ci-defer.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-# GAIA CI deferral helper. Source this from any local automatic wiki trigger.
-# When .gaia/automation.json says wiki.mode == "ci", emit a one-line log and
+# GAIA CI deferral helper. Source this from any local automatic trigger that
+# wants to honor the per-tool ci/local/off mode in .gaia/automation.json.
+# When the matching config entry has mode == "ci", emit a one-line log and
 # exit 0. Otherwise return without side effects so the caller continues.
+#
+# The argument is the snake_case CONFIG KEY from the automation schema —
+# the same identifier used as the top-level field in .gaia/automation.json
+# (e.g. `wiki`, `pnpm_audit`, `stale_branches`, `sharpen`, `update_gaia`).
+# It is NOT necessarily the CLI tool id (kebab-case `pnpm-audit` vs
+# snake_case `pnpm_audit`). Callers must pass the config-key form.
 #
 # Usage (from a hook script):
 #   . .claude/hooks/lib/gaia-ci-defer.sh
@@ -12,17 +19,17 @@
 # when to check deferral.
 
 gaia_ci_defer_if_managed() {
-  local tool="$1"
+  local config_key="$1"
   local config_path=".gaia/automation.json"
 
   [ -f "$config_path" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
   local mode
-  mode=$(jq -r --arg t "$tool" '(.[$t].mode) // "local"' "$config_path" 2>/dev/null) || return 0
+  mode=$(jq -r --arg k "$config_key" '(.[$k].mode) // "local"' "$config_path" 2>/dev/null) || return 0
 
   if [ "$mode" = "ci" ]; then
-    echo 'wiki is CI-managed; deferring'
+    echo "$config_key is CI-managed; deferring"
     exit 0
   fi
 }

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -15404,6 +15404,15 @@ var run2 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
+  const knownFields = Object.keys(AutomationStateFileSchema.shape);
+  if (!knownFields.includes(field)) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown field: ${field}`,
+      subcommand: "automation bump-state"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
   let repoRoot2;
   try {
     repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
@@ -15574,8 +15583,8 @@ var HELP_TEXT3 = `Usage: gaia automation cron-decide <tool> [--json]
   per-tool state file, then emits {decision, reason, skip_log_line}.
   Decision priority:
     1. tool_off       (config.<tool>.mode == "off")
-    2. cost_overage   (state.cost_overage == true)
-    3. first_run      (state file missing)
+    2. first_run      (state file missing)
+    3. cost_overage   (state.cost_overage == true)
     4. ceiling_14d    (last_run_at > 14 days ago)
     5. skip_safety_5  (skip_count > 5)
     6. floor_24h      (last_run_at < 24 hours ago)
@@ -16738,7 +16747,7 @@ var run12 = (command, args, options = {}) => {
     env: options.env ?? process.env,
     stdio: ["ignore", "pipe", "pipe"]
   });
-  const exitCode = result.status ?? (result.signal === null ? 1 : 1);
+  const exitCode = result.status ?? 1;
   return {
     exitCode,
     stderr: result.stderr ?? "",
@@ -21770,7 +21779,7 @@ var run47 = async (argv, options = {}) => {
   });
   if (!result.ok) {
     process.stdout.write(
-      `${JSON.stringify({ applied: false, error: result.stderr.trim() })}
+      `${JSON.stringify({ applied: false, error: "gh_api_error" })}
 `
     );
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
@@ -22112,6 +22121,7 @@ var HELP_TEXT39 = `Usage: gaia setup-ci verify-run <workflow-file> [--timeout-se
 var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_TIMEOUT_SECONDS = 600;
 var DEFAULT_POLL_INTERVAL_MS = 1e4;
+var RACE_WINDOW_GUARD_MS = 5e3;
 var sleep = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);
 });
@@ -22211,6 +22221,7 @@ var run52 = async (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwd = options.cwd ?? process.cwd();
+  const triggerTime = Date.now();
   const triggerResult = await runGh2({
     args: ["workflow", "run", workflowFile, "--ref", "main"],
     cwd
@@ -22259,6 +22270,15 @@ var run52 = async (argv, options = {}) => {
       return EXIT_CODES.UNKNOWN_SUBCOMMAND;
     }
     runId = String(first.databaseId);
+    if (first.createdAt !== void 0) {
+      const createdAtMs = new Date(first.createdAt).getTime();
+      if (!Number.isNaN(createdAtMs) && createdAtMs < triggerTime - RACE_WINDOW_GUARD_MS) {
+        process.stderr.write(
+          `verify-run: warning \u2014 picked run ${runId} createdAt ${first.createdAt} predates trigger time by ${triggerTime - createdAtMs}ms; may be a concurrent dispatch
+`
+        );
+      }
+    }
   } catch (error51) {
     structuredError({
       code: "run_list_malformed",

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -15403,6 +15403,15 @@ var run2 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
+  const knownFields = Object.keys(AutomationStateFileSchema.shape);
+  if (!knownFields.includes(field)) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown field: ${field}`,
+      subcommand: "automation bump-state"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
   let repoRoot2;
   try {
     repoRoot2 = resolveRepoRoot2(options.cwd ?? process.cwd());
@@ -15573,8 +15582,8 @@ var HELP_TEXT3 = `Usage: gaia automation cron-decide <tool> [--json]
   per-tool state file, then emits {decision, reason, skip_log_line}.
   Decision priority:
     1. tool_off       (config.<tool>.mode == "off")
-    2. cost_overage   (state.cost_overage == true)
-    3. first_run      (state file missing)
+    2. first_run      (state file missing)
+    3. cost_overage   (state.cost_overage == true)
     4. ceiling_14d    (last_run_at > 14 days ago)
     5. skip_safety_5  (skip_count > 5)
     6. floor_24h      (last_run_at < 24 hours ago)

--- a/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
+++ b/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
@@ -85,6 +85,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
+          default=$(gh api repos/\${{ github.repository }} --jq '.default_branch')
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then
@@ -106,7 +107,7 @@ jobs:
                   --body "Severity: $severity\\nPackage: $pkg\\nAdvisory: $url"
                 # Targeted single-package security PR
                 branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
-                git checkout -b "$branch" main
+                git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"

--- a/.gaia/cli/src/automation/__tests__/bump-state.test.ts
+++ b/.gaia/cli/src/automation/__tests__/bump-state.test.ts
@@ -97,4 +97,14 @@ describe('automation bump-state', () => {
     expect(exit).not.toBe(0);
     expect(stdio.errors.join('')).toContain('state_missing');
   });
+
+  it('exits non-zero when --field is unknown', () => {
+    sandbox.writeState('wiki', baseState(sandbox.headSha));
+    const exit = run(['wiki', '--field', 'unrecognized', '--value', '5'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('invalid_arguments');
+    expect(stdio.errors.join('')).toContain('unknown field: unrecognized');
+  });
 });

--- a/.gaia/cli/src/automation/bump-state.ts
+++ b/.gaia/cli/src/automation/bump-state.ts
@@ -119,6 +119,21 @@ export const run = (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
+  // Zod's `.strip()` silently drops unknown keys at parse time, so an
+  // unrecognized --field would round-trip as a no-op. Reject early with
+  // a structured error so the caller knows the bump did not happen.
+  const knownFields = Object.keys(AutomationStateFileSchema.shape);
+
+  if (!knownFields.includes(field)) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown field: ${field}`,
+      subcommand: 'automation bump-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
   let repoRoot: string;
 
   try {

--- a/.gaia/cli/src/automation/cron-decide.ts
+++ b/.gaia/cli/src/automation/cron-decide.ts
@@ -48,8 +48,8 @@ const HELP_TEXT = `Usage: gaia automation cron-decide <tool> [--json]
   per-tool state file, then emits {decision, reason, skip_log_line}.
   Decision priority:
     1. tool_off       (config.<tool>.mode == "off")
-    2. cost_overage   (state.cost_overage == true)
-    3. first_run      (state file missing)
+    2. first_run      (state file missing)
+    3. cost_overage   (state.cost_overage == true)
     4. ceiling_14d    (last_run_at > 14 days ago)
     5. skip_safety_5  (skip_count > 5)
     6. floor_24h      (last_run_at < 24 hours ago)

--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -21,6 +21,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then
@@ -42,7 +43,7 @@ jobs:
                   --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
                 # Targeted single-package security PR
                 branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
-                git checkout -b "$branch" main
+                git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"

--- a/.gaia/cli/src/ci/util/run-process.ts
+++ b/.gaia/cli/src/ci/util/run-process.ts
@@ -39,9 +39,8 @@ const run = (
   });
 
   // spawnSync sets `status: null` on signal-terminated children; treat
-  // that as a non-zero exit so callers don't accidentally see it as
-  // success.
-  const exitCode = result.status ?? (result.signal === null ? 1 : 1);
+  // that as exit code 1 so callers don't accidentally see it as success.
+  const exitCode = result.status ?? 1;
 
   return {
     exitCode,

--- a/.gaia/cli/src/setup-ci/__tests__/enable-delete-branch.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/enable-delete-branch.test.ts
@@ -83,6 +83,27 @@ describe('setup-ci enable-delete-branch', () => {
 
     const parsed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
     expect(parsed.applied).toBe(false);
+    expect(parsed.error).toBe('gh_api_error');
+  });
+
+  it('JSON output never leaks gh stderr substrings on failure', async () => {
+    const sentinel = 'TOKEN_LEAK_CANARY_abc123:repo/secret';
+    const handle = sandbox.installGhShim({
+      exitCode: 1,
+      stderrQueue: [`gh: api error: ${sentinel}\n`],
+    });
+    restore = handle.restore;
+
+    const exit = await run(['--owner', 'foo', '--repo', 'bar'], {cwd: sandbox.root});
+    expect(exit).not.toBe(0);
+
+    const stdoutText = stdio.out.join('');
+    expect(stdoutText).not.toContain(sentinel);
+    expect(stdoutText).not.toContain('gh: api error');
+
+    const parsed = JSON.parse(stdoutText.trim()) as Record<string, unknown>;
+    expect(parsed.applied).toBe(false);
+    expect(parsed.error).toBe('gh_api_error');
   });
 
   it('exits non-zero when --owner missing', async () => {

--- a/.gaia/cli/src/setup-ci/enable-delete-branch.ts
+++ b/.gaia/cli/src/setup-ci/enable-delete-branch.ts
@@ -7,10 +7,14 @@
  *
  * Output JSON:
  *   `{ "applied": true }` on success.
- *   `{ "applied": false, "error": "<gh stderr>" }` on failure.
+ *   `{ "applied": false, "error": "gh_api_error" }` on failure.
+ *
+ * The error code is a stable identifier — never raw `gh` stderr —
+ * because the slash command echoes this JSON to operator surfaces
+ * that could leak tokens or repository internals.
  *
  * Exits 0 on success, non-zero on failure (so callers can branch on
- * exit code AND inspect the JSON for the error message).
+ * exit code AND inspect the JSON for the error code).
  */
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -90,7 +94,7 @@ export const run = async (
 
   if (!result.ok) {
     process.stdout.write(
-      `${JSON.stringify({applied: false, error: result.stderr.trim()})}\n`
+      `${JSON.stringify({applied: false, error: 'gh_api_error'})}\n`
     );
 
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;

--- a/.gaia/cli/src/setup-ci/verify-run.ts
+++ b/.gaia/cli/src/setup-ci/verify-run.ts
@@ -18,7 +18,10 @@
  * `conclusion: "polling_timeout"` and `verified: false`. Race-window
  * note: step 3 picks the most recent run for the workflow file. If
  * the user triggered a manual run between step 2 and step 3, the
- * latest one could be theirs. v1 accepts this risk.
+ * latest one could be theirs. As a soft guard, the handler captures
+ * `Date.now()` immediately before step 1 and compares it against the
+ * picked run's `createdAt`; a `createdAt` more than 5s before that
+ * timestamp emits a stderr warning but proceeds without failing.
  *
  * The handler exits 0 regardless of `verified` — the slash command
  * branches on the JSON. Exits non-zero only on hard `gh` errors (e.g.
@@ -39,6 +42,7 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const DEFAULT_TIMEOUT_SECONDS = 600;
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
+const RACE_WINDOW_GUARD_MS = 5_000;
 
 type RunOptions = {
   cwd?: string;
@@ -186,6 +190,13 @@ export const run = async (
 
   const cwd = options.cwd ?? process.cwd();
 
+  // Captured before step 1 so the race-window guard below can compare
+  // the picked run's `createdAt` against the moment we asked GH to
+  // start one. Any run created earlier than this minus a small fudge
+  // is suspicious (someone else dispatched between our list call and
+  // ours actually appearing).
+  const triggerTime = Date.now();
+
   // Step 1: trigger the run.
   const triggerResult = await runGh({
     args: ['workflow', 'run', workflowFile, '--ref', 'main'],
@@ -245,6 +256,21 @@ export const run = async (
       return EXIT_CODES.UNKNOWN_SUBCOMMAND;
     }
     runId = String(first.databaseId);
+
+    if (first.createdAt !== undefined) {
+      const createdAtMs = new Date(first.createdAt).getTime();
+
+      if (
+        !Number.isNaN(createdAtMs)
+        && createdAtMs < triggerTime - RACE_WINDOW_GUARD_MS
+      ) {
+        process.stderr.write(
+          `verify-run: warning — picked run ${runId} createdAt `
+            + `${first.createdAt} predates trigger time by `
+            + `${triggerTime - createdAtMs}ms; may be a concurrent dispatch\n`
+        );
+      }
+    }
   } catch (error) {
     structuredError({
       code: 'run_list_malformed',

--- a/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -21,6 +21,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then
@@ -42,7 +43,7 @@ jobs:
                   --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
                 # Targeted single-package security PR
                 branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
-                git checkout -b "$branch" main
+                git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"

--- a/wiki/concepts/Claude Skills.md
+++ b/wiki/concepts/Claude Skills.md
@@ -53,7 +53,7 @@ GAIA's skills split into three groups: a `/gaia` router for user-invoked workflo
 
 `sharpen` and `update-gaia` are surfaced by the **statusline**, not by a hook. `.gaia/statusline/gaia-statusline.sh` reads `.gaia/cache/update-check.json` and right-aligns a yellow `Run /sharpen (N outdated)` and/or cyan `Run /update-gaia (X.Y.Z available)` segment when applicable. The wrapper delegates left-side rendering to `~/.claude/settings.json`'s existing `statusLine.command` (or falls back to `.gaia/statusline/preferred-base.sh` via the `.use-vendored-base` sentinel) so the adopter's existing statusline appears unchanged. The hot path is cache-only — no network, no `pnpm` calls — and a background refresher (`.gaia/scripts/check-updates.sh`, TTL 6h) keeps the cache fresh. Silent on missing cache or missing `jq`.
 
-A prior design used a `SessionStart` `<system-reminder>` hook. It was dropped because the reminder is invisible to the user (only the model sees it), so prompts fired and snoozed without the user ever being shown a choice. The statusline is always visible, has no snooze state, and clears itself the moment the underlying cache reports clean.
+The statusline surface is chosen over a `SessionStart` `<system-reminder>` hook because system-reminders are visible only to the model; the user never sees them, so prompts fire and snooze without the user being shown a choice. The statusline is always visible, has no snooze state, and clears itself the moment the underlying cache reports clean.
 
 ## Rules vs. Skills — decision criteria
 


### PR DESCRIPTION
## Summary

Mechanical fixes from the SPEC-001 implementation run that the per-slice
audits flagged as advisory or deferred. Eight fixes, one logical group.

| # | File | Fix |
|---|---|---|
| 1 | `automation/cron-decide.ts` | HELP_TEXT priorities 2/3 swap (doc-only) |
| 2 | `automation/bump-state.ts` | Reject unknown `--field` instead of silent no-op |
| 3 | `.claude/hooks/lib/gaia-ci-defer.sh` | Rename param + document snake_case config-key contract |
| 4 | `templates/workflows/gaia-ci-pnpm-audit.yml.tmpl` | Capture default branch dynamically (no `main` hardcode) |
| 5 | `ci/util/run-process.ts` | Simplify constant ternary `result.status ?? 1` |
| 6 | `setup-ci/enable-delete-branch.ts` | Replace raw `gh` stderr with stable `gh_api_error` code |
| 7 | `setup-ci/verify-run.ts` | Soft race-window guard via `triggerTime` vs `createdAt` |
| 8 | `wiki/concepts/Claude Skills.md` | Present-tense rewrite of SessionStart-design paragraph |

Quality gates: CLI typecheck clean, 1045 tests pass. Snapshot regenerated for
the pnpm-audit template; bundled `templates/workflows/` copy re-synced via
`pnpm bundle`. No `app/**` source touched, so root project gate has nothing
to check.

Audit references in `.gaia/local/specs/SPEC-001-REPORT.md` (slices 1, 2, 3,
4, 6 follow-up sections).

## Test plan

- [x] `pnpm --dir .gaia/cli typecheck`
- [x] `pnpm --dir .gaia/cli test --run` — 1045 / 1045 passing
- [x] New tests: bump-state unknown-field rejection, enable-delete-branch JSON canary
- [x] Updated snapshot: gaia-ci-pnpm-audit.yml renders the dynamic default-branch capture
- [ ] CI green
- [ ] Pre-merge `code-review-audit` agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)