### PR TITLE
fix: health-audit distribution-boundary remediation

### DIFF
--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -179,6 +179,7 @@
     ".specify/extensions/gaia/lib/spec-renumber.sh": "owned",
     ".specify/extensions/gaia/lib/uat-write.sh": "owned",
     ".specify/extensions/gaia/lib/version-check.sh": "owned",
+    ".specify/extensions/gaia/lib/with-ledger-lock.sh": "owned",
     ".specify/extensions/gaia/README.md": "owned",
     ".specify/extensions/gaia/rules/smoke.md": "owned",
     ".specify/extensions/gaia/rules/uat-divergence.md": "owned",
@@ -465,6 +466,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-05-12T11:35:50.498Z",
+  "generated": "2026-05-19T09:53:53.577Z",
   "version": "1.2.0"
 }

--- a/.gaia/release-scrub.yml
+++ b/.gaia/release-scrub.yml
@@ -241,7 +241,7 @@ transforms:
       # excluded slugs; a new excluded page requires updating this list.
       - id: wikilink-to-excluded
         description: "Wikilinks pointing at release-excluded wiki slugs"
-        pattern: "\\[\\[(Release Workflow|Bundle-time Scrub|GAIA|Steven Sacks|dashboard|Entities|Meta|CLI-Binary-Split)\\]\\]"
+        pattern: "\\[\\[(Release Workflow|Bundle-time Scrub|GAIA|Steven Sacks|dashboard|Entities|Meta|CLI-Binary-Split|Forensics Triage Workflow)\\]\\]"
         scope:
           - "wiki/**/*.md"
         path-allowlist:

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ coverage
 .claude/agent-memory/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
 # claude-code-action runtime working area (mirrors .claude/ for sandboxed execution)
 .claude-pr/
 

--- a/.specify/extensions/gaia/lib/spec-folderize.sh
+++ b/.specify/extensions/gaia/lib/spec-folderize.sh
@@ -18,9 +18,9 @@
 #   - Each flat sibling file SPEC-NNN-<rest>.md is moved to SPEC-NNN/<REST>.md,
 #     where <REST> is the remainder uppercased, hyphens kept. Any SPEC-NNN-*
 #     file is a sibling — no suffix allowlist.
-#     Examples: SPEC-001-REPORT.md          → SPEC-001/REPORT.md
-#               SPEC-001-FOLLOWUP-REPORT.md → SPEC-001/FOLLOWUP-REPORT.md
-#               SPEC-001-revised-contracts.md → SPEC-001/REVISED-CONTRACTS.md
+#     Examples: SPEC-NNN-REPORT.md          → SPEC-NNN/REPORT.md
+#               SPEC-NNN-FOLLOWUP-REPORT.md → SPEC-NNN/FOLLOWUP-REPORT.md
+#               SPEC-NNN-revised-contracts.md → SPEC-NNN/REVISED-CONTRACTS.md
 #   - `.gaia/local/specs/` and `.gaia/local/specs/archived/` are both scanned.
 #   - Tracked files (git ls-files --error-unmatch) move with `git mv`;
 #     untracked files (the common adopter case — specs are gitignored) move

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -81,4 +81,4 @@ Editing HEAD between the local stamp and `gh pr merge` invalidates the trailer (
 - [[Code Review Audit Agent]] — the agent the workflow invokes.
 - [[PR Merge Workflow]] — the local-side gate handshake (`.gaia/local/audit/<sha>.ok` marker file).
 - [[Quality Gate]] — the lint/typecheck/test/knip gate that still runs alongside this audit.
-- [[Forensics Triage Workflow]] — sibling autonomous CI workflow built on the same `claude-code-action` setup.
+- Forensics Triage Workflow — sibling autonomous CI workflow built on the same `claude-code-action` setup.

--- a/wiki/decisions/Claude Integration Fitness.md
+++ b/wiki/decisions/Claude Integration Fitness.md
@@ -98,6 +98,8 @@ Things audits keep re-discovering that are not findings:
 
 **`wiki/.state.json` lagging HEAD.** Normal pre-release state. The session-start hook reports drift informationally; the wiki-fitness category surfaces it as `info` (not `error` or `warning`) and recommends `/gaia wiki sync`. Do not escalate to a blocking finding.
 
+**Release-excluded wiki pages flagged as orphans by `gaia wiki orphans`.** Expected state, not a defect. Shipped pages must not `[[wikilink]]` release-excluded pages (enforced by `wikilink-to-excluded`); plain-text references to them are correct. `gaia wiki orphans` cannot see release-exclusion, so it will always flag such a page. Surface as `info`; do not escalate to a blocking finding.
+
 **`@`-imports that use valid repo-relative paths.** An `@`-import is a finding only when it imports a skill file from inside a rule. Imports of always-loaded rule files from `CLAUDE.md` are the correct pattern; do not flag them.
 
 **Dead backticked path in `wiki/log.md` or `wiki/hot.md`.** These files are exempt from `gaia wiki dead-paths` by design — `wiki/log.md` is the append-only historical record; `wiki/hot.md` is the auto-overwritten session cache. Do not raise dead-path findings against either.

--- a/wiki/decisions/Quality Gate.md
+++ b/wiki/decisions/Quality Gate.md
@@ -70,4 +70,4 @@ This page is the source of truth for quality gate steps. The always-loaded `.cla
 
 See [[Pre-commit Hooks]], [[PR Merge Workflow]], [[Task Orchestration]], [[Claude Hooks]] (the source-edit and Bash safeguards keep `.env`, lockfile, secrets, and destructive-git footguns out of the staged surface before the gate ever runs).
 
-The [[Forensics Triage Workflow]] runs the gate (install + typecheck + lint + test + knip) on every auto-fix branch; gate failure abandons the branch and demotes the issue to `needs-human` instead of opening a partial PR.
+The Forensics Triage Workflow runs the gate (install + typecheck + lint + test + knip) on every auto-fix branch; gate failure abandons the branch and demotes the issue to `needs-human` instead of opening a partial PR.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -95,7 +95,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Co-located Tests Folder]]
 - [[composeStory Pattern]]
 - [[Dark Mode Modernization]]
-- [[Forensics Triage Workflow]] — autonomous triage for `gaia-forensics`-labeled issues; default-deny path policy + draft-PR contract.
+- Forensics Triage Workflow — autonomous triage for `gaia-forensics`-labeled issues; default-deny path policy + draft-PR contract.
 - [[Quality Gate]]
 - [[pnpm]]
 - [[DragonScale Opt-Out]]


### PR DESCRIPTION
## Summary

Remediation for findings from a `/health-audit` run (3 cycles, terminated **clean A+**; oscillation guards empty each cycle).

- **spec-concrete-ids leak** — `spec-folderize.sh` header examples used concrete `SPEC-001` IDs; replaced with `SPEC-NNN` placeholders (this file ships to adopters).
- **wikilink-to-excluded gap** — `wiki/decisions/Forensics Triage Workflow.md` is release-excluded but its slug was missing from the `wikilink-to-excluded` enumeration in `release-scrub.yml`, and 3 shipped pages linked to it. Added the slug to the enumeration and unwrapped the 3 shipped `[[Forensics Triage Workflow]]` wikilinks to plain text so they don't dangle post-scrub (`wiki/index.md`, `wiki/decisions/Quality Gate.md`, `wiki/concepts/Code Review Audit CI.md`).
- **settings hygiene** — added `.claude/settings.local.json` to `.gitignore`.
- **stale manifest** — regenerated `.gaia/manifest.json` (`with-ledger-lock.sh` was git-tracked but absent from the manifest).
- **decided-not-finding (human-confirmed)** — documented the structural conflict between `gaia wiki orphans` and `wikilink-to-excluded` in `Claude Integration Fitness.md`: a release-excluded wiki page will always be flagged orphan and must *not* be cross-linked from shipped pages, so this is expected state, not a defect.

## Test plan

- [ ] Quality Gate skipped — no `.ts|tsx|js|jsx|mjs|cjs|css` or lint/typecheck/test gate-affecting config changed
- [ ] `gaia-maintainer release manifest --check` returns clean (verified during audit cycle 3)
- [ ] `gaia-maintainer release scrub` reports no leaks on a staged bundle (verified during audit cycle 3)
- [ ] Bundle simulation: 3 shipped Forensics wikilinks no longer dangle post-scrub
- [ ] `gaia wiki dead-paths` clean; orphan on the release-excluded Forensics page is now a documented decided-not-finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)