### PR TITLE
chore(deps): bump conform, tailwind-merge; remove obsolete fast-uri override

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -61,17 +61,18 @@ If the detection does not fire, fall through to the existing `## Pre-flight: Bra
 git branch --show-current
 ```
 
-If the current branch is `main` or `master` **and not running in CI**, create and switch to a new branch:
+If the current branch is `main` or `master` **and not running in CI**, create and switch to a new branch and **remember that you created it** (this determines publish behavior in Phase 8):
 
 ```bash
 if [ "${CI:-}" != "true" ] && { [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; }; then
   git checkout -b chore/update-deps-$(date +%Y-%m-%d-%H-%M)
+  # CREATED_NEW_BRANCH=true — used in Phase 8
 fi
 ```
 
 In CI (`CI=true`, set by GitHub Actions, GitLab CI, CircleCI, and most CI providers), skip branch creation — the workflow owns branch management and pre-creates the appropriate branch before this skill runs.
 
-Otherwise proceed on the current branch.
+Otherwise proceed on the current branch. **Remember that you did NOT create a new branch** (this determines publish behavior in Phase 8).
 
 ## Composition: --scope &lt;group-name&gt;
 
@@ -299,4 +300,24 @@ rm -f .gaia/cache/update-check.json
 
 The next SessionStart hook fires the background refresher; the session after that sees zero outdated packages.
 
-Stop and wait for user review.
+## Phase 8: Publish
+
+**If nothing was updated** (all packages were already up to date or all were skipped), skip this phase entirely.
+
+**If a new branch was created** (you were on `main`/`master` at pre-flight and branched off):
+
+1. Push the branch:
+   ```bash
+   git push -u origin <branch-name>
+   ```
+2. Open a PR against `main`. Title: the commit message from the update commit. Body: the migration report rendered as markdown. Use `--body-file` with a temp file to avoid shell-hook false positives on package manager keywords in the body.
+
+**If you were already on a non-main branch** at pre-flight (no new branch was created):
+
+1. Push the branch:
+   ```bash
+   git push
+   ```
+2. Do not open a PR — the user owns the branch context.
+
+In both cases, print the resulting PR URL (if created) or confirm the push completed.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build-storybook": "storybook build --test"
   },
   "dependencies": {
-    "@conform-to/react": "1.19.1",
-    "@conform-to/zod": "1.19.1",
+    "@conform-to/react": "1.19.2",
+    "@conform-to/zod": "1.19.2",
     "@epic-web/client-hints": "1.3.9",
     "@epic-web/invariant": "1.0.0",
     "@react-router/node": "7.15.0",
@@ -61,7 +61,7 @@
     "remix-utils": "9.3.1",
     "sonner": "2.0.7",
     "spark-md5": "3.0.2",
-    "tailwind-merge": "3.5.0",
+    "tailwind-merge": "3.6.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
@@ -115,9 +115,7 @@
     "vitest": "4.1.5"
   },
   "pnpm": {
-    "overrides": {
-      "fast-uri": ">=3.1.2"
-    },
+    "overrides": {},
     "onlyBuiltDependencies": [
       "core-js-pure",
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,19 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  fast-uri: '>=3.1.2'
-
 importers:
 
   .:
     dependencies:
       '@conform-to/react':
-        specifier: 1.19.1
-        version: 1.19.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 1.19.2
+        version: 1.19.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@conform-to/zod':
-        specifier: 1.19.1
-        version: 1.19.1(zod@4.4.3)
+        specifier: 1.19.2
+        version: 1.19.2(zod@4.4.3)
       '@epic-web/client-hints':
         specifier: 1.3.9
         version: 1.3.9
@@ -102,8 +99,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
       tailwind-merge:
-        specifier: 3.5.0
-        version: 3.5.0
+        specifier: 3.6.0
+        version: 3.6.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -429,17 +426,17 @@ packages:
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
-  '@conform-to/dom@1.19.1':
-    resolution: {integrity: sha512-h4/T04zgASuiHMVEiXiyQA4jIW9zhpVFbp0HrWCQUDBxd8Zc1JbTarR7cuJyzkmqshC4tdm4VKIHguLp+7AYCw==}
+  '@conform-to/dom@1.19.2':
+    resolution: {integrity: sha512-CzuY8tP2hp4K15NpvVRHn4O5LE8QVT6I5D3Cjns8/4JMJ8AnlUmswhj3O5dcPWA3vJcTJgNhI/4xDjd4bN4Pwg==}
 
-  '@conform-to/react@1.19.1':
-    resolution: {integrity: sha512-RrSfpy3B7bn1RoXCztlmQYMs113AWcvtqAluDqAx4yVbbVB+EcHWc3Ze/EXJhbtFDmljT2nMtcx/VY8f2RPGFg==}
+  '@conform-to/react@1.19.2':
+    resolution: {integrity: sha512-SCGunoi4pC/et0cxhV1H3BlzjerBufVGXSQrxA9qSFCBgAi7MKpRohOV3MhdMIY16T0TLdAShuib/CL8yqe+zw==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  '@conform-to/zod@1.19.1':
-    resolution: {integrity: sha512-S/C+Byhk87RdutjCuxhKcDf9lrmTx0V1OrtZPt5zrVG3RqcXVZz3NvLLZ7pNqdSg5DHGvuzPuotGfmPVu936ow==}
+  '@conform-to/zod@1.19.2':
+    resolution: {integrity: sha512-+gHFXv/U54hWhH0fKWG1so+JY+XBrSUtdNueW1YZhcMJ2BqOuT5ieiWgXQtj+B2KCKsNCc48Gk7s4phNoNdEJQ==}
     peerDependencies:
       zod: ^3.21.0 || ^4.0.0
 
@@ -4866,8 +4863,8 @@ packages:
       '@eslint/css':
         optional: true
 
-  tailwind-merge@3.5.0:
-    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
@@ -5597,17 +5594,17 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@conform-to/dom@1.19.1': {}
+  '@conform-to/dom@1.19.2': {}
 
-  '@conform-to/react@1.19.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@conform-to/react@1.19.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@conform-to/dom': 1.19.1
+      '@conform-to/dom': 1.19.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@conform-to/zod@1.19.1(zod@4.4.3)':
+  '@conform-to/zod@1.19.2(zod@4.4.3)':
     dependencies:
-      '@conform-to/dom': 1.19.1
+      '@conform-to/dom': 1.19.2
       zod: 4.4.3
 
   '@csstools/color-helpers@6.0.2': {}
@@ -10088,7 +10085,7 @@ snapshots:
 
   tailwind-csstree@0.3.1: {}
 
-  tailwind-merge@3.5.0: {}
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.0: {}
 


### PR DESCRIPTION
## Summary

- `@conform-to/react` 1.19.1 → 1.19.2 (patch)
- `@conform-to/zod` 1.19.1 → 1.19.2 (patch)
- `tailwind-merge` 3.5.0 → 3.6.0 (patch)
- Removed obsolete `pnpm.overrides` entry for `fast-uri` (no longer needed — peer-dep check confirmed clean without it)
- `update-deps` skill: auto push + open PR when branched from main; push only when already on a branch

No major bumps. Quality gate passed: typecheck, lint, 46 tests, build.

## Test plan
- [x] typecheck — clean
- [x] lint — clean
- [x] vitest (46 tests passing)
- [x] build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)