### PR TITLE
wiki: re-anchor state + cross-link CLI Binary Split

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "86b5032f90bec4b1b527795536ba0e5d371e63ff",
+  "last_evaluated_sha": "c6b876bf15457113a5a5cb53137ee0ae3bfec843",
   "last_evaluated_at": "2026-05-11T06:43:57.663Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -105,6 +105,8 @@ Adopters receive only the bundled binary at `.gaia/cli/gaia` plus the runtime te
 
 Excluding the source prevents adopters from accidentally rebuilding the binary out from under themselves with a different toolchain.
 
+`pnpm bundle` builds two binaries from two entry points: `.gaia/cli/gaia` (adopter — no `release` namespace) and `.gaia/cli/gaia-maintainer` (maintainer-only — includes `release`). The maintainer binary is excluded from tarballs alongside the source. See [[CLI Binary Split]] for why the CLI ships as two binaries and how esbuild tree-shakes the release surface out of the adopter build.
+
 ### 5. Release-time maintainer tooling
 
 - `.gaia/release-exclude` — this exclusion file itself.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,4 +11,5 @@ tags: [meta, log]
 
 ## [v1.1.1] 2026-05-11 | Released
 
+- 2026-05-12 c6b876b RE_ANCHOR — re-anchored after history rewrite
 See CHANGELOG.md for details.


### PR DESCRIPTION
## Summary

- **State re-anchor** (`04d5013`) — `wiki/.state.json`'s `last_evaluated_sha` (`86b5032`) was orphaned by the squash-merges of #170/#171. `/gaia wiki sync` detected the unreachable baseline and reset it to current HEAD. Touches only `wiki/.state.json`.
- **Orphan fix** (`64453cb`) — `wiki/decisions/CLI-Binary-Split.md` had zero inbound links (flagged by `/gaia fitness`'s wiki-fitness check). Added a `[[CLI Binary Split]]` reference from the CLI-maintainer-source section of `wiki/concepts/Release Workflow.md`. Both pages are maintainer-only / release-excluded — no wikilink-to-excluded leak from an adopter-shipped page.

After merge: `gaia wiki orphans` and `gaia wiki dead-paths` are clean; `/gaia fitness` reaches A+.

## Test plan
- [ ] `code-review-audit` — no Critical/Important
- [ ] `gaia wiki orphans` empty, `gaia wiki dead-paths` empty