### PR TITLE
chore: stabilize wiki state.test.ts "21+ commits" flake

### DIFF
--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -16,6 +16,13 @@ import {run} from './state.js';
 type Sandbox = {
   cleanup: () => void;
   commit: (message: string, files: Record<string, string>) => string;
+  // Creates N empty commits in a single shell spawn. Each spawned
+  // `git commit` carries the Node-process startup tax for the full
+  // sandbox `commit()` helper (write, add, commit, rev-parse = 3-4
+  // spawns); under full-suite contention 21 invocations at ~150ms
+  // each blow past a 30s per-test timeout. Batching into one bash
+  // subshell amortizes the cost.
+  commitEmptyChain: (count: number) => void;
   root: string;
 };
 
@@ -44,11 +51,35 @@ const setupSandbox = (): Sandbox => {
     }).trim();
   };
 
+  const commitEmptyChain = (count: number): void => {
+    if (count <= 0) return;
+    const lines: string[] = [];
+    for (let i = 0; i < count; i += 1) {
+      lines.push(
+        'commit refs/heads/main',
+        `mark :${i + 1}`,
+        `committer Test <test@example.com> ${1_700_000_000 + i} +0000`,
+        'data <<COMMITMSG',
+        `feat: change ${i}`,
+        'COMMITMSG',
+        i === 0 ? 'from refs/heads/main^0' : `from :${i}`,
+        ''
+      );
+    }
+    lines.push('done', '');
+    execFileSync('git', ['fast-import', '--quiet'], {
+      cwd: root,
+      input: lines.join('\n'),
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+  };
+
   return {
     cleanup: () => {
       rmSync(root, {force: true, recursive: true});
     },
     commit,
+    commitEmptyChain,
     root,
   };
 };
@@ -177,9 +208,7 @@ describe('wiki state', () => {
     () => {
       const baseSha = sandbox.commit('initial', {'README.md': '# repo\n'});
       writeStateFile(sandbox.root, baseSha);
-      for (let i = 0; i < 21; i += 1) {
-        sandbox.commit(`feat: change ${i}`, {[`app/foo${i}.ts`]: 'x\n'});
-      }
+      sandbox.commitEmptyChain(21);
 
       const exit = run(['--json'], {cwd: sandbox.root});
       expect(exit).toBe(0);
@@ -191,7 +220,7 @@ describe('wiki state', () => {
       expect(json.commits_ahead).toBe(21);
       expect(json.drift_severity).toBe('high');
     },
-    30_000
+    60_000
   );
 
   test('marks reachable=false when state SHA is not an ancestor of HEAD', () => {


### PR DESCRIPTION
## Summary

Pre-existing flake in `.gaia/cli/src/wiki/state.test.ts > "reports drift_severity high for 21+ commits"`. Test created 21 commits via 63 sequential Node→git spawns; under full-suite contention this blew past the 30s per-test timeout. The test passed in isolation but failed intermittently on roughly 1-in-3 full-suite runs.

## Fix

Single-spawn `git fast-import` replaces the per-iteration `execFileSync` loop:

- New `sandbox.commitEmptyChain(count)` helper streams a fast-import
  payload of N empty commits chained from current HEAD into one
  `git fast-import --quiet` process.
- Per-test timeout bumped to 60s (defense-in-depth; isolated runtime
  is ~6s).

Empty commits are correct here — the assertion only inspects
`commits_ahead` and `drift_severity`, neither of which depends on
file content (`state.ts` computes severity from `git rev-list --count`).

## Verification

5 consecutive full-suite runs:

```
=== Run 1 === Tests  1045 passed (1045)
=== Run 2 === Tests  1045 passed (1045)
=== Run 3 === Tests  1045 passed (1045)
=== Run 4 === Tests  1045 passed (1045)
=== Run 5 === Tests  1045 passed (1045)
```

Previously: state.test.ts failed on ~1-in-3 runs at 19s+ contention spikes.

## Test plan

- [x] `pnpm --dir .gaia/cli typecheck`
- [x] `pnpm --dir .gaia/cli test --run` × 5 — all green
- [x] Test still asserts `commits_ahead === 21` and `drift_severity === 'high'`
- [ ] CI green
- [ ] Pre-merge `code-review-audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)