### PR TITLE
docs(release): correct the release PR merge step

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -8,7 +8,7 @@ Cut a new GAIA release. Thin orchestrator over the `.gaia/cli/gaia-maintainer re
 This command is **maintainer-only** — both this slash command and the `gaia-maintainer` binary are stripped from distributed tarballs by `.gaia/release-exclude` so adopters never see them. The adopter `gaia` binary has no `release` namespace at all; only `gaia-maintainer` does. Unlike `/gaia-init`, this command does not self-delete; it runs every release.
 
 > [!important] `main` is protected
-> Direct pushes to `main` are blocked. The release commit lands on a `release/v<NEW_VERSION>` branch, goes through a PR, and the tag is created on the merge commit _after_ it lands on `main`. Release branches have no required checks, so the PR is merged immediately by this command — no manual merge step needed.
+> Direct pushes to `main` are blocked. The release commit lands on a `release/v<NEW_VERSION>` branch, goes through a PR, and the tag is created on the merge commit _after_ it lands on `main`. The release PR is subject to the same CI gate (`Vitest and Playwright`, `Run Chromatic` — a few minutes) and `code-review-audit` merge handshake as any other PR. `gh pr merge --merge --auto` is the normal path: base-branch protection rejects a plain `--merge`, so `--auto` is required to queue the merge until checks pass. See `wiki/concepts/PR Merge Workflow.md`.
 
 ## Workflow
 
@@ -100,20 +100,39 @@ Stages `package.json`, `.gaia/VERSION`, `.gaia/manifest.json`, `CHANGELOG.md`, `
 
 If the pre-commit hook fails, STOP and report — fix the issue and create a **new** commit; do not `--amend`.
 
-### 9. Push the release branch and merge the PR
+### 9. Push the release branch and open the PR
 
 ```bash
 git push -u origin "release/v<NEW_VERSION>"
 gh pr create --base main --head "release/v<NEW_VERSION>" \
   --title "chore: release v<NEW_VERSION>" \
   --body "<release summary — link CHANGELOG entry, list highlights>"
-gh pr merge --merge "release/v<NEW_VERSION>"
 ```
 
-### 10. Tag the merge commit
+### 10. Code-review-audit + marker handshake
+
+The release PR is **not** exempt from the merge gate — `.claude/hooks/pr-merge-audit-check.sh` denies `gh pr merge` until a `code-review-audit` marker exists for the release commit's HEAD SHA. Run the four-step protocol in `wiki/concepts/PR Merge Workflow.md`: spawn `code-review-audit` on the branch, fix every Critical and Important finding, push (HEAD moves), re-spawn until the agent writes `.gaia/local/audit/<HEAD-sha>.ok`. Knip / react-doctor advisories never block the marker.
+
+### 11. Merge the PR
 
 ```bash
-sleep 5
+gh pr merge <N> --merge --auto --delete-branch
+# --auto is mandatory: base-branch protection rejects a plain --merge, and the
+# Vitest/Playwright + Chromatic checks take a few minutes. --auto queues the
+# merge; GitHub completes it once checks pass.
+for i in $(seq 1 20); do
+  state=$(gh pr view <N> --json state -q .state)
+  [ "$state" = "MERGED" ] && break
+  sleep 30
+done
+[ "$state" = "MERGED" ] || { echo "release PR did not merge — investigate before tagging"; exit 1; }
+```
+
+Do not run any local cleanup or tagging until the poll confirms `MERGED`. If it times out, inspect `gh pr view <N>` for a failing check or a stuck merge queue. This mirrors the safe pattern in `wiki/concepts/PR Merge Workflow.md`, with `--merge` instead of `--squash`.
+
+### 12. Tag the merge commit
+
+```bash
 git checkout main
 git pull --ff-only origin main
 git log -1 --oneline    # verify this is the merge commit

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -70,7 +70,7 @@ The scrubbed `wiki/hot.md` + `wiki/log.md` contain only the release marker — n
 
 Marker-delimited maintainer-only blocks let the source repo carry content useful to maintainers (entity pages, internal cross-references, audit-decision rationale) without leaking into adopter scaffolds. Wrap a block in `<!-- gaia:maintainer-only:start -->` / `<!-- gaia:maintainer-only:end -->`; `gaia-maintainer release scrub` strips the block before tar.
 
-The leak-check pass is the convergence mechanism the post-#97 audit trajectory predicted: free-form audits found roughly one novel issue class per round; codified detection patterns running against the staging tree close the loop. New leak patterns become explicit `.gaia/release-scrub.yml` entries — visible, reviewable, deterministic.
+The leak-check pass is the convergence mechanism the audit trajectory predicted: free-form audits found roughly one novel issue class per round; codified detection patterns running against the staging tree close the loop. New leak patterns become explicit `.gaia/release-scrub.yml` entries — visible, reviewable, deterministic.
 
 ## Distribution Boundary
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -142,7 +142,7 @@ Excluding the source prevents adopters from accidentally rebuilding the binary o
 ### 10. Maintainer-only health-audit infrastructure
 
 - `.gaia/cli/health/` — health-audit taxonomy and per-cycle run state. Documents the issue classes prior independent audits found and the "decided / not findings" list so future audits don't re-litigate settled questions.
-- `.gaia/cli/src/health/` — health-audit orchestrator + check primitives (added post-PR-#97 on a separate branch). Not imported by `.gaia/cli/src/index.ts`, so esbuild tree-shakes it out of the bundled `gaia` binary.
+- `.gaia/cli/src/health/` — health-audit orchestrator + check primitives. Not imported by `.gaia/cli/src/index.ts`, so esbuild tree-shakes it out of the bundled `gaia` binary.
 
 Adopters audit their own app via the standard `code-review-audit` agent under `.claude/agents/`; the GAIA-template-specific health audit is maintainer-only because its taxonomy and detections target the GAIA repo's surface, not an adopter project.
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Release Workflow
 status: active
 created: 2026-04-22
-updated: 2026-05-08
+updated: 2026-05-12
 tags: [release, claude, maintainer, versioning]
 ---
 
@@ -46,10 +46,13 @@ Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 9. Overwrite `wiki/log.md` with a single release-milestone entry (dev history lives in git).
 10. Regenerate `.gaia/manifest.json` via `gaia-maintainer release manifest`.
 11. Commit on the release branch: `chore(release): vX.Y.Z`. The pre-commit dance updates `wiki/.state.json`'s `last_evaluated_sha` to the new commit's own SHA via amend, so adopters' state files match their release commit on first scaffold.
-12. Push branch, open PR via `gh`, merge inline via `gh pr merge --merge`. Release branches have no required checks, so the merge is immediate.
-13. Pull `main`, tag the merge commit (`v<NEW_VERSION>`), push the tag.
+12. Push branch, open PR via `gh`. The release PR is subject to the same CI gate (`Vitest and Playwright`, `Run Chromatic`) and `code-review-audit` merge handshake as any other PR — see [[PR Merge Workflow]]. `gh pr merge --merge --auto` is the normal path: base-branch protection rejects a plain `--merge`, and `--auto` lets GitHub complete the merge once checks pass.
+13. Once the PR shows `MERGED`, pull `main`, tag the merge commit (`v<NEW_VERSION>`), push the tag.
 
 The tag push triggers [`release.yml`](../../.github/workflows/release.yml), which produces the scrubbed tarball.
+
+> [!note] `state_sha` is abbreviated
+> `gaia wiki state --json` reports `state_sha` in short form. A caller that feeds it into a git range query (`<state_sha>..HEAD`) resolves it to a full SHA first via `git rev-parse --verify` — the `release preflight` subcommand does this before its wiki-sync drift scan (Step 2). Skipping the resolution makes the range query fail or silently return the wrong set on repos where the short SHA is ambiguous.
 
 ## Tarball scrubbing
 
@@ -181,6 +184,7 @@ The CLI is deliberately thin — heavy lifting (i18n, branding strip, plugin ins
 ## See also
 
 - [[Update Workflow]] — how adopters pull later releases into an initialized project without clobbering drift.
+- [[PR Merge Workflow]] — the audit + marker handshake and `--auto` merge pattern the release PR follows like any other.
 - [[Quality Gate]] — must pass before `/gaia-release` will let you tag.
 - [[Wiki Sync]] — drift gate at Step 2; release is blocked until `wiki/.state.json` matches HEAD.
 - [[Bundle-time Scrub]] — rationale for marker-strip + leak-check + runtime-deps; what the system catches, what it does not.


### PR DESCRIPTION
## Summary

Follow-up from the v1.2.0 release — the `/gaia-release` runbook and `wiki/concepts/Release Workflow.md` overstated how clean the release-branch merge is. In practice the release PR is CI-gated and goes through the same handshake as any other PR.

- **`/gaia-release` Step 9/10/12** — split "push + open PR" from the merge; added Step 10 (code-review-audit + marker handshake, referencing `wiki/concepts/PR Merge Workflow.md`) and Step 11 (`gh pr merge <N> --merge --auto --delete-branch` + a bounded `MERGED` poll before any cleanup or tagging). Removed the `sleep 5; git checkout main` race.
- **`main` is protected callout** — replaced "release branches have no required checks, merged immediately, no manual step" with the real picture: same CI gate (`Vitest and Playwright`, `Run Chromatic`) + audit handshake, `--auto` required because base-branch protection rejects a plain `--merge`.
- **`Release Workflow.md`** — same correction in the 13-step list; added `[[PR Merge Workflow]]` to See also; added a note that `gaia wiki state --json`'s `state_sha` is abbreviated and must be resolved via `git rev-parse --verify` before git range queries (the `release preflight` code already does this).

Docs-only — no `.gaia/cli/` changes. Wiki-style audit greps pass.

## Test plan

- [ ] `code-review-audit` agent on this branch reports clean (doc-only)
- [ ] wiki-style audit greps from `.claude/rules/wiki-style.md` return empty (verified locally)