### PR TITLE
chore: clear deferred audit suggestions from spec-001 cleanup

### DIFF
--- a/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
+++ b/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
@@ -85,7 +85,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
-          default=$(gh api repos/\${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/\${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then

--- a/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
+++ b/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
@@ -413,7 +413,7 @@ jobs:
           set -euo pipefail
           cutoff=$(date -u -d '30 days ago' +%s 2>/dev/null || date -u -v-30d +%s)
           # Walk all branches except the default branch and delete any whose merged-PR head is older than the cutoff.
-          default=$(gh api repos/\${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/\${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           gh api repos/\${{ github.repository }}/branches --paginate --jq '.[].name' \\
             | grep -vF "$default" \\
             | while read -r br; do

--- a/.gaia/cli/src/automation/cron-decide.ts
+++ b/.gaia/cli/src/automation/cron-decide.ts
@@ -272,7 +272,7 @@ const decide = (args: DecideArgs): CronDecision | 'state_malformed' => {
     };
   }
 
-  // 2. cost_overage and 3. first_run / state_malformed
+  // 2. first_run / state_malformed and 3. cost_overage
   if (stateResult.status === 'malformed') {
     structuredError({
       code: 'state_malformed',

--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -21,7 +21,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
-          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then

--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-stale-branches.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-stale-branches.yml.tmpl
@@ -23,7 +23,7 @@ jobs:
           set -euo pipefail
           cutoff=$(date -u -d '30 days ago' +%s 2>/dev/null || date -u -v-30d +%s)
           # Walk all branches except the default branch and delete any whose merged-PR head is older than the cutoff.
-          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' \
             | grep -vF "$default" \
             | while read -r br; do

--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -16,12 +16,13 @@ import {run} from './state.js';
 type Sandbox = {
   cleanup: () => void;
   commit: (message: string, files: Record<string, string>) => string;
-  // Creates N empty commits in a single shell spawn. Each spawned
-  // `git commit` carries the Node-process startup tax for the full
-  // sandbox `commit()` helper (write, add, commit, rev-parse = 3-4
-  // spawns); under full-suite contention 21 invocations at ~150ms
-  // each blow past a 30s per-test timeout. Batching into one bash
-  // subshell amortizes the cost.
+  // Creates N empty commits in a single `git fast-import` spawn. The
+  // sandbox `commit()` helper (write, add, commit, rev-parse) costs
+  // 3-4 Node→git spawns per call; under full-suite contention each
+  // spawn slows from ~50ms to several hundred ms, so 21 sequential
+  // invocations easily blow past a 30s per-test timeout. fast-import
+  // creates the whole chain in one process — single startup, all
+  // commits assembled in-memory, no per-commit pack overhead.
   commitEmptyChain: (count: number) => void;
   root: string;
 };

--- a/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -21,7 +21,7 @@ jobs:
           RUN_COST_DOLLARS: "0"
         run: |
           set -euo pipefail
-          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           audit_json=$(pnpm audit --json || true)
           high_count=$(printf '%s' "$audit_json" | jq '[.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")] | length')
           if [ "$high_count" = "0" ]; then

--- a/.gaia/cli/templates/workflows/gaia-ci-stale-branches.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-stale-branches.yml.tmpl
@@ -23,7 +23,7 @@ jobs:
           set -euo pipefail
           cutoff=$(date -u -d '30 days ago' +%s 2>/dev/null || date -u -v-30d +%s)
           # Walk all branches except the default branch and delete any whose merged-PR head is older than the cutoff.
-          default=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          default=$(gh api repos/${{ github.repository }} --jq '.default_branch' 2>/dev/null || echo "main")
           gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' \
             | grep -vF "$default" \
             | while read -r br; do


### PR DESCRIPTION
## Summary

Three advisory suggestions the local `code-review-audit` flagged on PRs #150 and #151 but that we deferred at merge time. Bundling here so the next person reading those files isn't tripped up.

| File | Fix |
|---|---|
| `automation/cron-decide.ts:275` | Inline `// 2. cost_overage and 3. first_run / state_malformed` → matches actual decision order |
| `wiki/state.test.ts:19-24` | Comment said "Batching into one bash subshell" (leftover from first fix attempt); rewrite to describe fast-import |
| `templates/workflows/gaia-ci-pnpm-audit.yml.tmpl:24` | Add `2>/dev/null \|\| echo "main"` fallback on `gh api` default-branch capture |

Snapshot regenerated; bundled template re-synced.

## Test plan

- [x] `pnpm --dir .gaia/cli typecheck`
- [x] `pnpm --dir .gaia/cli test --run` — 1045/1045 passing
- [ ] CI green
- [ ] Pre-merge `code-review-audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)