### PR TITLE
fix: audit findings — open redirect + tryCatch falsy-result bug

### DIFF
--- a/app/routes/actions+/set-language.ts
+++ b/app/routes/actions+/set-language.ts
@@ -1,15 +1,20 @@
 import {data, redirect, replace} from 'react-router';
 import {LANGUAGES} from '~/languages';
 import {languageCookie} from '~/sessions.server/language';
+import {isLocalRedirect} from '~/utils/http';
 import type {Route} from './+types/set-language';
 
 export const action = async ({request}: Route.ActionArgs) => {
   const requestText = await request.text();
   const form = new URLSearchParams(requestText);
-  const language = form.get('language') as string;
-  const redirectUrl = form.get('redirectUrl') as string;
+  const language = form.get('language');
+  const redirectUrl = form.get('redirectUrl');
 
-  if (!LANGUAGES.includes(language) || !redirectUrl) {
+  if (
+    language == null ||
+    !LANGUAGES.includes(language) ||
+    !isLocalRedirect(redirectUrl)
+  ) {
     return data(
       {
         message: `language value of ${language} is not a valid language`,

--- a/app/utils/function.ts
+++ b/app/utils/function.ts
@@ -29,11 +29,11 @@ export const tryCatch = <T, A extends readonly unknown[]>(
       ]) as TryCatchResult<T>;
   }
 
-  if (result) {
-    return [undefined, result] as TryCatchResult<T>;
+  if (error) {
+    return [error, undefined] as TryCatchResult<T>;
   }
 
-  return [error, undefined] as TryCatchResult<T>;
+  return [undefined, result] as TryCatchResult<T>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type

--- a/app/utils/http.ts
+++ b/app/utils/http.ts
@@ -6,3 +6,16 @@ export const toHeadersObject = (
       Object.fromEntries(headers)
     : headers
   : undefined;
+
+/*
+  True only for same-origin, path-relative redirect targets. Rejects
+  protocol-relative ("//host") and backslash ("/\host") forms, which
+  browsers normalize to an absolute off-site URL — the open-redirect vector.
+*/
+export const isLocalRedirect = (
+  url: null | string | undefined
+): url is string =>
+  url != null &&
+  url.startsWith('/') &&
+  !url.startsWith('//') &&
+  !url.startsWith('/\\');

--- a/app/utils/tests/function.test.ts
+++ b/app/utils/tests/function.test.ts
@@ -33,4 +33,11 @@ describe('function utils', () => {
       })
     ).toEqual([new Error('failed'), undefined]);
   });
+
+  test('tryCatch preserves falsy sync results as success', () => {
+    expect(tryCatch(() => 0)).toEqual([undefined, 0]);
+    expect(tryCatch(() => false)).toEqual([undefined, false]);
+    expect(tryCatch(() => '')).toEqual([undefined, '']);
+    expect(tryCatch(() => null)).toEqual([undefined, null]);
+  });
 });

--- a/app/utils/tests/http.test.ts
+++ b/app/utils/tests/http.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {toHeadersObject} from '../http';
+import {isLocalRedirect, toHeadersObject} from '../http';
 
 describe('http utils', () => {
   const obj = {fizz: 'buzz', foo: 'bar'};
@@ -14,5 +14,21 @@ describe('http utils', () => {
 
   test('toHeadersObject should work with undefined', () => {
     expect(toHeadersObject()).toBeUndefined();
+  });
+
+  test('isLocalRedirect accepts same-origin path targets', () => {
+    expect(isLocalRedirect('/')).toBe(true);
+    expect(isLocalRedirect('/dashboard')).toBe(true);
+    expect(isLocalRedirect('/a/b?c=d#e')).toBe(true);
+  });
+
+  test('isLocalRedirect rejects off-site and empty targets', () => {
+    expect(isLocalRedirect('//evil.com')).toBe(false);
+    expect(isLocalRedirect(String.raw`/\evil.com`)).toBe(false);
+    expect(isLocalRedirect('https://evil.com')).toBe(false);
+    expect(isLocalRedirect('mailto:a@b.com')).toBe(false);
+    expect(isLocalRedirect('')).toBe(false);
+    expect(isLocalRedirect(null)).toBe(false);
+    expect(isLocalRedirect(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two fixes from the one-time full-codebase audit.

**1. Open redirect in `set-language`** (security)
`app/routes/actions+/set-language.ts` passed the `redirectUrl` form field straight to `replace()` with no validation — an attacker-crafted POST could redirect users off-site (phishing). Adds `isLocalRedirect()` to `app/utils/http.ts`: a type-predicate guard accepting only same-origin path targets, rejecting protocol-relative (`//host`), backslash (`/\host`), and scheme URLs. The action now gates on it; two unsound `as string` casts dropped.

**2. `tryCatch` discarded falsy results**
`app/utils/function.ts` gated success on `if (result)` truthiness, so a function returning `0`, `''`, `false`, or `null` returned `[undefined, undefined]` — the real value lost. Success is now determined by whether an error was caught.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm build` pass
- [x] `tryCatch` falsy-result test went red → green (TDD)
- [x] `isLocalRedirect` — 5 new assertions covering `//`, `/\`, scheme, empty/null
- [x] 54/54 unit tests pass (+3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)