### PR TITLE
fix(ci): drop default id-token: write from pnpm-audit workflow

### DIFF
--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -3,7 +3,8 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
+  # Add `id-token: write` only if your registry authenticates `pnpm audit`
+  # via OIDC / workload-identity federation rather than a static _authToken.
 
 {{> partials/concurrency }}
 {{> partials/auth-env }}

--- a/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -3,7 +3,8 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
+  # Add `id-token: write` only if your registry authenticates `pnpm audit`
+  # via OIDC / workload-identity federation rather than a static _authToken.
 
 {{> partials/concurrency }}
 {{> partials/auth-env }}


### PR DESCRIPTION
## Summary

The `gaia-ci-pnpm-audit` workflow template granted `id-token: write` by default, but that workflow has no OIDC consumer — it has no `anthropics/claude-code-action` step (unlike `wiki` and `update-deps`, which legitimately need OIDC and keep the grant). `pnpm audit` authenticates to registries via a static `_authToken`, so the default grant is an unnecessary blast-radius widening: a job that runs dependency resolution + `gh` CLI shouldn't be able to mint OIDC tokens unless the adopter's registry actually requires it.

Replaced the permission with a comment so an adopter on an OIDC / workload-identity-federated registry can self-add it (one adopter already triaged this path successfully).

- `id-token: write` removed from **pnpm-audit** source + generated templates (kept in parity)
- `wiki` / `update-deps` templates unchanged — `claude-code-action` requires OIDC there
- No CLI/binary changes (deterministic bundle), no manifest change (file list unchanged)

## Test plan

- [ ] code-review-audit handshake clean
- [ ] Confirm generated `gaia-ci-pnpm-audit.yml.tmpl` matches source after bundle