### PR TITLE
Per-SPEC folder layout (spec-folder-layout)

### DIFF
--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -14,10 +14,10 @@ Otherwise, ask: **"What do you want me to orchestrate?"** and wait for the respo
 
 Check the description for a SPEC reference. The canonical form (emitted by `/gaia spec`) is:
 
-    SPEC-NNN: <intent first line> — see .gaia/local/specs/SPEC-NNN.md
+    SPEC-NNN: <intent first line> — see .gaia/local/specs/SPEC-NNN/SPEC.md
 
 Match either pattern:
-- A path matching `.gaia/local/specs/SPEC-\d+\.md`
+- A path matching `.gaia/local/specs/SPEC-\d+/SPEC\.md`
 - A `SPEC-\d+:` prefix at the start of the description
 
 If matched:

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -1,6 +1,6 @@
 # /gaia spec
 
-Socratic discovery wrapper around spec-kit. Produces an immutable SPEC artifact at `.gaia/local/specs/SPEC-NNN.md` and prompts to chain into `/gaia plan`. Do not implement anything — this skill produces an artifact and stops.
+Socratic discovery wrapper around spec-kit. Produces an immutable SPEC artifact at `.gaia/local/specs/SPEC-NNN/SPEC.md` and prompts to chain into `/gaia plan`. Do not implement anything — this skill produces an artifact and stops.
 
 ## Argument parsing
 
@@ -226,7 +226,7 @@ Persist the answer as `gh_mirror_optin: <bool>` in working memory for this sessi
 
 Run `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"`. If the output is a `SPEC-NNN` id (not `none`), an in-progress SPEC already exists.
 
-The id may name a **draft-phase** session — a SPEC allocated in another terminal whose interactive loop has not yet reached the canonical save (step 8), so `.gaia/local/specs/SPEC-NNN.md` may not exist yet and the live draft is at `.gaia/local/cache/draft-SPEC-NNN.md`. The `WORKING`-selection below resolves this correctly, preferring the draft cache when the canonical file is absent or older.
+The id may name a **draft-phase** session — a SPEC allocated in another terminal whose interactive loop has not yet reached the canonical save (step 8), so `.gaia/local/specs/SPEC-NNN/SPEC.md` may not exist yet and the live draft is at `.gaia/local/cache/draft-SPEC-NNN.md`. The `WORKING`-selection below resolves this correctly, preferring the draft cache when the canonical file is absent or older.
 
 **Auto-mode exception:** skip the resume prompt entirely. Always start new — append `spec_started` telemetry with `resumed: false, auto: true` and proceed to step 3 with a fresh allocation. The in-progress SPEC (if any) remains untouched. Per Auto-mode rule 3 the user's `auto` invocation is the signal that they want a fresh artifact; resuming an existing draft into a non-interactive context risks silently overwriting work in progress.
 
@@ -234,7 +234,7 @@ Before prompting, gather context for an informed choice. The newer of the canoni
 
 ```bash
 SPEC_ID="<from allocator>"
-SPEC_PATH=".gaia/local/specs/${SPEC_ID}.md"
+SPEC_PATH=".gaia/local/specs/${SPEC_ID}/SPEC.md"
 DRAFT_PATH=".gaia/local/cache/draft-${SPEC_ID}.md"
 if [[ -f "$DRAFT_PATH" && "$DRAFT_PATH" -nt "$SPEC_PATH" ]]; then
   WORKING="$DRAFT_PATH"
@@ -266,11 +266,11 @@ Honor the user's choice. Never silently overwrite, never silently start new.
 
 ### 3. /speckit-specify (initial draft)
 
-Invoke `/speckit-specify` with the description from step 1. The GAIA preset (registered via `specify preset add`) wraps core with `{CORE_TEMPLATE}` and replaces `spec-template`, so the artifact is GAIA-shaped (frontmatter, immutable flag, `SPEC-NNN` id) and lands at `.gaia/local/specs/SPEC-NNN.md`. The preset's body invokes `lib/spec-allocator.sh next "$PWD"` to allocate the SPEC id.
+Invoke `/speckit-specify` with the description from step 1. The GAIA preset (registered via `specify preset add`) wraps core with `{CORE_TEMPLATE}` and replaces `spec-template`, so the artifact is GAIA-shaped (frontmatter, immutable flag, `SPEC-NNN` id) and lands at `.gaia/local/specs/SPEC-NNN/SPEC.md`. The preset's body invokes `lib/spec-allocator.sh next "$PWD"` to allocate the SPEC id.
 
 Spec-kit fires the `before_specify` hook (constitution + version-pin check) automatically before this step runs. If the hook blocks, surface its message and halt.
 
-When core completes, `/speckit-gaia-spec`'s preset relocates the artifact to `.gaia/local/specs/SPEC-NNN.md`. Cache the working draft path; you will read and re-render it across the rest of these steps. (Step 2 already appended `spec_started` telemetry for both fresh and resumed flows.)
+When core completes, `/speckit-gaia-spec`'s preset relocates the artifact to `.gaia/local/specs/SPEC-NNN/SPEC.md`. Cache the working draft path; you will read and re-render it across the rest of these steps. (Step 2 already appended `spec_started` telemetry for both fresh and resumed flows.)
 
 Initialize the session-shape cache for the just-allocated SPEC id (no-op if it already exists from a resume):
 
@@ -470,9 +470,15 @@ On confirmation:
 
 Only after gate-2 confirmation may you proceed to step 8.
 
-### 8. Save to .gaia/local/specs/SPEC-NNN.md
+### 8. Save to .gaia/local/specs/SPEC-NNN/SPEC.md
 
-Write the confirmed draft to `.gaia/local/specs/SPEC-NNN.md` (using the `spec_id` allocated in step 3). This is the canonical save location — never anywhere else, never duplicate copies.
+Create the SPEC folder, then write the confirmed draft to its canonical inner file (using the `spec_id` allocated in step 3):
+
+```bash
+mkdir -p .gaia/local/specs/${SPEC_ID}
+```
+
+Write to `.gaia/local/specs/SPEC-NNN/SPEC.md`. This is the canonical save location — never anywhere else, never duplicate copies. The folder is the archival unit; sibling artifacts live beside `SPEC.md` in the same folder.
 
 Update the frontmatter `updated` field to today's date.
 
@@ -481,7 +487,7 @@ After the canonical write succeeds:
 2. **Update the ledger row:** flip the row in `.gaia/specs.json` from `status: draft` to `status: in-progress` and stamp the intent (first prose line of the SPEC's `intent` field) for at-a-glance scanning. Failure is non-blocking — log to stderr and continue. The ledger is a fast index over git; the SPEC artifact and git history remain authoritative.
 
 ```bash
-SPEC_PATH=".gaia/local/specs/${SPEC_ID}.md"
+SPEC_PATH=".gaia/local/specs/${SPEC_ID}/SPEC.md"
 INTENT=$(awk '
   /^intent:[[:space:]]*\|/ { in_block=1; next }
   /^intent:[[:space:]]*[^|[:space:]]/ {
@@ -502,7 +508,7 @@ bash .specify/extensions/gaia/lib/ledger-update.sh "$PWD" "$SPEC_ID" "$PATCH" \
 4. **Emit `time_to_resolved_spec`:** read the session-shape cache, derive `area_tags` from the SPEC's UAT clusters, fire one mentorship event, then delete the cache. Failure to emit must NEVER block the save:
 
 ```bash
-SPEC_PATH=".gaia/local/specs/${SPEC_ID}.md"
+SPEC_PATH=".gaia/local/specs/${SPEC_ID}/SPEC.md"
 CACHE=".gaia/local/cache/spec-session-${SPEC_ID}.json"
 if [[ -f "$CACHE" ]]; then
   START_AT="$(jq -r '.start_at' "$CACHE" 2>/dev/null || echo "")"
@@ -577,7 +583,7 @@ If `gh_mirror_optin` (captured at step 1) is `false`, **skip this step entirely*
 If `gh_mirror_optin` is `true`, run:
 
 ```bash
-bash .specify/extensions/gaia/lib/gh-mirror.sh "$PWD" "<spec-id>" ".gaia/local/specs/<spec-id>.md"
+bash .specify/extensions/gaia/lib/gh-mirror.sh "$PWD" "<spec-id>" ".gaia/local/specs/<spec-id>/SPEC.md"
 ```
 
 The script handles the conditional logic without intervention:
@@ -607,7 +613,7 @@ On `No`, stop and report to the user that the SPEC is saved and `/gaia plan` can
 
 Construct the dispatch input string in this exact form (literal interpolation, no quotes around the result):
 
-    SPEC-NNN: <intent first line> — see <absolute path to .gaia/local/specs/SPEC-NNN.md>
+    SPEC-NNN: <intent first line> — see <absolute path to .gaia/local/specs/SPEC-NNN/SPEC.md>
 
 where:
 - `SPEC-NNN` is the allocated SPEC id
@@ -651,7 +657,7 @@ Spawn a fresh Agent with the same template as 11a. Parse its return, append the 
 
 Print a single summary block after the loop exits:
 
-> SPEC-NNN saved to `.gaia/local/specs/SPEC-NNN.md`.
+> SPEC-NNN saved to `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 > Plans authored: <count>
 >   - <PLAN_DIRS[0]>
 >   - <PLAN_DIRS[1]>

--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -232,6 +232,21 @@ fi
 
 Persist `INVALIDATED_COUNT` for Step 9.
 
+### Step 8b: Migrate SPEC artifacts to per-SPEC folders
+
+SPEC artifacts live in per-SPEC folders: `.gaia/local/specs/<spec_id>/SPEC.md` (archived: `.gaia/local/specs/archived/<spec_id>/`). `.gaia/local/specs/**` is adopter-owned data the three-way merge never touches, so the freshly-updated runbooks reference the folder layout while the adopter's existing specs may still be flat files. Run the migration script to fold any flat specs into the folder layout. It is idempotent — a no-op when specs are already foldered or none exist — so run it unconditionally:
+
+```bash
+spec_folderize_out=$(bash .specify/extensions/gaia/lib/spec-folderize.sh 2>&1)
+spec_folderize_rc=$?
+```
+
+Parse the result for the Step 9 summary:
+
+- The script writes `spec-folderize: migrated <n> SPEC artifact(s) ...` to stderr on a successful migration. Persist `<n>` as `SPECS_MIGRATED`. On a no-op (already foldered or no specs) the script exits `0` with a `nothing to migrate` line — set `SPECS_MIGRATED=0`.
+- Exit code `4` is a migration conflict: a flat `SPEC-<id>.md` **and** a folder `<id>/SPEC.md` both exist for the same id. The script names both conflicting paths on stderr and changes nothing. **Do not swallow this and do not auto-resolve it.** Capture the conflicting ids/paths from `$spec_folderize_out`, set `SPECS_MIGRATED="conflict"`, and surface it in Step 9 as a blocking action item the user must reconcile by hand.
+- Any other non-zero exit (`2` usage, `3` unresolvable repo root) is a script-invocation error: surface `$spec_folderize_out` to the user and treat it as a blocking action item.
+
 ### Step 9: Summary
 
 Print a table:
@@ -245,8 +260,13 @@ GAIA update: v$BASELINE → $LATEST_TAG
   Conflicts:    <n>  (see .gaia-merge/)
   Deleted:      <n>
   Backed up:    <n>  (see .gaia-backup/<timestamp>/)
+  Specs migrated: <n>  (flat .gaia/local/specs files folded into per-SPEC folders)
   Trailer invalidations: <n>  (open PRs stamped v$BASELINE will re-audit on next push)
 ```
+
+Use `SPECS_MIGRATED` for the `Specs migrated` row. If it is `"conflict"`, emit the row as `Specs migrated: conflict — see action item below` and, after the table, print a blocking action item naming the conflicting ids/paths from `$spec_folderize_out`:
+
+> **Action required:** SPEC migration could not complete. A flat `SPEC-<id>.md` and a folder `<id>/SPEC.md` exist for the same id: <conflicting paths>. Resolve by hand (keep one, remove the other), then re-run `bash .specify/extensions/gaia/lib/spec-folderize.sh` to finish the migration. The freshly-updated runbooks reference the folder layout, so leaving this unresolved breaks SPEC tooling.
 
 If `INVALIDATED_COUNT` is `"unknown"`, emit instead:
 

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -175,6 +175,7 @@
     ".specify/extensions/gaia/lib/ledger-update.sh": "owned",
     ".specify/extensions/gaia/lib/lint.sh": "owned",
     ".specify/extensions/gaia/lib/spec-allocator.sh": "owned",
+    ".specify/extensions/gaia/lib/spec-folderize.sh": "owned",
     ".specify/extensions/gaia/lib/spec-renumber.sh": "owned",
     ".specify/extensions/gaia/lib/uat-write.sh": "owned",
     ".specify/extensions/gaia/lib/version-check.sh": "owned",

--- a/.gaia/tests/lib/README.md
+++ b/.gaia/tests/lib/README.md
@@ -13,6 +13,7 @@ down; no reliance on the real project `.gaia/specs.json`.
 |------|---------------|
 | `with-ledger-lock.bats` | The mutex helper in isolation (Contract C1): acquire/release, exit-code passthrough, no-stdout rule, forced mkdir fallback, acquisition timeout → 75, stale-lock recovery, flock path when present. |
 | `spec-allocator-concurrency.bats` | Allocator + ledger-update concurrency (Contracts C2/C3): N-parallel `next` with no lost rows and no duplicate ids (real flock and forced fallback), stale-lock recovery, `in_progress` draft surfacing + legacy fallback + none, read-only modes take no lock, exit-code preservation, and the cross-script `ledger-update` racing `next` interleaving. |
+| `spec-folder-layout.bats` | Per-SPEC folder layout + migration (Contract C7): `spec-folderize.sh` happy path (flat + `archived/` → `<id>/SPEC.md`, byte-identical contents), idempotent re-run, `--dry-run` no-op, empty-tree no-op, flat+foldered conflict → exit 4, tracked-vs-untracked move strategy (`git mv` vs `mv`); allocator `highest`/`next`/`in_progress` over foldered specs (`next` creates no folder, ledger-first wins, foldered fallback resolves); `spec-renumber.sh` folder rename keeping `SPEC.md` named `SPEC.md` with siblings carried + collision guard; a flat→folderize→`next`→renumber→archive round-trip; read-only modes take no lock and create no folder. |
 
 The N-parallel test uses a start-flag barrier so the `next` calls genuinely
 overlap. A passing run with no contention proves nothing — with the barrier,

--- a/.gaia/tests/lib/helpers/tmp-spec-repo.sh
+++ b/.gaia/tests/lib/helpers/tmp-spec-repo.sh
@@ -18,6 +18,15 @@
 #   --seed-file SPEC-NNN        write .gaia/local/specs/SPEC-NNN.md with
 #                               status: in-progress frontmatter and NO ledger
 #                               row (the legacy fallback case)
+#   --seed-flat SPEC-NNN        write a legacy flat .gaia/local/specs/
+#                               SPEC-NNN.md (status: draft frontmatter) — a
+#                               migration candidate for spec-folderize.sh
+#   --seed-archived-flat SPEC-NNN  same but under
+#                               .gaia/local/specs/archived/SPEC-NNN.md
+#   --seed-folder SPEC-NNN      write the foldered shape
+#                               .gaia/local/specs/SPEC-NNN/SPEC.md with
+#                               status: in-progress frontmatter and NO ledger
+#                               row (the foldered legacy fallback case)
 set -euo pipefail
 
 # Real repo containing this helper: the helper lives at
@@ -40,7 +49,8 @@ printf '{\n  "version": 1,\n  "specs": []\n}\n' > .gaia/specs.json
 
 # Copy (not symlink) so the scripts' ${BASH_SOURCE[0]}-relative source of
 # with-ledger-lock.sh resolves to this tmp lib dir.
-for s in spec-allocator.sh ledger-update.sh with-ledger-lock.sh; do
+for s in spec-allocator.sh ledger-update.sh with-ledger-lock.sh \
+         spec-folderize.sh spec-renumber.sh; do
   cp "${real_lib}/${s}" ".specify/extensions/gaia/lib/${s}"
   chmod +x ".specify/extensions/gaia/lib/${s}"
 done
@@ -68,6 +78,41 @@ while [[ $# -gt 0 ]]; do
     --seed-file)
       id="$2"; shift 2
       cat > ".gaia/local/specs/${id}.md" <<EOF
+---
+spec_id: ${id}
+status: in-progress
+---
+
+# ${id}
+EOF
+      ;;
+    --seed-flat)
+      id="$2"; shift 2
+      cat > ".gaia/local/specs/${id}.md" <<EOF
+---
+spec_id: ${id}
+status: draft
+---
+
+# ${id}
+EOF
+      ;;
+    --seed-archived-flat)
+      id="$2"; shift 2
+      mkdir -p .gaia/local/specs/archived
+      cat > ".gaia/local/specs/archived/${id}.md" <<EOF
+---
+spec_id: ${id}
+status: archived
+---
+
+# ${id}
+EOF
+      ;;
+    --seed-folder)
+      id="$2"; shift 2
+      mkdir -p ".gaia/local/specs/${id}"
+      cat > ".gaia/local/specs/${id}/SPEC.md" <<EOF
 ---
 spec_id: ${id}
 status: in-progress

--- a/.gaia/tests/lib/spec-allocator-concurrency.bats
+++ b/.gaia/tests/lib/spec-allocator-concurrency.bats
@@ -105,8 +105,8 @@ _run_parallel_next() {
   [ "$output" = "SPEC-007" ]
 }
 
-@test "11: in_progress legacy fallback — canonical file, no ledger row" {
-  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-file SPEC-013)"
+@test "11: in_progress fallback — canonical folder file, no ledger row" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-013)"
   cd "$REPO"
   run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
   [ "$status" -eq 0 ]

--- a/.gaia/tests/lib/spec-folder-layout.bats
+++ b/.gaia/tests/lib/spec-folder-layout.bats
@@ -1,0 +1,277 @@
+#!/usr/bin/env bats
+# Folder-layout tests for the SPEC artifact migration + path machinery
+# (Contract C7). A SPEC artifact lives at .gaia/local/specs/<id>/SPEC.md;
+# the migration script spec-folderize.sh moves any legacy flat
+# .gaia/local/specs/SPEC-NNN.md (and archived/SPEC-NNN.md) into that shape.
+#
+# Each test spins up its own tmp git repo via helpers/tmp-spec-repo.sh and
+# tears it down — hermetic, no reliance on the real project ledger. The
+# teardown uses the explicit-if form (the && idiom is a bats teardown
+# footgun: a falsy first clause makes teardown itself "fail").
+
+setup() {
+  HELPERS="$BATS_TEST_DIRNAME/helpers"
+  ALLOC=".specify/extensions/gaia/lib/spec-allocator.sh"
+  FOLDERIZE=".specify/extensions/gaia/lib/spec-folderize.sh"
+  RENUMBER=".specify/extensions/gaia/lib/spec-renumber.sh"
+}
+
+teardown() {
+  if [ -n "${REPO:-}" ]; then
+    rm -rf "$REPO"
+  fi
+}
+
+# Deterministic snapshot of the specs tree: relative paths + per-file sha,
+# sorted. Used to assert "nothing changed" across idempotent / dry-run runs.
+_snapshot() {
+  local root="$1"
+  ( cd "$root/.gaia/local/specs" 2>/dev/null \
+      && find . -type f -print0 2>/dev/null \
+         | sort -z \
+         | xargs -0 shasum 2>/dev/null ) || true
+}
+
+# --- 1: folderize happy path -------------------------------------------------
+
+@test "1: folderize migrates flat + archived specs into folders, contents byte-identical" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" \
+    --seed-flat SPEC-001 --seed-flat SPEC-002 --seed-archived-flat SPEC-000)"
+  cd "$REPO"
+
+  c1="$(cat "$REPO/.gaia/local/specs/SPEC-001.md")"
+  c2="$(cat "$REPO/.gaia/local/specs/SPEC-002.md")"
+  c0="$(cat "$REPO/.gaia/local/specs/archived/SPEC-000.md")"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  # Foldered shape exists.
+  [ -f "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-002/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md" ]
+
+  # No flat files remain.
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-001.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-002.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/archived/SPEC-000.md" ]
+
+  # Contents moved byte-for-byte.
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/SPEC.md")" = "$c1" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-002/SPEC.md")" = "$c2" ]
+  [ "$(cat "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md")" = "$c0" ]
+}
+
+# --- 2: idempotent re-run ----------------------------------------------------
+
+@test "2: re-running folderize on an already-foldered tree is a no-op" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-001 --seed-flat SPEC-002)"
+  cd "$REPO"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  before="$(_snapshot "$REPO")"
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to migrate"* ]] || [ -z "$output" ]
+  after="$(_snapshot "$REPO")"
+  [ "$before" = "$after" ]
+}
+
+# --- 3: dry-run --------------------------------------------------------------
+
+@test "3: --dry-run prints the plan and changes nothing" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-001)"
+  cd "$REPO"
+
+  before="$(_snapshot "$REPO")"
+  run bash -c "bash '$REPO/$FOLDERIZE' --dry-run '$REPO'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"mv "* ]]
+  [[ "$output" == *"SPEC-001/SPEC.md"* ]]
+
+  # Tree stays flat — no folder created, flat file untouched.
+  [ -f "$REPO/.gaia/local/specs/SPEC-001.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" ]
+  after="$(_snapshot "$REPO")"
+  [ "$before" = "$after" ]
+}
+
+# --- 4: no specs -------------------------------------------------------------
+
+@test "4: no flat specs — exit 0, stderr 'nothing to migrate'" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh")"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO' 2>&1 1>/dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to migrate"* ]]
+}
+
+# --- 5: conflict -------------------------------------------------------------
+
+@test "5: flat + foldered for same id — exit 4, both paths in stderr, neither modified" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-003 --seed-folder SPEC-003)"
+  cd "$REPO"
+
+  flat_before="$(cat "$REPO/.gaia/local/specs/SPEC-003.md")"
+  fold_before="$(cat "$REPO/.gaia/local/specs/SPEC-003/SPEC.md")"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO' 2>&1 1>/dev/null"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"SPEC-003.md"* ]]
+  [[ "$output" == *"SPEC-003/SPEC.md"* ]]
+
+  # Neither file modified.
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003.md")" = "$flat_before" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003/SPEC.md")" = "$fold_before" ]
+}
+
+# --- 6: tracked vs untracked -------------------------------------------------
+
+@test "6: untracked specs migrate via mv; tracked specs via git mv" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-001 --seed-flat SPEC-002)"
+  cd "$REPO"
+
+  # The helper commits all seeded files in its init commit, so both flats
+  # start tracked. Untrack SPEC-002 (keep the working file) so the two
+  # branches of the tracked-vs-untracked detection are both exercised:
+  # SPEC-001 stays tracked, SPEC-002 becomes a typical gitignored adopter spec.
+  git -C "$REPO" rm --quiet --cached .gaia/local/specs/SPEC-002.md
+  [ -f "$REPO/.gaia/local/specs/SPEC-002.md" ]
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  # Tracked file moved with git mv — git now tracks the new path, not the old.
+  git -C "$REPO" ls-files --error-unmatch .gaia/local/specs/SPEC-001/SPEC.md
+  run bash -c "git -C '$REPO' ls-files --error-unmatch .gaia/local/specs/SPEC-001.md"
+  [ "$status" -ne 0 ]
+
+  # Untracked file simply moved; still untracked at the new path.
+  [ -f "$REPO/.gaia/local/specs/SPEC-002/SPEC.md" ]
+  run bash -c "git -C '$REPO' ls-files --error-unmatch .gaia/local/specs/SPEC-002/SPEC.md"
+  [ "$status" -ne 0 ]
+}
+
+# --- 7: allocator over foldered specs ----------------------------------------
+
+@test "7a: highest reads foldered SPEC.md; next does not create a folder" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-004)"
+  cd "$REPO"
+  bash "$REPO/$FOLDERIZE" "$REPO" >/dev/null 2>&1
+
+  run bash -c "bash '$REPO/$ALLOC' highest '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-004" ]
+
+  run bash -c "bash '$REPO/$ALLOC' next '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-005" ]
+  # `next` only appends a ledger row — it must NOT create the folder.
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-005" ]
+  [ "$(jq -r '.specs[-1].id' "$REPO/.gaia/specs.json")" = "SPEC-005" ]
+}
+
+@test "7b: in_progress ledger-first wins over a foldered fallback artifact" {
+  # Ledger has an in-progress row for SPEC-009; a foldered SPEC-013/SPEC.md
+  # is also status:in-progress. Ledger order wins per Contract C3.
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-inprogress SPEC-009 --seed-folder SPEC-013)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-009" ]
+}
+
+@test "7c: in_progress fallback reads a foldered status:in-progress artifact" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-013)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-013" ]
+}
+
+# --- 8: renumber folder ------------------------------------------------------
+
+@test "8a: renumber renames the folder; SPEC.md keeps its name; siblings ride along" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-002)"
+  cd "$REPO"
+  # A sibling artifact in the same folder must move with the folder.
+  echo "report body" > "$REPO/.gaia/local/specs/SPEC-002/REPORT.md"
+
+  run bash -c "bash '$REPO/$RENUMBER' '$REPO' SPEC-002 SPEC-005"
+  [ "$status" -eq 0 ]
+
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-002" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-005/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-005/REPORT.md" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-005/REPORT.md")" = "report body" ]
+  # Inner SPEC.md frontmatter id rewritten.
+  grep -q '^spec_id: SPEC-005$' "$REPO/.gaia/local/specs/SPEC-005/SPEC.md"
+}
+
+@test "8b: renumber collision guard fires when the target folder exists" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-002 --seed-folder SPEC-005)"
+  cd "$REPO"
+  run bash -c "bash '$REPO/$RENUMBER' '$REPO' SPEC-002 SPEC-005"
+  [ "$status" -eq 4 ]
+  # Source folder untouched on a refused renumber.
+  [ -f "$REPO/.gaia/local/specs/SPEC-002/SPEC.md" ]
+}
+
+# --- 9: round-trip -----------------------------------------------------------
+
+@test "9: flat -> folderize -> next -> renumber -> archive round-trip" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-001 --seed-flat SPEC-002)"
+  cd "$REPO"
+
+  # 1. Migrate flat -> foldered.
+  bash "$REPO/$FOLDERIZE" "$REPO" >/dev/null 2>&1
+  [ -f "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-002/SPEC.md" ]
+
+  # 2. next allocates the right id (highest folder is 002 -> next is 003).
+  run bash -c "bash '$REPO/$ALLOC' next '$REPO'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "SPEC-003" ]
+
+  # 3. renumber a foldered spec.
+  run bash -c "bash '$REPO/$RENUMBER' '$REPO' SPEC-002 SPEC-010"
+  [ "$status" -eq 0 ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-002" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-010/SPEC.md" ]
+
+  # 4. Simulate the spec-close folder move to archived/<id>/.
+  mkdir -p "$REPO/.gaia/local/specs/archived"
+  mv "$REPO/.gaia/local/specs/SPEC-010" "$REPO/.gaia/local/specs/archived/SPEC-010"
+  [ -f "$REPO/.gaia/local/specs/archived/SPEC-010/SPEC.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-010" ]
+
+  # 5. highest ignores archived/ on the filesystem scan: only SPEC-001 is an
+  #    active foldered artifact, but the ledger still carries SPEC-003 and the
+  #    renumbered SPEC-010 row — the allocator's highest is ledger ∪ branches ∪
+  #    active folders, never archived/ (mindepth/maxdepth 2 stops at <id>/).
+  run bash -c "find '$REPO/.gaia/local/specs' -mindepth 2 -maxdepth 2 -type f -name SPEC.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SPEC-001/SPEC.md"* ]]
+  [[ "$output" != *"archived/SPEC-010/SPEC.md"* ]]
+}
+
+# --- 10: read-only modes take no lock and create no folder -------------------
+
+@test "10: highest / in_progress over foldered specs take no lock, create no folder" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-007)"
+  cd "$REPO"
+
+  before="$(_snapshot "$REPO")"
+  run bash -c "bash '$REPO/$ALLOC' highest '$REPO'"
+  [ "$status" -eq 0 ]
+  run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
+  [ "$status" -eq 0 ]
+
+  [ ! -e "$REPO/.gaia/specs.lock" ]
+  [ ! -e "$REPO/.gaia/specs.lock.d" ]
+  # No new folder created by a read-only mode.
+  after="$(_snapshot "$REPO")"
+  [ "$before" = "$after" ]
+}

--- a/.specify/extensions/gaia/commands/lint.md
+++ b/.specify/extensions/gaia/commands/lint.md
@@ -8,12 +8,12 @@ Fired automatically by spec-kit on the `after_specify` event (mandatory hook). T
 
 ## Locate the artifact
 
-The lint target is the SPEC artifact written by the preceding `/speckit-specify` invocation. In a GAIA project the preset redirects writes into `.gaia/local/specs/SPEC-NNN.md`; in a bare spec-kit project the artifact lives at `specs/<NNN>-<slug>/spec.md`.
+The lint target is the SPEC artifact written by the preceding `/speckit-specify` invocation. In a GAIA project the preset redirects writes into `.gaia/local/specs/SPEC-NNN/SPEC.md`; in a bare spec-kit project the artifact lives at `specs/<NNN>-<slug>/spec.md`.
 
 Resolve the path in this order:
 
 1. If `$ARGUMENTS` carries an explicit path, use it.
-2. Otherwise inspect `.gaia/local/specs/` for a SPEC file modified within the last five minutes (the just-written artifact).
+2. Otherwise inspect `.gaia/local/specs/SPEC-*/SPEC.md` for a SPEC file modified within the last five minutes (the just-written artifact).
 3. Otherwise fall back to `.specify/feature.json` (spec-kit's pointer to the active feature directory) and resolve `<feature-dir>/spec.md`.
 
 If no candidate resolves, surface:

--- a/.specify/extensions/gaia/commands/spec-close.md
+++ b/.specify/extensions/gaia/commands/spec-close.md
@@ -19,7 +19,7 @@ If `$ARGUMENTS` matches `SPEC-NNN`, target that SPEC.
 Otherwise, build the candidate list:
 
 1. Caches (deferred-drain candidates): `ls .gaia/local/cache/wiki-promote/*.json 2>/dev/null` → SPEC IDs awaiting drain.
-2. Specs (in-flight or pending disposition): `ls .gaia/local/specs/SPEC-*.md 2>/dev/null` → SPEC IDs (excludes `archived/`).
+2. Specs (in-flight or pending disposition): `ls -d .gaia/local/specs/SPEC-*/ 2>/dev/null` → SPEC IDs from folder names (excludes `archived/`).
 
 If exactly one candidate exists, default to it. If multiple, surface via `AskUserQuestion`:
 
@@ -45,31 +45,31 @@ Track `drained = <bool>` for telemetry and the final report.
 
 ## Step 3 — Disposition prompt
 
-Resolve the SPEC artifact path: `.gaia/local/specs/<spec_id>.md`.
+Resolve the SPEC folder: `.gaia/local/specs/<spec_id>/` (canonical artifact at `.gaia/local/specs/<spec_id>/SPEC.md`).
 
-If the file is missing, set `disposition = "skipped"`, skip Step 4, and continue to Step 5. Report line surfaces "(artifact missing; nothing to dispose)".
+If the folder is missing, set `disposition = "skipped"`, skip Step 4, and continue to Step 5. Report line surfaces "(artifact missing; nothing to dispose)".
 
 Surface via `AskUserQuestion`:
 
 - Question: `<spec_id> implementation complete and PR merged. Disposition?`
 - Header: `SPEC dispose`
 - Options:
-  - `{ label: "Archive (Recommended)", description: "Move to .gaia/local/specs/archived/ with status=archived. Preserves the SPEC artifact for posterity. Wiki content was already promoted at implement time; no re-summarization." }`
-  - `{ label: "Delete", description: "Remove the SPEC artifact. Local-only (.gaia/local/ is gitignored), so the SPEC is not recoverable from git history." }`
-  - `{ label: "Keep in place", description: "Leave the artifact at .gaia/local/specs/<spec_id>.md unchanged. Choose if undecided — re-run /gaia spec close <spec_id> later to revisit." }`
+  - `{ label: "Archive (Recommended)", description: "Move the SPEC folder to .gaia/local/specs/archived/ with status=archived. Preserves the SPEC artifact and its siblings for posterity. Wiki content was already promoted at implement time; no re-summarization." }`
+  - `{ label: "Delete", description: "Remove the SPEC folder. Local-only (.gaia/local/ is gitignored), so the SPEC is not recoverable from git history." }`
+  - `{ label: "Keep in place", description: "Leave the folder at .gaia/local/specs/<spec_id>/ unchanged. Choose if undecided — re-run /gaia spec close <spec_id> later to revisit." }`
 
 ## Step 4 — Apply disposition
 
 **On `Archive`:**
 
 1. `mkdir -p .gaia/local/specs/archived/`.
-2. Read `.gaia/local/specs/<spec_id>.md`. Update frontmatter: set `status: archived`; set `archived_at: <ISO 8601 UTC>`. Preserve all other fields verbatim.
-3. Write the updated artifact to `.gaia/local/specs/archived/<spec_id>.md`.
-4. `rm .gaia/local/specs/<spec_id>.md`.
+2. If `.gaia/local/specs/archived/<spec_id>/` already exists, the SPEC is already archived — report `<spec_id> already archived at .gaia/local/specs/archived/<spec_id>/.`, set `disposition = "archive"`, and skip the remaining sub-steps.
+3. Edit `.gaia/local/specs/<spec_id>/SPEC.md` frontmatter in place: set `status: archived`; set `archived_at: <ISO 8601 UTC>`. Preserve all other fields verbatim.
+4. Move the whole folder: `mv .gaia/local/specs/<spec_id> .gaia/local/specs/archived/<spec_id>`. Sibling artifacts move with it.
 
 **On `Delete`:**
 
-1. `rm .gaia/local/specs/<spec_id>.md`.
+1. `rm -rf .gaia/local/specs/<spec_id>`.
 
 **On `Keep in place`:**
 
@@ -106,9 +106,9 @@ The compute-profile command short-circuits when mentorship is disabled (no-op ex
 
 Print one of (prefix with `Drained <N> wiki pages. ` if Step 2 drained, where `<N>` is the count from wiki-promote's report):
 
-- `<spec_id> closed. Archived to .gaia/local/specs/archived/<spec_id>.md.`
-- `<spec_id> closed. SPEC artifact deleted.`
-- `<spec_id> closed. SPEC artifact kept at .gaia/local/specs/<spec_id>.md.`
+- `<spec_id> closed. Archived to .gaia/local/specs/archived/<spec_id>/.`
+- `<spec_id> closed. SPEC folder deleted.`
+- `<spec_id> closed. SPEC folder kept at .gaia/local/specs/<spec_id>/.`
 - `<spec_id> closed. (Artifact missing; nothing to dispose.)`
 
 If wiki content was promoted, also surface: `Run /gaia wiki consolidate periodically to keep the wiki coherent across SPECs.`
@@ -117,5 +117,5 @@ If wiki content was promoted, also surface: `Run /gaia wiki consolidate periodic
 
 - **Disposition does NOT re-summarize into the wiki.** `wiki-promote` (the `after_implement` hook) already wrote `wiki/<domain>/<slug>.md` pages with `promoted_from: <spec_id>` provenance at implement time. Re-summarizing here would duplicate. To consolidate redundant or superseded wiki pages across SPECs, run `/gaia wiki consolidate`.
 - This command never touches `wiki/`. The wiki-promote → wiki-sync chain owns wiki writes.
-- Archive is reversible (rename back). Delete is local-only — `.gaia/local/` is gitignored, so the SPEC is not recoverable from git history. Default to Archive if uncertain.
+- Archive is reversible (move the folder back). Delete is local-only — `.gaia/local/` is gitignored, so the SPEC is not recoverable from git history. Default to Archive if uncertain.
 - The chain from wiki-promote Step 8 fires only on the immediate-merge path. The deferred-drain path runs spec-close once and does not re-enter via the chain (see Step 2's `drained: true` guard).

--- a/.specify/extensions/gaia/commands/uat-write.md
+++ b/.specify/extensions/gaia/commands/uat-write.md
@@ -8,13 +8,13 @@ Fired automatically by spec-kit on the `before_implement` event (mandatory hook)
 
 ## Locate the active SPEC
 
-The render target is the SPEC artifact whose UATs back the upcoming `/speckit-implement` run. In a GAIA project that artifact lives at `.gaia/local/specs/SPEC-NNN.md`.
+The render target is the SPEC artifact whose UATs back the upcoming `/speckit-implement` run. In a GAIA project that artifact lives at `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 
 Resolve the path in this order (4-step algorithm; locked post-probe — `.specify/feature.json` carries no SPEC backreference, so a feature-cross-walk step was dropped):
 
 1. If `$ARGUMENTS` carries an explicit `SPEC-NNN` id or absolute path, use it.
-2. Otherwise pick the most-recent `.gaia/local/specs/SPEC-NNN.md` with `status: in-progress`, modified within the last 30 minutes.
-3. Otherwise the single `.gaia/local/specs/SPEC-NNN.md` with `status: in-progress` (only if exactly one exists).
+2. Otherwise pick the most-recent `.gaia/local/specs/SPEC-NNN/SPEC.md` with `status: in-progress`, modified within the last 30 minutes.
+3. Otherwise the single `.gaia/local/specs/SPEC-NNN/SPEC.md` with `status: in-progress` (only if exactly one exists).
 4. Otherwise `AskUserQuestion`: list all in-progress SPECs and ask which one to render. Do NOT guess.
 
 The GAIA preset's `/speckit-specify` wrapper relocates and stamps the SPEC immediately after authoring, so the just-written SPEC is the most-recent in-progress entry — step 2 covers the `/speckit-specify` → `/gaia plan` → `/speckit-implement` chain. Step 3 handles the common single-feature case.

--- a/.specify/extensions/gaia/commands/wiki-promote.md
+++ b/.specify/extensions/gaia/commands/wiki-promote.md
@@ -11,7 +11,7 @@ Fires automatically on `/speckit-implement` completion. Reads the SPEC artifact,
 
 The hook fires on `/speckit-implement` completion. The agent has the SPEC ID in conversation context (the implementer agent referenced it).
 
-Identify the SPEC ID from the running conversation. If ambiguous, fall back to the most-recently-modified file under `.gaia/local/specs/SPEC-*.md` (excluding `-revised-contracts` and `-refit-decision` suffixes).
+Identify the SPEC ID from the running conversation. If ambiguous, fall back to the most-recently-modified `.gaia/local/specs/SPEC-*/SPEC.md` (deriving the SPEC ID from the parent folder name; excluding `-revised-contracts` and `-refit-decision` suffixes).
 
 Read the SPEC frontmatter. Required fields: `spec_id`, `wiki_promote_default`, `wiki_promote_targets` (default `[]`).
 
@@ -163,7 +163,7 @@ Fields:
 - `updated` — today's ISO date.
 - `promoted_from` — the SPEC ID (e.g. `SPEC-NNN`).
 - `promoted_at` — current ISO 8601 UTC timestamp.
-- `spec_artifact_path` — `.gaia/local/specs/SPEC-NNN.md`.
+- `spec_artifact_path` — `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 - `pr_number` — from Step 3.
 - `pr_url` — from Step 3.
 - `tags` — copied from the SPEC's frontmatter `tags` if present and non-empty; otherwise `[promoted, <subdomain>]`.
@@ -213,7 +213,7 @@ Render the body in the following sections, in order, immediately after the closi
    ```markdown
    ## References
 
-   - Source SPEC: [SPEC-NNN](../../.gaia/local/specs/SPEC-NNN.md) (local SPEC artifact, gitignored — link does not resolve from GitHub web view)
+   - Source SPEC: [SPEC-NNN](../../.gaia/local/specs/SPEC-NNN/SPEC.md) (local SPEC artifact, gitignored — link does not resolve from GitHub web view)
    - Implementing PR: [PR #NNN](https://github.com/<owner>/<repo>/pull/NNN)
    - Promoted at: <ISO 8601 UTC>
    ```
@@ -321,6 +321,6 @@ Otherwise, invoke `/speckit-gaia-spec-close` directly:
 
 `Invoke /speckit-gaia-spec-close <spec_id> now. wiki-promote completed inline; the cache is already cleared. Spec-close will skip drain and go straight to the disposition prompt.`
 
-This presents the user with the archive / delete / keep prompt for the local SPEC artifact. The wiki content is already committed (Step 6's wiki-sync handoff); the disposition only affects `.gaia/local/specs/<spec_id>.md`.
+This presents the user with the archive / delete / keep prompt for the local SPEC artifact. The wiki content is already committed (Step 6's wiki-sync handoff); the disposition only affects `.gaia/local/specs/<spec_id>/`.
 
 If `/speckit-gaia-spec-close` fails or refuses, exit with the warning `wiki-promote: pages staged and committed; spec-close chain failed. Run /gaia spec close <spec_id> manually to dispose of the SPEC artifact.` Do NOT retry the chain — the wiki side is already settled.

--- a/.specify/extensions/gaia/lib/spec-allocator.sh
+++ b/.specify/extensions/gaia/lib/spec-allocator.sh
@@ -54,7 +54,7 @@ require_git() {
 # Sources (all deterministic markers — no free-text scanning):
 #   1. .gaia/specs.json ledger
 #   2. Local + remote branches matching ^spec-NNN-
-#   3. Working-tree files .gaia/local/specs/SPEC-NNN.md
+#   3. Working-tree folders .gaia/local/specs/<spec_id>/SPEC.md
 known_spec_numbers() {
   if [ -f "$ledger_path" ]; then
     jq -r '.specs[].id // empty' "$ledger_path" 2>/dev/null \
@@ -66,8 +66,8 @@ known_spec_numbers() {
     | sed -nE 's|^.*/?spec-0*([0-9]+)(-.*)?$|\1|p' || true
 
   if [ -d "$specs_dir" ]; then
-    find "$specs_dir" -maxdepth 1 -type f -name 'SPEC-*.md' -print 2>/dev/null \
-      | sed -nE 's|.*/SPEC-0*([0-9]+)\.md$|\1|p' || true
+    find "$specs_dir" -mindepth 2 -maxdepth 2 -type f -name 'SPEC.md' -print 2>/dev/null \
+      | sed -nE 's|.*/SPEC-0*([0-9]+)/SPEC\.md$|\1|p' || true
   fi
 }
 
@@ -118,9 +118,9 @@ append_ledger_row() {
 #      draft-<spec_id>.md cache write, so this covers the widest in-flight
 #      window — including the draft phase a parallel session would otherwise
 #      miss.
-#   2. Fallback: canonical .gaia/local/specs/SPEC-*.md frontmatter scan for
-#      status: in-progress (legacy case — SPEC file in-progress but no ledger
-#      row, e.g. a backfilled / hand-edited ledger).
+#   2. Fallback: canonical .gaia/local/specs/<spec_id>/SPEC.md frontmatter
+#      scan for status: in-progress (legacy case — SPEC file in-progress but
+#      no ledger row, e.g. a backfilled / hand-edited ledger).
 in_progress_spec() {
   if [ -f "$ledger_path" ]; then
     local id
@@ -140,6 +140,9 @@ in_progress_spec() {
   local f
   while IFS= read -r -d '' f; do
     local in_fm=0 status="" id=""
+    # Canonical id is the containing folder's basename, not the filename
+    # (the inner file is always named SPEC.md).
+    id="$(basename "$(dirname "$f")")"
     local line
     while IFS= read -r line; do
       if [ "$in_fm" -eq 0 ] && [ "$line" = "---" ]; then
@@ -156,11 +159,6 @@ in_progress_spec() {
             status="${status## }"
             status="${status%% *}"
             ;;
-          spec_id:*)
-            id="${line#spec_id:}"
-            id="${id## }"
-            id="${id%% *}"
-            ;;
         esac
       fi
     done < "$f"
@@ -168,7 +166,7 @@ in_progress_spec() {
       echo "$id"
       return
     fi
-  done < <(find "$specs_dir" -maxdepth 1 -type f -name 'SPEC-*.md' -print0 2>/dev/null | sort -z)
+  done < <(find "$specs_dir" -mindepth 2 -maxdepth 2 -type f -name 'SPEC.md' -print0 2>/dev/null | sort -z)
   echo "none"
 }
 

--- a/.specify/extensions/gaia/lib/spec-folderize.sh
+++ b/.specify/extensions/gaia/lib/spec-folderize.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# spec-folderize.sh — Migrate flat SPEC artifacts into per-SPEC folders.
+#
+# A SPEC artifact lives at .gaia/local/specs/<spec_id>/SPEC.md (and, when
+# archived, .gaia/local/specs/archived/<spec_id>/SPEC.md). This script moves
+# any legacy flat .gaia/local/specs/SPEC-NNN.md (and archived/SPEC-NNN.md)
+# into that folder shape. The folder is the archival unit — moving it carries
+# all sibling artifacts (REPORT.md, evidence) with it.
+#
+# Usage:
+#   spec-folderize.sh [--dry-run] [<repo_root>]
+#
+#   <repo_root>   defaults to `git rev-parse --show-toplevel`
+#   --dry-run     print the planned moves to stdout, change nothing
+#
+# Behavior:
+#   - Each flat regular file SPEC-NNN.md is moved to SPEC-NNN/SPEC.md.
+#     `.gaia/local/specs/` and `.gaia/local/specs/archived/` are both scanned.
+#   - Tracked files (git ls-files --error-unmatch) move with `git mv`;
+#     untracked files (the common adopter case — specs are gitignored) move
+#     with plain `mv`.
+#   - Idempotent: a SPEC already at <id>/SPEC.md is skipped. Running twice is
+#     a no-op. Contents are moved byte-for-byte; no frontmatter edits.
+#   - Stdout carries only the dry-run plan; all diagnostics go to stderr.
+#
+# Exit codes:
+#   0  ok, or no-op (already foldered / nothing to migrate / --dry-run)
+#   2  usage error
+#   3  repo root not resolvable
+#   4  migration conflict (both flat SPEC-<id>.md and folder <id>/SPEC.md
+#      exist for the same id — never guess, never overwrite)
+#
+# macOS-first: no GNU coreutils assumptions.
+set -euo pipefail
+
+dry_run=0
+repo_root=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --*)
+      echo "spec-folderize: unknown option '$1'" >&2
+      echo "usage: spec-folderize.sh [--dry-run] [<repo_root>]" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$repo_root" ]; then
+        echo "spec-folderize: unexpected extra argument '$1'" >&2
+        echo "usage: spec-folderize.sh [--dry-run] [<repo_root>]" >&2
+        exit 2
+      fi
+      repo_root="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$repo_root" ]; then
+  if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    echo "spec-folderize: cannot resolve repo root (not in a git work tree); pass <repo_root>" >&2
+    exit 3
+  fi
+fi
+
+if [ ! -d "$repo_root" ]; then
+  echo "spec-folderize: repo root '$repo_root' is not a directory" >&2
+  exit 3
+fi
+
+repo_root="${repo_root%/}"
+specs_dir="${repo_root}/.gaia/local/specs"
+
+# Resolve once whether we are inside a git work tree rooted at (or above)
+# repo_root; only then is per-file tracked detection / `git mv` meaningful.
+in_git_tree=0
+if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  in_git_tree=1
+fi
+
+moved=0
+planned=0
+
+# Migrate every flat SPEC-NNN.md regular file directly under $1 into
+# $1/SPEC-NNN/SPEC.md. $1 is either the specs dir or its archived/ subdir.
+folderize_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+
+  local flat id folder target
+  for flat in "$dir"/SPEC-*.md; do
+    # No glob match → bash leaves the pattern literal; skip it.
+    [ -e "$flat" ] || continue
+    # Only flat regular files are migration candidates.
+    [ -f "$flat" ] || continue
+
+    id="$(basename "$flat" .md)"
+    folder="$dir/$id"
+    target="$folder/SPEC.md"
+
+    if [ -e "$target" ]; then
+      echo "spec-folderize: conflict — both flat and foldered artifact exist for $id:" >&2
+      echo "  flat:   $flat" >&2
+      echo "  folder: $target" >&2
+      exit 4
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+      echo "mv $flat $target"
+      planned=$((planned + 1))
+      continue
+    fi
+
+    mkdir -p "$folder"
+    if [ "$in_git_tree" -eq 1 ] && git -C "$repo_root" ls-files --error-unmatch "$flat" >/dev/null 2>&1; then
+      git -C "$repo_root" mv "$flat" "$target"
+    else
+      mv "$flat" "$target"
+    fi
+    moved=$((moved + 1))
+  done
+}
+
+folderize_dir "$specs_dir"
+folderize_dir "$specs_dir/archived"
+
+if [ "$dry_run" -eq 1 ]; then
+  if [ "$planned" -eq 0 ]; then
+    echo "spec-folderize: nothing to migrate (no flat SPEC files)" >&2
+  fi
+  exit 0
+fi
+
+if [ "$moved" -eq 0 ]; then
+  echo "spec-folderize: nothing to migrate (no flat SPEC files)" >&2
+  exit 0
+fi
+
+echo "spec-folderize: migrated $moved SPEC artifact(s) into per-SPEC folders" >&2
+exit 0

--- a/.specify/extensions/gaia/lib/spec-renumber.sh
+++ b/.specify/extensions/gaia/lib/spec-renumber.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# spec-renumber.sh — Renumber a SPEC. Renames the local SPEC file, updates its
-# frontmatter, and rewrites the .gaia/specs.json ledger row. Does NOT touch
-# external state (branch names, GH issue titles, commit-message history) — those
-# are reported as next steps for the caller to handle consciously.
+# spec-renumber.sh — Renumber a SPEC. Renames the local SPEC folder, updates the
+# inner SPEC.md frontmatter, and rewrites the .gaia/specs.json ledger row. The
+# inner SPEC.md keeps its name; any sibling artifacts in the folder move with it.
+# Does NOT touch external state (branch names, GH issue titles, commit-message
+# history) — those are reported as next steps for the caller to handle consciously.
 #
 # Usage:
 #   spec-renumber.sh <repo_root> <old_id> <new_id>
@@ -10,7 +11,7 @@
 # Refuses if:
 #   - repo_root is not a git working tree
 #   - old/new id is not in SPEC-NNN form
-#   - old SPEC file is missing
+#   - old SPEC folder is missing
 #   - new id is already taken (per spec-allocator.sh self-heal scan)
 set -euo pipefail
 
@@ -43,16 +44,18 @@ if [ "$old_id" = "$new_id" ]; then
   exit 2
 fi
 
-old_path="${specs_dir}/${old_id}.md"
-new_path="${specs_dir}/${new_id}.md"
+old_path="${specs_dir}/${old_id}"
+new_path="${specs_dir}/${new_id}"
+old_spec="${old_path}/SPEC.md"
+new_spec="${new_path}/SPEC.md"
 
-if [ ! -f "$old_path" ]; then
-  echo "spec-renumber: source SPEC file not found at $old_path" >&2
+if [ ! -f "$old_spec" ]; then
+  echo "spec-renumber: source SPEC file not found at $old_spec" >&2
   exit 4
 fi
 
 if [ -e "$new_path" ]; then
-  echo "spec-renumber: target file $new_path already exists" >&2
+  echo "spec-renumber: target folder $new_path already exists" >&2
   exit 4
 fi
 
@@ -74,14 +77,19 @@ if [ -x "$allocator" ] || [ -f "$allocator" ]; then
       git -C "$repo_root" for-each-ref --format='%(refname:short)' \
         'refs/heads/spec-*' 'refs/remotes/*/spec-*' 2>/dev/null \
         | sed -nE 's|^.*/?spec-0*([0-9]+)(-.*)?$|\1|p' || true
-      find "$specs_dir" -maxdepth 1 -type f -name 'SPEC-*.md' -print 2>/dev/null \
-        | sed -nE 's|.*/SPEC-0*([0-9]+)\.md$|\1|p' || true
+      find "$specs_dir" -mindepth 2 -maxdepth 2 -type f -name 'SPEC.md' -print 2>/dev/null \
+        | sed -nE 's|.*/SPEC-0*([0-9]+)/SPEC\.md$|\1|p' || true
     )
   fi
 fi
 
-# 1. Move the file.
-mv "$old_path" "$new_path"
+# 1. Move the folder whole. Inner SPEC.md keeps its name; siblings ride along.
+#    git mv when the inner SPEC.md is tracked, plain mv otherwise.
+if git -C "$repo_root" ls-files --error-unmatch "$old_spec" >/dev/null 2>&1; then
+  git -C "$repo_root" mv "$old_path" "$new_path"
+else
+  mv "$old_path" "$new_path"
+fi
 
 # 2. Rewrite frontmatter spec_id (and stamp renamed_from for traceability).
 #    Operates on the YAML frontmatter block between the first two `---` lines.
@@ -98,8 +106,8 @@ awk -v new_id="$new_id" -v old_id="$old_id" '
   }
   in_fm && /^spec_id:[[:space:]]/ { print "spec_id: " new_id; next }
   { print }
-' "$new_path" > "$tmp_spec"
-mv "$tmp_spec" "$new_path"
+' "$new_spec" > "$tmp_spec"
+mv "$tmp_spec" "$new_spec"
 
 # 3. Update ledger row in place.
 if [ -f "$ledger_path" ]; then
@@ -114,8 +122,12 @@ if [ -f "$ledger_path" ]; then
     mv "$tmp_ledger" "$ledger_path"
   else
     rm -f "$tmp_ledger"
-    echo "spec-renumber: failed to update ledger; reverting file move" >&2
-    mv "$new_path" "$old_path"
+    echo "spec-renumber: failed to update ledger; reverting folder move" >&2
+    if git -C "$repo_root" ls-files --error-unmatch "$new_spec" >/dev/null 2>&1; then
+      git -C "$repo_root" mv "$new_path" "$old_path"
+    else
+      mv "$new_path" "$old_path"
+    fi
     exit 5
   fi
 fi
@@ -133,7 +145,7 @@ if [ -n "$current_branch" ] && [[ "$current_branch" =~ spec-0*${old_num}(-|$) ]]
 fi
 
 # GH issue title — flag if the SPEC frontmatter has a stamped issue url.
-issue_url="$(awk '/^---[[:space:]]*$/{c++; if(c==2)exit} /^gh_issue_url:/{sub(/^gh_issue_url:[[:space:]]*/,""); print}' "$new_path" || true)"
+issue_url="$(awk '/^---[[:space:]]*$/{c++; if(c==2)exit} /^gh_issue_url:/{sub(/^gh_issue_url:[[:space:]]*/,""); print}' "$new_spec" || true)"
 if [ -n "$issue_url" ]; then
   echo "  - GH issue $issue_url was titled with $old_id."
   echo "    Update:   gh issue edit <number> --title '$new_id: <intent>'"

--- a/.specify/extensions/gaia/templates/system-prompt.md
+++ b/.specify/extensions/gaia/templates/system-prompt.md
@@ -126,7 +126,7 @@ Common stall patterns and how to handle them:
 You are not building the feature. You are not writing the code. You
 are building the SPEC artifact — the contract that drives the
 autonomous downstream pipeline. Your output is one file at
-`.gaia/local/specs/SPEC-NNN.md`, immutable from the moment it is
+`.gaia/local/specs/SPEC-NNN/SPEC.md`, immutable from the moment it is
 saved. Treat every UAT you author as something a stranger will read
 six months from now and use to verify a regression.
 

--- a/.specify/extensions/gaia/test/smoke-telemetry-v1.md
+++ b/.specify/extensions/gaia/test/smoke-telemetry-v1.md
@@ -126,7 +126,7 @@ Pattern-detection clusters explicitly note "wired-but-inert; assertion is agains
 
 **Expected.**
 
-- **UAT-027.** Run `/gaia spec` end-to-end. When Gate-2 confirmation completes and the canonical save lands at `.gaia/local/specs/SPEC-NNN.md`, a `time_to_resolved_spec` mentorship event emits with the session's question count and elapsed time. Verify by grepping today's mentorship JSONL.
+- **UAT-027.** Run `/gaia spec` end-to-end. When Gate-2 confirmation completes and the canonical save lands at `.gaia/local/specs/SPEC-NNN/SPEC.md`, a `time_to_resolved_spec` mentorship event emits with the session's question count and elapsed time. Verify by grepping today's mentorship JSONL.
 - **UAT-028.** Run `/gaia plan` against an existing SPEC. Mid-flow, request a revision (e.g. ask the planner to add two more dispatch artifacts). When the planner re-emits dispatch artifacts, a `plan_revised` mentorship event emits with the appropriate `revision_class` (`scope_change` for the example above; `sequencing_change` / `dispatch_artifact_refinement` / `bug_fix_added` for other shapes).
 
 **Harness fast-path.** None — these require a live slash-command session.

--- a/.specify/extensions/gaia/test/smoke.md
+++ b/.specify/extensions/gaia/test/smoke.md
@@ -49,7 +49,7 @@ Before starting, capture two snapshots so the post-run audits can diff cleanly:
 
 ## Step 3 — Resume-vs-start-new prompt
 
-**Action.** With an in-progress SPEC already at `.gaia/local/specs/SPEC-NNN.md`, invoke `/gaia spec "another feature"` without a force-new flag.
+**Action.** With an in-progress SPEC already at `.gaia/local/specs/SPEC-NNN/SPEC.md`, invoke `/gaia spec "another feature"` without a force-new flag.
 
 **Expected outcome.**
 
@@ -192,7 +192,7 @@ Before starting, capture two snapshots so the post-run audits can diff cleanly:
 
 **Expected outcome.**
 
-- File exists at `.gaia/local/specs/SPEC-NNN.md`.
+- File exists at `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 - Frontmatter includes all schema fields, `status: in-progress`, `immutable: true`, stable `UAT-NNN` IDs, no placeholder text.
 - No duplicate copies anywhere else in the tree.
 
@@ -243,7 +243,7 @@ Before starting, capture two snapshots so the post-run audits can diff cleanly:
 
 ## Step 16 — Immutable UAT enforcement (post-save mutation attempt)
 
-**Action.** Manually edit `.gaia/local/specs/SPEC-NNN.md` to change a UAT body. Re-invoke `/gaia spec` so the lint hook re-evaluates the saved artifact.
+**Action.** Manually edit `.gaia/local/specs/SPEC-NNN/SPEC.md` to change a UAT body. Re-invoke `/gaia spec` so the lint hook re-evaluates the saved artifact.
 
 **Expected outcome.**
 

--- a/.specify/extensions/gaia/test/uat-evidence.md
+++ b/.specify/extensions/gaia/test/uat-evidence.md
@@ -2,21 +2,21 @@
 
 Maps each of SPEC-001's UAT-001..UAT-018 to the v2 implementation. Every UAT is cross-referenced to the artifact (manifest, command body, helper script, or sandbox transcript) that satisfies it.
 
-Source SPEC: `.gaia/local/specs/SPEC-001.md` (frozen).
-Revised contracts: `.gaia/local/specs/SPEC-001-revised-contracts.md`.
+Source SPEC: `.gaia/local/specs/SPEC-001/SPEC.md` (frozen).
+Revised contracts: `.gaia/local/specs/SPEC-001/REVISED-CONTRACTS.md`.
 Sandbox transcript: `.specify/extensions/gaia/test/v2-validation.md`.
 
 ## UAT-001 — SPEC artifact shape
 
 **Given** spec-kit installed at the GAIA pin, GAIA extension loaded, constitution populated.
 **When** `/gaia spec` runs through both gates.
-**Then** SPEC artifact at `.gaia/local/specs/SPEC-NNN.md` has all schema fields populated, no placeholders, `status: in-progress`, `immutable: true`, stable `UAT-NNN` ids.
+**Then** SPEC artifact at `.gaia/local/specs/SPEC-NNN/SPEC.md` has all schema fields populated, no placeholders, `status: in-progress`, `immutable: true`, stable `UAT-NNN` ids.
 
 Evidence:
 
 - `.specify/extensions/gaia/templates/spec-template.md` — frontmatter with `spec_id`, `type`, `status: in-progress`, `immutable: true`, `wiki_promote_default`, `chain_trigger`, plus body fields.
 - `.specify/presets/gaia/templates/spec-template.md` — same skeleton, applied via the preset for any `/speckit-specify` entry path.
-- `.claude/skills/gaia/references/spec.md` Step 8 — explicit save target `.gaia/local/specs/SPEC-NNN.md`.
+- `.claude/skills/gaia/references/spec.md` Step 8 — explicit save target `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 - `lib/spec-allocator.sh` — monotonic zero-padded `SPEC-NNN` ids.
 
 ## UAT-002 — preset overrides applied at /specify time
@@ -99,7 +99,7 @@ Evidence (v2 reshape — slash-command, not shell script):
 
 - `.specify/extensions/gaia/extension.yml` — `hooks.after_specify.command: speckit.gaia.lint` (mandatory).
 - `.specify/extensions/gaia/commands/lint.md` — slash-command body that invokes `bash .specify/extensions/gaia/lib/lint.sh <path>` and surfaces findings.
-- `lib/lint.sh` — pure helper: stdin-free, takes a path arg, returns `{"ok": bool, "findings": [...]}`. Smoke test against `.gaia/local/specs/SPEC-001.md` returns `{"ok":true,"findings":[]}`.
+- `lib/lint.sh` — pure helper: stdin-free, takes a path arg, returns `{"ok": bool, "findings": [...]}`. Smoke test against `.gaia/local/specs/SPEC-001/SPEC.md` returns `{"ok":true,"findings":[]}`.
 - Sandbox transcript: `after_specify` event renders `EXECUTE_COMMAND: speckit.gaia.lint` directive automatically.
 - The block semantics live in `references/spec.md` Step 9 — the wrapper agent reads the lint failure message and chooses not to advance past save.
 
@@ -158,7 +158,7 @@ Evidence:
 Evidence:
 
 - `.claude/skills/gaia/references/spec.md` Step 2 — pre-flight `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"` returns the in-progress SPEC id (or `none`); on hit, prompt with the normative phrasing and two options.
-- `lib/spec-allocator.sh in_progress <root>` — scans `.gaia/local/specs/SPEC-*.md` for frontmatter `status: in-progress`. Smoke test against the live repo finds nothing in-progress (SPEC-001 is in-progress per its own frontmatter).
+- `lib/spec-allocator.sh in_progress <root>` — scans `.gaia/local/specs/SPEC-*/SPEC.md` for frontmatter `status: in-progress`. Smoke test against the live repo finds nothing in-progress (SPEC-001 is in-progress per its own frontmatter).
 
 ## UAT-014 — research subagent dispatch with announce
 

--- a/.specify/extensions/gaia/test/v2-validation.md
+++ b/.specify/extensions/gaia/test/v2-validation.md
@@ -106,7 +106,7 @@ grep -E '^## Step|^## Pre-Execution Checks|^## Outline' /tmp/specify-validate-00
 27:## Step 1 — core /speckit-specify
 38:## Pre-Execution Checks
 73:## Outline
-349:## Step 2 — relocate to .gaia/local/specs/SPEC-NNN.md
+349:## Step 2 — relocate to .gaia/local/specs/SPEC-NNN/SPEC.md
 382:## Step 3 — return
 ```
 
@@ -193,7 +193,7 @@ EXECUTE_COMMAND_INVOCATION: /speckit-gaia-self-review
 Both helpers run pure CLI args; no stdin payload:
 
 ```bash
-$ bash .specify/extensions/gaia/lib/lint.sh .gaia/local/specs/SPEC-001.md
+$ bash .specify/extensions/gaia/lib/lint.sh .gaia/local/specs/SPEC-001/SPEC.md
 {"ok":true,"findings":[]}
 
 $ bash .specify/extensions/gaia/lib/spec-allocator.sh next /Users/stevensacks/Development/gaia-react/gaia

--- a/.specify/presets/gaia/commands/speckit.specify.md
+++ b/.specify/presets/gaia/commands/speckit.specify.md
@@ -1,5 +1,5 @@
 ---
-description: 'GAIA-wrapped /speckit-specify: writes through core, then relocates the artifact to .gaia/local/specs/SPEC-NNN.md and stamps GAIA frontmatter.'
+description: 'GAIA-wrapped /speckit-specify: writes through core, then relocates the artifact to .gaia/local/specs/SPEC-NNN/SPEC.md and stamps GAIA frontmatter.'
 ---
 
 # /speckit-specify (GAIA preset)
@@ -19,7 +19,7 @@ If the hook blocks, the agent halts here and surfaces the block message. Do not 
 
 {CORE_TEMPLATE}
 
-## Step 2 — relocate to .gaia/local/specs/SPEC-NNN.md
+## Step 2 — relocate to .gaia/local/specs/SPEC-NNN/SPEC.md
 
 After core has written its artifact (typically at `specs/<NNN>-<slug>/spec.md`):
 
@@ -32,7 +32,7 @@ After core has written its artifact (typically at `specs/<NNN>-<slug>/spec.md`):
 
    Capture the printed `SPEC-NNN` token.
 
-3. Create `.gaia/local/specs/` if absent. Copy the core artifact to `.gaia/local/specs/<SPEC-NNN>.md`.
+3. Create the SPEC folder (`mkdir -p .gaia/local/specs/<SPEC-NNN>`). Copy the core artifact to `.gaia/local/specs/<SPEC-NNN>/SPEC.md`.
 4. Stamp GAIA frontmatter at the top of the relocated file. If the core artifact has no frontmatter (spec-kit's bundled `spec-template.md` does not), prepend a frontmatter block with these required fields:
 
    ```yaml
@@ -56,7 +56,7 @@ After core has written its artifact (typically at `specs/<NNN>-<slug>/spec.md`):
 
 Surface a single confirmation line naming both paths:
 
-> SPEC-NNN written. Core: `<core-path>`; GAIA: `.gaia/local/specs/<SPEC-NNN>.md`.
+> SPEC-NNN written. Core: `<core-path>`; GAIA: `.gaia/local/specs/<SPEC-NNN>/SPEC.md`.
 
 The `after_specify` extension hook fires next and lints the GAIA copy.
 

--- a/.specify/presets/gaia/preset.yml
+++ b/.specify/presets/gaia/preset.yml
@@ -4,7 +4,7 @@ preset:
   id: "gaia"
   name: "GAIA"
   version: "0.1.0"
-  description: "GAIA-shaped artifacts for spec-kit: every /speckit-specify produces a GAIA frontmatter spec, saved to .gaia/local/specs/SPEC-NNN.md."
+  description: "GAIA-shaped artifacts for spec-kit: every /speckit-specify produces a GAIA frontmatter spec, saved to .gaia/local/specs/SPEC-NNN/SPEC.md."
   author: "GAIA"
   repository: "https://github.com/gaia-react/gaia"
   license: "MIT"
@@ -17,7 +17,7 @@ provides:
     - type: "command"
       name: "speckit.specify"
       file: "commands/speckit.specify.md"
-      description: "Wraps core /speckit-specify; redirects output to .gaia/local/specs/SPEC-NNN.md."
+      description: "Wraps core /speckit-specify; redirects output to .gaia/local/specs/SPEC-NNN/SPEC.md."
       replaces: "speckit.specify"
       strategy: "wrap"
 


### PR DESCRIPTION
## Summary

Move every SPEC artifact from a flat file (`.gaia/local/specs/SPEC-NNN.md`) into a per-SPEC folder (`.gaia/local/specs/SPEC-NNN/SPEC.md`) so a finished SPEC and its sibling artifacts archive/delete as one unit. Inner file is `SPEC.md` (the folder carries the id; renumber = a single folder rename).

Executed post-#176-merge per the `spec-folder-layout` plan. Phased delivery:

- **Phase 1** — new idempotent `spec-folderize.sh` migration script (C2); manifest-tracked.
- **Phase 2** — allocator/renumber folder globs (C3/C4) + template-distributed runbook prose (C5).
- **Phase 3** — `/update-gaia` runs the migration on update (C6) + `.gaia/tests/lib/` folder-layout suite (C7).

Existing flat specs are migrated by the shipped, idempotent `spec-folderize.sh` (run once by the maintainer here; invoked by `/update-gaia` so adopters' specs migrate on upgrade).

## Test plan

- [ ] Phase 1: `bash -n` + tmp-repo smoke (migrate / idempotent / dry-run / conflict→4 / tracked-vs-untracked) — green
- [ ] Phase 2: `bash -n` allocator+renumber + foldered-repo smoke + path/wiki-style audits
- [ ] Phase 3: `bash .gaia/tests/lib/run-all.sh` green (new folder suite + no #176 concurrency/lock regression)
- [ ] `code-review-audit` clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)