### PR TITLE
ci: run check-trailer.bats in CI + single-pass deepRemoveNil

### DIFF
--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -107,7 +107,11 @@ wiki/decisions/Forensics Triage Workflow.md
 # `release.yml` cuts releases of the GAIA template itself (triggered by
 # `v*.*.*` tags); adopters never release GAIA. `cli-tests.yml` runs the
 # .gaia/cli/ vitest suite; adopters receive only the bundled binary, so
-# the test workflow has nothing to test on their side. `distribution.yml`
+# the test workflow has nothing to test on their side.
+# `audit-ci-tests.yml` runs the bats suite for
+# `.github/audit/check-trailer.sh`; adopters receive that script as
+# GAIA-controlled code they never edit, so the suite guards only
+# maintainer changes. `distribution.yml`
 # runs the maintainer-only `.gaia/tests/distribution/` harness against a
 # staged release tree using a Claude OAuth org secret; adopters never
 # distribute GAIA. `forensics-triage.yml` runs autonomous Claude Code
@@ -118,6 +122,7 @@ wiki/decisions/Forensics Triage Workflow.md
 # best and confusing CI failures at worst on adopter clones.
 .github/workflows/release.yml
 .github/workflows/cli-tests.yml
+.github/workflows/audit-ci-tests.yml
 .github/workflows/distribution.yml
 .github/workflows/forensics-triage.yml
 .github/forensics

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -1,0 +1,44 @@
+name: Audit CI Tests
+
+# Runs the bats suite for .github/audit/check-trailer.sh — the skip-logic
+# gate that code-review-audit.yml consumes. Maintainer-only: adopters
+# receive check-trailer.sh as GAIA-controlled (`owned`) code they never
+# modify, so the suite only catches regressions from maintainer edits.
+# Mirrors cli-tests.yml's narrow-surface, paths-filtered, step-gated shape.
+#
+# Pinned action SHAs match .github/workflows/cli-tests.yml:
+#   actions/checkout    @ 93cb6efe18208431cddfb8368fd83d5badbf9bfd (v5.0.1)
+#   dorny/paths-filter  @ fbd0ab8f3e69293af611ebaee6363fc25e6d187d (v4.0.1)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit-ci-tests:
+    name: bats (.github/audit)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      # PRs that don't touch the audit scripts report this check green
+      # without installing or running anything.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/audit/**'
+              - '.github/workflows/audit-ci-tests.yml'
+      - if: steps.filter.outputs.code == 'true'
+        name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - if: steps.filter.outputs.code == 'true'
+        name: Run check-trailer.sh bats suite
+        run: bats .github/audit/tests/check-trailer.bats

--- a/app/utils/nonce.ts
+++ b/app/utils/nonce.ts
@@ -1,6 +1,5 @@
 import {createContext, useContext} from 'react';
 
-// No NonceProvider wraps the hydrated client tree; the '' default covers that path.
 const NonceContext = createContext<string>('');
 
 export const NonceProvider = NonceContext.Provider;

--- a/app/utils/nonce.ts
+++ b/app/utils/nonce.ts
@@ -1,5 +1,6 @@
 import {createContext, useContext} from 'react';
 
+// No NonceProvider wraps the hydrated client tree; the '' default covers that path.
 const NonceContext = createContext<string>('');
 
 export const NonceProvider = NonceContext.Provider;

--- a/app/utils/object.ts
+++ b/app/utils/object.ts
@@ -46,18 +46,25 @@ export const deepRemoveNil = (input: unknown): unknown => {
   }
 
   if (Array.isArray(input)) {
-    return input
-      .filter((value) => !isNil(value))
-      .map((value) => deepRemoveNil(value));
+    return input.reduce<unknown[]>((acc, value) => {
+      if (!isNil(value)) {
+        acc.push(deepRemoveNil(value));
+      }
+
+      return acc;
+    }, []);
   }
 
   if (isObject(input)) {
-    const keys = Object.keys(input);
+    return Object.entries(input).reduce<Record<string, unknown>>(
+      (acc, [key, value]) => {
+        if (!isNil(value)) {
+          acc[key] = deepRemoveNil(value);
+        }
 
-    return Object.fromEntries(
-      keys
-        .filter((key) => !isNil(input[key]))
-        .map((key) => [key, deepRemoveNil(input[key])])
+        return acc;
+      },
+      {}
     );
   }
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -135,6 +135,7 @@ Excluding the source prevents adopters from accidentally rebuilding the binary o
 
 - `.github/workflows/release.yml` — cuts releases of the GAIA template itself, triggered by `v*.*.*` tags against `.gaia/VERSION`. Adopters never release GAIA, so the workflow is at best a silent passenger and at worst a CI failure if they accidentally tag with `v*`.
 - `.github/workflows/cli-tests.yml` — runs `.gaia/cli/` typecheck and vitest. Adopters receive only the bundled binary at `.gaia/cli/gaia`, so there is nothing for the workflow to test on their side.
+- `.github/workflows/audit-ci-tests.yml` — runs the bats suite for `.github/audit/check-trailer.sh`. Adopters receive that script as GAIA-controlled (`owned`) code they never modify, so the suite only guards maintainer edits.
 - `.github/workflows/distribution.yml` — runs the `.gaia/tests/distribution/` harness on a GitHub runner. Manual trigger only (`workflow_dispatch`); the maintainer's `CLAUDE_CODE_OAUTH_TOKEN` org secret authenticates the in-container `claude` calls used by Layer 2 scenarios. Adopters never run distribution tests against their own scaffold, so the workflow is irrelevant on their side.
 
 `tests.yml` and `chromatic.yml` DO ship; both are adopter-relevant. Their `paths-filter` allowlists are written without reference to maintainer-only paths so the filter stays meaningful on an adopter clone.


### PR DESCRIPTION
## Summary

Two follow-ups surfaced while smoke-testing the PR #191 audit-CI fix.

**1. Wire `check-trailer.bats` into CI**
- New `.github/workflows/audit-ci-tests.yml` installs bats and runs the 15-test `check-trailer.bats` suite on PRs touching `.github/audit/**`. The suite previously ran only when a developer invoked it locally.
- Maintainer-only (mirrors `cli-tests.yml`): registered in `.gaia/release-exclude` category 9 and the Release Workflow wiki Distribution Boundary narrative. Adopters receive `check-trailer.sh` as GAIA-controlled code they never modify, so the suite only guards maintainer edits.

**2. Single-pass `deepRemoveNil`** (`app/utils/object.ts`)
- Both `filter().map()` chains converted to `reduce`, matching the file's existing idiom (`mapKeys`/`mapValues`/`compact`). Each branch iterates once instead of twice; clears react-doctor's `filter().map()` warning. Behavior unchanged.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm build` pass
- [x] `deepRemoveNil` behavior covered by `object.test.ts` (nested array/object cases)
- [x] `audit-ci-tests.yml` actionlint clean; `check-trailer.bats` 15/15 locally
- [ ] `audit-ci-tests.yml` runs green on this PR (self-validates — the PR adds the workflow, which its own paths-filter matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)