### PR TITLE
fix(cli-wiki): correctness gaps in wiki/update/update-deps

### DIFF
--- a/.gaia/cli/src/update-deps/run.test.ts
+++ b/.gaia/cli/src/update-deps/run.test.ts
@@ -591,6 +591,47 @@ describe('update-deps run — computeUpdates', () => {
     expect(sbReact?.latest).toBe('9.0.0');
     expect(sbReact?.kind).toBe('major');
   });
+
+  test('sibling expansion: current version comes from node_modules, not the spec', () => {
+    sandbox.writePackageJson({
+      devDependencies: {
+        storybook: '^8.0.0',
+        '@storybook/react': '^8.0.0',
+      },
+    });
+    // @storybook/react is already on 9.0.0 in node_modules even though the
+    // package.json spec still floors at ^8.0.0.
+    mkdirSync(path.join(sandbox.root, 'node_modules', '@storybook', 'react'), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(
+        sandbox.root,
+        'node_modules',
+        '@storybook',
+        'react',
+        'package.json'
+      ),
+      JSON.stringify({name: '@storybook/react', version: '9.0.0'}),
+      'utf8'
+    );
+
+    const result = computeUpdates({
+      cwd: sandbox.root,
+      pnpmRunner: makePnpmRunner(
+        {storybook: {current: '8.0.0', latest: '9.0.0', wanted: '8.0.0'}},
+        undefined,
+        {'@storybook/react': '9.0.0'}
+      ),
+    });
+
+    const sbReact = result.wave_b[0]?.packages.find(
+      (p) => p.name === '@storybook/react'
+    );
+    expect(sbReact?.current).toBe('9.0.0');
+    // current === latest → classified patch (no-op), not major.
+    expect(sbReact?.kind).toBe('patch');
+  });
 });
 
 describe('update-deps run — group membership', () => {

--- a/.gaia/cli/src/update-deps/run.ts
+++ b/.gaia/cli/src/update-deps/run.ts
@@ -200,6 +200,29 @@ const readPackageJson = (cwd: string): PackageJsonShape => {
   return JSON.parse(raw) as PackageJsonShape;
 };
 
+/**
+ * The version actually installed in `node_modules`. The package.json range
+ * spec does not reveal it — a `^1.2.3` spec can resolve to any 1.x, and
+ * `workspace:*` / tag / url specs carry no version at all. Returns
+ * `undefined` when the package is not installed.
+ */
+const readInstalledVersion = (
+  cwd: string,
+  name: string
+): string | undefined => {
+  try {
+    const raw = readFileSync(
+      path.join(cwd, 'node_modules', name, 'package.json'),
+      'utf8'
+    );
+    const parsed = JSON.parse(raw) as {version?: unknown};
+
+    return typeof parsed.version === 'string' ? parsed.version : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const lookupSpec = (pkg: PackageJsonShape, name: string): string | undefined =>
   pkg.dependencies?.[name] ??
   pkg.devDependencies?.[name] ??
@@ -406,10 +429,18 @@ export const computeUpdates = (options: ComputeOptions): UpdatesPayload => {
   const pnpmRunner = options.pnpmRunner ?? defaultPnpmRunner;
   const pkg = readPackageJson(options.cwd);
 
-  // pnpm outdated exits 1 when packages are outdated — that is normal.
-  // We ignore the exit code and parse stdout regardless. Empty / invalid
-  // stdout falls through to an empty entry list.
+  // `pnpm outdated` exits 0 (nothing outdated) or 1 (packages outdated) on
+  // a healthy run. Any other status — including the null status of a
+  // failed spawn — means pnpm itself failed; parsing its empty stdout
+  // would masquerade as "everything up to date".
   const result = pnpmRunner(['outdated', '--json'], {cwd: options.cwd});
+
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(
+      `pnpm outdated failed (exit ${result.status ?? 'null'}): ${result.stderr.trim()}`
+    );
+  }
+
   const raw = parseOutdated(result.stdout);
 
   const eslintCache: {versions?: readonly string[]} = {};
@@ -481,8 +512,13 @@ export const computeUpdates = (options: ComputeOptions): UpdatesPayload => {
       // Sibling is in package.json but not flagged by pnpm outdated.
       const spec = lookupSpec(pkg, siblingName);
 
-      // strip spec prefix to get current installed version
-      const current = spec !== undefined ? stripRange(spec) : '';
+      // Prefer the version actually installed in node_modules; the
+      // package.json spec (`^x`, `workspace:*`, a tag, …) is not a usable
+      // version. Fall back to the spec floor only when node_modules has no
+      // entry (e.g. dependencies not installed).
+      const current =
+        readInstalledVersion(options.cwd, siblingName) ??
+        (spec !== undefined ? stripRange(spec) : '');
       const latest = fetchLatestVersion(siblingName, options.cwd, pnpmRunner);
 
       if (latest === undefined) {

--- a/.gaia/cli/src/update/merge.ts
+++ b/.gaia/cli/src/update/merge.ts
@@ -271,7 +271,7 @@ const handleManifestPath = (
   if (!currentSnap.exists) {
     if (!baselineSnap.exists) {
       // New file; copy latest into the working tree.
-      writeWorkingTree(ctx, relativePath, latestSnap.bytes as Buffer);
+      writeWorkingTree(ctx, relativePath, latestSnap.bytes);
 
       return {kind: 'add'};
     }
@@ -285,7 +285,7 @@ const handleManifestPath = (
     if (bytesEqual(currentSnap.bytes, latestSnap.bytes)) {
       return {kind: 'skip'};
     }
-    writeWorkingTree(ctx, relativePath, latestSnap.bytes as Buffer);
+    writeWorkingTree(ctx, relativePath, latestSnap.bytes);
 
     return {kind: 'overwrite'};
   }
@@ -311,14 +311,9 @@ const handleManifestPath = (
   }
 
   if (klass === 'shared') {
-    if (
-      baselineSnap.bytes === null ||
-      currentSnap.bytes === null ||
-      latestSnap.bytes === null
-    ) {
-      // Defensive: bytesEqual already handled the null-cases above. If
-      // we reach here with a null buffer something is wrong with the
-      // input snapshots — fall back to a conflict patch.
+    if (baselineSnap.bytes === null) {
+      // No baseline to three-way merge against (the file is new since the
+      // adopter's baseline) — fall back to a conflict patch.
       const patch = unifiedDiff(currentSnap.bytes, latestSnap.bytes, {
         fromLabel: relativePath,
         toLabel: relativePath,
@@ -348,7 +343,7 @@ const handleManifestPath = (
   }
 
   // `upstream` class — collapse to overwrite-on-difference.
-  writeWorkingTree(ctx, relativePath, latestSnap.bytes as Buffer);
+  writeWorkingTree(ctx, relativePath, latestSnap.bytes);
 
   return {kind: 'overwrite'};
 };
@@ -409,7 +404,7 @@ const computeReport = (ctx: Context): UpdateMergeReport => {
     const latestSnap = snapshot(path.join(ctx.latestDir, relativePath));
 
     if (!latestSnap.exists) continue;
-    writeWorkingTree(ctx, relativePath, latestSnap.bytes as Buffer);
+    writeWorkingTree(ctx, relativePath, latestSnap.bytes);
     add.push(relativePath);
   }
 

--- a/.gaia/cli/src/update/util/three-way.ts
+++ b/.gaia/cli/src/update/util/three-way.ts
@@ -23,13 +23,13 @@ import {
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 
-export type FileSnapshot = {
-  /** Absolute path in the working tree / baseline / latest. May not exist. */
-  absPath: string;
-  exists: boolean;
-  /** Raw bytes when present. `null` when missing. */
-  bytes: Buffer | null;
-};
+/**
+ * Discriminated on `exists` so a passed `exists` check narrows `bytes` to a
+ * non-null `Buffer` without a cast.
+ */
+export type FileSnapshot =
+  | {absPath: string; bytes: Buffer; exists: true}
+  | {absPath: string; bytes: null; exists: false};
 
 export const snapshot = (absPath: string): FileSnapshot => {
   if (!existsSync(absPath)) {

--- a/.gaia/cli/src/wiki/sync-land.test.ts
+++ b/.gaia/cli/src/wiki/sync-land.test.ts
@@ -347,6 +347,16 @@ describe('wiki sync land', () => {
       args: ['branch', '-D', 'wiki-sync/2026-05-07-ddddddd'],
       command: 'git',
     });
+    // The staged `wiki` index is reset before switching branches, so the
+    // failed commit does not carry a dirty index onto the original branch.
+    const resetIndex = gitCalls.findIndex(
+      (c) => c.args.join(' ') === 'reset HEAD -- wiki'
+    );
+    const checkoutIndex = gitCalls.findIndex(
+      (c) => c.args.join(' ') === 'checkout main'
+    );
+    expect(resetIndex).toBeGreaterThanOrEqual(0);
+    expect(resetIndex).toBeLessThan(checkoutIndex);
     // No push / gh once the local sequence failed.
     expect(recorded.find((c) => c.args[0] === 'push')).toBeUndefined();
     expect(recorded.filter((c) => c.command === 'gh')).toHaveLength(0);

--- a/.gaia/cli/src/wiki/sync-land.test.ts
+++ b/.gaia/cli/src/wiki/sync-land.test.ts
@@ -304,6 +304,54 @@ describe('wiki sync land', () => {
     expect(ghCalls).toHaveLength(0);
   });
 
+  test('protected-branch flow rolls back local steps when commit fails', () => {
+    sandbox = setupSandbox();
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {
+          argv: ['status', '--porcelain=v1', '-uall'],
+          result: okResult(' M wiki/log.md\n'),
+        },
+        {
+          argv: ['rev-parse', 'HEAD'],
+          result: okResult('dddddddddddddddddddddddddddddddddddddddd\n'),
+        },
+        {
+          argv: ['commit', '-m', 'wiki: sync through ddddddd'],
+          result: failResult(1, 'nothing to commit'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run(['--branch-aware'], {
+      cwd: sandbox.root,
+      runner,
+      today: '2026-05-07',
+    });
+    expect(exit).toBe(2);
+
+    // After the commit failure the handler returns to the original branch
+    // and deletes the half-created sync branch.
+    const gitCalls = recorded.filter((c) => c.command === 'git');
+    expect(gitCalls).toContainEqual({
+      args: ['checkout', 'main'],
+      command: 'git',
+    });
+    expect(gitCalls).toContainEqual({
+      args: ['branch', '-D', 'wiki-sync/2026-05-07-ddddddd'],
+      command: 'git',
+    });
+    // No push / gh once the local sequence failed.
+    expect(recorded.find((c) => c.args[0] === 'push')).toBeUndefined();
+    expect(recorded.filter((c) => c.command === 'gh')).toHaveLength(0);
+  });
+
   test('working tree with non-wiki changes — exit 1', () => {
     sandbox = setupSandbox();
     const recorded: RecordedCall[] = [];

--- a/.gaia/cli/src/wiki/sync-land.ts
+++ b/.gaia/cli/src/wiki/sync-land.ts
@@ -183,6 +183,13 @@ const rollbackLocalLanding = (
 ): void => {
   if (!onSyncBranch) return;
 
+  // Unstage `wiki` before switching branches so a failed commit does not
+  // carry a dirty index back to the original branch on checkout.
+  runStep(
+    ctx.runner,
+    {args: ['reset', 'HEAD', '--', 'wiki'], command: 'git'},
+    ctx.cwd
+  );
   runStep(
     ctx.runner,
     {args: ['checkout', ctx.originalBranch], command: 'git'},

--- a/.gaia/cli/src/wiki/sync-land.ts
+++ b/.gaia/cli/src/wiki/sync-land.ts
@@ -122,6 +122,7 @@ const stepSucceeded = (result: SpawnSyncReturns<string>): boolean =>
 
 type LandingContext = {
   cwd: string;
+  originalBranch: string;
   runner: CommandRunner;
   shortHead: string;
 };
@@ -133,10 +134,25 @@ const inPlaceLanding = (ctx: LandingContext): number => {
     {args: ['commit', '-m', message], command: 'git'},
   ];
 
+  let staged = false;
+
   for (const step of sequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
 
-    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+    if (!stepSucceeded(result)) {
+      if (staged) {
+        // Unstage `wiki` so a failed commit leaves a clean index behind.
+        runStep(
+          ctx.runner,
+          {args: ['reset', 'HEAD', '--', 'wiki'], command: 'git'},
+          ctx.cwd
+        );
+      }
+
+      return passthroughFailure(result, step);
+    }
+
+    if (step.args[0] === 'add') staged = true;
   }
 
   process.stdout.write(
@@ -154,6 +170,31 @@ const todayUtc = (now: Date = new Date()): string => {
   return `${year}-${month}-${day}`;
 };
 
+/**
+ * Best-effort rollback of the local-only landing steps: return to the
+ * original branch and delete the half-created sync branch. Remote state is
+ * never auto-reverted. The rollback git calls are themselves best-effort —
+ * a failure here is not surfaced over the original step failure.
+ */
+const rollbackLocalLanding = (
+  ctx: LandingContext,
+  branchName: string,
+  onSyncBranch: boolean
+): void => {
+  if (!onSyncBranch) return;
+
+  runStep(
+    ctx.runner,
+    {args: ['checkout', ctx.originalBranch], command: 'git'},
+    ctx.cwd
+  );
+  runStep(
+    ctx.runner,
+    {args: ['branch', '-D', branchName], command: 'git'},
+    ctx.cwd
+  );
+};
+
 const protectedBranchLanding = (
   ctx: LandingContext,
   options: {today: string}
@@ -162,16 +203,36 @@ const protectedBranchLanding = (
   const message = `wiki: sync through ${ctx.shortHead}`;
   const prTitle = message;
   const prBody = `Automated wiki sync landed via \`gaia wiki sync land --branch-aware\`. State advanced to ${ctx.shortHead}.`;
-  const sequence: RunStep[] = [
+
+  // Steps through the local commit are reversible; once `push` succeeds the
+  // branch (and possibly a PR) exists on the remote and is left for the
+  // maintainer to resolve rather than force-reverted.
+  const localSequence: RunStep[] = [
     {args: ['checkout', '-b', branchName], command: 'git'},
     {args: ['add', 'wiki'], command: 'git'},
     {args: ['commit', '-m', message], command: 'git'},
+  ];
+  const remoteSequence: RunStep[] = [
     {args: ['push', '-u', 'origin', branchName], command: 'git'},
     {args: ['pr', 'create', '--title', prTitle, '--body', prBody], command: 'gh'},
     {args: ['pr', 'merge', '--squash', '--auto'], command: 'gh'},
   ];
 
-  for (const step of sequence) {
+  let onSyncBranch = false;
+
+  for (const step of localSequence) {
+    const result = runStep(ctx.runner, step, ctx.cwd);
+
+    if (!stepSucceeded(result)) {
+      rollbackLocalLanding(ctx, branchName, onSyncBranch);
+
+      return passthroughFailure(result, step);
+    }
+
+    if (step.args[0] === 'checkout') onSyncBranch = true;
+  }
+
+  for (const step of remoteSequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
 
     if (!stepSucceeded(result)) return passthroughFailure(result, step);
@@ -275,6 +336,7 @@ export const run = (
 
   const ctx: LandingContext = {
     cwd: repoRoot,
+    originalBranch: branch,
     runner,
     shortHead,
   };

--- a/.gaia/cli/src/wiki/util/git.ts
+++ b/.gaia/cli/src/wiki/util/git.ts
@@ -16,6 +16,9 @@ const runGit = (args: readonly string[], options: RunOptions = {}): string => {
   const result = execFileSync('git', args, {
     cwd,
     encoding: 'utf8',
+    // `git log` over a large history easily exceeds the 1 MiB default and
+    // throws ENOBUFS; 64 MiB covers any realistic sync window.
+    maxBuffer: 64 * 1024 * 1024,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 


### PR DESCRIPTION
## Summary
- **`wiki/util/git.ts`** — `execFileSync` had no `maxBuffer`; a large `git log` history exceeds the 1 MiB default and throws ENOBUFS. Now 64 MiB.
- **`update/util/three-way.ts` + `update/merge.ts`** — `FileSnapshot` is now a discriminated union on `exists`, so a passed `exists` check narrows `bytes` to a non-null `Buffer`. Removes four unsound `as Buffer` casts and a provably-dead null guard.
- **`update-deps/run.ts`** — a `pnpm outdated` exit status outside `{0,1}` (including the `null` of a failed spawn) now throws, instead of parsing empty stdout and masquerading as "nothing outdated". Companion-group siblings now read their installed version from `node_modules` rather than `stripRange(spec)`, which returns garbage for `workspace:*` / tag / url specs (falls back to the spec floor only when not installed).
- **`wiki/sync-land.ts`** — the protected-branch landing rolls back its local-only steps (return to the original branch, delete the half-created sync branch) on a pre-push failure; the in-place landing unstages `wiki` on a failed commit. Once `push` has succeeded, remote state is left for the maintainer rather than force-reverted.

**Verified not a bug** — `state-bump.ts` `tryParseJson` coercing `"true"`/`"123"` matches its documented contract ("parsed as JSON when it parses (numbers, booleans, null, …)"). Skipped.

**Deferred SUGGEST** — help-on-stdout/exit-code polish and `diff-size.ts` subprocess count are style-tier and left out of this correctness PR.

## Test plan
- [x] New tests: sync-land rollback on commit failure; update-deps reads sibling version from node_modules
- [x] CLI gate: `pnpm -C .gaia/cli typecheck` + full vitest suite (1120 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)