### PR TITLE
chore: exclude .gaia/specs.json from the distribution tarball

### DIFF
--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -134,7 +134,6 @@
     ".gaia/scripts/read-audit-ci-config.sh": "owned",
     ".gaia/scripts/tests/link-worktree.bats": "owned",
     ".gaia/scripts/tests/read-audit-ci-config.bats": "owned",
-    ".gaia/specs.json": "owned",
     ".gaia/statusline/gaia-statusline.sh": "owned",
     ".gaia/templates/ci-issues/priority-critical-revert-failed.md": "owned",
     ".gaia/templates/ci-issues/priority-high-revert-opened.md": "owned",
@@ -463,6 +462,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-05-11T06:43:28.695Z",
+  "generated": "2026-05-12T09:30:42.108Z",
   "version": "1.1.1"
 }

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -83,10 +83,15 @@ wiki/decisions/Forensics Triage Workflow.md
 
 # --- 7. Scratch + transient ---
 # Local working directories: scratchpad ingestion, CLI build cache,
-# per-machine state, update-merge stage area, init backup.
+# per-machine state, update-merge stage area, init backup. `.gaia/specs.json`
+# is the SPEC-id ledger over `.gaia/local/specs/` — runtime-generated per
+# clone (`spec-allocator.sh` recreates it empty on the first `/gaia spec`),
+# not template content; adopters must start their own SPEC numbering from
+# zero rather than inherit the GAIA template's allocations.
 .raw
 .gaia/cache
 .gaia/local
+.gaia/specs.json
 .gaia-backup
 .gaia-merge
 


### PR DESCRIPTION
## Summary

`.gaia/specs.json` is the SPEC-id ledger over `.gaia/local/specs/` — per-clone **runtime state**, not template content. Today it ships in the release tarball (it's classified `owned` in `.gaia/manifest.json` and isn't release-excluded), so an adopter who runs `npx create-gaia@latest` inherits the GAIA template's own `SPEC-001` / `SPEC-002` allocations instead of starting their own numbering from zero.

`spec-allocator.sh` already has `ensure_ledger()` — it recreates `.gaia/specs.json` as `{"version": 1, "specs": []}` on the first `/gaia spec` run if the file is absent — so shipping it is unnecessary.

This PR:
- Adds `.gaia/specs.json` to `.gaia/release-exclude` (category 7, alongside `.gaia/local/`).
- Regenerates `.gaia/manifest.json` (`gaia-maintainer release manifest`) so the adopter-facing manifest no longer references it. Diff is a single removed line (`.gaia/specs.json`) + the `generated` timestamp.

GAIA-the-template keeps tracking its own `.gaia/specs.json` in the repo as before — release-exclude only affects what goes into the distribution tarball.

## Test plan

- [x] `gaia-maintainer release manifest --check` → clean (manifest fresh, classifier sets coherent)
- [x] `pnpm typecheck && pnpm lint` clean
- [x] No distribution test (`.gaia/tests/distribution/`) references `.gaia/specs.json`
- [x] `spec-allocator.sh` / `ledger-update.sh` / `spec-renumber.sh` handle the file being absent (`ensure_ledger` recreates it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)