### PR TITLE
fix(utils): close correctness gaps in utils and api helpers

### DIFF
--- a/app/services/api/tests/utils.test.ts
+++ b/app/services/api/tests/utils.test.ts
@@ -1,5 +1,16 @@
+import type {BeforeRequestState} from 'ky';
 import {describe, expect, test} from 'vitest';
-import {appendSearchParams, getUri, setPathParams} from '../utils';
+import {appendSearchParams, getHooks, getUri, setPathParams} from '../utils';
+
+const runRequestToSnakeCase = async (body: string) => {
+  const hook = getHooks(true)?.beforeRequest?.[0];
+  const state = {
+    options: {body},
+    request: new Request('https://example.test', {method: 'POST'}),
+  } as unknown as BeforeRequestState;
+
+  return hook?.(state);
+};
 
 describe('api utils', () => {
   test('appendSearchParams should return comma array snake_case params', () => {
@@ -57,5 +68,18 @@ describe('api utils', () => {
     ).toBe(
       'api/test/3/edit?name=foo&animal=dog,cat,fish&hello_world=foobar&some_number=5'
     );
+  });
+
+  test('requestToSnakeCase converts a JSON body to snake_case', async () => {
+    const result = await runRequestToSnakeCase(JSON.stringify({helloWorld: 1}));
+
+    expect(result).toBeInstanceOf(Request);
+    expect(await (result as Request).text()).toBe('{"hello_world":1}');
+  });
+
+  test('requestToSnakeCase forwards a non-JSON body unchanged', async () => {
+    const result = await runRequestToSnakeCase('plain text body');
+
+    expect(result).toBeUndefined();
   });
 });

--- a/app/services/api/utils.ts
+++ b/app/services/api/utils.ts
@@ -6,9 +6,17 @@ import {toCamelCase, toSnakeCase} from '~/utils/object';
 
 const requestToSnakeCase = async ({options, request}: BeforeRequestState) => {
   if (options.body && !(options.body instanceof FormData)) {
-    const body = JSON.stringify(
-      toSnakeCase(JSON.parse(options.body as string))
+    const [error, parsed] = tryCatch(
+      () => JSON.parse(options.body as string) as unknown
     );
+
+    // A non-JSON body (plain string, URLSearchParams, etc.) is forwarded
+    // unchanged rather than failing the request.
+    if (error) {
+      return;
+    }
+
+    const body = JSON.stringify(toSnakeCase(parsed));
 
     // eslint-disable-next-line unicorn/no-invalid-fetch-options
     return new Request(request, {body});

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -12,7 +12,15 @@ export const uniqBy = <T, K extends keyof T>(
       index === self.findIndex((other) => iteratee(other) === iteratee(value))
   );
 
-export const sortBy = <T>(array: T[], key: keyof T): T[] =>
+type Comparable = bigint | boolean | Date | number | string;
+
+// Keys of `T` whose values have a defined sort order. Sorting by any other
+// key would silently compare to 0, so it is rejected at compile time.
+type ComparableKey<T> = {
+  [K in keyof T]: T[K] extends Comparable ? K : never;
+}[keyof T];
+
+export const sortBy = <T>(array: T[], key: ComparableKey<T>): T[] =>
   array.toSorted((a, b) => {
     const valueA = a[key];
     const valueB = b[key];

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -2,8 +2,16 @@ import type {Locale} from 'date-fns';
 import {format} from 'date-fns';
 import {ja} from 'date-fns/locale';
 
-const LOCALE_FORMATS: Record<string, Locale> = {
+// date-fns falls back to en-US when no `locale` option is supplied; `en` and
+// any language without a registered date-fns locale share that default.
+const LOCALE_FORMATS: Partial<Record<string, Locale>> = {
   ja,
+};
+
+const getLocaleOptions = (language: string): undefined | {locale: Locale} => {
+  const locale = LOCALE_FORMATS[language];
+
+  return locale ? {locale} : undefined;
 };
 
 // Jan 15, Nov 3, etc.
@@ -14,29 +22,20 @@ export const formatAbbreviatedMonthDay = (
   format(
     date,
     `MMM d${language === 'en' ? '' : 'o'}`,
-    language === 'en' ? undefined : {locale: LOCALE_FORMATS[language]}
+    getLocaleOptions(language)
   );
 
 // Jan 15th, Nov 3rd, etc.
 export const formatAbbreviatedMonthOrdinalDay = (
   date: Date,
   language: string
-): string =>
-  format(
-    date,
-    'MMM do',
-    language === 'en' ? undefined : {locale: LOCALE_FORMATS[language]}
-  );
+): string => format(date, 'MMM do', getLocaleOptions(language));
 
 export const formatISO8601Date = (date: Date): string =>
   format(date, 'yyyy-MM-dd');
 
 export const formatFullDate = (date: Date, language: string): string =>
-  language === 'en' ?
-    format(date, 'PPPP')
-  : format(date, 'PPPP', {
-      locale: LOCALE_FORMATS[language],
-    });
+  format(date, 'PPPP', getLocaleOptions(language));
 
 export const formatMY = (date = new Date()): string => format(date, 'MM/yy');
 
@@ -44,24 +43,12 @@ export const formatFullYear = (date: Date, language: string): string =>
   language === 'en' ? format(date, 'yyyy') : `${format(date, 'yyyy')}年`;
 
 export const formatAbbreviatedMonth = (date: Date, language: string): string =>
-  language === 'en' ?
-    format(date, 'MMM')
-  : format(date, 'MMM', {
-      locale: LOCALE_FORMATS[language],
-    });
+  format(date, 'MMM', getLocaleOptions(language));
 
 export const formatOrdinalDay = (date: Date, language: string): string =>
-  format(
-    date,
-    'do',
-    language === 'en' ? undefined : {locale: LOCALE_FORMATS[language]}
-  );
+  format(date, 'do', getLocaleOptions(language));
 
 export const formatTime = (date: Date, language: string): string =>
-  format(
-    date,
-    'p',
-    language === 'en' ? undefined : {locale: LOCALE_FORMATS[language]}
-  );
+  format(date, 'p', getLocaleOptions(language));
 
 export const formatTime24 = (date: Date): string => format(date, 'HH:mm');

--- a/app/utils/string.ts
+++ b/app/utils/string.ts
@@ -4,4 +4,5 @@ export const toInitialCap = (value?: string): string | undefined =>
 export const toTitleCase = (value: string, delimiter = '_'): string =>
   value.split(delimiter).map(toInitialCap).join(' ');
 
-export const isString = (value?: unknown): boolean => typeof value === 'string';
+export const isString = (value?: unknown): value is string =>
+  typeof value === 'string';

--- a/app/utils/tests/array.test.ts
+++ b/app/utils/tests/array.test.ts
@@ -29,6 +29,18 @@ describe('array', () => {
     ]);
   });
 
+  test('sortBy only accepts keys with comparable values', () => {
+    const data = [
+      {id: 1, tags: ['x']},
+      {id: 2, tags: ['y']},
+    ];
+
+    expect(sortBy(data, 'id')).toHaveLength(2);
+
+    // @ts-expect-error - `tags` holds an array, which has no sort order
+    sortBy(data, 'tags');
+  });
+
   test('uniqBy should work', () => {
     const data = [
       {id: 1, name: 'Foo'},

--- a/app/utils/tests/date.test.ts
+++ b/app/utils/tests/date.test.ts
@@ -45,4 +45,9 @@ describe('date utilities', () => {
     expect(formatTime24(TEST_DATE)).toBe('12:00');
     expect(formatTime24(TEST_DATE)).toBe('12:00');
   });
+
+  test('falls back to en-US for a language with no registered locale', () => {
+    expect(formatAbbreviatedMonthDay(TEST_DATE, 'fr')).toBe('Mar 15th');
+    expect(formatFullDate(TEST_DATE, 'fr')).toBe('Tuesday, March 15th, 2022');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes the audit's IMPORTANT utils / api-helper findings, each covered by a test.

**IMPORTANT**
- **`sortBy` non-comparable values** — `array.ts` `sortBy` accepted any `keyof T`, so sorting by a key whose value is an object/array silently compared to `0` (no-op sort). The `key` parameter is now typed `ComparableKey<T>` — only keys with `bigint | boolean | Date | number | string` values — so the misuse is a compile error. Runtime behaviour for valid keys is unchanged.
- **`date.ts` missing-locale fallback** — `LOCALE_FORMATS` was typed `Record<string, Locale>`, which lied: only `ja` is registered, so any other non-`en` language indexed to `undefined` and silently fell back to en-US. It is now `Partial<Record<…>>`, and a single `getLocaleOptions` helper resolves the locale honestly (and de-duplicates the `language === 'en' ? …` ternary across eight formatters).
- **`requestToSnakeCase` unsafe `JSON.parse`** — `JSON.parse(options.body as string)` threw inside the ky `beforeRequest` hook for any non-JSON string body, failing the request. It now parses through `tryCatch` and forwards a non-JSON body unchanged.

**SUGGEST (included, zero-risk)**
- `string.ts` `isString` is now a `value is string` type predicate.

**Deferred SUGGEST (not in scope here)**
- `object.ts` `convertCase` redundant array branch — collapsing it is correct (and fixes nested-array recursion) but is a refactor with an edge-case behaviour change; better as its own change.
- `helpers.ts` mixed throw/return, `function.ts` `compose` `Function` typing, `http.server.ts` `'domain.tld'` placeholder, `useBreakpoint.ts` SSR assumption — design/environmental, not bugs.

## Test plan
- [x] `sortBy` compile-time rejection (`@ts-expect-error`), date-fns fallback, `requestToSnakeCase` JSON + non-JSON paths
- [x] Quality Gate: typecheck, lint, test (55), build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)