### PR TITLE
fix: Linux WSL compatibility for husky hook and CI workflow permissions

### DIFF
--- a/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -3,6 +3,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 {{> partials/concurrency }}
 {{> partials/auth-env }}

--- a/.gaia/cli/templates/workflows/gaia-ci-update-deps.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-update-deps.yml.tmpl
@@ -3,6 +3,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 {{> partials/concurrency }}
 {{> partials/auth-env }}
@@ -109,6 +110,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.run.outputs.wave_b_matrix) }}

--- a/.gaia/cli/templates/workflows/gaia-ci-wiki.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-wiki.yml.tmpl
@@ -3,6 +3,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 {{> partials/concurrency }}
 {{> partials/auth-env }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,10 @@
 printf '\n🔎 Running pre-commit check\n'
 
-declare HAS_APP_CHANGED=$(git diff --cached --name-only --diff-filter=ACDM | grep 'app/')
-declare HAS_TEST_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep 'test/')
-declare HAS_STORYBOOK_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep '.storybook/')
+HAS_APP_CHANGED=$(git diff --cached --name-only --diff-filter=ACDM | grep 'app/' || true)
+HAS_TEST_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep 'test/' || true)
+HAS_STORYBOOK_CHANGED=$(git diff --cached --name-only --diff-filter=ACM | grep '.storybook/' || true)
 
-if [[ $HAS_APP_CHANGED || $HAS_TEST_CHANGED || $HAS_STORYBOOK_CHANGED ]]
+if [ -n "$HAS_APP_CHANGED" ] || [ -n "$HAS_TEST_CHANGED" ] || [ -n "$HAS_STORYBOOK_CHANGED" ]
 then
   printf "\x1b[33m"
   printf "⚠️ Changes detected - running lint-staged\n"


### PR DESCRIPTION
## Summary

- **`.husky/pre-commit`**: Replace bash-specific `declare` + `[[` syntax with POSIX sh-compatible variable assignment and `[ -n ]` conditionals; add `|| true` to `grep` calls so non-matches don't abort under dash (`/bin/sh` on Linux/WSL)
- **CI workflow templates**: Add `id-token: write` to permissions in `gaia-ci-pnpm-audit`, `gaia-ci-update-deps` (both `run` and `wave_b` jobs), and `gaia-ci-wiki`

## Test plan

- [ ] Verify pre-commit hook runs without error on Linux/WSL with `/bin/sh` (dash)
- [ ] Verify pre-commit hook still works on macOS
- [ ] Regenerate CI workflows via `setup-gaia-ci` and confirm `id-token: write` appears in permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)