### PR TITLE
fix(cli): atomic file writes with fsync

### DIFF
--- a/.gaia/cli/src/init/rename.ts
+++ b/.gaia/cli/src/init/rename.ts
@@ -16,8 +16,9 @@
  *
  * Stdout: nothing on success. Exit codes: 0 / 1 / 2.
  */
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {markStepCompleted} from './util/state.js';
@@ -130,7 +131,7 @@ const renamePackageJson = (cwd: string, kebab: string): void => {
   if (parsed.name === kebab) return;
   parsed.name = kebab;
   const trailing = raw.endsWith('\n') ? '\n' : '';
-  writeFileSync(target, `${JSON.stringify(parsed, null, 2)}${trailing}`, 'utf8');
+  atomicWriteFileSync(target, `${JSON.stringify(parsed, null, 2)}${trailing}`);
 };
 
 const renameClaudeMd = (cwd: string, title: string): void => {
@@ -142,7 +143,7 @@ const renameClaudeMd = (cwd: string, title: string): void => {
   const next = original.replace(/^#\s+.*$/mu, `# ${title}`);
 
   if (next !== original) {
-    writeFileSync(target, next, 'utf8');
+    atomicWriteFileSync(target, next);
   }
 };
 
@@ -177,7 +178,7 @@ const renameCommonTs = (cwd: string, title: string): void => {
   const next = replaceStringPropertyAll(original, 'siteName', title);
 
   if (next !== original) {
-    writeFileSync(target, next, 'utf8');
+    atomicWriteFileSync(target, next);
   }
 };
 
@@ -195,7 +196,7 @@ const renameIndexPage = (cwd: string, title: string): void => {
   next = replaceStringPropertyAll(next, 'title', title);
 
   if (next !== original) {
-    writeFileSync(target, next, 'utf8');
+    atomicWriteFileSync(target, next);
   }
 };
 

--- a/.gaia/cli/src/init/strip-branding.ts
+++ b/.gaia/cli/src/init/strip-branding.ts
@@ -16,8 +16,9 @@
  *
  * Stdout: nothing on success. Exit codes: 0 / 1 / 2.
  */
-import {existsSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync, rmSync} from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {markStepCompleted} from './util/state.js';
@@ -122,7 +123,7 @@ const writeReadme = (cwd: string, title: string): void => {
 
     if (current === rendered) return;
   }
-  writeFileSync(target, rendered, 'utf8');
+  atomicWriteFileSync(target, rendered);
 };
 
 const WORDMARK_REPLACEMENT =
@@ -148,7 +149,7 @@ const stripGaiaLogoFromHeader = (cwd: string): void => {
   next = next.replaceAll(/<GaiaLogo\b[^>]*\/>/gu, WORDMARK_REPLACEMENT);
 
   if (next !== original) {
-    writeFileSync(target, next, 'utf8');
+    atomicWriteFileSync(target, next);
   }
 };
 

--- a/.gaia/cli/src/init/util/state.ts
+++ b/.gaia/cli/src/init/util/state.ts
@@ -7,8 +7,9 @@
  * temp + rename so a partial write can never leave a half-serialized
  * file behind.
  */
-import {existsSync, mkdirSync, readFileSync, renameSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../../util/atomic-write.js';
 
 export const STATE_FILE_RELATIVE = '.gaia/init-state.json';
 
@@ -63,9 +64,7 @@ export const writeState = (cwd: string, state: InitState): void => {
   const target = stateFilePath(cwd);
   mkdirSync(path.dirname(target), {recursive: true});
   const serialized = `${JSON.stringify(state, null, 2)}\n`;
-  const tmp = `${target}.tmp`;
-  writeFileSync(tmp, serialized, 'utf8');
-  renameSync(tmp, target);
+  atomicWriteFileSync(target, serialized);
 };
 
 export const isStepCompleted = (cwd: string, step: string): boolean => {

--- a/.gaia/cli/src/mentorship/config.ts
+++ b/.gaia/cli/src/mentorship/config.ts
@@ -1,11 +1,6 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {MentorshipConfigSchema} from '../schemas/mentorship-config.js';
 import type {MentorshipConfig} from '../schemas/mentorship-config.js';
 import type {StorageRoots} from '../storage/paths.js';
@@ -100,13 +95,8 @@ export const writeMentorshipConfig = (arguments_: WriteArguments): void => {
   }
 
   const contents = `${JSON.stringify(config, null, 2)}\n`;
-  const temporaryPath = `${filePath}.tmp-${process.pid}`;
 
-  // Atomic write contract: write-temp-and-rename. POSIX rename is atomic
-  // on the same filesystem, so a crash mid-write leaves either the old
-  // file or the new file — never a half-written one.
-  writeFileSync(temporaryPath, contents, {mode: 0o644});
-  renameSync(temporaryPath, filePath);
+  atomicWriteFileSync(filePath, contents, {mode: 0o644});
 };
 
 /**

--- a/.gaia/cli/src/profile/writer.ts
+++ b/.gaia/cli/src/profile/writer.ts
@@ -5,7 +5,7 @@
  * - Atomic write contract: write-temp-and-rename, mode 0o600.
  * - DO-NOT-EDIT header is the first line, exact wording.
  */
-import {rename, writeFile} from 'node:fs/promises';
+import {atomicWriteFile} from '../util/atomic-write.js';
 import {ADAPTATION_TEXT, PATTERN_TO_ADAPTATION} from './adaptation-map.js';
 import type {AdaptationId, PatternId} from './adaptation-map.js';
 import {PROFILE_DO_NOT_EDIT_HEADER} from './header.js';
@@ -181,21 +181,13 @@ export const renderProfile = (args: ProfileRenderArgs): string => {
 };
 
 /**
- * Atomic write: write-temp-and-rename. POSIX `rename` is atomic on the same
- * filesystem; concurrent compute-profile invocations either land the prior
- * version or the latest version completely — never a half-written state.
- * Mode 0o600 because profile.md lives under the off-project
- * mentorship subtree (chmod 600 on every file there).
+ * Atomic write via the shared temp-fsync-rename helper. Mode 0o600 because
+ * profile.md lives under the off-project mentorship subtree (chmod 600 on
+ * every file there).
  */
 export const atomicWriteProfile = async (
   profilePath: string,
   contents: string
-): Promise<void> => {
-  // PID + monotonic high-res time keeps two same-process or two different-
-  // process invocations from colliding on the temp file name.
-  const temporaryPath = `${profilePath}.tmp.${process.pid}.${Date.now()}.${process.hrtime.bigint().toString()}`;
-  await writeFile(temporaryPath, contents, {mode: 0o600});
-  await rename(temporaryPath, profilePath);
-};
+): Promise<void> => atomicWriteFile(profilePath, contents, {mode: 0o600});
 
 export {PATTERN_TO_ADAPTATION};

--- a/.gaia/cli/src/release/bump.ts
+++ b/.gaia/cli/src/release/bump.ts
@@ -23,7 +23,8 @@
  * maintainer-facing slash command to confirm before re-invoking.
  */
 import {type SpawnSyncReturns, spawnSync} from 'node:child_process';
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -282,7 +283,7 @@ const writePackageJsonVersion = (
   if (replaced === raw) {
     throw new Error('failed to rewrite "version" field in package.json');
   }
-  writeFileSync(packagePath, replaced, 'utf8');
+  atomicWriteFileSync(packagePath, replaced);
 };
 
 const writeVersionFile = (cwd: string, newVersion: string): void => {
@@ -292,7 +293,7 @@ const writeVersionFile = (cwd: string, newVersion: string): void => {
   // Preserve trailing newline if originally present.
   const original = readFileSync(target, 'utf8');
   const trailing = original.endsWith('\n') ? '\n' : '';
-  writeFileSync(target, `${newVersion}${trailing}`, 'utf8');
+  atomicWriteFileSync(target, `${newVersion}${trailing}`);
 };
 
 type RunOptions = {

--- a/.gaia/cli/src/release/changelog.ts
+++ b/.gaia/cli/src/release/changelog.ts
@@ -16,7 +16,8 @@
  * version block already exists.
  */
 import {type SpawnSyncReturns, spawnSync} from 'node:child_process';
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -424,7 +425,7 @@ export const run = (
   }
 
   try {
-    writeFileSync(changelogPath, outcome.updated, 'utf8');
+    atomicWriteFileSync(changelogPath, outcome.updated);
   } catch (error) {
     structuredError({
       code: 'changelog_write_failed',

--- a/.gaia/cli/src/release/commit-and-tag.ts
+++ b/.gaia/cli/src/release/commit-and-tag.ts
@@ -20,7 +20,8 @@
  * per mode; stderr explains every refusal.
  */
 import {type SpawnSyncReturns, spawnSync} from 'node:child_process';
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -204,7 +205,7 @@ const writeStateSha = (cwd: string, sha: string): void => {
 
   if (!saw) next.last_evaluated_sha = sha;
   const trailingNewline = raw.endsWith('\n') ? '\n' : '';
-  writeFileSync(target, `${JSON.stringify(next, null, 2)}${trailingNewline}`, 'utf8');
+  atomicWriteFileSync(target, `${JSON.stringify(next, null, 2)}${trailingNewline}`);
 };
 
 const runCommitMode = (ctx: CommitContext): number => {

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -18,7 +18,8 @@
  * manifest fails the build at tag-time before any bundle work runs.
  */
 import {execFileSync} from 'node:child_process';
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -569,7 +570,7 @@ export const run = (
   }
 
   try {
-    writeFileSync(target, serialized, 'utf8');
+    atomicWriteFileSync(target, serialized);
   } catch (error) {
     structuredError({
       code: 'manifest_write_failed',

--- a/.gaia/cli/src/release/scrub-wiki.ts
+++ b/.gaia/cli/src/release/scrub-wiki.ts
@@ -8,7 +8,8 @@
  *
  * No stdout on success. Exit 0 / 1 / 2.
  */
-import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
@@ -214,8 +215,8 @@ export const run = (
 
   try {
     mkdirSync(wikiDir, {recursive: true});
-    writeFileSync(hotPath, renderHotMd(version, date), 'utf8');
-    writeFileSync(logPath, renderLogMd(version, date), 'utf8');
+    atomicWriteFileSync(hotPath, renderHotMd(version, date));
+    atomicWriteFileSync(logPath, renderLogMd(version, date));
   } catch (error) {
     structuredError({
       code: 'scrub_write_failed',

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -28,7 +28,8 @@
  *       staging dir, malformed config flags)
  *   2 — unexpected (config parse error, filesystem IO failure)
  */
-import {readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs';
+import {readdirSync, readFileSync, statSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import path from 'node:path';
 import {load as parseYaml} from 'js-yaml';
 import {z} from 'zod';
@@ -259,7 +260,7 @@ const applyMarkerStrip = (
     }
 
     if (result.blocks > 0) {
-      writeFileSync(absolutePath, result.output, 'utf8');
+      atomicWriteFileSync(absolutePath, result.output);
       filesTouched.push(relativePath);
       blocksStripped += result.blocks;
     }
@@ -337,7 +338,7 @@ const applyJsonStrip = (
     }
 
     if (removed > 0) {
-      writeFileSync(absolutePath, `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
+      atomicWriteFileSync(absolutePath, `${JSON.stringify(obj, null, 2)}\n`);
       filesTouched.push(relativePath);
       keysRemoved += removed;
     }

--- a/.gaia/cli/src/storage/install-id.ts
+++ b/.gaia/cli/src/storage/install-id.ts
@@ -1,5 +1,6 @@
 import {ulid} from 'ulid';
-import {chmodSync, existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import type {StorageRoots} from './paths.js';
 
 /**
@@ -22,10 +23,9 @@ export const readOrCreateInstallId = (roots: StorageRoots): string => {
     // Malformed (truncated, empty, or wrong length) — regenerate.
   }
   const id = ulid();
-  writeFileSync(filePath, `${id}\n`, {mode: 0o600});
-  // writeFileSync's mode option is honored only on file creation; explicit
-  // chmod handles the regenerate-over-malformed case.
-  chmodSync(filePath, 0o600);
+  // The helper always creates a fresh temp file with the given mode, so the
+  // regenerate-over-malformed case gets 0o600 without a follow-up chmod.
+  atomicWriteFileSync(filePath, `${id}\n`, {mode: 0o600});
 
   return id;
 };

--- a/.gaia/cli/src/update/merge.ts
+++ b/.gaia/cli/src/update/merge.ts
@@ -234,6 +234,8 @@ const writePatch = (
   const mergeRoot = path.join(ctx.cwd, MERGE_DIR);
   const patchAbs = path.join(mergeRoot, `${relativePath}.patch`);
   ensureDir(path.dirname(patchAbs));
+  // Patch files are regenerated scratch output under .gaia-merge/, not
+  // durable state — a plain write is sufficient; no atomic rename needed.
   writeFileSync(patchAbs, patch, 'utf8');
 
   return path.relative(ctx.cwd, patchAbs);

--- a/.gaia/cli/src/update/merge.ts
+++ b/.gaia/cli/src/update/merge.ts
@@ -39,6 +39,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {
@@ -245,7 +246,7 @@ const writeWorkingTree = (
 ): void => {
   const target = path.join(ctx.cwd, relativePath);
   ensureDir(path.dirname(target));
-  writeFileSync(target, bytes);
+  atomicWriteFileSync(target, bytes);
 };
 
 type Decision =

--- a/.gaia/cli/src/util/atomic-write.test.ts
+++ b/.gaia/cli/src/util/atomic-write.test.ts
@@ -1,0 +1,66 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {atomicWriteFile, atomicWriteFileSync} from './atomic-write.js';
+
+describe('atomic-write', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'gaia-atomic-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, {force: true, recursive: true});
+  });
+
+  test('atomicWriteFileSync writes content to a new file', () => {
+    const target = path.join(dir, 'out.txt');
+
+    atomicWriteFileSync(target, 'hello');
+
+    expect(readFileSync(target, 'utf8')).toBe('hello');
+  });
+
+  test('atomicWriteFileSync replaces an existing file', () => {
+    const target = path.join(dir, 'out.txt');
+    writeFileSync(target, 'old', 'utf8');
+
+    atomicWriteFileSync(target, 'new');
+
+    expect(readFileSync(target, 'utf8')).toBe('new');
+  });
+
+  test('atomicWriteFileSync leaves no temp files behind', () => {
+    const target = path.join(dir, 'out.txt');
+
+    atomicWriteFileSync(target, 'hello');
+
+    expect(readdirSync(dir)).toEqual(['out.txt']);
+  });
+
+  test('atomicWriteFileSync applies the requested file mode', () => {
+    const target = path.join(dir, 'secret.txt');
+
+    atomicWriteFileSync(target, 'x', {mode: 0o600});
+
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  test('atomicWriteFile (async) writes content and leaves no temp files', async () => {
+    const target = path.join(dir, 'async.txt');
+
+    await atomicWriteFile(target, 'async hello');
+
+    expect(readFileSync(target, 'utf8')).toBe('async hello');
+    expect(readdirSync(dir)).toEqual(['async.txt']);
+  });
+});

--- a/.gaia/cli/src/util/atomic-write.test.ts
+++ b/.gaia/cli/src/util/atomic-write.test.ts
@@ -1,4 +1,5 @@
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -62,5 +63,23 @@ describe('atomic-write', () => {
 
     expect(readFileSync(target, 'utf8')).toBe('async hello');
     expect(readdirSync(dir)).toEqual(['async.txt']);
+  });
+
+  test('atomicWriteFileSync removes the temp file when rename fails', () => {
+    // An existing directory at the target path makes renameSync fail after
+    // the temp file has been created and written.
+    const target = path.join(dir, 'blocked');
+    mkdirSync(target);
+
+    expect(() => atomicWriteFileSync(target, 'data')).toThrow();
+    expect(readdirSync(dir)).toEqual(['blocked']);
+  });
+
+  test('atomicWriteFile (async) removes the temp file when rename fails', async () => {
+    const target = path.join(dir, 'blocked');
+    mkdirSync(target);
+
+    await expect(atomicWriteFile(target, 'data')).rejects.toThrow();
+    expect(readdirSync(dir)).toEqual(['blocked']);
   });
 });

--- a/.gaia/cli/src/util/atomic-write.ts
+++ b/.gaia/cli/src/util/atomic-write.ts
@@ -1,0 +1,57 @@
+/**
+ * Atomic file writes: serialize to a uniquely-named temporary file in the
+ * target's own directory, fsync it so the bytes are durable, then rename
+ * over the target. POSIX `rename` is atomic on the same filesystem; the
+ * fsync is what makes the result crash-safe — without it a crash right
+ * after the rename can leave the target pointing at unflushed (empty or
+ * partial) data.
+ */
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import {open, rename} from 'node:fs/promises';
+
+// PID + monotonic high-res clock keeps concurrent writers — same process
+// or different processes — from colliding on the temp file name.
+const temporaryPath = (filePath: string): string =>
+  `${filePath}.tmp.${process.pid}.${process.hrtime.bigint().toString()}`;
+
+export const atomicWriteFileSync = (
+  filePath: string,
+  data: Buffer | string,
+  options?: {mode?: number}
+): void => {
+  const tmp = temporaryPath(filePath);
+  const fd = openSync(tmp, 'w', options?.mode ?? 0o644);
+
+  try {
+    writeFileSync(fd, data);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  renameSync(tmp, filePath);
+};
+
+export const atomicWriteFile = async (
+  filePath: string,
+  data: Buffer | string,
+  options?: {mode?: number}
+): Promise<void> => {
+  const tmp = temporaryPath(filePath);
+  const handle = await open(tmp, 'w', options?.mode ?? 0o644);
+
+  try {
+    await handle.writeFile(data);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  await rename(tmp, filePath);
+};

--- a/.gaia/cli/src/util/atomic-write.ts
+++ b/.gaia/cli/src/util/atomic-write.ts
@@ -11,9 +11,10 @@ import {
   fsyncSync,
   openSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import {open, rename} from 'node:fs/promises';
+import {open, rename, unlink} from 'node:fs/promises';
 
 // PID + monotonic high-res clock keeps concurrent writers — same process
 // or different processes — from colliding on the temp file name.
@@ -35,7 +36,19 @@ export const atomicWriteFileSync = (
     closeSync(fd);
   }
 
-  renameSync(tmp, filePath);
+  try {
+    renameSync(tmp, filePath);
+  } catch (error) {
+    // Rename failed (cross-device, permissions, target dir removed): drop the
+    // temp file so failed writes don't accumulate beside the target.
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // best-effort cleanup
+    }
+
+    throw error;
+  }
 };
 
 export const atomicWriteFile = async (
@@ -53,5 +66,17 @@ export const atomicWriteFile = async (
     await handle.close();
   }
 
-  await rename(tmp, filePath);
+  try {
+    await rename(tmp, filePath);
+  } catch (error) {
+    // Rename failed (cross-device, permissions, target dir removed): drop the
+    // temp file so failed writes don't accumulate beside the target.
+    try {
+      await unlink(tmp);
+    } catch {
+      // best-effort cleanup
+    }
+
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
The maintainer CLI wrote directly onto committed / user-owned files with a non-atomic `writeFileSync`; a crash mid-write corrupts the file. A couple of writers did temp-file+rename but skipped `fsync` — so the "atomic write" claim was unmet (the rename can land before the data is flushed to disk) — and used a fixed `.tmp` name that two concurrent writers would collide on.

- New shared helper `.gaia/cli/src/util/atomic-write.ts` — `atomicWriteFileSync` and `atomicWriteFile` (async). Writes to a uniquely-named temp file (pid + hrtime) in the target's directory, `fsync`s the fd, then `rename`s over the target.
- Routed the non-atomic committed-file writes through it: the six `release/` writers (`scrub`, `changelog`, `bump`, `commit-and-tag`, `scrub-wiki`, `manifest`), `init/util/state.ts`, `init/strip-branding.ts`, `init/rename.ts`, `storage/install-id.ts`, `update/merge.ts` (working-tree writes), `profile/writer.ts` and `mentorship/config.ts`.
- `storage/install-id.ts`: the follow-up `chmodSync` is no longer needed — the helper always creates a fresh temp file with the requested mode.

Scope note: this PR covers the audit's IMPORTANT-flagged non-atomic writes. A handful of lower-traffic writers in `scaffold/`, `wiki/state-*`, `init/configure-i18n.ts` and `mentorship/display-rule-memory.ts` use the same pattern and are a reasonable follow-up.

## Test plan
- [x] New unit test for the helper (new file, replace existing, no temp-file leaks, mode honored, async variant)
- [x] CLI gate: `pnpm -C .gaia/cli typecheck` + full vitest suite (1123 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)