### PR TITLE
Sibling-suffix migration rule for spec-folderize.sh

### DIFF
--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -478,7 +478,7 @@ Create the SPEC folder, then write the confirmed draft to its canonical inner fi
 mkdir -p .gaia/local/specs/${SPEC_ID}
 ```
 
-Write to `.gaia/local/specs/SPEC-NNN/SPEC.md`. This is the canonical save location — never anywhere else, never duplicate copies. The folder is the archival unit; sibling artifacts live beside `SPEC.md` in the same folder.
+Write to `.gaia/local/specs/SPEC-NNN/SPEC.md`. This is the canonical save location — never anywhere else, never duplicate copies. The folder is the archival unit; sibling artifacts live beside `SPEC.md` in the same folder. A sibling's filename is the uppercased remainder of its flat form (`SPEC-NNN-<rest>.md` → `SPEC-NNN/<REST>.md`); any `SPEC-NNN-*` file is a sibling. `lib/spec-folderize.sh` applies this mapping for any legacy flat files.
 
 Update the frontmatter `updated` field to today's date.
 

--- a/.gaia/tests/lib/helpers/tmp-spec-repo.sh
+++ b/.gaia/tests/lib/helpers/tmp-spec-repo.sh
@@ -27,6 +27,11 @@
 #                               .gaia/local/specs/SPEC-NNN/SPEC.md with
 #                               status: in-progress frontmatter and NO ledger
 #                               row (the foldered legacy fallback case)
+#   --seed-flat-sibling SPEC-NNN-SUFFIX  write a legacy flat sibling file
+#                               .gaia/local/specs/SPEC-NNN-SUFFIX.md — a
+#                               sibling migration candidate for spec-folderize.sh
+#   --seed-archived-flat-sibling SPEC-NNN-SUFFIX  same but under
+#                               .gaia/local/specs/archived/SPEC-NNN-SUFFIX.md
 set -euo pipefail
 
 # Real repo containing this helper: the helper lives at
@@ -108,6 +113,15 @@ status: archived
 
 # ${id}
 EOF
+      ;;
+    --seed-flat-sibling)
+      id="$2"; shift 2
+      printf 'sibling body for %s\n' "$id" > ".gaia/local/specs/${id}.md"
+      ;;
+    --seed-archived-flat-sibling)
+      id="$2"; shift 2
+      mkdir -p .gaia/local/specs/archived
+      printf 'sibling body for %s\n' "$id" > ".gaia/local/specs/archived/${id}.md"
       ;;
     --seed-folder)
       id="$2"; shift 2

--- a/.gaia/tests/lib/spec-folder-layout.bats
+++ b/.gaia/tests/lib/spec-folder-layout.bats
@@ -257,6 +257,100 @@ _snapshot() {
   [[ "$output" != *"archived/SPEC-010/SPEC.md"* ]]
 }
 
+# --- 11: sibling migration ---------------------------------------------------
+
+@test "11: folderize migrates flat + siblings into correct sub-paths, byte-identical" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" \
+    --seed-flat SPEC-001 \
+    --seed-flat-sibling SPEC-001-REPORT \
+    --seed-flat-sibling SPEC-001-FOLLOWUP-REPORT)"
+  cd "$REPO"
+
+  c_spec="$(cat "$REPO/.gaia/local/specs/SPEC-001.md")"
+  c_report="$(cat "$REPO/.gaia/local/specs/SPEC-001-REPORT.md")"
+  c_followup="$(cat "$REPO/.gaia/local/specs/SPEC-001-FOLLOWUP-REPORT.md")"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  # Foldered shape exists.
+  [ -f "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-001/REPORT.md" ]
+  [ -f "$REPO/.gaia/local/specs/SPEC-001/FOLLOWUP-REPORT.md" ]
+
+  # No flat files remain.
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-001.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-001-REPORT.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/SPEC-001-FOLLOWUP-REPORT.md" ]
+
+  # Contents moved byte-for-byte.
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/SPEC.md")" = "$c_spec" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/REPORT.md")" = "$c_report" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/FOLLOWUP-REPORT.md")" = "$c_followup" ]
+}
+
+# --- 12: sibling conflict ----------------------------------------------------
+
+@test "12: flat sibling + existing foldered sibling — exit 4, both paths in stderr, neither modified" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" \
+    --seed-flat-sibling SPEC-003-REPORT \
+    --seed-folder SPEC-003)"
+  cd "$REPO"
+  # Pre-existing foldered sibling triggers the conflict.
+  echo "existing report" > "$REPO/.gaia/local/specs/SPEC-003/REPORT.md"
+  git -C "$REPO" add .gaia/local/specs/SPEC-003/REPORT.md
+  git -C "$REPO" commit --quiet -m "add foldered report"
+
+  flat_before="$(cat "$REPO/.gaia/local/specs/SPEC-003-REPORT.md")"
+  fold_before="$(cat "$REPO/.gaia/local/specs/SPEC-003/REPORT.md")"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO' 2>&1 1>/dev/null"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"SPEC-003-REPORT.md"* ]]
+  [[ "$output" == *"SPEC-003/REPORT.md"* ]]
+
+  # Neither file modified.
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003-REPORT.md")" = "$flat_before" ]
+  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003/REPORT.md")" = "$fold_before" ]
+}
+
+# --- 13: idempotent re-run after sibling migration ---------------------------
+
+@test "13: re-running folderize after sibling migration is a no-op" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" \
+    --seed-flat SPEC-002 \
+    --seed-flat-sibling SPEC-002-REPORT)"
+  cd "$REPO"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  before="$(_snapshot "$REPO")"
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+  after="$(_snapshot "$REPO")"
+  [ "$before" = "$after" ]
+}
+
+# --- 14: archived/ siblings --------------------------------------------------
+
+@test "14: folderize migrates flat siblings under archived/" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" \
+    --seed-archived-flat SPEC-000 \
+    --seed-archived-flat-sibling SPEC-000-REPORT)"
+  cd "$REPO"
+
+  c_report="$(cat "$REPO/.gaia/local/specs/archived/SPEC-000-REPORT.md")"
+
+  run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
+  [ "$status" -eq 0 ]
+
+  [ -f "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md" ]
+  [ -f "$REPO/.gaia/local/specs/archived/SPEC-000/REPORT.md" ]
+  [ ! -e "$REPO/.gaia/local/specs/archived/SPEC-000-REPORT.md" ]
+  [ "$(cat "$REPO/.gaia/local/specs/archived/SPEC-000/REPORT.md")" = "$c_report" ]
+}
+
 # --- 10: read-only modes take no lock and create no folder -------------------
 
 @test "10: highest / in_progress over foldered specs take no lock, create no folder" {

--- a/.specify/extensions/gaia/lib/spec-folderize.sh
+++ b/.specify/extensions/gaia/lib/spec-folderize.sh
@@ -116,6 +116,7 @@ folderize_dir() {
     else
       # Sibling: SPEC-NNN-<rest>.md → SPEC-NNN/<REST>.md
       rest="${filename#${id}-}"
+      [ -n "$rest" ] || continue
       target_name="$(printf '%s' "$rest" | tr '[:lower:]' '[:upper:]').md"
     fi
     target="$folder/$target_name"

--- a/.specify/extensions/gaia/lib/spec-folderize.sh
+++ b/.specify/extensions/gaia/lib/spec-folderize.sh
@@ -14,21 +14,27 @@
 #   --dry-run     print the planned moves to stdout, change nothing
 #
 # Behavior:
-#   - Each flat regular file SPEC-NNN.md is moved to SPEC-NNN/SPEC.md.
-#     `.gaia/local/specs/` and `.gaia/local/specs/archived/` are both scanned.
+#   - Each flat canonical file SPEC-NNN.md is moved to SPEC-NNN/SPEC.md.
+#   - Each flat sibling file SPEC-NNN-<rest>.md is moved to SPEC-NNN/<REST>.md,
+#     where <REST> is the remainder uppercased, hyphens kept. Any SPEC-NNN-*
+#     file is a sibling — no suffix allowlist.
+#     Examples: SPEC-001-REPORT.md          → SPEC-001/REPORT.md
+#               SPEC-001-FOLLOWUP-REPORT.md → SPEC-001/FOLLOWUP-REPORT.md
+#               SPEC-001-revised-contracts.md → SPEC-001/REVISED-CONTRACTS.md
+#   - `.gaia/local/specs/` and `.gaia/local/specs/archived/` are both scanned.
 #   - Tracked files (git ls-files --error-unmatch) move with `git mv`;
 #     untracked files (the common adopter case — specs are gitignored) move
 #     with plain `mv`.
-#   - Idempotent: a SPEC already at <id>/SPEC.md is skipped. Running twice is
-#     a no-op. Contents are moved byte-for-byte; no frontmatter edits.
+#   - Idempotent: a file already at its target path is skipped. Running twice
+#     is a no-op. Contents are moved byte-for-byte; no frontmatter edits.
 #   - Stdout carries only the dry-run plan; all diagnostics go to stderr.
 #
 # Exit codes:
 #   0  ok, or no-op (already foldered / nothing to migrate / --dry-run)
 #   2  usage error
 #   3  repo root not resolvable
-#   4  migration conflict (both flat SPEC-<id>.md and folder <id>/SPEC.md
-#      exist for the same id — never guess, never overwrite)
+#   4  migration conflict (a flat file and its foldered counterpart both exist
+#      for the same path — never guess, never overwrite)
 #
 # macOS-first: no GNU coreutils assumptions.
 set -euo pipefail
@@ -84,22 +90,35 @@ fi
 moved=0
 planned=0
 
-# Migrate every flat SPEC-NNN.md regular file directly under $1 into
-# $1/SPEC-NNN/SPEC.md. $1 is either the specs dir or its archived/ subdir.
+# Migrate every flat SPEC-NNN.md (and SPEC-NNN-<rest>.md sibling) regular file
+# directly under $1 into the per-SPEC folder shape. $1 is either the specs
+# dir or its archived/ subdir.
 folderize_dir() {
   local dir="$1"
   [ -d "$dir" ] || return 0
 
-  local flat id folder target
+  local flat filename id rest target_name folder target
   for flat in "$dir"/SPEC-*.md; do
     # No glob match → bash leaves the pattern literal; skip it.
     [ -e "$flat" ] || continue
     # Only flat regular files are migration candidates.
     [ -f "$flat" ] || continue
 
-    id="$(basename "$flat" .md)"
+    filename="$(basename "$flat" .md)"
+    # Extract leading SPEC-<digits> as the canonical id. Field 2 after
+    # splitting on '-' is the numeric part; rejoining gives SPEC-NNN.
+    id="$(printf '%s' "$filename" | awk -F'-' '{print $1 "-" $2}')"
     folder="$dir/$id"
-    target="$folder/SPEC.md"
+
+    if [ "$filename" = "$id" ]; then
+      # Canonical: SPEC-NNN.md → SPEC-NNN/SPEC.md
+      target_name="SPEC.md"
+    else
+      # Sibling: SPEC-NNN-<rest>.md → SPEC-NNN/<REST>.md
+      rest="${filename#${id}-}"
+      target_name="$(printf '%s' "$rest" | tr '[:lower:]' '[:upper:]').md"
+    fi
+    target="$folder/$target_name"
 
     if [ -e "$target" ]; then
       echo "spec-folderize: conflict — both flat and foldered artifact exist for $id:" >&2

--- a/wiki/concepts/GAIA Spec.md
+++ b/wiki/concepts/GAIA Spec.md
@@ -9,7 +9,7 @@ tags: [concept, claude, skill, orchestration, spec-kit]
 
 # GAIA Spec
 
-`/gaia spec [description]` is GAIA's Socratic discovery wrapper around [[spec-kit]]. It produces an immutable SPEC artifact at `.gaia/local/specs/SPEC-NNN.md` and chains into [[GAIA Plan]] on confirmation. The skill body lives at `.claude/skills/gaia/references/spec.md` (dispatched by the `/gaia` router skill).
+`/gaia spec [description]` is GAIA's Socratic discovery wrapper around [[spec-kit]]. It produces an immutable SPEC artifact at `.gaia/local/specs/SPEC-NNN/SPEC.md` and chains into [[GAIA Plan]] on confirmation. The skill body lives at `.claude/skills/gaia/references/spec.md` (dispatched by the `/gaia` router skill).
 
 The wrapper is implemented as a spec-kit extension plus preset; the architectural rationale (why extension+preset, the `wrap` strategy, version-pin range, hook semantics) is in [[spec-kit Extension Strategy]].
 
@@ -25,12 +25,12 @@ The wrapper is implemented as a spec-kit extension plus preset; the architectura
 
 1. **Get description.** Use `$ARGUMENTS` if non-empty; otherwise ask "What do you want to spec?" and wait.
 2. **Resume-vs-start prompt.** `lib/spec-allocator.sh in_progress` reports any open SPEC; user picks Resume or Start new. No silent overwrite, no silent fresh allocation.
-3. **`/speckit.specify`.** Spec-kit fires the `before_specify` hook (constitution-check + version-pin drift detection) automatically, then runs core. The GAIA preset replaces the core template under `strategy: wrap` so the artifact is GAIA-shaped (frontmatter, immutable flag, frozen `SPEC-NNN` id) and lands at `.gaia/local/specs/SPEC-NNN.md`.
+3. **`/speckit.specify`.** Spec-kit fires the `before_specify` hook (constitution-check + version-pin drift detection) automatically, then runs core. The GAIA preset replaces the core template under `strategy: wrap` so the artifact is GAIA-shaped (frontmatter, immutable flag, frozen `SPEC-NNN` id) and lands at `.gaia/local/specs/SPEC-NNN/SPEC.md`.
 4. **Gate 1 — shape confirmation.** Present `intent` + UATs in plain English. On confirmation, cache the gate-1 snapshot to `.gaia/local/cache/gate1-<spec_id>.json` (the `after_clarify` hook reads this to detect scope drift in gate 2).
 5. **`/speckit.clarify` (Socratic loop).** Sequential coverage-based questioning. Closed-set goes through `AskUserQuestion`; open-ended uses plain prompts; `Discuss this` drops into plain Q&A and records the settled outcome. Per-topic exhaustion checkpoint forbids silent topic advance. Research questions dispatch a `general-purpose` Agent — never punt to the human.
 6. **`after_clarify` hook.** Spec-kit fires `/speckit-gaia-self-review`, which audits drift (vs. the gate-1 snapshot), placeholders, ambiguity, and pending clarifications. Save remains blocked while any pending item is unresolved (block-or-defer prompt).
 7. **Gate 2 — artifact confirmation.** Render the full draft and present for review. Plain prompt, not `AskUserQuestion`. Revise to convergence, then proceed.
-8. **Save** to `.gaia/local/specs/SPEC-NNN.md`. Canonical location; never duplicate copies.
+8. **Save** to `.gaia/local/specs/SPEC-NNN/SPEC.md`. The folder is the archival unit. Sibling artifacts (reports, evidence) live beside `SPEC.md` in the same folder; a flat `SPEC-NNN-<rest>.md` file maps to `SPEC-NNN/<REST>.md` (remainder uppercased, hyphens kept). `lib/spec-folderize.sh` applies this mapping for any legacy flat files.
 9. **`after_specify` hook.** Spec-kit fires `/speckit-gaia-lint`, which runs `lib/lint.sh` (frontmatter, frozen UAT-NNN ids, no placeholders, write-allowlist audit). For mutations of an already-saved SPEC, the lint enforces the explicit reopen ceremony — `## Reopen rationale` and `## UAT diff` sections required.
 10. **Optional GH Issue mirror.** `lib/gh-mirror.sh` creates an Issue if `gh auth status` succeeds, the repo has Issues enabled, and the viewer has write/admin permission. Otherwise appends a skip record to `.gaia/local/telemetry/gh-mirror.jsonl` and exits 0. Absence never blocks save.
 11. **Inline chain-trigger to `/gaia plan`.** No `on_save` hook exists in spec-kit; the chain lives here, inline. `AskUserQuestion` offers "Yes, trigger /gaia plan (Recommended)" or "No, defer". On Yes, dispatch `/gaia plan` with the SPEC path; on No, stop.


### PR DESCRIPTION
## Summary

- `spec-folderize.sh`: flat `SPEC-NNN-<rest>.md` siblings now migrate to `SPEC-NNN/<REST>.md` (remainder uppercased, hyphens kept). Any `SPEC-NNN-*` file is a sibling — no allowlist. Empty-rest guard skips malformed trailing-hyphen filenames.
- `tmp-spec-repo.sh`: two new seed flags (`--seed-flat-sibling`, `--seed-archived-flat-sibling`) for bats fixtures.
- `spec-folder-layout.bats`: 4 new tests — sibling happy path, sibling conflict (exit 4), idempotent re-run, and `archived/` siblings.
- `wiki/concepts/GAIA Spec.md`: stale `.gaia/local/specs/SPEC-NNN.md` paths corrected to `.gaia/local/specs/SPEC-NNN/SPEC.md`; sibling naming contract added to Step 8.
- `.claude/skills/gaia/references/spec.md`: sibling naming contract added to Step 8.

## Test plan

- [ ] `bash -n .specify/extensions/gaia/lib/spec-folderize.sh` — syntax ok
- [ ] `bash .gaia/tests/lib/run-all.sh` — all 17 tests pass (13 pre-existing + 4 new), zero regressions
- [ ] `code-review-audit` clean pass (no Critical, no Important)
- [ ] Post-merge dogfood: `bash .specify/extensions/gaia/lib/spec-folderize.sh` against real `.gaia/local/specs/` — `SPEC-001/{SPEC.md,REPORT.md,FOLLOWUP-REPORT.md}`, `SPEC-002/SPEC.md`, no flat files remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)