### PR TITLE
fix(cli-setup): correctness gaps in setup-ci/ci/setup

### DIFF
--- a/.gaia/cli/src/ci/__tests__/revert.test.ts
+++ b/.gaia/cli/src/ci/__tests__/revert.test.ts
@@ -152,19 +152,22 @@ describe('ci-revert', () => {
         status: 'open',
       });
 
-      // Verify all five external commands were called in order.
+      // Verify the external commands were called in order. A
+      // `symbolic-ref` probe runs between fetch and checkout to capture
+      // the rollback target.
       const ghArgsList = ghSpy.mock.calls.map((call: [readonly string[], unknown?]) => call[0]);
       const gitArgsList = gitSpy.mock.calls.map((call: [readonly string[], unknown?]) => call[0]);
 
       expect(ghArgsList[0]?.slice(0, 3)).toEqual(['pr', 'view', '99']);
       expect(gitArgsList[0]).toEqual(['fetch', 'origin', 'main']);
-      expect(gitArgsList[1]?.[0]).toBe('checkout');
-      expect(gitArgsList[2]?.slice(0, 3)).toEqual([
+      expect(gitArgsList[1]?.[0]).toBe('symbolic-ref');
+      expect(gitArgsList[2]?.[0]).toBe('checkout');
+      expect(gitArgsList[3]?.slice(0, 3)).toEqual([
         'revert',
         '--no-edit',
         '0123456789abcdef0123456789abcdef01234567',
       ]);
-      expect(gitArgsList[3]).toEqual([
+      expect(gitArgsList[4]).toEqual([
         'push',
         '-u',
         'origin',
@@ -277,6 +280,66 @@ describe('ci-revert', () => {
       const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
       expect(printed.error).toBe('revert_failed');
       expect(printed.step).toBe('git_revert');
+    });
+
+    it('rolls back the local branch when git push fails', () => {
+      const impl: RunFn = (args) => {
+        if (args[0] === 'symbolic-ref') {
+          return {exitCode: 0, stderr: '', stdout: 'main\n'};
+        }
+
+        if (args[0] === 'push') {
+          return {exitCode: 1, stderr: 'remote rejected', stdout: ''};
+        }
+
+        return {exitCode: 0, stderr: '', stdout: ''};
+      };
+      gitSpy.mockImplementation(impl);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('revert_failed');
+      expect(printed.step).toBe('git_push');
+
+      // Rollback: checkout back to the prior branch and delete the
+      // revert branch must both have run after the failed push.
+      const gitArgsList = gitSpy.mock.calls.map(
+        (call: [readonly string[], unknown?]) => call[0]
+      );
+      const checkoutBack = gitArgsList.find(
+        (a: readonly string[]) =>
+          a[0] === 'checkout' && a[1] === '--force' && a[2] === 'main'
+      );
+      const deleteBranch = gitArgsList.find(
+        (a: readonly string[]) => a[0] === 'branch' && a[1] === '-D'
+      );
+      expect(checkoutBack).toBeDefined();
+      expect(deleteBranch).toBeDefined();
+
+      // The ledger must not be written on a failed push.
+      expect(() => readFileSync(sandbox.ledgerPath, 'utf8')).toThrow();
+    });
+
+    it('refuses when the ledger lock is already held', () => {
+      mkdirSync(`${sandbox.ledgerPath}.lock`, {recursive: true});
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
+
+      // Hard cap: zero gh / git invocations while a revert is in flight.
+      expect(ghSpy.mock.calls.length).toBe(0);
+      expect(gitSpy.mock.calls.length).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('revert_lock_held');
     });
 
     it('parses the new PR number even with a banner line in stdout', () => {

--- a/.gaia/cli/src/ci/revert.ts
+++ b/.gaia/cli/src/ci/revert.ts
@@ -13,6 +13,7 @@ import {EXIT_CODES} from '../exit.js';
 import {
   emptyRevertLedger,
   readRevertLedger,
+  withRevertLedgerLock,
   writeRevertLedger,
   type RevertLedger,
 } from '../schemas/revert-ledger.js';
@@ -263,6 +264,43 @@ const handleOpen = (
 
   if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 
+  // Serialize the ledger read-check-write so the "one revert per PR"
+  // hard cap is not defeated by two concurrent `ci-revert open` runs
+  // both passing the existence check before either writes.
+  const locked = withRevertLedgerLock(repoRoot, () =>
+    handleOpenLocked({json, label, options, pr, reason, repoRoot})
+  );
+
+  if (!locked.locked) {
+    const payload = {error: 'revert_lock_held'};
+    structuredError({
+      code: 'revert_lock_held',
+      message: 'another ci-revert open is in progress for this repository',
+      subcommand: 'ci-revert open',
+    });
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify(payload)}\n`);
+    }
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  return locked.value;
+};
+
+type HandleOpenLockedArgs = {
+  json: boolean;
+  label: string;
+  options: RunOptions;
+  pr: number;
+  reason: string | undefined;
+  repoRoot: string;
+};
+
+const handleOpenLocked = (args: HandleOpenLockedArgs): number => {
+  const {json, label, options, pr, reason, repoRoot} = args;
+
   const ledger = ensureLedger(repoRoot, 'open', json);
 
   if (ledger === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
@@ -372,6 +410,16 @@ const handleOpen = (
     return surfaceRevertFailure('git_fetch', fetchResult, json);
   }
 
+  // Capture the branch the repo was on before we create the revert
+  // branch, so a later failure can restore it. An empty result (detached
+  // HEAD) is fine — the rollback simply skips the checkout-back step.
+  const priorBranchResult = runGit(
+    ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+    {cwd: repoRoot}
+  );
+  const priorBranch =
+    priorBranchResult.exitCode === 0 ? priorBranchResult.stdout.trim() : '';
+
   const checkoutResult = runGit(
     ['checkout', '-b', revertBranch, `origin/${baseRefName}`],
     {cwd: repoRoot}
@@ -381,13 +429,25 @@ const handleOpen = (
     return surfaceRevertFailure('git_checkout', checkoutResult, json);
   }
 
+  // Restore the repo to its pre-revert state: leave the revert branch
+  // and delete it. Best-effort — every step is non-fatal because the
+  // surfaced failure is the one that matters.
+  const rollbackRevertBranch = (): void => {
+    if (priorBranch !== '') {
+      runGit(['checkout', '--force', priorBranch], {cwd: repoRoot});
+    } else {
+      runGit(['checkout', '--force', `origin/${baseRefName}`], {cwd: repoRoot});
+    }
+    runGit(['branch', '-D', revertBranch], {cwd: repoRoot});
+  };
+
   const revertResult = runGit(['revert', '--no-edit', mergeSha], {cwd: repoRoot});
 
   if (revertResult.exitCode !== 0) {
-    // Best-effort cleanup so the working tree isn't left in a half-reverted
-    // state on the runner. Failure of --abort is non-fatal — the runner is
-    // ephemeral.
+    // Abort the in-progress revert, then unwind the branch we created so
+    // the repo is left exactly as we found it.
     runGit(['revert', '--abort'], {cwd: repoRoot});
+    rollbackRevertBranch();
 
     return surfaceRevertFailure('git_revert', revertResult, json);
   }
@@ -395,6 +455,11 @@ const handleOpen = (
   const pushResult = runGit(['push', '-u', 'origin', revertBranch], {cwd: repoRoot});
 
   if (pushResult.exitCode !== 0) {
+    // The local branch carries a committed revert; a failed push leaves
+    // a non-atomic mutation behind. Roll the local repo back to its
+    // prior state so a retry starts clean.
+    rollbackRevertBranch();
+
     return surfaceRevertFailure('git_push', pushResult, json);
   }
 

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -10,7 +10,14 @@
  * consults `attempts[<original_pr>]` before doing any git/`gh` work and
  * refuses to re-open if an entry already exists.
  */
-import {existsSync, mkdirSync, readFileSync, renameSync, writeFileSync} from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import {z} from 'zod';
 import {revertLedgerPath} from '../ci/paths.js';
@@ -99,4 +106,41 @@ export const writeRevertLedger = (
   const tmpPath = `${target}.tmp`;
   writeFileSync(tmpPath, serialized, 'utf8');
   renameSync(tmpPath, target);
+};
+
+/**
+ * Acquire an advisory lock around a ledger read-modify-write.
+ *
+ * The "one revert per PR" hard cap is a check-then-act on a shared file:
+ * `ci-revert open` reads the ledger, confirms no entry exists, then does
+ * several slow `git`/`gh` calls before writing the entry back. Two
+ * concurrent invocations can both pass the check and both open a revert
+ * PR. `mkdir` is atomic on POSIX, so it serves as the lock primitive —
+ * exactly one caller wins the directory create.
+ *
+ * Returns `true` and runs `critical` under the lock, or returns `false`
+ * without running it when the lock is already held (a concurrent revert
+ * is in flight — refuse rather than race).
+ */
+export const withRevertLedgerLock = <T>(
+  repoRoot: string,
+  critical: () => T
+): {locked: false} | {locked: true; value: T} => {
+  const target = revertLedgerPath(repoRoot);
+  mkdirSync(path.dirname(target), {recursive: true});
+  const lockDir = `${target}.lock`;
+
+  try {
+    // `recursive: false` is the default — fails with EEXIST if the lock
+    // directory already exists, which is the contended path.
+    mkdirSync(lockDir);
+  } catch {
+    return {locked: false};
+  }
+
+  try {
+    return {locked: true, value: critical()};
+  } finally {
+    rmSync(lockDir, {force: true, recursive: true});
+  }
 };

--- a/.gaia/cli/src/setup-ci/__tests__/verify-run.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/verify-run.test.ts
@@ -57,6 +57,11 @@ const runListPayload = JSON.stringify([
   {createdAt: '2026-05-09T05:00:00.000Z', databaseId: 12_345},
 ]);
 
+// Step 0 of every run resolves the default branch via `gh repo view`.
+const repoViewPayload = JSON.stringify({
+  defaultBranchRef: {name: 'main'},
+});
+
 describe('setup-ci verify-run', () => {
   let sandbox: Sandbox;
   let stdio: ReturnType<typeof captureStdio>;
@@ -76,9 +81,9 @@ describe('setup-ci verify-run', () => {
   });
 
   it('returns verified: true on completed/success', async () => {
-    // Sequence: workflow run, run list, run view (completed success).
+    // Sequence: repo view, workflow run, run list, run view (success).
     const handle = sandbox.installGhShim({
-      stdoutQueue: ['', runListPayload, completedSuccess],
+      stdoutQueue: [repoViewPayload, '', runListPayload, completedSuccess],
     });
     restore = handle.restore;
 
@@ -96,7 +101,7 @@ describe('setup-ci verify-run', () => {
 
   it('returns verified: false on completed/failure', async () => {
     const handle = sandbox.installGhShim({
-      stdoutQueue: ['', runListPayload, completedFailure],
+      stdoutQueue: [repoViewPayload, '', runListPayload, completedFailure],
     });
     restore = handle.restore;
 
@@ -112,9 +117,17 @@ describe('setup-ci verify-run', () => {
   });
 
   it('polls until completed when status starts in_progress', async () => {
-    // 5 calls: workflow run, run list, view in_progress, view in_progress, view completed.
+    // 6 calls: repo view, workflow run, run list, view in_progress,
+    // view in_progress, view completed.
     const handle = sandbox.installGhShim({
-      stdoutQueue: ['', runListPayload, inProgress, inProgress, completedSuccess],
+      stdoutQueue: [
+        repoViewPayload,
+        '',
+        runListPayload,
+        inProgress,
+        inProgress,
+        completedSuccess,
+      ],
     });
     restore = handle.restore;
 
@@ -145,7 +158,7 @@ describe('setup-ci verify-run', () => {
   it('returns conclusion: polling_timeout on hard timeout', async () => {
     // Endless in_progress responses -> the handler should hit the
     // timeout and emit polling_timeout.
-    const queue: string[] = ['', runListPayload];
+    const queue: string[] = [repoViewPayload, '', runListPayload];
 
     for (let i = 0; i < 50; i += 1) queue.push(inProgress);
 
@@ -171,7 +184,11 @@ describe('setup-ci verify-run', () => {
   });
 
   it('exits non-zero when gh workflow run fails', async () => {
-    const handle = sandbox.installGhShim({exitCode: 1});
+    // Step 0 (repo view) succeeds; step 1 (workflow run) fails.
+    const handle = sandbox.installGhShim({
+      exitCodeQueue: [0, 1],
+      stdoutQueue: [repoViewPayload, ''],
+    });
     restore = handle.restore;
 
     const exit = await run(
@@ -182,9 +199,46 @@ describe('setup-ci verify-run', () => {
     expect(stdio.err.join('')).toContain('workflow_run_failed');
   });
 
+  it('exits non-zero when gh repo view fails', async () => {
+    const handle = sandbox.installGhShim({exitCode: 1});
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('default_branch_lookup_failed');
+  });
+
+  it('dispatches against a non-main default branch', async () => {
+    const handle = sandbox.installGhShim({
+      stdoutQueue: [
+        JSON.stringify({defaultBranchRef: {name: 'trunk'}}),
+        '',
+        runListPayload,
+        completedSuccess,
+      ],
+    });
+    restore = handle.restore;
+
+    const exit = await run(
+      ['.github/workflows/gaia-ci-wiki.yml', '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+
+    const recorded = JSON.parse(readFileSync(sandbox.ghArgvPath, 'utf8')) as string[][];
+    const dispatch = recorded.find(
+      (args) => args[0] === 'workflow' && args[1] === 'run'
+    );
+    expect(dispatch).toContain('--ref');
+    expect(dispatch?.[dispatch.indexOf('--ref') + 1]).toBe('trunk');
+  });
+
   it('exits non-zero when gh run list returns no runs', async () => {
     const handle = sandbox.installGhShim({
-      stdoutQueue: ['', '[]'],
+      stdoutQueue: [repoViewPayload, '', '[]'],
     });
     restore = handle.restore;
 
@@ -194,6 +248,15 @@ describe('setup-ci verify-run', () => {
     );
     expect(exit).not.toBe(0);
     expect(stdio.err.join('')).toContain('run_list_empty');
+  });
+
+  it('rejects --timeout-seconds with trailing garbage', async () => {
+    const exit = await run(
+      ['.github/workflows/foo.yml', '--timeout-seconds', '30abc'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('invalid_arguments');
   });
 
   it('exits non-zero when --timeout-seconds is invalid', async () => {

--- a/.gaia/cli/src/setup-ci/util/__tests__/gh.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/gh.test.ts
@@ -1,4 +1,5 @@
-import {readFileSync} from 'node:fs';
+import {chmodSync, readFileSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {setupSandbox, type Sandbox} from '../../__tests__/sandbox.js';
 import {runGh} from '../gh.js';
@@ -70,5 +71,33 @@ describe('runGh wrapper', () => {
     if (!result.ok) {
       expect(result.exitCode).toBe(7);
     }
+  });
+
+  it('does not crash on EPIPE when the child closes stdin early', async () => {
+    // Install a shim that exits immediately WITHOUT draining stdin, so a
+    // large payload fills the pipe buffer and the wrapper's write/end
+    // hits EPIPE. Without an `error` handler this would be an unhandled
+    // stream error that aborts the process.
+    const handle = sandbox.installGhShim({exitCode: 0});
+    restore = handle.restore;
+
+    const shimPath = path.join(sandbox.binDir, 'gh');
+    writeFileSync(
+      shimPath,
+      '#!/usr/bin/env node\n'
+        + '// Exit at once; never read stdin.\n'
+        + 'process.exit(0);\n',
+      'utf8'
+    );
+    chmodSync(shimPath, 0o755);
+
+    // Payload larger than a typical 64KiB pipe buffer.
+    const result = await runGh({
+      args: ['secret', 'set', 'NAME'],
+      stdin: 'x'.repeat(256 * 1024),
+    });
+
+    // The wrapper must resolve (via the child's `close`) rather than throw.
+    expect(result.ok).toBe(true);
   });
 });

--- a/.gaia/cli/src/setup-ci/util/gh.ts
+++ b/.gaia/cli/src/setup-ci/util/gh.ts
@@ -87,9 +87,21 @@ export const runGh = (options: GhOptions): Promise<GhResult> => {
       settle({exitCode, ok: false, stderr: stderrBuf});
     });
 
+    // A child that exits before draining stdin leaves the pipe closed;
+    // a subsequent write/end then emits EPIPE on the stream. Without an
+    // `error` listener that EPIPE becomes an unhandled stream error and
+    // crashes the process. The child's exit is already captured by the
+    // `close` handler above, so a broken stdin pipe is benign here.
+    child.stdin.on('error', () => {
+      // Intentionally swallowed — `close` carries the real outcome.
+    });
+
     if (options.stdin !== undefined) {
-      child.stdin.write(options.stdin);
+      // `end(payload)` writes then closes in one call; respecting
+      // backpressure is unnecessary because we are done after this.
+      child.stdin.end(options.stdin);
+    } else {
+      child.stdin.end();
     }
-    child.stdin.end();
   });
 };

--- a/.gaia/cli/src/setup-ci/verify-run.ts
+++ b/.gaia/cli/src/setup-ci/verify-run.ts
@@ -1,9 +1,11 @@
 /**
  * `gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]` handler.
  *
- * Triggers a `workflow_dispatch` run via `gh workflow run <file> --ref main`,
- * captures the run id, and polls `gh run view <id>` until the run
- * completes or the timeout fires.
+ * Triggers a `workflow_dispatch` run via `gh workflow run <file> --ref
+ * <default-branch>`, captures the run id, and polls `gh run view <id>`
+ * until the run completes or the timeout fires. The dispatch ref is
+ * resolved from `gh repo view` so the command works in repositories
+ * whose default branch is not `main`.
  *
  * Output JSON:
  *
@@ -59,6 +61,36 @@ type RunListEntry = {createdAt?: string; databaseId: number | string};
 
 type RunViewPayload = {conclusion?: null | string; status?: string; url?: string};
 
+/**
+ * Parse a strictly-decimal positive integer. Unlike `Number.parseInt`,
+ * this rejects trailing garbage (`"30abc"`), leading signs, and empty
+ * strings — returns `null` for anything that is not all digits.
+ */
+const parsePositiveInt = (value: string): number | null => {
+  if (!/^\d+$/u.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+
+  return parsed > 0 ? parsed : null;
+};
+
+/**
+ * Extract `defaultBranchRef.name` from `gh repo view --json
+ * defaultBranchRef` stdout. Returns `null` if the payload is malformed
+ * or the field is absent.
+ */
+export const parseDefaultBranch = (stdout: string): null | string => {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      defaultBranchRef?: {name?: unknown} | null;
+    };
+    const name = parsed.defaultBranchRef?.name;
+
+    return typeof name === 'string' && name.length > 0 ? name : null;
+  } catch {
+    return null;
+  }
+};
+
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -79,8 +111,8 @@ export const run = async (
 ): Promise<number> => {
   let json = false;
   let workflowFile: string | undefined;
-  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
-  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  let timeoutSeconds: number | null = DEFAULT_TIMEOUT_SECONDS;
+  let pollIntervalMs: number | null = DEFAULT_POLL_INTERVAL_MS;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index] as string;
@@ -109,7 +141,7 @@ export const run = async (
 
         return EXIT_CODES.UNKNOWN_SUBCOMMAND;
       }
-      timeoutSeconds = Number.parseInt(value, 10);
+      timeoutSeconds = parsePositiveInt(value);
       index += 1;
 
       continue;
@@ -127,7 +159,7 @@ export const run = async (
 
         return EXIT_CODES.UNKNOWN_SUBCOMMAND;
       }
-      pollIntervalMs = Number.parseInt(value, 10);
+      pollIntervalMs = parsePositiveInt(value);
       index += 1;
 
       continue;
@@ -168,7 +200,7 @@ export const run = async (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  if (Number.isNaN(timeoutSeconds) || timeoutSeconds <= 0) {
+  if (timeoutSeconds === null) {
     structuredError({
       code: 'invalid_arguments',
       message: '--timeout-seconds must be a positive integer',
@@ -178,7 +210,7 @@ export const run = async (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  if (Number.isNaN(pollIntervalMs) || pollIntervalMs <= 0) {
+  if (pollIntervalMs === null) {
     structuredError({
       code: 'invalid_arguments',
       message: '--poll-interval-ms must be a positive integer',
@@ -190,6 +222,35 @@ export const run = async (
 
   const cwd = options.cwd ?? process.cwd();
 
+  // Step 0: resolve the repository's default branch. Hardcoding `main`
+  // breaks repos whose default branch differs (e.g. `master`, `trunk`).
+  const repoViewResult = await runGh({
+    args: ['repo', 'view', '--json', 'defaultBranchRef'],
+    cwd,
+  });
+
+  if (!repoViewResult.ok) {
+    structuredError({
+      code: 'default_branch_lookup_failed',
+      message: repoViewResult.stderr.trim(),
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const defaultBranch = parseDefaultBranch(repoViewResult.stdout);
+
+  if (defaultBranch === null) {
+    structuredError({
+      code: 'default_branch_lookup_failed',
+      message: 'could not resolve defaultBranchRef from gh repo view output',
+      subcommand: 'setup-ci verify-run',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
   // Captured before step 1 so the race-window guard below can compare
   // the picked run's `createdAt` against the moment we asked GH to
   // start one. Any run created earlier than this minus a small fudge
@@ -199,7 +260,7 @@ export const run = async (
 
   // Step 1: trigger the run.
   const triggerResult = await runGh({
-    args: ['workflow', 'run', workflowFile, '--ref', 'main'],
+    args: ['workflow', 'run', workflowFile, '--ref', defaultBranch],
     cwd,
   });
 

--- a/.gaia/cli/src/setup/__tests__/setup.test.ts
+++ b/.gaia/cli/src/setup/__tests__/setup.test.ts
@@ -274,6 +274,12 @@ describe('state file robustness', () => {
     vi.restoreAllMocks();
   });
 
+  const writeStateJson = (value: unknown): void => {
+    const stateDirectory = path.dirname(sandbox.statePath);
+    execFileSync('mkdir', ['-p', stateDirectory]);
+    writeFileSync(sandbox.statePath, JSON.stringify(value), 'utf8');
+  };
+
   test('rejects malformed state file', () => {
     const stateDirectory = path.dirname(sandbox.statePath);
     execFileSync('mkdir', ['-p', stateDirectory]);
@@ -282,5 +288,31 @@ describe('state file robustness', () => {
     const exit = runStatus(['--json'], {cwd: sandbox.root});
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('state_malformed');
+  });
+
+  test('surfaces an unrecognized completed step instead of dropping it', () => {
+    writeStateJson({
+      completed_at: null,
+      completed_steps: ['install-tools', 'not-a-real-step'],
+      started_at: '2026-05-07T11:00:00.000Z',
+      version: 1,
+    });
+
+    const exit = runStatus(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('state_malformed');
+    expect(stdio.errors.join('')).toContain('not-a-real-step');
+  });
+
+  test('rejects a state file with a missing started_at', () => {
+    writeStateJson({
+      completed_at: null,
+      completed_steps: ['install-tools'],
+      version: 1,
+    });
+
+    const exit = runStatus(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('started_at');
   });
 });

--- a/.gaia/cli/src/setup/util/state-file.ts
+++ b/.gaia/cli/src/setup/util/state-file.ts
@@ -106,10 +106,29 @@ export const readStateFile = (repoRoot: string): SetupState | null => {
     );
   }
 
+  const rawSteps = parsed.completed_steps ?? [];
+  const unknownSteps = rawSteps.filter((step) => !isSetupStep(step));
+
+  if (unknownSteps.length > 0) {
+    // An unrecognized step is corruption (or a downgrade from a newer
+    // GAIA release). Silently dropping it would let `finalize` pass a
+    // gate it should not. Surface it instead.
+    throw new Error(
+      `setup-state.json has unrecognized completed_steps: `
+        + `${unknownSteps.join(', ')}`
+    );
+  }
+
+  if (typeof parsed.started_at !== 'string') {
+    // `started_at` is stamped on first write; a missing/non-string value
+    // means a corrupt file. A read helper must not fabricate it.
+    throw new Error('setup-state.json is missing a valid started_at');
+  }
+
   return {
     completed_at: parsed.completed_at ?? null,
-    completed_steps: (parsed.completed_steps ?? []).filter(isSetupStep),
-    started_at: parsed.started_at ?? new Date().toISOString(),
+    completed_steps: rawSteps.filter(isSetupStep),
+    started_at: parsed.started_at,
     version: 1,
   };
 };

--- a/.gaia/cli/test-fixtures/ci-shape/revert-flow.test.ts
+++ b/.gaia/cli/test-fixtures/ci-shape/revert-flow.test.ts
@@ -88,15 +88,17 @@ describe('UAT-009 — auto-revert on post-merge failure', () => {
       status: 'open',
     });
 
-    // Verify the call sequence: gh pr view → git fetch/checkout/revert/push
-    // → gh pr create → gh pr merge --auto.
+    // Verify the call sequence: gh pr view → git fetch → symbolic-ref
+    // (rollback-target probe) → checkout/revert/push → gh pr create →
+    // gh pr merge --auto.
     expect(mock.ghCalls.length).toBe(3);
-    expect(mock.gitCalls.length).toBe(4);
+    expect(mock.gitCalls.length).toBe(5);
     expect(mock.ghCalls[0]?.argv.slice(0, 3)).toEqual(['pr', 'view', '99']);
     expect(mock.gitCalls[0]?.argv).toEqual(['fetch', 'origin', 'main']);
-    expect(mock.gitCalls[1]?.argv[0]).toBe('checkout');
-    expect(mock.gitCalls[2]?.argv).toEqual(['revert', '--no-edit', MERGE_SHA]);
-    expect(mock.gitCalls[3]?.argv).toEqual([
+    expect(mock.gitCalls[1]?.argv[0]).toBe('symbolic-ref');
+    expect(mock.gitCalls[2]?.argv[0]).toBe('checkout');
+    expect(mock.gitCalls[3]?.argv).toEqual(['revert', '--no-edit', MERGE_SHA]);
+    expect(mock.gitCalls[4]?.argv).toEqual([
       'push',
       '-u',
       'origin',


### PR DESCRIPTION
## Summary

Remediates pre-release audit findings in the maintainer CLI (`@gaia-react/cli`, `.gaia/cli/`). Each finding was verified against the live code before fixing.

### Fixed (audit IMPORTANT items)
- **gh.ts EPIPE** — `runGh` wrote to `child.stdin` with no `error` handler; a child that exits before draining stdin closes the pipe and the unhandled EPIPE crashed the process. Added an `error` listener on `child.stdin` and switched to `end(payload)`.
- **revert.ts non-atomic mutation** — a failed `git push` left the runner on a freshly created revert branch with a revert commit and no rollback. Now captures the prior branch (`symbolic-ref`) before checkout and unwinds (checkout-back + `branch -D`) on a failed `push` or `revert`.
- **state-file.ts silent drops** — `readStateFile` did `.filter(isSetupStep)`, silently discarding unrecognized steps, and fabricated `started_at` with `new Date()` when the field was missing. Both now throw a malformed-state error, surfaced by callers as `state_malformed`.
- **revert.ts TOCTOU cap** — the "one revert per PR" hard cap read the ledger, checked, then ran ~6 slow `git`/`gh` calls before writing it back; two concurrent `ci-revert open` runs could both pass the check. Wrapped the ledger read-check-write in an atomic `mkdir` advisory lock (`withRevertLedgerLock`); a contended lock refuses with `revert_lock_held` and does zero external work.
- **verify-run.ts hardcoded `--ref main`** — broke repos whose default branch is not `main`. Added a step-0 `gh repo view --json defaultBranchRef` resolution (`parseDefaultBranch` helper) and dispatch against the resolved branch.

### Fixed (audit SUGGEST items)
- **parseInt trailing garbage** — `verify-run.ts` `--timeout-seconds` / `--poll-interval-ms` accepted `30abc` via `Number.parseInt`. Replaced with a strict `^\d+$` digit check (`parsePositiveInt`).
- **fabricated `started_at`** — covered by the state-file fix above (a read-only helper no longer invents data).

### Skipped (audit SUGGEST items)
- **exit-code reuse** — the same operational-failure exit code is reused for distinct conditions CLI-wide (verify-run, revert, etc.), and `EXIT_CODES` values are documented as parsed by hooks. Renumbering is a cross-cutting contract change, out of scope for a surgical per-finding fix.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — clean
- [x] `pnpm -C .gaia/cli exec vitest run` — 1126 passed / 107 files
- [x] New tests: EPIPE-on-early-close (gh), push-failure rollback + lock-held refusal (revert), unrecognized-step + missing-`started_at` rejection (state-file), non-`main` default-branch dispatch + trailing-garbage rejection + `gh repo view` failure (verify-run)
- [x] Updated call-sequence assertions in `revert.test.ts` and `revert-flow.test.ts` fixture for the new `symbolic-ref` probe and verify-run's step-0 `gh repo view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)