### PR TITLE
wiki: sync through 310aa3f

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "c6b876bf15457113a5a5cb53137ee0ae3bfec843",
-  "last_evaluated_at": "2026-05-11T06:43:57.663Z",
+  "last_evaluated_sha": "310aa3f3cba6eeb72a40ffe3bd5b55760b8e16d1",
+  "last_evaluated_at": "2026-05-12T11:06:38Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,5 +11,6 @@ tags: [meta, log]
 
 ## [v1.1.1] 2026-05-11 | Released
 
+- 2026-05-12 310aa3f WORTHY — re-anchored state + added cross-link CLI Binary Split → wiki/concepts/Release Workflow.md
 - 2026-05-12 c6b876b RE_ANCHOR — re-anchored after history rewrite
 See CHANGELOG.md for details.


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 310aa3f.