### PR TITLE
fix(hooks): harden block-main against multiple git -C flags

### DIFF
--- a/.claude/hooks/block-main-destructive-git.sh
+++ b/.claude/hooks/block-main-destructive-git.sh
@@ -30,11 +30,15 @@ deny() {
   exit 0
 }
 
-# Normalize: strip -C <path> for regex matching; capture path for git queries.
-# Handles `git -C /abs/path <subcommand>` (required by shell-cwd rule).
-# Uses sed — bash 3.2 (macOS default) doesn't populate BASH_REMATCH reliably.
-git_cwd=$(echo "$cmd" | sed -nE 's/.*git -C ([^ ]+).*/\1/p')
-norm=$(echo "$cmd" | sed -E 's/git -C [^ ]+ /git /')
+# Normalize: strip EVERY -C <path> for regex matching; capture the path git
+# would actually use for git queries. git applies multiple -C cumulatively
+# with the last absolute one winning, so capture the LAST occurrence (greedy
+# .* consumes through it) — a first-only capture lets `git -C <a> -C <b>
+# commit` slip past the commit/push regexes. Handles `git -C /abs/path`
+# (required by shell-cwd rule). Uses sed — bash 3.2 (macOS default) doesn't
+# populate BASH_REMATCH reliably.
+git_cwd=$(echo "$cmd" | sed -nE 's/.*[[:space:]]-C[[:space:]]+([^[:space:]]+).*/\1/p')
+norm=$(echo "$cmd" | sed -E 's/[[:space:]]-C[[:space:]]+[^[:space:]]+//g')
 
 current_branch() {
   if [[ -n "$git_cwd" ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #186. `block-main-destructive-git.sh` derived `norm` (for subcommand regex matching) and `git_cwd` (for the branch check) by stripping/capturing only the **first** `git -C <path>`. So `git -C <a> -C <b> commit -m x` normalized to `git -C <b> commit …` — the `git[[:space:]]+commit` / `git[[:space:]]+push` regexes never matched, and a commit/push to a protected `main` could slip past the guard.

Fix:
- `norm`: strip **every** ` -C <path>` (global), so subcommand detection always fires.
- `git_cwd`: capture the **last** `-C` (greedy `.*`), matching git's last-absolute-`-C`-wins semantics, so `current_branch()` queries the repo git actually operates on.

This is the pre-existing limitation the #186 audit explicitly scoped out as not-a-regression; closing it now per the tracked follow-up.

## Verification

- shellcheck clean at warning severity (SC1091-info on the `repo-scope.sh` source line only — established baseline shared with 3 other hooks).
- Test matrix (run via script file to avoid tripping the live hook): repo-scope unit suite 9/9; block-main integration — `git push origin main` → **deny**; single foreign `git -C <other> push origin main` → **allow** (repo-scope); `git -C <other> -C <home> commit -m x` → **deny**; `git -C <other> -C <home> push origin main` → **deny**. All pass.
- Quality Gate skipped per its own rule (no `.ts/.tsx/.css`/gate-config staged — single `.claude/**` shell file).

## Test plan

- [ ] code-review-audit handshake clean
- [ ] Confirm no regression for single-`-C` and no-`-C` forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)