### PR TITLE
docs(rules): codify post-merge state verification + --auto vs --admin

### DIFF
--- a/.claude/rules/pr-merge.md
+++ b/.claude/rules/pr-merge.md
@@ -1,0 +1,3 @@
+# PR Merge
+
+Before any `gh pr merge`, complete the audit + marker handshake in `wiki/concepts/PR Merge Workflow.md`. After the call, verify `gh pr view <N> --json state` returns `"MERGED"` before any local cleanup (`git checkout main`, `git branch -D`, `git fetch --prune`) — `gh pr merge` can fail when checks are pending or branch protection blocks; proceeding to cleanup leaves a deleted local branch with the PR still OPEN. Use `--auto` (not `--admin`) when branch protection rejects with "base branch policy prohibits the merge". Full contract and post-merge state verification: `wiki/concepts/PR Merge Workflow.md`.

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "dc6fb506b11dc12ecfc969d60385638267625a8a",
+  "last_evaluated_sha": "e37332a1030dec690514c80c34b06c9001b439bd",
   "last_evaluated_at": "2026-05-10T03:13:23Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-08
+updated: 2026-05-10
 tags: [concept, ci, review]
 ---
 
@@ -39,6 +39,27 @@ If the agent declines to write the marker, the report names what remains unaddre
 ### 4. Merge
 
 Once the marker exists for HEAD, run `gh pr merge`. The hook short-circuits to allow the call.
+
+## Post-merge verification before cleanup
+
+`gh pr merge` can fail without aborting the rest of a script — branch protection ("base branch policy prohibits the merge"), pending CI checks, missing `--auto` for queued merges, or auth issues. Proceeding to local cleanup (`git checkout main`, `git branch -D <pr-branch>`, `git fetch --prune`) before confirming the merge actually succeeded leaves the local branch deleted while the PR is still OPEN. Recoverable via `git checkout -b <branch> origin/<branch>` while the remote ref still exists, but it's avoidable churn.
+
+The safe pattern after any `gh pr merge`:
+
+```bash
+gh pr merge <N> --squash --delete-branch [--auto]
+for i in 1 2 3 4 5; do
+  state=$(gh pr view <N> --json state -q .state)
+  [ "$state" = "MERGED" ] && break
+  sleep 30
+done
+[ "$state" = "MERGED" ] || { echo "merge did not complete"; exit 1; }
+git checkout main && git pull origin main
+git branch -D <pr-branch>  # force needed for squash (orphaned commits)
+git fetch --prune origin
+```
+
+**`--auto` vs `--admin`:** when `gh pr merge` rejects with "base branch policy prohibits the merge", the right escape is `--auto` — it queues the merge and GitHub completes it once checks pass. Never reach for `--admin` to bypass branch protection without explicit permission; it removes the safety the policy exists to provide.
 
 ## Local-sync failure mode
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-05-10 e37332a RE_ANCHOR — re-anchored after history rewrite
 - 2026-05-10 38d6ace SKIP — chore: generic chore
 - 2026-05-10 0551e1b SKIP — chore: generic chore
 - 2026-05-10 9bfc381 SKIP — chore: generic chore


### PR DESCRIPTION
## Summary

Adds `.claude/rules/pr-merge.md` (a tight 3-sentence rule mirroring `quality-gate.md`) and extends `wiki/concepts/PR Merge Workflow.md` with a "Post-merge verification before cleanup" section.

## Why

`gh pr merge` can fail without aborting the rest of a script — branch protection ("base branch policy prohibits the merge"), pending CI checks, missing `--auto` for queued merges, or auth issues. Proceeding to local cleanup (`git checkout main`, `git branch -D <pr-branch>`, `git fetch --prune`) before confirming the merge actually succeeded leaves a deleted local branch with the PR still OPEN. Recoverable via `git checkout -b <branch> origin/<branch>` while the remote ref still exists, but it's avoidable churn.

The lesson came up during PR #153's merge — the merge was rejected by branch protection because two CI checks were still in flight, but the cleanup script charged ahead and deleted the local branch. The contract was recoverable but should not have been needed.

## Contents

- **`.claude/rules/pr-merge.md`** — always-loaded rule. Three sentences: (1) run the audit + marker handshake; (2) verify `gh pr view <N> --json state == "MERGED"` before any local cleanup; (3) `--auto` is the right escape for branch-policy rejections, never `--admin`.
- **`wiki/concepts/PR Merge Workflow.md`** — adds a "Post-merge verification before cleanup" section with the safe `poll-until-MERGED` pattern, plus the `--auto` vs `--admin` guidance. The existing "Local-sync failure mode" section stays — they're related but cover distinct failure modes (cleanup-before-verify vs. verify-confirms-merge-already-succeeded).

## Why a separate rule file (not folded into quality-gate.md)

Quality gate is pre-commit code-quality (typecheck/lint/tests). PR merge is post-commit workflow safety (audit marker, state verification, `--auto` vs `--admin`). They're sequential workflow steps but the gates are independent — different commands, different failure modes, different concerns. The rules-dir convention is one-discipline-per-file; bundling would dilute focus and break that pattern.

## How adopters benefit

`.claude/rules/` and `wiki/` are template-distributed surfaces. Adopter projects pick this up via `gaia-init` and via `update-gaia` for existing clones. Future Claude sessions on adopter machines load the rule, see the pointer, and respect the contract.

## Test plan

- [x] wiki-style audit clean (no UAT/concrete-SPEC narrative refs in the touched paths)
- [x] historical-phrasing audit clean (present tense throughout)
- [x] absolute-path audit clean (paths are repo-relative per `instruction-files.md`)
- [x] quality-gate skip check confirms (no source/config files in this PR — gate skips)
- [ ] code-review-audit + marker (will run as part of merge gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)