### PR TITLE
feat(hooks): repo-scope main/PR-merge guards + create-gaia release lockstep

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -141,6 +141,51 @@ git log -1 --oneline    # verify this is the merge commit
 
 Push the tag, which kicks the GitHub Release workflow (`release.yml`) to build the scrubbed tarball.
 
+### 13. Lockstep `create-gaia`
+
+`create-gaia` (the `npx create-gaia` scaffolder) must stay in **version lockstep** with the GAIA template: its `package.json` `version` and its offline `FALLBACK_VERSION` (`bin/index.js`) both track the release just cut. Its `publish.yml` triggers on a `v*.*.*` tag and refuses to publish unless the tag equals `package.json` version.
+
+It lives in a sibling checkout (`../create-gaia` relative to the GAIA repo root). If the sibling is absent on this machine, STOP and report — do not silently skip; lockstep is mandatory and a maintainer with the checkout must complete it.
+
+```bash
+CG="$(git rev-parse --show-toplevel)/../create-gaia"
+[ -d "$CG/.git" ] || { echo "create-gaia checkout not found at $CG — lockstep cannot complete here"; exit 1; }
+git -C "$CG" fetch origin --quiet && git -C "$CG" checkout main --quiet && git -C "$CG" pull --ff-only origin main --quiet
+```
+
+Set both version sites to `<NEW_VERSION>` (no `v` in `package.json`, `v`-prefixed in `FALLBACK_VERSION`):
+
+- `$CG/package.json` → `"version": "<NEW_VERSION>"`
+- `$CG/bin/index.js` → `const FALLBACK_VERSION = 'v<NEW_VERSION>';`
+
+Commit on a branch, open + merge a PR, then tag. The PR-merge and main-push guards are repo-scoped (`.claude/hooks/lib/repo-scope.sh`): a `gh pr merge` / `git push` carrying a `-C "$CG"` or `cd "$CG" &&` prefix targets the sibling repo, so this repo's audit gate and main-protection do **not** fire — no manual-UI detour needed. `create-gaia` has no audit infrastructure or branch protection of its own; a plain `--merge` (not `--auto`) is correct there.
+
+```bash
+git -C "$CG" checkout -b "release/v<NEW_VERSION>"
+# (edit package.json + bin/index.js as above)
+node --check "$CG/bin/index.js"   # smoke: no syntax error
+git -C "$CG" add package.json bin/index.js
+git -C "$CG" commit -m "chore: release v<NEW_VERSION>"
+git -C "$CG" push -u origin "release/v<NEW_VERSION>"
+gh pr create -R gaia-react/create-gaia --base main --head "release/v<NEW_VERSION>" \
+  --title "chore: release v<NEW_VERSION>" --body "Lockstep with GAIA v<NEW_VERSION>."
+gh pr merge -R gaia-react/create-gaia <N> --merge --delete-branch
+for i in $(seq 1 10); do
+  st=$(gh pr view -R gaia-react/create-gaia <N> --json state -q .state)
+  [ "$st" = "MERGED" ] && break; sleep 15
+done
+[ "$st" = "MERGED" ] || { echo "create-gaia PR did not merge — investigate before tagging"; exit 1; }
+git -C "$CG" fetch origin --quiet && git -C "$CG" checkout main --quiet && git -C "$CG" pull --ff-only origin main --quiet
+git -C "$CG" tag "v<NEW_VERSION>" && git -C "$CG" push origin "v<NEW_VERSION>"
+```
+
+The tag push triggers `create-gaia`'s `publish.yml` (npm publish with `--provenance`). Confirm it before considering the release complete:
+
+```bash
+gh run list -R gaia-react/create-gaia --workflow=publish.yml --limit 1
+npm view create-gaia@<NEW_VERSION> version    # registry CDN may lag a minute
+```
+
 ## Recovery: I tagged on the wrong commit
 
 ```bash

--- a/.claude/hooks/block-main-destructive-git.sh
+++ b/.claude/hooks/block-main-destructive-git.sh
@@ -9,6 +9,16 @@ cmd=$(echo "$payload" | jq -r '.tool_input.command // empty')
 # Only act on git commands — short-circuit everything else
 [[ "$cmd" =~ (^|[[:space:]&;|])git([[:space:]]|$) ]] || exit 0
 
+# Repo-scope: this repo's main-branch policy governs this repo only. A git
+# command aimed at a different repo (e.g. `git -C ../other push origin main`
+# or `cd ../other && git push`) is out of scope — allow it. Fail-closed: any
+# ambiguity falls through and the policy still enforces.
+[ -f .claude/hooks/lib/repo-scope.sh ] && . .claude/hooks/lib/repo-scope.sh
+if type cmd_targets_foreign_repo >/dev/null 2>&1 \
+   && cmd_targets_foreign_repo "$cmd"; then
+  exit 0
+fi
+
 deny() {
   jq -n --arg r "$1" '{
     hookSpecificOutput: {

--- a/.claude/hooks/lib/repo-scope.sh
+++ b/.claude/hooks/lib/repo-scope.sh
@@ -15,8 +15,11 @@
 #
 # Fail-closed: returns 0 (true, "foreign") ONLY when it can POSITIVELY resolve
 # a target whose git toplevel differs from the home repo (or an explicit
-# `gh -R owner/repo` whose repo name differs). Any ambiguity or parse failure
-# returns 1 so the caller still enforces — protection never weakens silently.
+# `gh -R/--repo owner/repo` whose repo name differs). Any ambiguity, parse
+# failure, OR a deliberately under-specified form it cannot model exactly
+# (e.g. multiple `git -C` flags, where git's last-wins semantics defeat a
+# single capture) returns 1 so the caller still enforces — protection never
+# weakens silently, even for crafted command strings.
 
 cmd_targets_foreign_repo() {
   local cmd="$1"
@@ -25,15 +28,24 @@ cmd_targets_foreign_repo() {
   home_top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
   [ -n "$home_top" ] || return 1
 
-  # 1. Explicit `gh ... -R owner/repo` / `--repo owner/repo`. gh ignores cwd
-  #    when this is given, so it is the authoritative target.
-  ghrepo=$(printf '%s' "$cmd" | sed -nE 's/.*(-R|--repo)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  # 1. Explicit `gh ... -R owner/repo` / `--repo owner/repo` (space OR `=`
+  #    form). gh ignores cwd when this is given, so it is authoritative.
+  #    Comparison is repo-NAME only (basename): a same-named fork
+  #    (`-R myfork/<homename>`) classifies as home and over-enforces —
+  #    fail-closed and safe, but worth knowing for fork workflows.
+  ghrepo=$(printf '%s' "$cmd" | sed -nE 's/.*(-R|--repo)[[:space:]=]+([^[:space:]]+).*/\2/p' | head -1)
   if [ -n "$ghrepo" ]; then
     [ "${ghrepo##*/}" != "${home_top##*/}" ] && return 0
     return 1
   fi
 
-  # 2. Explicit `git -C <path>`.
+  # 2. Explicit `git -C <path>`. git applies multiple -C cumulatively with
+  #    the LAST winning, which a single-capture regex cannot model. More
+  #    than one -C is therefore genuinely ambiguous here: stay fail-closed
+  #    (return 1 = enforce) rather than risk a wrong "foreign" verdict.
+  if [ "$(printf '%s' "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]|[[:space:]]-C[[:space:]]' | wc -l | tr -d ' ')" -gt 1 ]; then
+    return 1
+  fi
   target_dir=$(printf '%s' "$cmd" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
 
   # 3. Leading `cd <path> &&|;` before the git/gh invocation.

--- a/.claude/hooks/lib/repo-scope.sh
+++ b/.claude/hooks/lib/repo-scope.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared helper: decide whether a Bash command acts on a DIFFERENT git repo
+# than the one these hooks are installed in (the "home repo").
+#
+# Template-distributed and portable: the home repo is whatever repo contains
+# .claude/hooks (resolved via `git rev-parse --show-toplevel`) — never a
+# hardcoded slug. Adopters get the same cross-repo isolation for free: a
+# guard installed in project A never fires on a `git`/`gh` command aimed at
+# a sibling project B.
+#
+# Usage (from a PreToolUse Bash hook, after extracting $cmd):
+#   [ -f .claude/hooks/lib/repo-scope.sh ] && . .claude/hooks/lib/repo-scope.sh
+#   if type cmd_targets_foreign_repo >/dev/null 2>&1 \
+#      && cmd_targets_foreign_repo "$cmd"; then exit 0; fi   # foreign: allow
+#
+# Fail-closed: returns 0 (true, "foreign") ONLY when it can POSITIVELY resolve
+# a target whose git toplevel differs from the home repo (or an explicit
+# `gh -R owner/repo` whose repo name differs). Any ambiguity or parse failure
+# returns 1 so the caller still enforces — protection never weakens silently.
+
+cmd_targets_foreign_repo() {
+  local cmd="$1"
+  local home_top target_dir top ghrepo
+
+  home_top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -n "$home_top" ] || return 1
+
+  # 1. Explicit `gh ... -R owner/repo` / `--repo owner/repo`. gh ignores cwd
+  #    when this is given, so it is the authoritative target.
+  ghrepo=$(printf '%s' "$cmd" | sed -nE 's/.*(-R|--repo)[[:space:]]+([^[:space:]]+).*/\2/p' | head -1)
+  if [ -n "$ghrepo" ]; then
+    [ "${ghrepo##*/}" != "${home_top##*/}" ] && return 0
+    return 1
+  fi
+
+  # 2. Explicit `git -C <path>`.
+  target_dir=$(printf '%s' "$cmd" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+
+  # 3. Leading `cd <path> &&|;` before the git/gh invocation.
+  if [ -z "$target_dir" ]; then
+    target_dir=$(printf '%s' "$cmd" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:]]+)[[:space:]]*(\&\&|;).*/\1/p' | head -1)
+  fi
+
+  # No redirection found: the command runs against the home repo.
+  [ -n "$target_dir" ] || return 1
+
+  # Expand a leading ~ (our cross-repo flows use ~/path targets). The tilde
+  # arrives as a literal character in the command text — bash never expanded
+  # it because it was inside the tool_input string — so strip it by offset.
+  # SC2088 fires on the quoted tilde, but these are case PATTERNS matching a
+  # literal '~' in the input string, not an expansion attempt — intentional.
+  # shellcheck disable=SC2088
+  case "$target_dir" in
+    '~') target_dir="$HOME" ;;
+    '~/'*) target_dir="$HOME/${target_dir:2}" ;;
+  esac
+
+  top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -n "$top" ] || return 1
+
+  local a b
+  a=$(cd "$top" 2>/dev/null && pwd -P) || return 1
+  b=$(cd "$home_top" 2>/dev/null && pwd -P) || return 1
+  [ "$a" != "$b" ] && return 0
+  return 1
+}

--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -57,6 +57,16 @@ else
   exit 0
 fi
 
+# Repo-scope: this gate enforces the home repo's audit contract only. A
+# `gh pr merge` aimed at a different repo (e.g. a sibling project merged via
+# `cd ../other && gh pr merge` or `gh pr merge -R owner/other`) has no bearing
+# on this repo's audit markers — allow it.
+[ -f .claude/hooks/lib/repo-scope.sh ] && . .claude/hooks/lib/repo-scope.sh
+if type cmd_targets_foreign_repo >/dev/null 2>&1 \
+   && cmd_targets_foreign_repo "$cmd"; then
+  exit 0
+fi
+
 # Resolve HEAD SHA. If we cannot (no git, detached state we can't read),
 # fall back to permissive: this hook only enforces in repos where git answers.
 sha=$(git rev-parse HEAD 2>/dev/null || true)

--- a/wiki/concepts/Git Workflow.md
+++ b/wiki/concepts/Git Workflow.md
@@ -10,6 +10,8 @@ tags: [concept, git, workflow]
 
 Two invariants, machine-enforced by `.claude/hooks/block-main-destructive-git.sh` (PreToolUse `Bash` hook with `if: Bash(git *)`). The hook emits `permissionDecision: "deny"` with a reason string, so Claude cannot bypass it without explicit user override.
 
+The guard is **repo-scoped** via `.claude/hooks/lib/repo-scope.sh`: it governs this repo only. A `git` command positively aimed at a different checkout (`git -C <other>` or `cd <other> &&`) is allowed — that sibling repo's own policy applies there, not this one's. Scoping is fail-closed: any ambiguity still enforces.
+
 ## 1. Never commit directly to `main` or `master`
 
 Always work on a feature branch. If HEAD is on `main`/`master`, create one first:

--- a/wiki/concepts/Git Workflow.md
+++ b/wiki/concepts/Git Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-21
-updated: 2026-04-21
+updated: 2026-05-19
 tags: [concept, git, workflow]
 ---
 

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-10
+updated: 2026-05-19
 tags: [concept, ci, review]
 ---
 

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -10,6 +10,8 @@ tags: [concept, ci, review]
 
 Mandatory before any `gh pr merge`. Machine-enforced by `.claude/hooks/pr-merge-audit-check.sh`, which denies `gh pr merge` calls when no `code-review-audit` marker exists for the current HEAD SHA.
 
+The gate is **repo-scoped** via `.claude/hooks/lib/repo-scope.sh`: it enforces this repo's audit contract only. A `gh pr merge` positively aimed at a different repo (`-R owner/other`, or `cd <other> &&`) is allowed — this repo's audit markers have no bearing on a sibling repo's merge. Scoping is fail-closed: any ambiguity still enforces.
+
 ## Four-step protocol
 
 ### 1. Run code-review-audit


### PR DESCRIPTION
## Summary

Two related fixes surfaced by the v1.2.2 / create-gaia release:

1. **Repo-scope the guard hooks.** `block-main-destructive-git.sh` and `pr-merge-audit-check.sh` matched their command strings regardless of target repo, so a `gh pr merge` / `git push origin main` aimed at a sibling checkout (create-gaia) was blocked with *this* repo's HEAD/audit state — forcing a manual GitHub-UI merge. New shared lib `.claude/hooks/lib/repo-scope.sh` positively resolves the target repo (`git -C <path>`, leading `cd <path> &&`, or `gh -R owner/repo`) and compares git toplevels.
   - **Fail-closed**: any ambiguity or parse failure still enforces — this repo's protections never weaken; only a *positively-identified* foreign repo is exempted.
   - **Portable**: "home repo" is resolved via `git rev-parse --show-toplevel`, never a hardcoded slug, so adopters get the same cross-repo isolation.

2. **create-gaia version lockstep.** New `/gaia-release` step 13: every GAIA release also bumps `create-gaia` `package.json` + `bin/index.js` `FALLBACK_VERSION` to the same version and publishes it. The now-scoped hooks let its PR merge run inline (no UI detour).

Wiki policy pages (`Git Workflow.md`, `PR Merge Workflow.md`) note the repo-scoping so the docs stay accurate.

## Verification

- `shellcheck` clean on `repo-scope.sh`; the two hooks emit only SC1091-info for the dynamic source — identical to the 3 existing `gaia-ci-defer.sh`-sourcing hooks (established baseline).
- Functional matrix (home vs. foreign) for both hooks: home `git push origin main` / `git commit` on main / `gh pr merge` (no marker) / `-R <home>` → **deny**; foreign `-C <other>` / `cd <other> &&` / `-R owner/other` → **allow**. All pass.
- Quality Gate skipped per its own rule (no `.ts/.tsx/.css`/gate-config staged — pure `.claude/**` + `wiki/**` + shell).

## Test plan

- [ ] code-review-audit handshake clean
- [ ] Confirm fail-closed: ambiguous/unparseable target still enforces

🤖 Generated with [Claude Code](https://claude.com/claude-code)