### PR TITLE
refactor(api): thread auth and language per request

### DIFF
--- a/.claude/instructions/remove-i18n.md
+++ b/.claude/instructions/remove-i18n.md
@@ -63,11 +63,8 @@ Remove these imports:
 ```ts
 import {useTranslation} from 'react-i18next';
 import {getLanguage, i18nextMiddleware} from '~/middleware/i18next';
-import {setApiLanguage} from '~/services/api';
 import {languageCookie} from '~/sessions.server/language';
 ```
-
-(`setApiLanguage` is only kept if it's still used elsewhere — grep before deciding. The other three are deleted unconditionally.)
 
 Delete the middleware export:
 
@@ -79,8 +76,6 @@ Inside the loader, delete:
 
 ```ts
 const language = getLanguage(context);
-
-setApiLanguage(language);
 ```
 
 ```ts

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,7 +7,6 @@ import Document from '~/components/Document';
 import RootErrorBoundary from '~/components/Errors/RootErrorBoundary';
 import Toast, {notify} from '~/components/Toast';
 import {getLanguage, i18nextMiddleware} from '~/middleware/i18next';
-import {setApiLanguage} from '~/services/api';
 import {languageCookie} from '~/sessions.server/language';
 import State from '~/state';
 import {isProductionHost} from '~/utils/http.server';
@@ -23,8 +22,6 @@ export const loader = async ({context, request}: Route.LoaderArgs) => {
   const isProduction = isProductionHost(request);
 
   const language = getLanguage(context);
-
-  setApiLanguage(language);
 
   setToastCookieOptions({secrets: [env.SESSION_SECRET]});
 

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -1,8 +1,7 @@
 import ky from 'ky';
-import type {KyInstance, Options} from 'ky';
+import type {Options} from 'ky';
 import type {StringifyOptions} from 'query-string';
-import i18n from '~/i18n';
-import {getBaseUrl, getHooks, getUri} from './utils';
+import {buildRequestHeaders, getBaseUrl, getHooks, getUri} from './utils';
 
 type CreateOptions = Options & {
   arrayFormat?: StringifyOptions['arrayFormat'];
@@ -10,11 +9,11 @@ type CreateOptions = Options & {
 };
 
 type RequestOptions = Options & {
+  language?: string;
   pathParams?: Record<string, unknown>;
   searchParams?: Record<string, unknown>;
+  token?: string;
 };
-
-const instances: KyInstance[] = [];
 
 export const create = <ApiResponseType>({
   arrayFormat = 'comma',
@@ -29,48 +28,15 @@ export const create = <ApiResponseType>({
     ...apiOptions,
   });
 
-  instances.push(kyInstance);
-
   return async (
     uri: string,
-    {pathParams, searchParams, ...options}: RequestOptions = {}
+    {language, pathParams, searchParams, token, ...options}: RequestOptions = {}
   ): Promise<ApiResponseType> =>
     kyInstance<ApiResponseType>(
       getUri(uri, {arrayFormat, pathParams, searchParams, useSnakeCase}),
-      options
+      {
+        ...options,
+        headers: buildRequestHeaders(options.headers, token, language),
+      }
     ).json();
-};
-
-// Set Authorization Bearer header for all instances
-export const setApiAuthorization = (token: string): void => {
-  instances.forEach((kyInstance) => {
-    kyInstance.extend({
-      hooks: {
-        beforeRequest: [
-          async ({request}) => {
-            request.headers.set('Authorization', `Bearer ${token}`);
-          },
-        ],
-      },
-    });
-  });
-};
-
-const apiLanguage = i18n.fallbackLng;
-
-// Set Accept-Language header for all instances
-export const setApiLanguage = (language: string): void => {
-  if (apiLanguage !== language) {
-    instances.forEach((kyInstance) => {
-      kyInstance.extend({
-        hooks: {
-          beforeRequest: [
-            async ({request}) => {
-              request.headers.set('Accept-Language', language);
-            },
-          ],
-        },
-      });
-    });
-  }
 };

--- a/app/services/api/tests/utils.test.ts
+++ b/app/services/api/tests/utils.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, test} from 'vitest';
-import {appendSearchParams, getUri, setPathParams} from '../utils';
+import {
+  appendSearchParams,
+  buildRequestHeaders,
+  getUri,
+  setPathParams,
+} from '../utils';
 
 describe('api utils', () => {
   test('appendSearchParams should return comma array snake_case params', () => {
@@ -57,5 +62,20 @@ describe('api utils', () => {
     ).toBe(
       'api/test/3/edit?name=foo&animal=dog,cat,fish&hello_world=foobar&some_number=5'
     );
+  });
+
+  test('buildRequestHeaders applies per-request token and language', () => {
+    const headers = buildRequestHeaders(undefined, 'abc123', 'ja');
+
+    expect(headers.get('Authorization')).toBe('Bearer abc123');
+    expect(headers.get('Accept-Language')).toBe('ja');
+  });
+
+  test('buildRequestHeaders preserves caller headers and omits absent values', () => {
+    const headers = buildRequestHeaders({'X-Custom': 'keep'});
+
+    expect(headers.get('X-Custom')).toBe('keep');
+    expect(headers.get('Authorization')).toBeNull();
+    expect(headers.get('Accept-Language')).toBeNull();
   });
 });

--- a/app/services/api/utils.ts
+++ b/app/services/api/utils.ts
@@ -1,4 +1,4 @@
-import type {AfterResponseState, BeforeRequestState, Hooks} from 'ky';
+import type {AfterResponseState, BeforeRequestState, Hooks, Options} from 'ky';
 import type {StringifyOptions} from 'query-string';
 import queryString from 'query-string';
 import {tryCatch} from '~/utils/function';
@@ -105,4 +105,27 @@ export const getBaseUrl = (): string => {
 
   // fallback
   return '';
+};
+
+/*
+  Merges per-request auth/language onto any caller-supplied headers.
+  Auth is threaded per request — never stored module-side — so a server
+  process cannot leak one user's token into another user's request.
+*/
+export const buildRequestHeaders = (
+  headers: Options['headers'],
+  token?: string,
+  language?: string
+): Headers => {
+  const merged = new Headers(headers as HeadersInit | undefined);
+
+  if (token) {
+    merged.set('Authorization', `Bearer ${token}`);
+  }
+
+  if (language) {
+    merged.set('Accept-Language', language);
+  }
+
+  return merged;
 };

--- a/app/services/api/utils.ts
+++ b/app/services/api/utils.ts
@@ -107,11 +107,7 @@ export const getBaseUrl = (): string => {
   return '';
 };
 
-/*
-  Merges per-request auth/language onto any caller-supplied headers.
-  Auth is threaded per request — never stored module-side — so a server
-  process cannot leak one user's token into another user's request.
-*/
+// Merges per-request auth/language onto caller-supplied headers; never stored module-side to prevent SSR token cross-contamination.
 export const buildRequestHeaders = (
   headers: Options['headers'],
   token?: string,

--- a/wiki/dependencies/Ky.md
+++ b/wiki/dependencies/Ky.md
@@ -14,7 +14,7 @@ tags: [dependency, http]
 Tiny HTTP client built on `fetch`. GAIA's `app/services/api/index.ts` wraps it:
 
 - `create()` factory that returns a typed request function
-- `setApiAuthorization(token)` and `setApiLanguage(language)` mutate **all** instances at once
+- per-request `token` / `language` options that set `Authorization` and `Accept-Language` headers per call
 - snake_case ↔ camelCase conversion via hooks (`useSnakeCase: true` by default)
 - Path-param + search-param interpolation via `query-string`
 

--- a/wiki/flows/Language Flow.md
+++ b/wiki/flows/Language Flow.md
@@ -13,10 +13,11 @@ How a user's language preference flows through the request lifecycle.
 1. **i18next middleware** (`app/middleware/i18next.ts`) — runs on every request, attaches an i18next instance and resolved language to `context`.
 2. **Loader** — `root.tsx`:
    - `getLanguage(context)` reads the resolved language
-   - `setApiLanguage(language)` updates the `Accept-Language` header on **all** Ky instances
    - Sets the `language` cookie via `languageCookie.serialize(language)` so the choice survives the redirect
 3. **Client init** — the `App` effect calls `i18n.changeLanguage(language)` so client-side i18next matches.
 4. **Switcher** — `LanguageSelect` component → `POST /actions/set-language` (`app/routes/actions+/set-language.ts`) writes the cookie and revalidates.
+
+API requests that need the resolved language pass it per call via the `language` request option — there is no global API language state. See [[API Service Pattern]].
 
 ## Detection order
 

--- a/wiki/modules/Services.md
+++ b/wiki/modules/Services.md
@@ -18,7 +18,7 @@ tags: [module, services, api]
 
 ## `api/` vs `gaia/` — the convention
 
-- `app/services/api/` — the [[Ky]] wrapper. A `create()` factory plus path/search-param interpolation, snake_case ↔ camelCase conversion, and shared `setApiAuthorization` / `setApiLanguage` hooks. **Reusable across domains.**
+- `app/services/api/` — the [[Ky]] wrapper. A `create()` factory plus path/search-param interpolation, snake_case ↔ camelCase conversion, and per-request `token` / `language` request options. **Reusable across domains.**
 - `app/services/gaia/` — the GAIA template's domain layer. Rename to your company name or 3rd-party API name; Claude updates imports, barrels, and references across the app.
 
 The pattern: each domain owns its own `Ky` instance (`api.ts`), its URL constants (`urls.ts`), and a server-only barrel (`index.server.ts`). Domain subfolders (`auth/`, `users/`, etc.) hold request functions, types, and parsers. `/new-service` scaffolds the full pattern.


### PR DESCRIPTION
## Summary
- Auth (`Authorization`) and language (`Accept-Language`) were held in module-side mutable state — `setApiAuthorization`/`setApiLanguage` mutated shared Ky instances via `instances[]`. On a long-lived server process this can leak one user's token into another user's request.
- Thread `token`/`language` per request instead: new `RequestOptions` fields, plus `buildRequestHeaders` in `app/services/api/utils.ts` that merges per-request auth/language onto caller headers.
- Removed the dead `setApiLanguage` call from `app/root.tsx` and the `i18n`-backed `apiLanguage` module state.
- Reconciled docs: `wiki/dependencies/Ky.md`, `wiki/modules/Services.md`, `wiki/flows/Language Flow.md`, `.claude/instructions/remove-i18n.md`.

## Test plan
- [x] `buildRequestHeaders` unit tests (per-request token/language applied; caller headers preserved; absent values omitted)
- [x] Quality Gate: typecheck, lint, test, build all clean
- [ ] Confirm authed API calls still send `Authorization` / `Accept-Language` in a running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)