### PR TITLE
docs(fitness): auditor reference lists, A−/C− rubric bands, Bucket E loop-nesting

### DIFF
--- a/.claude/skills/gaia/references/fitness.md
+++ b/.claude/skills/gaia/references/fitness.md
@@ -31,7 +31,7 @@ That page defines:
 - The bucket-and-model spec for triage Auditors (Haiku for mechanical checks, Sonnet for judgment-bearing checks and grade synthesis).
 - The Fixer lanes for the heal phase (`claude-surface`, `settings`, `gitignore`, `manifest`).
 - The bounded loop (default 3 cycles) and oscillation detection (fingerprint format: `{check-id}:{file}:{line}:{first-40-chars-of-match-text}`).
-- The F-to-A+ grading rubric (A+ = zero findings; A = info only; B+ = one warning; B = two warnings; B− = three or more warnings; C+ = one error; C = two errors; D+ = three errors; D = four errors; D− = five or more errors; F = structurally broken category).
+- The F-to-A+ grading rubric (A+ = zero findings; A = one or two info; A− = three or more info; B+ = one warning; B = two warnings; B− = three or more warnings; C+ = one error; C = two errors; C− = three errors; D+ = four errors; D = five errors; D− = six or more errors; F = structurally broken category — grade keys off the worst severity present, then the count at that severity).
 - The findings schema (`{severity, file, remediation, fingerprint}`) and chat report format.
 - The Decided / not findings section (skip the round-trips listed there).
 
@@ -169,7 +169,7 @@ Group findings by the seven taxonomy category names. For each finding:
 - [severity] `file:line` — remediation
 ```
 
-Unresolved / unfixable findings are included with their recommended approach.
+Unresolved / unfixable findings are included with their recommended approach. On a clean run (zero adjudicated findings, overall A+), omit the Findings section entirely — print only the grades table and the "no findings" post-heal line.
 
 ### Grades section
 

--- a/.gaia/cli/health/runbook.md
+++ b/.gaia/cli/health/runbook.md
@@ -205,16 +205,16 @@ Crash-safety: read-only file reads; no scratch state. Phase 2 redirection to `bu
 
 Reads: `wiki/decisions/Claude Integration Fitness.md` (the protocol spec).
 
-**This bucket runs the triage/heal protocol defined in `wiki/decisions/Claude Integration Fitness.md` verbatim over the seven fitness categories.** Do not re-specify the check taxonomy, grading rubric, or Fixer lanes here — reference the page and run it. Any drift from the wiki page's spec is the failure mode this indirection prevents.
+**This bucket runs the triage phase of the protocol defined in `wiki/decisions/Claude Integration Fitness.md` over the seven fitness categories.** Do not re-specify the check taxonomy, grading rubric, or Fixer lanes here — reference the page and run it. Any drift from the wiki page's spec is the failure mode this indirection prevents.
 
 The wiki page defines:
 - The seven categories (hook integrity; skill/command/agent frontmatter; rule hygiene; `CLAUDE.md` hygiene; settings hygiene; GAIA-install fitness; wiki fitness).
 - Per-category Auditor model assignments (mechanical on Haiku; judgment on Sonnet) — see the wiki page's Triage phase table.
 - The Fixer lanes — fitness findings route to the **existing `claude-surface` lane** (`.claude/skills/**`, `.claude/commands/**`, `.claude/agents/**`, `.claude/hooks/**`, `CLAUDE.md`, `.claude/rules/**`) plus the `settings`, `gitignore`, and `manifest` lanes as defined in the wiki page's Heal phase.
-- The F-to-A+ per-category grading rubric.
-- The bounded loop (default 3 cycles) with oscillation detection.
+- The F-to-A+ per-category grading rubric (every band — including `A−` and `C−` — reachable; `shared_fitness_grade` may be any of them).
+- The bounded loop (default 3 cycles) with oscillation detection — which the wiki page's own "Composed inside a deeper loop" note hands off to the outer harness when this protocol runs as a bucket. See the loop-nesting rule below.
 
-When `/health-audit` runs Bucket E, the Orchestrator is already running its own outer cycle loop — Bucket E's inner loop runs inside that. Bucket E reports a `shared_fitness_grade` (F-to-A+, the floor of the seven category grades) and per-category grades to the Triager. The Triager routes fitness findings to the `claude-surface` Fixer lane (or `settings`/`gitignore`/`manifest` lanes as appropriate). No new Fixer lane is introduced.
+**Loop nesting.** Bucket E does not run the wiki page's bounded heal loop. The outer `/health-audit` cycle loop *is* that loop: each outer cycle, Bucket E runs the wiki page's triage phase once (audit the seven categories, adjudicate, grade) and returns a `shared_fitness_grade` (F-to-A+, the floor of the seven category grades) plus per-category grades to the Triager — it does not heal or verify on its own. The Triager folds Bucket E's findings into `c<N>/findings.json` alongside the other buckets' findings, so fitness fingerprints participate in the **outer** oscillation guard (no separate inner guard), and routes the fitness fixes to the `claude-surface` Fixer lane (or `settings`/`gitignore`/`manifest` as appropriate) in the outer heal phase. The verify step for a cycle's fitness fixes is the next outer cycle's fresh Bucket E run. No new Fixer lane is introduced, and there is no inner cycle count to tune — the outer `1..3` bound covers fitness too.
 
 **Outputs:** `.gaia/local/audit/c<N>/bucket-e/` — per-category findings JSON and the per-category + overall fitness grade report, following the same structure as the wiki page's Findings Schema.
 
@@ -329,7 +329,7 @@ Fingerprint format: `{check-id}:{file}:{line}:{first-40-chars-of-match-text}`. S
 
 ## Composition
 
-The seven shared Claude-integration fitness categories (hook integrity; skill/command/agent frontmatter; rule hygiene; `CLAUDE.md` hygiene; settings hygiene; GAIA-install fitness; wiki fitness), their grading rubric, and the triage/heal orchestration protocol are defined in `wiki/decisions/Claude Integration Fitness.md`. Bucket E runs that page's protocol verbatim over those seven categories — do not re-specify the check classes or the grading rubric here. Cross-references are one-directional: this runbook references the wiki page; the wiki page never references `.gaia/cli/health/` paths.
+The seven shared Claude-integration fitness categories (hook integrity; skill/command/agent frontmatter; rule hygiene; `CLAUDE.md` hygiene; settings hygiene; GAIA-install fitness; wiki fitness), their grading rubric, and the triage/heal orchestration protocol are defined in `wiki/decisions/Claude Integration Fitness.md`. Bucket E runs that page's triage phase over those seven categories — its bounded heal loop is subsumed by the outer cycle loop (see §Bucket E — Shared Claude-integration fitness for the loop-nesting rule). Do not re-specify the check classes or the grading rubric here. Cross-references are one-directional: this runbook references the wiki page; the wiki page never references `.gaia/cli/health/` paths.
 
 ## Pointers
 

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -85,9 +85,10 @@ wiki/decisions/Forensics Triage Workflow.md
 # Local working directories: scratchpad ingestion, CLI build cache,
 # per-machine state, update-merge stage area, init backup. `.gaia/specs.json`
 # is the SPEC-id ledger over `.gaia/local/specs/` — runtime-generated per
-# clone (`spec-allocator.sh` recreates it empty on the first `/gaia spec`),
-# not template content; adopters must start their own SPEC numbering from
-# zero rather than inherit the GAIA template's allocations.
+# clone (`.specify/extensions/gaia/lib/spec-allocator.sh` recreates it empty
+# on the first `/gaia spec`), not template content; adopters must start their
+# own SPEC numbering from zero rather than inherit the GAIA template's
+# allocations.
 .raw
 .gaia/cache
 .gaia/local

--- a/wiki/decisions/Claude Integration Fitness.md
+++ b/wiki/decisions/Claude Integration Fitness.md
@@ -28,6 +28,8 @@ Checks `.claude/settings.json` and `.claude/settings.local.json` hook entries:
 - No relative path that resolves only when the shell's working directory is the project root — paths must be stated in a form that is unambiguous regardless of cwd.
 - Every hook event name is a valid Claude Code hook event.
 
+The valid Claude Code hook events — the canonical list the auditor checks against, so it does not re-derive an incomplete set from memory — are: `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `UserPromptExpansion`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, `SessionStart`, `SessionEnd`, `WorktreeCreate` — plus any project-specific events the repo registers (a project that wires its own event names extends this list; an unfamiliar name is a finding only when it is neither in the list above nor registered by the project's own tooling).
+
 Findings here are typically `error` severity.
 
 ### 2. Skill / command / agent frontmatter
@@ -71,6 +73,8 @@ Checks `.claude/settings.json`:
 - Any secret-shaped value in the `env` block (`error`).
 - `.claude/settings.local.json` not listed in `.gitignore` (`warning`).
 
+Permission-glob semantics — the rule the auditor applies for the strict-subset check, so it does not over-flag distinct entries: `Bash(cmd)` matches the exact command with no arguments; `Bash(cmd:*)` matches `cmd` invoked *with* arguments. The two are distinct entries, not a redundant pair — a project that runs a command both ways keeps both deliberately. Flag a redundancy only on a genuine strict-subset shadow, e.g. `Bash(git status)` is fully covered by `Bash(git:*)` and is the redundant one.
+
 ### 6. GAIA-install fitness
 
 Checks the GAIA installation:
@@ -98,9 +102,9 @@ Things audits keep re-discovering that are not findings:
 
 **Dead backticked path in `wiki/log.md` or `wiki/hot.md`.** These files are exempt from `gaia wiki dead-paths` by design — `wiki/log.md` is the append-only historical record; `wiki/hot.md` is the auto-overwritten session cache. Do not raise dead-path findings against either.
 
-**A bare `Bash(cmd)` permission entry alongside `Bash(cmd:*)`.** These match different invocations — `Bash(pnpm typecheck)` matches the exact command with no arguments; `Bash(pnpm typecheck:*)` matches it with arguments. A project that runs a command both ways keeps both entries deliberately. This is not a shadowed-permission finding.
+**A bare `Bash(cmd)` permission entry alongside `Bash(cmd:*)`.** Not a shadowed-permission finding — they match different invocations (no-args vs. with-args). See the permission-glob semantics note under [Settings hygiene](#5-settings-hygiene) for the strict-subset rule that governs this check.
 
-**A `WorktreeCreate` hook entry.** Hook-event auditors working from a stale event list flag `WorktreeCreate` as an unknown event; it is intentional — projects wire it to a worktree-link script. Do not flag it. (If worktree symlink-handoff is demonstrably broken, that is a separate concern, not a fitness finding.)
+**A `WorktreeCreate` hook entry.** Not an unknown-event finding — `WorktreeCreate` is in the canonical event list under [Hook integrity](#1-hook-integrity); projects wire it to a worktree-link script. (If worktree symlink-handoff is demonstrably broken, that is a separate concern, not a fitness finding.)
 
 ---
 
@@ -113,19 +117,20 @@ Per-category grade is deterministic given the finding set for that category. The
 | Grade | Condition |
 |---|---|
 | **A+** | Zero findings in the category |
-| **A** | Only `info` findings |
+| **A** | One or two `info` findings, no `warning` or `error` |
+| **A−** | Three or more `info` findings, no `warning` or `error` |
 | **B+** | One `warning`, no `error` |
 | **B** | Two `warning`s, no `error` |
 | **B−** | Three or more `warning`s, no `error` |
 | **C+** | One `error` |
 | **C** | Two `error`s |
-| **C−** | (reserved — treat three errors as D band entry) |
-| **D+** | Three `error`s |
-| **D** | Four `error`s |
-| **D−** | Five or more `error`s |
+| **C−** | Three `error`s |
+| **D+** | Four `error`s |
+| **D** | Five `error`s |
+| **D−** | Six or more `error`s |
 | **F** | Category is structurally broken — e.g. `.claude/settings.json` is unparseable (settings F); no `CLAUDE.md` exists (`CLAUDE.md` F) |
 
-The exact +/− band thresholds are tunable — adjust the counts above for your project's tolerance.
+The grade keys off the worst severity present, then the count at that severity: any `error` → the C/D band for the error count; else any `warning` → the B band for the warning count; else any `info` → the A band for the info count; else `A+`. Every band in the table — including `A−` and `C−` — is reachable for a single category, and the overall (floor) grade can therefore land on any of them. The exact +/− band thresholds are tunable — adjust the counts above for your project's tolerance.
 
 ### Overall grade
 
@@ -209,6 +214,8 @@ Detection is mechanical: compare fingerprint sets across consecutive cycles. Any
 ### Bounded loop
 
 Default: **3 cycles** (tunable — adjust the cycle count in this page for your project's tolerance). Each cycle runs triage → heal → verify. The loop exits early when all findings resolve. On loop exhaustion, `/gaia fitness` reports the remaining unresolved findings with the affected category grades and the overall grade. No escalation handoff — it reports and stops.
+
+**Composed inside a deeper loop.** When a larger audit harness runs this protocol as one bucket of its own cycle loop, that outer loop subsumes this bounded loop: the harness runs the **triage phase** once per outer cycle, folds the fitness findings into its own findings set and oscillation guard, and dispatches fixes through the [heal-phase](#heal-phase) Fixer lanes above. It does not nest a second 3-cycle loop or a second oscillation guard inside each outer cycle. The bounded loop and the oscillation detection described here govern only the standalone `/gaia fitness` invocation; the per-category grading rubric and Fixer lanes apply unchanged in both modes.
 
 ### Verify phase
 


### PR DESCRIPTION
## Summary

Three SPEC-002 follow-ups (post #169), all doc/instruction edits — no source, no tests.

1. **Canonical auditor reference lists** (`wiki/decisions/Claude Integration Fitness.md`) — pin the valid Claude Code hook-event list (`PreToolUse … WorktreeCreate`, plus project-registered events) into the *Hook integrity* check and the permission-glob `Bash(cmd)` vs. `Bash(cmd:*)` semantics into the *Settings hygiene* check, so triage auditors (esp. Haiku) stop re-deriving stale/incomplete sets and over-flagging. Slimmed the two band-aid "Decided / not findings" entries to one-liners that point at the canonical definitions (belt-and-suspenders).
2. **Grading-rubric gaps** (same file, `## Grading Rubric`) — `A−` and `C−` are now real per-category bands: `A−` = three or more `info`; `C−` = three `error`s; `D+`/`D`/`D−` shifted to 4 / 5 / 6+. Added the explicit worst-severity-then-count rule. Ordinal encoding is now fully used; `findings.json`'s `shared_fitness_grade` enum already lists all 13 grades, so no schema change needed.
3. **Bucket E loop nesting** (`.gaia/cli/health/runbook.md`) — documented that Bucket E runs the wiki page's **triage phase only**: the outer `/health-audit` `1..3` cycle loop *is* the bounded loop; fitness findings fold into the outer `findings.json` and oscillation guard, fixes dispatch through the outer heal phase's existing lanes. No inner cycle count, no second oscillation guard. Added a "Composed inside a deeper loop" note to the wiki page's `### Bounded loop` section.

Optional bits, bundled in:
- `.gaia/release-exclude` — `spec-allocator.sh` → `.specify/extensions/gaia/lib/spec-allocator.sh`.
- `.claude/skills/gaia/references/fitness.md` Step 6 — omit the Findings section on a clean run; Step 1 rubric paraphrase kept in sync.

Quality gate: nothing to check (no staged `.ts|tsx|js|css` or gate-affecting config). `wiki-style.md` audit greps clean; `gaia wiki dead-paths` clean.

## Test plan
- [ ] `code-review-audit` agent — no Critical/Important findings
- [ ] Wiki-style greps stay clean