### PR TITLE
fix(plan): atomic mkdir prevents TOCTOU race on concurrent plan creation

### DIFF
--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -55,11 +55,10 @@ ROOT="$(git rev-parse --show-toplevel)"
 SLUG="<kebab-slug, prefixed with $SPEC_SLUG_SEED if set>"
 PLAN_DIR="${ROOT}/.gaia/local/plans/${SLUG}"
 n=2
-while [[ -e "$PLAN_DIR" ]]; do
+while ! mkdir "$PLAN_DIR" 2>/dev/null; do
   PLAN_DIR="${ROOT}/.gaia/local/plans/${SLUG}-${n}"
   n=$((n+1))
 done
-mkdir -p "$PLAN_DIR"
 ```
 
 Cache the resolved absolute `PLAN_DIR`; interpolate it into the planner prompt below and the kickoff prompt in step 5. The collision suffix lets parallel `/gaia plan` invocations (including multiple slices dispatched from one `/gaia spec`) coexist without overwriting each other.


### PR DESCRIPTION
## Summary

- Replaces the existence-check loop + `mkdir -p` pair in `/gaia plan` step 3 with a single atomic `mkdir` + retry loop.
- `mkdir` (without `-p`) fails atomically on POSIX/HFS+/APFS when the directory already exists — exactly one concurrent caller wins each suffix slot.
- Two `/gaia plan` invocations running simultaneously can no longer race to claim the same plan directory and overwrite each other's `README.md`, `ORCHESTRATOR.md`, `KICKOFF.md`, and task docs.

## Test plan

- [ ] Single `/gaia plan` run still creates the plan directory and proceeds normally
- [ ] Two concurrent `/gaia plan` invocations with the same description claim `slug` and `slug-2` respectively rather than both landing in `slug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)