### PR TITLE
chore(security): pin fast-uri >= 3.1.2 to close two high-severity alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,9 @@
     "vitest": "4.1.5"
   },
   "pnpm": {
-    "overrides": {},
+    "overrides": {
+      "fast-uri": ">=3.1.2"
+    },
     "onlyBuiltDependencies": [
       "core-js-pure",
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: '>=3.1.2'
+
 importers:
 
   .:
@@ -2965,8 +2968,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -6848,7 +6851,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8019,7 +8022,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes two high-severity Dependabot alerts on `fast-uri@3.1.0`, pulled in transitively via `stylelint → table → ajv`:

- [GHSA-q4q8-3p2g-vmmm](https://github.com/advisories/GHSA-q4q8-3p2g-vmmm) — host confusion via percent-encoded authority delimiters (≤ 3.1.1, patched 3.1.2)
- [GHSA-pjwq-6w9j-mxgw](https://github.com/advisories/GHSA-pjwq-6w9j-mxgw) — path traversal via percent-encoded dot segments (≤ 3.1.0, patched 3.1.1)

A single `pnpm.overrides` pin to `>= 3.1.2` closes both.

## Why an override

`fast-uri` reaches us four hops deep (`stylelint@17.11.0 → table@6.9.0 → ajv@8.20.0 → fast-uri@3.1.0`). None of the intermediate packages have released a version that pins past `fast-uri@3.1.1` yet, so a transitive override is the cleanest forward path. Single point of control; revisit on the next stylelint major.

## Test plan

- [x] `pnpm install` — lockfile clean update
- [x] `pnpm why fast-uri` reports `fast-uri@3.1.2` (single resolved version)
- [x] `pnpm audit --audit-level=high` — no known vulnerabilities
- [x] Root typecheck — clean
- [x] Root lint — clean
- [x] Root vitest one-shot — 46/46
- [x] `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)