### PR TITLE
fix(audit): defer stamp push until after marker write

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -392,6 +392,8 @@ Mapping:
 - `stamp: empty commit (created locally)` + `push_status=detached` → "empty commit (HEAD detached; runner pushes separately)"
 - `stamp: declined: <reason>` → "skipped (`<reason>`)"
 
+For the amend and declined variants, `push_status` stays at its default `not_attempted` and is not consulted — the `stamp_line` alone determines the surface line. `push_status` is only meaningful for the empty-commit branch.
+
 The skipped form applies when `stamp_line` begins with `stamp: declined:` — the marker is still written (the local gate is unblocked) but downstream CI will run a fresh audit because the trailer is absent.
 
 If you do not write the marker, surface this instead:

--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -322,11 +322,13 @@ After producing the report, decide whether to write the marker:
 
 Knip / react-doctor advisories and Suggestions never block the marker — they are advisory-by-design.
 
-When the marker is warranted, the write is a two-step "stamp then mark" sequence: first stamp HEAD with the `GAIA-Audit:` trailer (the helper picks amend vs empty-commit per the placement rule); then re-read HEAD (it may have moved due to amend / empty-commit) and write the marker file for the *new* HEAD. The `[ ! -f "$marker" ]` guard makes the write idempotent — re-running the audit on the same HEAD never overwrites an existing marker:
+When the marker is warranted, the write is a three-step "stamp → mark → push" sequence: first stamp HEAD locally with the `GAIA-Audit:` trailer (the helper picks amend vs empty-commit per the placement rule, but never pushes); then re-read HEAD (it may have moved due to amend / empty-commit) and write the marker file for the *new* HEAD; *then* push. Marker-before-push is load-bearing — it ensures a `chore: code review audit passed` commit never reaches remote history without a corresponding marker, even if the marker write step is interrupted (the un-pushed commit is recoverable via `git reset --hard HEAD~1`). The `[ ! -f "$marker" ]` guard makes the write idempotent — re-running the audit on the same HEAD never overwrites an existing marker:
 
 ```bash
 # 1. Stamp HEAD with the GAIA-Audit trailer (amend or empty-commit per
-#    the placement rule). The helper handles the decision and reports.
+#    the placement rule). The helper creates the commit locally only —
+#    push is deferred to step 3, AFTER the marker write proves the audit
+#    is clean.
 stamp_line=$(
   AUDIT_TREE_SHA="$AUDIT_TREE_SHA" AUDIT_SELF_HEALED="$AUDIT_SELF_HEALED" \
     .claude/hooks/audit-stamp-trailer.sh
@@ -342,9 +344,32 @@ if [ ! -f "$marker" ]; then
     "$HEAD_SHA" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     > "$marker"
 fi
+
+# 3. Push the stamp commit only when the helper created an empty commit
+#    AND HEAD is on an attached tracking branch with an upstream. Amend
+#    paths add no new commit (the next operator push carries the
+#    trailer); detached HEAD has no upstream from the agent's vantage
+#    (CI's own commit-and-push step handles propagation).
+push_status="not_attempted"
+if [ "$stamp_line" = "stamp: empty commit (created locally)" ]; then
+  head_branch=$(git symbolic-ref --short -q HEAD 2>/dev/null || true)
+  upstream=""
+  if [ -n "$head_branch" ]; then
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+  fi
+  if [ -n "$head_branch" ] && [ -n "$upstream" ]; then
+    if git push --quiet 2>/dev/null; then
+      push_status="pushed"
+    else
+      push_status="push_failed"
+    fi
+  else
+    push_status="detached"
+  fi
+fi
 ```
 
-Then surface, as the final line of your report — pick the line that matches `stamp_line`:
+Then surface, as the final line of your report — pick the line that matches the `stamp_line` + `push_status` combination:
 
 > Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer amended (un-pushed); gh pr merge is unblocked.
 
@@ -357,6 +382,15 @@ Then surface, as the final line of your report — pick the line that matches `s
 > Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer amended onto audit-self-heal HEAD; gh pr merge is unblocked.
 
 > Audit marker written for HEAD `<short-sha>`; GAIA-Audit trailer skipped (`<reason>`); gh pr merge is unblocked.
+
+Mapping:
+
+- `stamp: amended onto HEAD (un-pushed)` → "amended (un-pushed)"
+- `stamp: amended onto audit-self-heal HEAD` → "amended onto audit-self-heal HEAD"
+- `stamp: empty commit (created locally)` + `push_status=pushed` → "empty commit (pushed to upstream)"
+- `stamp: empty commit (created locally)` + `push_status=push_failed` → "empty commit (push to upstream FAILED — …)"
+- `stamp: empty commit (created locally)` + `push_status=detached` → "empty commit (HEAD detached; runner pushes separately)"
+- `stamp: declined: <reason>` → "skipped (`<reason>`)"
 
 The skipped form applies when `stamp_line` begins with `stamp: declined:` — the marker is still written (the local gate is unblocked) but downstream CI will run a fresh audit because the trailer is absent.
 

--- a/.claude/hooks/audit-stamp-trailer.sh
+++ b/.claude/hooks/audit-stamp-trailer.sh
@@ -27,9 +27,7 @@
 #        final surface line. Stamp lines:
 #          stamp: amended onto HEAD (un-pushed)
 #          stamp: amended onto audit-self-heal HEAD
-#          stamp: empty commit (pushed to upstream)
-#          stamp: empty commit (push to upstream failed)
-#          stamp: empty commit (HEAD already pushed)
+#          stamp: empty commit (created locally)
 #        Decline lines (prefix "stamp: declined: "):
 #          tree dirty
 #          version file missing
@@ -173,21 +171,15 @@ if [ "$push_status" = "un-pushed" ]; then
   exit 0
 fi
 
-# Pushed: never amend a published commit. Carry the trailer on an empty commit.
+# Pushed: never amend a published commit. Carry the trailer on an empty
+# commit created locally only — the caller pushes after writing the audit
+# marker (see .claude/agents/code-review-audit.md "Audit marker (gate
+# handshake)"). Marker-before-push ensures a "chore: code review audit
+# passed" commit never reaches remote history without a corresponding
+# marker: if the marker write is interrupted, the un-pushed commit is
+# recoverable via `git reset --hard HEAD~1`.
 git -C "$repo_root" commit --allow-empty --no-verify \
   -m "chore: code review audit passed" \
   --trailer "$trailer" >/dev/null
-
-# When on an attached tracking branch, push the empty commit so CI can read
-# the trailer and skip its own audit run. On detached HEAD (CI runner) the
-# workflow's own commit-and-push step handles propagation, so skip the push.
-if [ -n "$head_branch" ] && [ -n "${upstream:-}" ]; then
-  if git -C "$repo_root" push --quiet 2>/dev/null; then
-    emit_stamp "empty commit (pushed to upstream)"
-  else
-    emit_stamp "empty commit (push to upstream failed)"
-  fi
-else
-  emit_stamp "empty commit (HEAD already pushed)"
-fi
+emit_stamp "empty commit (created locally)"
 exit 0

--- a/.gaia/tests/hooks/audit-stamp-trailer.bats
+++ b/.gaia/tests/hooks/audit-stamp-trailer.bats
@@ -2,17 +2,22 @@
 
 # Tests for .claude/hooks/audit-stamp-trailer.sh.
 #
-# Covers all four stamp paths plus every refusal case from the frozen
-# stamp invariant (.gaia/local/plans/code-review-audit-ci/trailer-format.md):
+# Covers all stamp paths plus every refusal case from the frozen stamp
+# invariant (.gaia/local/plans/code-review-audit-ci/trailer-format.md):
 #   1. clean tree, un-pushed HEAD          -> amend
-#   2. clean tree, pushed HEAD             -> empty commit
+#   2. clean tree, pushed HEAD             -> empty commit (no auto-push)
 #   3. AUDIT_SELF_HEALED=true               -> amend regardless of push status
-#   4. detached HEAD (CI checkout)         -> empty commit (treats as pushed)
+#   4. detached HEAD (CI checkout)         -> empty commit (no auto-push)
 #   5. tree dirty                           -> decline "tree dirty"
 #   6. .gaia/VERSION missing                -> decline "version file missing"
 #   7. .gaia/VERSION empty                  -> decline "version file empty"
 #   8. AUDIT_TREE_SHA != current tree       -> decline "tree changed since audit started"
 #   9. not in a git repo                    -> decline "not in a git repo"
+#
+# The helper never pushes — the agent caller pushes after writing the
+# audit marker (see .claude/agents/code-review-audit.md "Audit marker
+# (gate handshake)"). Marker-before-push ensures a stamp commit never
+# reaches remote history without a corresponding marker.
 #
 # Each test asserts:
 #   - exit code (always 0 for stamp + decline cases)
@@ -20,6 +25,7 @@
 #   - presence/absence of the GAIA-Audit trailer on resulting HEAD
 #     (parsed via `git interpret-trailers --parse`)
 #   - HEAD sha movement (amend or empty commit moves it; decline does not)
+#   - bare upstream is NOT advanced for empty-commit cases (helper never pushes)
 
 setup() {
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/audit-stamp-trailer.sh
@@ -83,18 +89,19 @@ trailer_on_head() {
   [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
 }
 
-@test "clean tree + pushed HEAD: writes empty commit and pushes it to upstream" {
+@test "clean tree + pushed HEAD: writes empty commit locally (no auto-push)" {
   push_head_to_upstream
 
   before_sha=$(git -C "$REPO" rev-parse HEAD)
   before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
   before_count=$(git -C "$REPO" rev-list --count HEAD)
+  before_remote_sha=$(git -C "$REMOTE" rev-parse main)
 
   cd "$REPO"
   AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
 
   [ "$status" -eq 0 ]
-  [ "$output" = "stamp: empty commit (pushed to upstream)" ]
+  [ "$output" = "stamp: empty commit (created locally)" ]
 
   after_sha=$(git -C "$REPO" rev-parse HEAD)
   after_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
@@ -111,31 +118,10 @@ trailer_on_head() {
   trailer=$(trailer_on_head)
   [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
 
-  # The trailer commit must reach the bare upstream so CI can read it.
-  remote_sha=$(git -C "$REMOTE" rev-parse main)
-  [ "$remote_sha" = "$after_sha" ]
-}
-
-@test "clean tree + pushed HEAD + push fails: writes empty commit and reports failure" {
-  push_head_to_upstream
-
-  # Break the bare upstream so `git push` fails. Removing its objects/
-  # directory turns it into a non-repo from git's perspective; push
-  # exits non-zero, the helper catches it and emits the failure stamp.
-  rm -rf "$REMOTE"
-
-  before_sha=$(git -C "$REPO" rev-parse HEAD)
-  before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
-
-  cd "$REPO"
-  AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
-
-  [ "$status" -eq 0 ]
-  [ "$output" = "stamp: empty commit (push to upstream failed)" ]
-
-  # Empty commit still landed locally; only propagation failed.
-  trailer=$(trailer_on_head)
-  [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
+  # Helper never pushes — upstream must NOT have advanced. The caller
+  # pushes after writing the audit marker.
+  after_remote_sha=$(git -C "$REMOTE" rev-parse main)
+  [ "$before_remote_sha" = "$after_remote_sha" ]
 }
 
 @test "AUDIT_SELF_HEALED=true on un-pushed HEAD: amends" {
@@ -155,7 +141,7 @@ trailer_on_head() {
   [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
 }
 
-@test "detached HEAD: writes empty commit (treats as pushed regardless of upstream)" {
+@test "detached HEAD: writes empty commit (treats as pushed; helper never pushes)" {
   # Simulate the CI checkout: actions/checkout with `ref: <sha>` lands
   # on a detached HEAD. Without an upstream probe, the script must NOT
   # fall through to the un-pushed amend path — that would rewrite a
@@ -171,7 +157,7 @@ trailer_on_head() {
   AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
 
   [ "$status" -eq 0 ]
-  [ "$output" = "stamp: empty commit (HEAD already pushed)" ]
+  [ "$output" = "stamp: empty commit (created locally)" ]
 
   after_sha=$(git -C "$REPO" rev-parse HEAD)
   after_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")

--- a/.gaia/tests/hooks/audit-stamp-trailer.bats
+++ b/.gaia/tests/hooks/audit-stamp-trailer.bats
@@ -2,7 +2,7 @@
 
 # Tests for .claude/hooks/audit-stamp-trailer.sh.
 #
-# Covers all stamp paths plus every refusal case from the frozen stamp
+# Covers all 4 stamp paths plus every refusal case from the frozen stamp
 # invariant (.gaia/local/plans/code-review-audit-ci/trailer-format.md):
 #   1. clean tree, un-pushed HEAD          -> amend
 #   2. clean tree, pushed HEAD             -> empty commit (no auto-push)


### PR DESCRIPTION
## Summary

The `audit-stamp-trailer.sh` helper auto-pushed the empty `chore: code review audit passed` commit BEFORE the agent wrote the local marker file. If the marker write was interrupted, the misleading stamp commit was already in remote PR history with no corresponding marker. Observed on PR #156 commit `027db6b`: stamp commit pushed, no marker file written, agent went on to land more fixes (`4fed7e06 chore(a11y): finish lint 1.1.3 sweep`).

Reorder to **stamp → mark → push**: the helper now creates the empty commit locally only; the agent does the push after the marker write succeeds. If the marker write fails or the agent aborts, the un-pushed local commit is recoverable via `git reset --hard HEAD~1` and never reaches remote.

CI is unaffected: it already runs on detached HEAD and its own `Commit and push self-heal` step handles propagation.

## Files

- `.claude/hooks/audit-stamp-trailer.sh` — collapse the three pushed-empty-commit stamp lines (`pushed to upstream`, `push to upstream failed`, `HEAD already pushed`) into one `empty commit (created locally)`. Helper no longer pushes.
- `.claude/agents/code-review-audit.md` — add step 3 (`git push`) after the marker write. Map `(stamp_line + push_status)` combinations to the existing six surface lines.
- `.gaia/tests/hooks/audit-stamp-trailer.bats` — assert upstream is NOT advanced in the empty-commit case; rename the detached-HEAD test; delete the obsolete push-fails test.

## Test plan

- [x] `bats .gaia/tests/hooks/audit-stamp-trailer.bats` — 10/10 pass
- [x] Verified upstream bare repo is not advanced in the pushed-HEAD test
- [x] CI handshake unchanged — CI's invocation already takes the no-push branch (detached HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
