### PR TITLE
Harden SPEC ledger against concurrent /gaia spec sessions

### DIFF
--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -226,6 +226,8 @@ Persist the answer as `gh_mirror_optin: <bool>` in working memory for this sessi
 
 Run `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"`. If the output is a `SPEC-NNN` id (not `none`), an in-progress SPEC already exists.
 
+The id may name a **draft-phase** session — a SPEC allocated in another terminal whose interactive loop has not yet reached the canonical save (step 8), so `.gaia/local/specs/SPEC-NNN.md` may not exist yet and the live draft is at `.gaia/local/cache/draft-SPEC-NNN.md`. The `WORKING`-selection below resolves this correctly, preferring the draft cache when the canonical file is absent or older.
+
 **Auto-mode exception:** skip the resume prompt entirely. Always start new — append `spec_started` telemetry with `resumed: false, auto: true` and proceed to step 3 with a fresh allocation. The in-progress SPEC (if any) remains untouched. Per Auto-mode rule 3 the user's `auto` invocation is the signal that they want a fresh artifact; resuming an existing draft into a non-interactive context risks silently overwriting work in progress.
 
 Before prompting, gather context for an informed choice. The newer of the canonical artifact and the working-draft cache is the actual resume point:

--- a/.gaia/tests/lib/README.md
+++ b/.gaia/tests/lib/README.md
@@ -1,0 +1,56 @@
+# SPEC-ledger lib harness
+
+Maintainer-only bats suite for the SPEC ledger machinery:
+`.specify/extensions/gaia/lib/spec-allocator.sh`, `ledger-update.sh`, and the
+shared `with-ledger-lock.sh` mutex. Excluded from the release bundle via
+`.gaia/release-exclude` (category `.gaia/tests/`). Every test is hermetic —
+each spins up its own tmp git repo via `helpers/tmp-spec-repo.sh` and tears it
+down; no reliance on the real project `.gaia/specs.json`.
+
+## Coverage
+
+| File | What it tests |
+|------|---------------|
+| `with-ledger-lock.bats` | The mutex helper in isolation (Contract C1): acquire/release, exit-code passthrough, no-stdout rule, forced mkdir fallback, acquisition timeout → 75, stale-lock recovery, flock path when present. |
+| `spec-allocator-concurrency.bats` | Allocator + ledger-update concurrency (Contracts C2/C3): N-parallel `next` with no lost rows and no duplicate ids (real flock and forced fallback), stale-lock recovery, `in_progress` draft surfacing + legacy fallback + none, read-only modes take no lock, exit-code preservation, and the cross-script `ledger-update` racing `next` interleaving. |
+
+The N-parallel test uses a start-flag barrier so the `next` calls genuinely
+overlap. A passing run with no contention proves nothing — with the barrier,
+the unlocked read-modify-write would fail (duplicate id + lost ledger row).
+Several `@test`s assert that a non-zero exit code propagates *through*
+`with_ledger_lock` (forced jq failure → 4, invalid patch → 5, lock timeout →
+4); a single happy-path run stays green even with a swallowed-code bug, so
+these negative assertions are load-bearing.
+
+## Running
+
+```bash
+bash .gaia/tests/lib/run-all.sh
+```
+
+Individual test files:
+
+```bash
+bats .gaia/tests/lib/with-ledger-lock.bats
+bats .gaia/tests/lib/spec-allocator-concurrency.bats
+```
+
+## Prerequisites
+
+- `bats-core` on `$PATH`. Install via:
+  - macOS: `brew install bats-core`
+  - Debian/Ubuntu CI: `apt-get install -y bats`
+  - Any platform: `npx -y bats-core@latest` (the `run-all.sh` entrypoint falls
+    back to this)
+- `jq` on `$PATH`
+- `git` on `$PATH`
+
+`flock` is optional. On a box without it (e.g. stock macOS) the
+mkdir-fallback is the load-bearing lock path and is exercised by the forced
+fallback tests; the flock-path test `skip`s with a clear reason.
+
+## CI integration
+
+CI should add a `bash .gaia/tests/lib/run-all.sh` step parallel to the
+forensics suite, in whichever workflow runs the other bats harnesses. The
+actual CI YAML edit is out of scope for this suite.

--- a/.gaia/tests/lib/helpers/tmp-spec-repo.sh
+++ b/.gaia/tests/lib/helpers/tmp-spec-repo.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Create a tmp git repo seeded for SPEC-ledger lib testing. Prints the repo
+# path on stdout; the caller cd's into it. Modeled on
+# .gaia/tests/hooks/helpers/tmp-git-repo.sh.
+#
+# Inside the tmp repo:
+#   - git init (main), test identity, commit.gpgsign false
+#   - .gaia/local/specs, .gaia/local/cache, .specify/extensions/gaia/lib dirs
+#   - a minimal valid ledger .gaia/specs.json: { "version": 1, "specs": [] }
+#   - copies (NOT symlinks) of the three scripts under test from the real
+#     repo so ${BASH_SOURCE[0]}-relative sourcing inside the scripts resolves
+#     to the tmp lib dir and finds the sibling with-ledger-lock.sh
+#   - one initial commit so require_git / rev-parse --git-dir succeeds
+#
+# Flags (repeatable, order-independent):
+#   --seed-draft SPEC-NNN       append a ledger row status:"draft"
+#   --seed-inprogress SPEC-NNN  append a ledger row status:"in-progress"
+#   --seed-file SPEC-NNN        write .gaia/local/specs/SPEC-NNN.md with
+#                               status: in-progress frontmatter and NO ledger
+#                               row (the legacy fallback case)
+set -euo pipefail
+
+# Real repo containing this helper: the helper lives at
+# .gaia/tests/lib/helpers/ inside the real repo working tree.
+_helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+real_repo="$(git -C "$_helper_dir" rev-parse --show-toplevel)"
+real_lib="${real_repo}/.specify/extensions/gaia/lib"
+
+dir="$(mktemp -d -t gaia-spec-lib-test-XXXXXX)"
+cd "$dir"
+
+git init --quiet --initial-branch=main
+git config user.email "test@example.com"
+git config user.name "Test"
+git config commit.gpgsign false
+
+mkdir -p .gaia/local/specs .gaia/local/cache .specify/extensions/gaia/lib
+
+printf '{\n  "version": 1,\n  "specs": []\n}\n' > .gaia/specs.json
+
+# Copy (not symlink) so the scripts' ${BASH_SOURCE[0]}-relative source of
+# with-ledger-lock.sh resolves to this tmp lib dir.
+for s in spec-allocator.sh ledger-update.sh with-ledger-lock.sh; do
+  cp "${real_lib}/${s}" ".specify/extensions/gaia/lib/${s}"
+  chmod +x ".specify/extensions/gaia/lib/${s}"
+done
+
+# Apply seed flags before the initial commit so the seeded state is committed
+# (require_git only needs a git-dir; committing keeps the tree clean).
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --seed-draft)
+      id="$2"; shift 2
+      tmp="$(mktemp)"
+      jq --arg id "$id" \
+        '.specs += [{id: $id, allocated_at: "2026-01-01T00:00:00Z", source: "allocated", status: "draft"}]' \
+        .gaia/specs.json > "$tmp"
+      mv "$tmp" .gaia/specs.json
+      ;;
+    --seed-inprogress)
+      id="$2"; shift 2
+      tmp="$(mktemp)"
+      jq --arg id "$id" \
+        '.specs += [{id: $id, allocated_at: "2026-01-01T00:00:00Z", source: "allocated", status: "in-progress"}]' \
+        .gaia/specs.json > "$tmp"
+      mv "$tmp" .gaia/specs.json
+      ;;
+    --seed-file)
+      id="$2"; shift 2
+      cat > ".gaia/local/specs/${id}.md" <<EOF
+---
+spec_id: ${id}
+status: in-progress
+---
+
+# ${id}
+EOF
+      ;;
+    *)
+      echo "tmp-spec-repo.sh: unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+git add -A
+git commit --quiet -m "init"
+
+echo "$dir"

--- a/.gaia/tests/lib/run-all.sh
+++ b/.gaia/tests/lib/run-all.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run all SPEC-ledger lib tests (bats-core).
+# Walks .gaia/tests/lib/*.bats in lexicographic order.
+# Exits 0 if all tests pass, 1 if any fail.
+#
+# Prerequisites:
+#   bats-core on PATH — install via:
+#     brew install bats-core          (macOS)
+#     apt-get install -y bats         (Debian/Ubuntu CI)
+#     npx -y bats-core@latest         (fallback, any platform)
+#   jq and git on PATH (the scripts under test require them).
+#
+# CI: add the following step before this script in your workflow:
+#   - run: bash .gaia/tests/lib/run-all.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> .gaia/tests/lib/run-all.sh"
+
+# Ensure bats is available; attempt npx fallback if not on PATH.
+if ! command -v bats >/dev/null 2>&1; then
+  echo "bats not found on PATH — attempting: npx -y bats-core@latest"
+  if command -v npx >/dev/null 2>&1; then
+    # Run via npx; replace this process so $? propagates correctly.
+    exec npx -y bats-core@latest "$HERE"/*.bats
+  else
+    echo "ERROR: bats not installed and npx not available. Install bats-core first." >&2
+    exit 1
+  fi
+fi
+
+for f in "$HERE"/*.bats; do
+  echo "--> $(basename "$f")"
+  bats "$f"
+done
+
+echo "==> all lib tests passed"

--- a/.gaia/tests/lib/spec-allocator-concurrency.bats
+++ b/.gaia/tests/lib/spec-allocator-concurrency.bats
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+# Concurrency + behavior tests for the SPEC ledger lib (Contracts C2, C3).
+#
+# The N-parallel test is robust against flake by design: every background
+# `next` job blocks until a shared start-flag file exists, then all race at
+# once. A passing run with no contention proves nothing — the barrier forces
+# genuine overlap, so the UNLOCKED read-modify-write would fail this test
+# (two jobs read the same highest_num, allocate a duplicate id, and the
+# second `mv` clobbers the first appended row → fewer than N rows and/or a
+# duplicate id). The lock is what makes it green.
+
+setup() {
+  HELPERS="$BATS_TEST_DIRNAME/helpers"
+  ALLOC=".specify/extensions/gaia/lib/spec-allocator.sh"
+  LEDGER_UPDATE=".specify/extensions/gaia/lib/ledger-update.sh"
+}
+
+teardown() {
+  if [ -n "${REPO:-}" ]; then
+    rm -rf "$REPO"
+  fi
+}
+
+# Launch N barrier-gated `next` jobs, then release the barrier and wait.
+# Writes each job's stdout to "$REPO/out.<i>". $LOCK_ENV is prepended to each
+# job so a caller can force the mkdir fallback.
+_run_parallel_next() {
+  local n="$1"
+  local i
+  rm -f "$REPO"/out.* "$REPO/start.flag"
+  for i in $(seq 1 "$n"); do
+    bash -c '
+      repo="$1"; alloc="$2"; idx="$3"
+      until [ -f "$repo/start.flag" ]; do :; done
+      '"${LOCK_ENV:-}"' bash "$repo/$alloc" next "$repo" > "$repo/out.$idx" 2>/dev/null
+    ' _ "$REPO" "$ALLOC" "$i" &
+  done
+  # Release the barrier — all jobs were spinning on this file's existence.
+  touch "$REPO/start.flag"
+  wait
+}
+
+# --- Test 8: N-parallel next → N distinct ids, zero lost rows -----------------
+
+@test "8a: N-parallel next (real flock if present) — N distinct ids, N rows, no dupes" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  cd "$REPO"
+  N=10
+  LOCK_ENV="" _run_parallel_next "$N"
+
+  printed="$(cat "$REPO"/out.* | sort)"
+  distinct="$(printf '%s\n' "$printed" | sort -u)"
+  [ "$(printf '%s\n' "$printed" | grep -c '^SPEC-[0-9]\{3\}$')" -eq "$N" ]
+  [ "$(printf '%s\n' "$distinct" | wc -l | tr -d ' ')" -eq "$N" ]
+
+  rows="$(jq -r '.specs[].id' "$REPO/.gaia/specs.json")"
+  [ "$(printf '%s\n' "$rows" | wc -l | tr -d ' ')" -eq "$N" ]
+  # No duplicate ids in the ledger.
+  [ "$(printf '%s\n' "$rows" | sort | uniq -d | wc -l | tr -d ' ')" -eq 0 ]
+  # Every printed id appears in the ledger.
+  while IFS= read -r id; do
+    printf '%s\n' "$rows" | grep -qx "$id"
+  done <<< "$distinct"
+}
+
+@test "8b: N-parallel next (forced mkdir fallback) — N distinct ids, N rows, no dupes" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  cd "$REPO"
+  N=10
+  LOCK_ENV="GAIA_LEDGER_LOCK_FORCE_FALLBACK=1" _run_parallel_next "$N"
+
+  printed="$(cat "$REPO"/out.* | sort)"
+  distinct="$(printf '%s\n' "$printed" | sort -u)"
+  [ "$(printf '%s\n' "$printed" | grep -c '^SPEC-[0-9]\{3\}$')" -eq "$N" ]
+  [ "$(printf '%s\n' "$distinct" | wc -l | tr -d ' ')" -eq "$N" ]
+
+  rows="$(jq -r '.specs[].id' "$REPO/.gaia/specs.json")"
+  [ "$(printf '%s\n' "$rows" | wc -l | tr -d ' ')" -eq "$N" ]
+  [ "$(printf '%s\n' "$rows" | sort | uniq -d | wc -l | tr -d ' ')" -eq 0 ]
+  while IFS= read -r id; do
+    printf '%s\n' "$rows" | grep -qx "$id"
+  done <<< "$distinct"
+}
+
+# --- Test 9: stale-lock recovery in `next` -----------------------------------
+
+@test "9: stale-lock recovery in next — reclaims stale dir, allocates next id" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  cd "$REPO"
+  mkdir -p "$REPO/.gaia/specs.lock.d"
+  sleep 2  # age past GAIA_LEDGER_LOCK_STALE_SECS=1
+  run bash -c "GAIA_LEDGER_LOCK_FORCE_FALLBACK=1 GAIA_LEDGER_LOCK_STALE_SECS=1 bash '$REPO/$ALLOC' next '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-002" ]
+  [ "$(jq -r '[.specs[].id] | length' "$REPO/.gaia/specs.json")" -eq 2 ]
+}
+
+# --- Test 10–12: in_progress contract ----------------------------------------
+
+@test "10: in_progress surfaces a draft ledger row (defect-2 regression)" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-007)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-007" ]
+}
+
+@test "11: in_progress legacy fallback — canonical file, no ledger row" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-file SPEC-013)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-013" ]
+}
+
+@test "12: in_progress none — empty ledger, no files" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "none" ]
+}
+
+# --- Test 13: read-only modes take no lock -----------------------------------
+
+@test "13: highest and in_progress create no lock file or dir" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' highest '$REPO'"
+  [ "$status" -eq 0 ]
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ ! -e "$REPO/.gaia/specs.lock" ]
+  [ ! -e "$REPO/.gaia/specs.lock.d" ]
+}
+
+# --- Test 14: exit-code preservation -----------------------------------------
+
+@test "14a: non-git dir — next exits 3" {
+  # Build a tmp repo via the helper (so the scripts + sibling source resolve),
+  # then strip .git so require_git fails. REPO is set so teardown cleans up.
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  rm -rf "$REPO/.git"
+  run bash -c "bash '$REPO/$ALLOC' next '$REPO'"
+  [ "$status" -eq 3 ]
+}
+
+@test "14b: forced jq failure — next exits 4 (exit code propagates THROUGH the lock)" {
+  # This is the load-bearing negative assertion for the Phase-2 swallowed-rc
+  # bug: append_ledger_row returns 4 on jq failure; with_ledger_lock must
+  # pass that 4 through unchanged, and `next` must exit 4 (NOT 0). A failing
+  # `jq` is forced by shadowing it with a stub early on PATH.
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  cd "$REPO"
+  realjq="$(command -v jq)"
+  stubdir="$REPO/stubbin"
+  mkdir -p "$stubdir"
+  cat > "$stubdir/jq" <<EOF
+#!/usr/bin/env bash
+# Fail only the write (--arg id ... '.specs += ...'); pass read-side jq
+# (highest_num's '.specs[].id') through to the real jq so the script reaches
+# the append critical section and the write jq is the one that fails.
+for a in "\$@"; do
+  case "\$a" in
+    *".specs += "*) exit 1 ;;
+  esac
+done
+exec "$realjq" "\$@"
+EOF
+  chmod +x "$stubdir/jq"
+  run bash -c "PATH='$stubdir:$PATH' bash '$REPO/$ALLOC' next '$REPO'"
+  [ "$status" -eq 4 ]
+  # Ledger left unchanged — no row appended on the failed write.
+  [ "$(jq -r '[.specs[].id] | length' "$REPO/.gaia/specs.json")" -eq 0 ]
+}
+
+@test "14c: lock timeout — next exits 4, ledger unchanged (75 maps to 4)" {
+  # Hold the lock with a slow background job, then a real `next` with a tiny
+  # timeout cannot acquire it. The helper returns 75; `next` maps that to
+  # exit 4 (ledger-write-class failure) per Contract C2. Asserts the timeout
+  # path propagates THROUGH the lock as a non-zero exit, not a swallowed 0.
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  cd "$REPO"
+  before="$(jq -r '[.specs[].id] | length' "$REPO/.gaia/specs.json")"
+  run bash -c "
+    export GAIA_LEDGER_LOCK_FORCE_FALLBACK=1
+    . '$REPO/.specify/extensions/gaia/lib/with-ledger-lock.sh'
+    ( with_ledger_lock '$REPO/.gaia' sleep 4 ) &
+    holder=\$!
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+      [ -d '$REPO/.gaia/specs.lock.d' ] && break
+      sleep 0.1
+    done
+    GAIA_LEDGER_LOCK_TIMEOUT_SECS=1 bash '$REPO/$ALLOC' next '$REPO'
+    rc=\$?
+    wait \"\$holder\" 2>/dev/null || true
+    exit \"\$rc\"
+  "
+  [ "$status" -eq 4 ]
+  after="$(jq -r '[.specs[].id] | length' "$REPO/.gaia/specs.json")"
+  [ "$before" -eq "$after" ]
+}
+
+@test "14d: ledger-update invalid patch JSON exits 5 (propagates THROUGH the lock)" {
+  # Companion negative assertion for Contract C3: a bad patch makes
+  # apply_patch return 5; with_ledger_lock must pass 5 through and
+  # ledger-update.sh must exit 5 (NOT 0, and NOT the 4 reserved for lock
+  # timeout / missing ledger).
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$LEDGER_UPDATE' '$REPO' SPEC-001 'not-json'"
+  [ "$status" -eq 5 ]
+}
+
+# --- Test 15: ledger-update racing next (Contract C3 cross-script) ------------
+
+@test "15: ledger-update racing N-parallel next — ledger valid, no row lost" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  cd "$REPO"
+  N=8
+  rm -f "$REPO"/out.* "$REPO/start.flag"
+
+  # N barrier-gated allocator jobs.
+  for i in $(seq 1 "$N"); do
+    bash -c '
+      repo="$1"; alloc="$2"; idx="$3"
+      until [ -f "$repo/start.flag" ]; do :; done
+      GAIA_LEDGER_LOCK_FORCE_FALLBACK=1 bash "$repo/$alloc" next "$repo" > "$repo/out.$idx" 2>/dev/null
+    ' _ "$REPO" "$ALLOC" "$i" &
+  done
+  # One barrier-gated step-8-style flip of the seeded draft row.
+  bash -c '
+    repo="$1"; lu="$2"
+    until [ -f "$repo/start.flag" ]; do :; done
+    GAIA_LEDGER_LOCK_FORCE_FALLBACK=1 bash "$repo/$lu" "$repo" SPEC-001 "{\"status\":\"in-progress\"}" 2>/dev/null
+  ' _ "$REPO" "$LEDGER_UPDATE" &
+
+  touch "$REPO/start.flag"
+  wait
+
+  # Ledger is still valid JSON.
+  run jq -e . "$REPO/.gaia/specs.json"
+  [ "$status" -eq 0 ]
+  # Seeded row flipped to in-progress.
+  [ "$(jq -r '.specs[] | select(.id=="SPEC-001") | .status' "$REPO/.gaia/specs.json")" = "in-progress" ]
+  # SPEC-001 + N freshly allocated rows, all present, no row lost.
+  total="$(jq -r '[.specs[].id] | length' "$REPO/.gaia/specs.json")"
+  [ "$total" -eq "$((N + 1))" ]
+  # No duplicate ids.
+  dupes="$(jq -r '.specs[].id' "$REPO/.gaia/specs.json" | sort | uniq -d | wc -l | tr -d ' ')"
+  [ "$dupes" -eq 0 ]
+}

--- a/.gaia/tests/lib/with-ledger-lock.bats
+++ b/.gaia/tests/lib/with-ledger-lock.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# Unit tests for the with-ledger-lock.sh shared mutex helper (Contract C1).
+# The helper is sourced (it defines one function: with_ledger_lock) — these
+# tests source a fresh copy from a tmp repo and exercise the function in
+# isolation.
+
+setup() {
+  HELPERS="$BATS_TEST_DIRNAME/helpers"
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  LOCK_HELPER="$REPO/.specify/extensions/gaia/lib/with-ledger-lock.sh"
+  LOCKDIR="$REPO/.gaia"
+}
+
+teardown() {
+  if [ -n "${REPO:-}" ]; then
+    rm -rf "$REPO"
+  fi
+}
+
+@test "1: with_ledger_lock <d> true -> status 0" {
+  run bash -c ". '$LOCK_HELPER'; with_ledger_lock '$LOCKDIR' true"
+  [ "$status" -eq 0 ]
+}
+
+@test "2: passthrough — command exit 7 propagates as status 7" {
+  run bash -c ". '$LOCK_HELPER'; with_ledger_lock '$LOCKDIR' bash -c 'exit 7'"
+  [ "$status" -eq 7 ]
+}
+
+@test "3: helper writes nothing to stdout — only command stdout passes" {
+  run bash -c ". '$LOCK_HELPER'; with_ledger_lock '$LOCKDIR' bash -c 'echo HELLO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "HELLO" ]
+}
+
+@test "4: forced fallback — specs.lock.d appears during slow cmd, gone after" {
+  # The slow command observes the lock dir from inside the held mutex and
+  # records its presence; after the call the dir is released (rmdir'd).
+  run bash -c "
+    . '$LOCK_HELPER'
+    export GAIA_LEDGER_LOCK_FORCE_FALLBACK=1
+    seen=0
+    with_ledger_lock '$LOCKDIR' bash -c '[ -d \"$LOCKDIR/specs.lock.d\" ] && echo INSIDE_PRESENT; sleep 0.3'
+    [ -d '$LOCKDIR/specs.lock.d' ] && echo AFTER_PRESENT || echo AFTER_GONE
+    # mkdir path used: the flock file must NOT have been created.
+    [ -e '$LOCKDIR/specs.lock' ] && echo FLOCK_FILE_PRESENT || echo NO_FLOCK_FILE
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INSIDE_PRESENT"* ]]
+  [[ "$output" == *"AFTER_GONE"* ]]
+  [[ "$output" == *"NO_FLOCK_FILE"* ]]
+}
+
+@test "5: timeout — second caller waiting on a held lock returns 75, stderr 'timed out'" {
+  # Holder acquires the mkdir lock and sleeps; a second call with a 1s
+  # timeout cannot acquire it and must return 75.
+  run bash -c "
+    . '$LOCK_HELPER'
+    export GAIA_LEDGER_LOCK_FORCE_FALLBACK=1
+    ( with_ledger_lock '$LOCKDIR' sleep 3 ) &
+    holder=\$!
+    # Wait until the holder actually owns the lock dir.
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+      [ -d '$LOCKDIR/specs.lock.d' ] && break
+      sleep 0.1
+    done
+    GAIA_LEDGER_LOCK_TIMEOUT_SECS=1 with_ledger_lock '$LOCKDIR' true
+    rc=\$?
+    wait \"\$holder\" 2>/dev/null || true
+    exit \"\$rc\"
+  "
+  [ "$status" -eq 75 ]
+  [[ "$output" == *"timed out"* ]]
+}
+
+@test "6: stale recovery — pre-created stale lock dir is reclaimed, cmd code returned" {
+  run bash -c "
+    . '$LOCK_HELPER'
+    export GAIA_LEDGER_LOCK_FORCE_FALLBACK=1
+    export GAIA_LEDGER_LOCK_STALE_SECS=1
+    mkdir -p '$LOCKDIR/specs.lock.d'
+    sleep 2   # age the stale lock past the 1s threshold
+    with_ledger_lock '$LOCKDIR' bash -c 'exit 3'
+  "
+  # Stale dir reclaimed, command ran, its exit code (3) passed through.
+  [ "$status" -eq 3 ]
+}
+
+@test "7: flock path present — two serialized calls both succeed (skip if no flock)" {
+  if ! command -v flock >/dev/null 2>&1; then
+    skip "flock not installed on this machine — mkdir fallback is the load-bearing path here"
+  fi
+  run bash -c "
+    . '$LOCK_HELPER'
+    unset GAIA_LEDGER_LOCK_FORCE_FALLBACK
+    with_ledger_lock '$LOCKDIR' true && echo ONE
+    with_ledger_lock '$LOCKDIR' true && echo TWO
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ONE"* ]]
+  [[ "$output" == *"TWO"* ]]
+}

--- a/.specify/extensions/gaia/lib/ledger-update.sh
+++ b/.specify/extensions/gaia/lib/ledger-update.sh
@@ -6,7 +6,14 @@
 #   ledger-update.sh <repo_root> <spec_id> '<json-object>'
 #
 # Refuses if the row is missing — callers must allocate via spec-allocator.sh first.
-# Exit codes: 0 ok, 2 usage, 4 ledger or row missing, 5 invalid patch JSON.
+#
+# The jq…>tmp; mv critical section runs inside the shared ledger mutex
+# (with-ledger-lock.sh) so it serializes against spec-allocator.sh's row
+# append on the same .gaia/specs.json. See with-ledger-lock.sh for the lock
+# env knobs (GAIA_LEDGER_LOCK_*).
+#
+# Exit codes: 0 ok, 2 usage, 4 ledger or row missing OR lock-acquisition
+# timeout (could not safely apply the ledger write), 5 invalid patch JSON.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -19,6 +26,10 @@ spec_id="$2"
 patch="$3"
 ledger_path="${repo_root%/}/.gaia/specs.json"
 
+_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "${_lib_dir}/with-ledger-lock.sh"
+
 if [ ! -f "$ledger_path" ]; then
   echo "ledger-update: ledger not found at $ledger_path" >&2
   exit 4
@@ -29,13 +40,25 @@ if ! jq -e --arg id "$spec_id" '.specs[] | select(.id == $id)' "$ledger_path" >/
   exit 4
 fi
 
-tmp="$(mktemp)"
-if ! jq --arg id "$spec_id" --argjson patch "$patch" \
-  '.specs |= map(if .id == $id then . + $patch else . end)' \
-  "$ledger_path" > "$tmp" 2>/dev/null; then
-  rm -f "$tmp"
-  echo "ledger-update: jq failed (invalid patch JSON?)" >&2
-  exit 5
-fi
+apply_patch() {
+  local tmp
+  tmp="$(mktemp)"
+  if ! jq --arg id "$spec_id" --argjson patch "$patch" \
+    '.specs |= map(if .id == $id then . + $patch else . end)' \
+    "$ledger_path" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    echo "ledger-update: jq failed (invalid patch JSON?)" >&2
+    return 5
+  fi
+  mv "$tmp" "$ledger_path"
+}
 
-mv "$tmp" "$ledger_path"
+rc=0
+with_ledger_lock "${repo_root%/}/.gaia" apply_patch || rc=$?
+if [ "$rc" -ne 0 ]; then
+  if [ "$rc" -eq 75 ]; then
+    echo "ledger-update: could not acquire ledger lock; patch not applied" >&2
+    exit 4
+  fi
+  exit "$rc"
+fi

--- a/.specify/extensions/gaia/lib/spec-allocator.sh
+++ b/.specify/extensions/gaia/lib/spec-allocator.sh
@@ -14,6 +14,16 @@
 # missing from the ledger. A skipped slot is strictly cheaper than a duplicate id.
 # Commit messages are NOT scanned; they pick up free-text references (test
 # fixtures, regression notes) that would inflate the highest id incorrectly.
+#
+# Concurrency: the `next` read-modify-write critical section runs under the
+# shared ledger mutex from with-ledger-lock.sh (flock when present, atomic-mkdir
+# fallback on stock macOS). Two parallel `/gaia spec` sessions cannot allocate a
+# duplicate SPEC id. A lock-acquisition timeout (helper exit 75) maps to exit 4
+# — callers (the speckit preset) already handle 4 as "allocation failed", so a
+# new exit code would break their error handling. Lock env knobs
+# (GAIA_LEDGER_LOCK_TIMEOUT_SECS / _STALE_SECS / _POLL_SECS /
+# _FORCE_FALLBACK): see with-ledger-lock.sh. `highest` and `in_progress` are
+# read-only and take NO lock.
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
@@ -25,6 +35,13 @@ mode="$1"
 repo_root="$2"
 specs_dir="${repo_root%/}/.gaia/local/specs"
 ledger_path="${repo_root%/}/.gaia/specs.json"
+
+# Source the shared ledger mutex from this script's own directory so it
+# resolves identically from the speckit preset and from test copies of the
+# lib dir (no hardcoded repo path — template-distributed, repo-relative).
+_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "${_lib_dir}/with-ledger-lock.sh"
 
 require_git() {
   if ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
@@ -87,13 +104,35 @@ append_ledger_row() {
     "$ledger_path" > "$tmp"; then
     rm -f "$tmp"
     echo "spec-allocator: failed to update ledger at $ledger_path" >&2
-    exit 4
+    # return (not exit) so the mkdir-lock trap still releases the lock dir;
+    # allocate_next propagates this rc and `next)` re-maps it to exit 4.
+    return 4
   fi
   mv "$tmp" "$ledger_path"
 }
 
-# Print the first SPEC whose frontmatter has status: in-progress; "none" if none.
+# Print the first in-flight SPEC id, or "none". Single-id, none-when-empty
+# contract preserved. Source order:
+#   1. Ledger rows with status draft OR in-progress (ledger array order). The
+#      row is created at `next` (skill step 3), strictly before the first
+#      draft-<spec_id>.md cache write, so this covers the widest in-flight
+#      window — including the draft phase a parallel session would otherwise
+#      miss.
+#   2. Fallback: canonical .gaia/local/specs/SPEC-*.md frontmatter scan for
+#      status: in-progress (legacy case — SPEC file in-progress but no ledger
+#      row, e.g. a backfilled / hand-edited ledger).
 in_progress_spec() {
+  if [ -f "$ledger_path" ]; then
+    local id
+    id="$(jq -r '
+      [.specs[] | select(.status == "draft" or .status == "in-progress")][0].id // empty
+    ' "$ledger_path" 2>/dev/null || true)"
+    if [ -n "$id" ]; then
+      printf '%s\n' "$id"
+      return
+    fi
+  fi
+
   if [ ! -d "$specs_dir" ]; then
     echo "none"
     return
@@ -133,13 +172,39 @@ in_progress_spec() {
   echo "none"
 }
 
+# The read-modify-write critical section, run inside the ledger mutex so two
+# parallel `next` calls cannot read the same highest_num and allocate a
+# duplicate id. append_ledger_row returns (not exits) 4 on jq failure; we
+# propagate that rc so the helper passes it through and the trap still runs.
+allocate_next() {
+  local h next new_id
+  h="$(highest_num)"
+  next=$((h + 1))
+  new_id="$(printf 'SPEC-%03d' "$next")"
+  append_ledger_row "$new_id" || return $?
+  printf '%s\n' "$new_id"
+}
+
 case "$mode" in
   next)
-    h="$(highest_num)"
-    next=$((h + 1))
-    new_id="$(printf 'SPEC-%03d' "$next")"
-    append_ledger_row "$new_id"
-    echo "$new_id"
+    require_git
+    ensure_ledger
+    # C1 lock-dir precondition: the dir must exist before with_ledger_lock.
+    # ensure_ledger already mkdir -p's it via the ledger parent, but make the
+    # precondition explicit and independent of ledger-init ordering.
+    mkdir -p "${repo_root%/}/.gaia"
+    # Capture rc directly — NOT `if ! with_ledger_lock …; then rc=$?`: after a
+    # `!`-negated command, $? is the negation's status (0), masking the real
+    # rc. `|| rc=$?` preserves the helper's actual exit code under set -e.
+    rc=0
+    with_ledger_lock "${repo_root%/}/.gaia" allocate_next || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      if [ "$rc" -eq 75 ]; then
+        echo "spec-allocator: could not acquire ledger lock; refuse to allocate (would risk duplicate SPEC ids)" >&2
+        exit 4
+      fi
+      exit "$rc"   # propagate append_ledger_row's own rc 4, etc.
+    fi
     ;;
   highest)
     h="$(highest_num)"

--- a/.specify/extensions/gaia/lib/with-ledger-lock.sh
+++ b/.specify/extensions/gaia/lib/with-ledger-lock.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# with-ledger-lock.sh — Single shared mutex helper for .gaia/specs.json
+# read-modify-write critical sections. Sourced (not executed) by sibling lib
+# scripts (spec-allocator.sh, ledger-update.sh) so the locking logic is defined
+# exactly once and cannot drift between two copies.
+#
+# Public function:
+#   with_ledger_lock <lock_dir> <command> [args...]
+#
+# <lock_dir> is an already-existing directory (callers mkdir -p the ledger
+# parent before calling — typically "${repo_root%/}/.gaia"). <command> [args...]
+# runs inside the held mutex; its exit code passes through unchanged.
+#
+# Lock primitive selection, in order:
+#   1. GAIA_LEDGER_LOCK_FORCE_FALLBACK=1 → atomic-mkdir lock (test knob).
+#   2. flock present → flock on <lock_dir>/specs.lock (kernel releases the fd
+#      on process death; no stale handling needed).
+#   3. else → atomic-mkdir lock on <lock_dir>/specs.lock.d. mkdir is atomic on
+#      POSIX/HFS+/APFS: the process that creates the dir owns the lock. macOS
+#      has no util-linux flock, so this is the load-bearing path here.
+#
+# Deadlock prevention (mkdir path): a trap on EXIT INT TERM rmdirs the lock dir
+# iff this process created it; a stale lock dir older than
+# GAIA_LEDGER_LOCK_STALE_SECS is reclaimed and the mkdir retried once.
+#
+# Env knobs (all optional, read at call time):
+#   GAIA_LEDGER_LOCK_TIMEOUT_SECS    acquisition timeout       (default 10)
+#   GAIA_LEDGER_LOCK_STALE_SECS      stale-lock age threshold  (default 30)
+#   GAIA_LEDGER_LOCK_POLL_SECS       inter-attempt sleep       (default 0.2)
+#   GAIA_LEDGER_LOCK_FORCE_FALLBACK  =1 forces the mkdir path  (unset)
+#
+# Diagnostics go to stderr only — the helper writes nothing to stdout itself.
+# On acquisition timeout it returns 75 (EX_TEMPFAIL); callers map this onto
+# their own ledger-write-failure exit code (see spec-allocator.sh /
+# ledger-update.sh headers).
+#
+# This file is sourced, not run: it only defines the function and reads no env
+# until the function is called.
+
+if ! declare -f with_ledger_lock >/dev/null 2>&1; then
+
+with_ledger_lock() {
+  local lock_dir="$1"
+  shift
+
+  local timeout_secs="${GAIA_LEDGER_LOCK_TIMEOUT_SECS:-10}"
+  local stale_secs="${GAIA_LEDGER_LOCK_STALE_SECS:-30}"
+  local poll_secs="${GAIA_LEDGER_LOCK_POLL_SECS:-0.2}"
+  local force_fallback="${GAIA_LEDGER_LOCK_FORCE_FALLBACK:-}"
+
+  # ---- flock path: kernel-backed, releases the fd on subshell exit ----------
+  if [ "$force_fallback" != "1" ] && command -v flock >/dev/null 2>&1; then
+    local lock_file="${lock_dir%/}/specs.lock"
+    local rc=0
+    # The subshell holds fd 9 on the lock file; flock blocks (with a timeout)
+    # until it owns the lock, then runs the command. The fd — and therefore the
+    # lock — releases when the subshell exits, even if the command fails or the
+    # process is killed.
+    (
+      if ! flock -w "$timeout_secs" 9; then
+        echo "with-ledger-lock: timed out acquiring $lock_dir lock" >&2
+        exit 75
+      fi
+      "$@"
+    ) 9>"$lock_file"
+    rc=$?
+    return "$rc"
+  fi
+
+  # ---- portable atomic-mkdir fallback --------------------------------------
+  local lock_d="${lock_dir%/}/specs.lock.d"
+  local owned=0
+  local saved_exit saved_int saved_term
+
+  # Snapshot any pre-existing traps so we can restore them on return and not
+  # clobber a caller's handlers beyond the critical section.
+  saved_exit="$(trap -p EXIT)"
+  saved_int="$(trap -p INT)"
+  saved_term="$(trap -p TERM)"
+
+  _with_ledger_lock_release() {
+    if [ "$owned" -eq 1 ]; then
+      rmdir "$lock_d" 2>/dev/null || true
+      owned=0
+    fi
+  }
+
+  _with_ledger_lock_restore_traps() {
+    if [ -n "$saved_exit" ]; then eval "$saved_exit"; else trap - EXIT; fi
+    if [ -n "$saved_int" ]; then eval "$saved_int"; else trap - INT; fi
+    if [ -n "$saved_term" ]; then eval "$saved_term"; else trap - TERM; fi
+  }
+
+  # Portable lock-dir age in seconds, or empty if it cannot be determined.
+  _with_ledger_lock_age_secs() {
+    local now mtime
+    now="$(date +%s)"
+    if mtime="$(stat -f %m "$lock_d" 2>/dev/null)"; then
+      :
+    elif mtime="$(stat -c %Y "$lock_d" 2>/dev/null)"; then
+      :
+    else
+      return 1
+    fi
+    echo "$((now - mtime))"
+  }
+
+  trap '_with_ledger_lock_release' EXIT INT TERM
+
+  local start_ts now_ts elapsed age
+  start_ts="$(date +%s)"
+
+  while true; do
+    if mkdir "$lock_d" 2>/dev/null; then
+      owned=1
+      local rc=0
+      "$@" || rc=$?
+      _with_ledger_lock_release
+      _with_ledger_lock_restore_traps
+      return "$rc"
+    fi
+
+    # Lock held by someone else — reclaim if stale, then retry once.
+    if age="$(_with_ledger_lock_age_secs)" && [ -n "$age" ] \
+      && [ "$age" -gt "$stale_secs" ]; then
+      rm -rf "$lock_d" 2>/dev/null || true
+      if mkdir "$lock_d" 2>/dev/null; then
+        owned=1
+        local rc=0
+        "$@" || rc=$?
+        _with_ledger_lock_release
+        _with_ledger_lock_restore_traps
+        return "$rc"
+      fi
+    fi
+
+    now_ts="$(date +%s)"
+    elapsed=$((now_ts - start_ts))
+    if [ "$elapsed" -ge "$timeout_secs" ]; then
+      _with_ledger_lock_restore_traps
+      echo "with-ledger-lock: timed out acquiring $lock_dir lock" >&2
+      return 75
+    fi
+
+    sleep "$poll_secs"
+  done
+}
+
+fi


### PR DESCRIPTION
## Summary

Harden GAIA's SPEC ledger machinery against two concurrent `/gaia spec`
sessions run by one human in two simultaneous Claude Code terminals on the
same machine.

Two defects fixed:

1. **Non-atomic allocation.** `spec-allocator.sh next` and `ledger-update.sh`
   both did an unlocked read-modify-write of `.gaia/specs.json` → duplicate
   SPEC ids + lost ledger rows. Fixed with a shared `flock`+atomic-`mkdir`
   fallback mutex (`with-ledger-lock.sh`).
2. **`in_progress` draft-phase blindness.** A parallel session saw `none`
   because the canonical SPEC file is not written until skill step 8.
   Broadened `in_progress` to also read ledger `status: draft`/`in-progress`
   rows.

Plus a bats concurrency test suite and a one-line `spec.md` step-2
clarification.

Delivered in three phase commits:
- Phase 1: `with-ledger-lock.sh` shared mutex helper (C1)
- Phase 2: serialize ledger RMW in allocator + ledger-update (C2/C3)
- Phase 3: concurrency bats suite + spec.md draft-phase note (C4)

## Test plan

- [ ] `bash .gaia/tests/lib/run-all.sh` green (added in Phase 3)
- [ ] N-parallel `next` → N distinct ids, no lost rows (real flock + forced fallback)
- [ ] `ledger-update` racing `next` never loses a row
- [ ] `in_progress` surfaces a draft-phase ledger row
- [ ] read-only modes (`highest`/`in_progress`) take no lock
- [ ] exit codes 2/3/4/5 preserved; lock timeout maps to 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)