### PR TITLE
fix(cli-telemetry): correctness gaps in automation/telemetry

### DIFF
--- a/.gaia/cli/src/analytics/generator.ts
+++ b/.gaia/cli/src/analytics/generator.ts
@@ -52,6 +52,28 @@ const isoDateUtc = (date: Date): string => {
 };
 
 /**
+ * Recover the repo root from an in-project storage path.
+ *
+ * In-project paths all live under `<repoRoot>/.gaia/...`, so the repo root
+ * is everything before the first `.gaia` segment. Splitting on that marker
+ * is resilient to the path's depth below `.gaia` (unlike stripping a fixed
+ * number of `path.dirname` levels). Falls back to a fixed strip if no
+ * `.gaia` segment is present.
+ */
+const repoRootFromProjectIdPath = (projectIdPath: string): string => {
+  const marker = `${path.sep}.gaia${path.sep}`;
+  const markerIndex = projectIdPath.indexOf(marker);
+
+  if (markerIndex !== -1) {
+    return projectIdPath.slice(0, markerIndex);
+  }
+
+  // `.gaia` segment absent — fall back to stripping the known
+  // `.gaia/local/.project-id` tail (three segments).
+  return path.dirname(path.dirname(path.dirname(projectIdPath)));
+};
+
+/**
  * Read the GAIA package.json `version` field.
  *
  * Resolves relative to `roots.projectIdPath`'s repo root segment so the
@@ -60,11 +82,7 @@ const isoDateUtc = (date: Date): string => {
  * produce a valid report (the version field is a string per schema).
  */
 const readGaiaVersion = (roots: StorageRoots): string => {
-  // roots.projectIdPath is `<repoRoot>/.gaia/local/.project-id`.
-  // Strip 3 segments to get back to repoRoot.
-  const repoRoot = path.dirname(
-    path.dirname(path.dirname(roots.projectIdPath))
-  );
+  const repoRoot = repoRootFromProjectIdPath(roots.projectIdPath);
   const packagePath = path.join(repoRoot, 'package.json');
 
   if (!existsSync(packagePath)) return 'unknown';

--- a/.gaia/cli/src/automation/__tests__/init-state.test.ts
+++ b/.gaia/cli/src/automation/__tests__/init-state.test.ts
@@ -95,4 +95,13 @@ describe('automation init-state', () => {
     ) as Record<string, unknown>;
     expect(parsed.last_run_at).toBe('2026-04-01T00:00:00Z');
   });
+
+  it('rejects a malformed --at and does not write the state file', () => {
+    const exit = run(['wiki', '--sha', sandbox.headSha, '--at', 'not-a-date'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).not.toBe(0);
+    expect(stdio.errors.join('')).toContain('state_malformed');
+    expect(existsSync(automationStatePath(sandbox.root, 'wiki'))).toBe(false);
+  });
 });

--- a/.gaia/cli/src/automation/cron-decide.ts
+++ b/.gaia/cli/src/automation/cron-decide.ts
@@ -64,12 +64,10 @@ const FLOOR_HOURS = 24;
 const CEILING_DAYS = 14;
 const SKIP_SAFETY_THRESHOLD = 5;
 
-const toolConfigFor = (config: AutomationConfig, tool: ToolId): ToolConfig => {
-  const key = TOOL_ID_TO_CONFIG_KEY[tool];
-  // `update_gaia` is not a ToolId so this cast is safe — TOOL_ID_TO_CONFIG_KEY
-  // is restricted to ToolId keys.
-  return config[key] as unknown as ToolConfig;
-};
+const toolConfigFor = (config: AutomationConfig, tool: ToolId): ToolConfig =>
+  // `TOOL_ID_TO_CONFIG_KEY` is typed `Record<ToolId, ToolConfigKey>`, so the
+  // indexed access resolves directly to `ToolConfig` — no cast needed.
+  config[TOOL_ID_TO_CONFIG_KEY[tool]];
 
 type RunOptions = {
   cwd?: string;

--- a/.gaia/cli/src/automation/init-state.ts
+++ b/.gaia/cli/src/automation/init-state.ts
@@ -11,6 +11,7 @@ import {existsSync} from 'node:fs';
 import {EXIT_CODES} from '../exit.js';
 import {TOOL_IDS, type ToolId} from '../schemas/automation-config.js';
 import type {AutomationStateFile} from '../schemas/automation-state.js';
+import {AutomationStateFileSchema} from '../schemas/automation-state.js';
 import {structuredError} from '../stderr.js';
 import {resolveRepoRoot} from '../wiki/util/git.js';
 import {automationStatePath} from './paths.js';
@@ -170,7 +171,7 @@ export const run = (
   const nowDate = (options.now ?? (() => new Date()))();
   const isoNow = atIso ?? nowDate.toISOString();
 
-  const state: AutomationStateFile = {
+  const candidate: AutomationStateFile = {
     cost_overage: false,
     last_run_at: isoNow,
     last_run_cost: 0,
@@ -180,7 +181,23 @@ export const run = (
     version: 1,
   };
 
-  writeStateFile(repoRoot, tool, state);
+  // Validate the assembled shape before persisting — a malformed `--at`
+  // would otherwise silently corrupt the state file. Mirrors `record-run`.
+  const validation = AutomationStateFileSchema.safeParse(candidate);
+
+  if (!validation.success) {
+    structuredError({
+      code: 'state_malformed',
+      message: validation.error.issues
+        .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+        .join('; '),
+      subcommand: 'automation init-state',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  writeStateFile(repoRoot, tool, validation.data);
 
   return EXIT_CODES.OK;
 };

--- a/.gaia/cli/src/schemas/automation-config.ts
+++ b/.gaia/cli/src/schemas/automation-config.ts
@@ -44,14 +44,25 @@ export const AutomationConfigSchema = z.object({
 export type AutomationConfig = z.infer<typeof AutomationConfigSchema>;
 
 /**
+ * The `AutomationConfig` keys that hold a `ToolConfig` row — i.e. the
+ * per-tool slots a `ToolId` can resolve to. Excludes `update_gaia`
+ * (`UpdateGaiaConfig`) and the scalar config fields.
+ */
+export type ToolConfigKey = {
+  [K in keyof AutomationConfig]: AutomationConfig[K] extends ToolConfig ? K
+  : never;
+}[keyof AutomationConfig];
+
+/**
  * Map from kebab-case tool id (used in state file paths and CLI args)
  * to the snake_case key used inside `.gaia/automation.json`.
  *
  * The split is intentional: the SPEC names the JSON keys snake_case
  * (`pnpm_audit`, `stale_branches`) but workflow / state-file paths use
- * kebab-case. Locking the mapping in one place keeps callers typesafe.
+ * kebab-case. The value type is `ToolConfigKey` so `config[key]` resolves
+ * directly to `ToolConfig` — no cast needed at call sites.
  */
-export const TOOL_ID_TO_CONFIG_KEY: Readonly<Record<ToolId, keyof AutomationConfig>> = {
+export const TOOL_ID_TO_CONFIG_KEY: Readonly<Record<ToolId, ToolConfigKey>> = {
   'pnpm-audit': 'pnpm_audit',
   'stale-branches': 'stale_branches',
   'update-deps': 'update_deps',

--- a/.gaia/cli/src/telemetry/__tests__/ndjson-writer.test.ts
+++ b/.gaia/cli/src/telemetry/__tests__/ndjson-writer.test.ts
@@ -120,4 +120,40 @@ describe('appendIdempotent', () => {
 
     expect(statSync(filePath).mode & 0o777).toBe(0o600);
   });
+
+  test('dedupes an event_id already present on disk from a prior process', async () => {
+    // The in-memory seen-set is empty at process start, so a duplicate
+    // that only exists on disk must still be caught by a content check.
+    const filePath = path.join(directory, 'prior-run.jsonl');
+    const eventId = '01HZX0K3Q9JSAWC0TR6WYJ5ZNT';
+    const line = JSON.stringify({event_id: eventId, payload: {x: 1}});
+    writeFileSync(filePath, `${line}\n`, {mode: 0o600});
+
+    const result = await appendIdempotent({
+      eventId,
+      fileMode: 0o600,
+      filePath,
+      line,
+    });
+
+    expect(result).toEqual({written: false});
+    expect(
+      readFileSync(filePath, 'utf8').split('\n').filter(Boolean)
+    ).toHaveLength(1);
+  });
+
+  test('dedupes a repeated event_id across many appends without growth', async () => {
+    const filePath = path.join(directory, 'repeated.jsonl');
+    const eventId = '01HZX0K3Q9JSAWC0TR6WYJ5ZNT';
+    const line = JSON.stringify({event_id: eventId});
+
+    for (let i = 0; i < 25; i += 1) {
+      // eslint-disable-next-line no-await-in-loop -- sequential dedup check
+      await appendIdempotent({eventId, fileMode: 0o600, filePath, line});
+    }
+
+    expect(
+      readFileSync(filePath, 'utf8').split('\n').filter(Boolean)
+    ).toHaveLength(1);
+  });
 });

--- a/.gaia/cli/src/telemetry/__tests__/projection.test.ts
+++ b/.gaia/cli/src/telemetry/__tests__/projection.test.ts
@@ -175,6 +175,38 @@ describe('projectToCloud', () => {
 
       expect(result.field).toBe('timestamp');
     });
+
+    test('returns a string event_type even when event_type is absent', () => {
+      // event_type missing -> envelope parse fails. The drift result's
+      // event_type field is typed `string`; it must not be `undefined`.
+      const {event_type: _omitted, ...withoutType} = baseEnvelope;
+      const result = projectToCloud(
+        withoutType as unknown as typeof baseEnvelope
+      );
+
+      expect(result.ok).toBe(false);
+
+      if (result.ok) return;
+
+      expect(typeof result.event_type).toBe('string');
+    });
+
+    test('returns a string event_type when event_type is a non-string', () => {
+      const envelopeWithNonStringType = {
+        ...baseEnvelope,
+        event_type: 42,
+      };
+
+      const result = projectToCloud(
+        envelopeWithNonStringType as unknown as typeof baseEnvelope
+      );
+
+      expect(result.ok).toBe(false);
+
+      if (result.ok) return;
+
+      expect(typeof result.event_type).toBe('string');
+    });
   });
 
   describe('denylist sweep (belt-and-suspenders)', () => {

--- a/.gaia/cli/src/telemetry/emit.ts
+++ b/.gaia/cli/src/telemetry/emit.ts
@@ -22,31 +22,18 @@ import type {StorageRoots} from '../storage/index.js';
 import {buildEnvelope} from './envelope.js';
 import type {EventEnvelopeWithLocal} from './envelope.js';
 import {appendIdempotent} from './ndjson-writer.js';
-import {projectToCloud} from './projection.js';
+import {KNOWN_CLOUD_ONLY_EVENT_TYPES, projectToCloud} from './projection.js';
 
 /**
  * Cloud-only event types — accepted by the CLI for envelope-validation only.
  * Per-consumer payload shapes ship with the relevant Sequel feature; v1
  * accepts arbitrary payloads here and lets the cloud-projection module
  * surface drift via its `.strict()` defense.
+ *
+ * Single source of truth is `projection.ts`; re-exported here under the
+ * legacy name so emit's callers keep a stable import path.
  */
-export const CLOUD_ONLY_EVENT_TYPES = [
-  'pr_opened',
-  'pr_merged',
-  'dispatch_artifact_emitted',
-  'engineer_return',
-  'dry_violation_flagged',
-  'skill_loaded',
-  'skill_invoked',
-  'skill_failed',
-  'recurring_pattern_observed',
-  'update_deps_run',
-  'branch_opened',
-  'interlock_held',
-  'audit_finding',
-  'boundary_zone_touch',
-  'boundary_violation_flagged',
-] as const;
+export const CLOUD_ONLY_EVENT_TYPES = KNOWN_CLOUD_ONLY_EVENT_TYPES;
 
 type CloudOnlyEventType = (typeof CLOUD_ONLY_EVENT_TYPES)[number];
 

--- a/.gaia/cli/src/telemetry/ndjson-writer.ts
+++ b/.gaia/cli/src/telemetry/ndjson-writer.ts
@@ -15,15 +15,56 @@ type AppendResult = {
 };
 
 /**
+ * Process-lifetime cache of `event_id`s known to already be present in a
+ * given NDJSON file. Keyed by `filePath`. Seeded lazily by a single full
+ * read the first time a file is touched this process; every emit after
+ * that dedupes purely against the in-memory set.
+ *
+ * This bounds disk reads to one per file per process instead of one per
+ * emit — the prior implementation re-read the whole daily file on every
+ * call, which is O(n^2) over a day of emits from a long-lived process.
+ */
+const seenByFile = new Map<string, Set<string>>();
+
+const EVENT_ID_NEEDLE_REGEX = /"event_id":"([^"]+)"/gu;
+
+/**
+ * Lazily build (and cache) the seen-set for `filePath` by scanning the
+ * file once. A missing file yields an empty set.
+ */
+const seenSetFor = (filePath: string): Set<string> => {
+  const cached = seenByFile.get(filePath);
+
+  if (cached !== undefined) return cached;
+
+  const seen = new Set<string>();
+
+  if (existsSync(filePath)) {
+    const existing = readFileSync(filePath, 'utf8');
+
+    for (const match of existing.matchAll(EVENT_ID_NEEDLE_REGEX)) {
+      seen.add(match[1] as string);
+    }
+  }
+
+  seenByFile.set(filePath, seen);
+
+  return seen;
+};
+
+/**
  * Append a JSON line to the NDJSON file at `filePath`, but only if no line
- * with the same `event_id` already exists. The check is a substring grep:
- * `"event_id":"<eventId>"`. Cheap and bounded by daily rotation.
+ * with the same `event_id` already exists. Dedup runs against a
+ * process-lifetime in-memory seen-set, seeded by a single file read the
+ * first time the file is touched (catches duplicates from prior processes)
+ * and updated on every successful append.
  *
  * Concurrent emits of the same content yield the same `event_id`, so the
- * grep step may race (both processes grep before either writes). Acceptable
- * for v1 — the worst case is a duplicate line per content within the race
- * window, against the desired single line. Daily rotation keeps the dup
- * window finite. v1.1 may add `flock` if real-world rates demand it.
+ * dedup step may race across processes (both seed before either writes).
+ * Acceptable for v1 — the worst case is a duplicate line per content
+ * within the race window, against the desired single line. Daily rotation
+ * keeps the dup window finite. v1.1 may add `flock` if real-world rates
+ * demand it.
  *
  * Idempotency contract: same content twice -> exactly one event per stream.
  *
@@ -33,17 +74,14 @@ export const appendIdempotent = async (
   args: AppendArgs
 ): Promise<AppendResult> => {
   const {eventId, fileMode, filePath, line} = args;
-  const dedupNeedle = `"event_id":"${eventId}"`;
+  const seen = seenSetFor(filePath);
 
-  if (existsSync(filePath)) {
-    const existing = readFileSync(filePath, 'utf8');
-
-    if (existing.includes(dedupNeedle)) {
-      return {written: false};
-    }
+  if (seen.has(eventId)) {
+    return {written: false};
   }
 
   await appendFile(filePath, `${line}\n`, {mode: fileMode});
+  seen.add(eventId);
 
   // `appendFile`'s `mode` option only takes effect when creating the file.
   // Re-chmod to ensure the post-condition holds even when the file pre-existed

--- a/.gaia/cli/src/telemetry/parse-trailer.ts
+++ b/.gaia/cli/src/telemetry/parse-trailer.ts
@@ -143,8 +143,8 @@ const buildAuditFindings = (
 
   if (!Array.isArray(parsed)) return [];
 
-  const prNumber =
-    trailerScalar(trailer, 'pr_number')?.replace(/^"|"$/g, '') ?? '0';
+  // `trailerScalar` already strips surrounding quotes; no extra strip here.
+  const prNumber = trailerScalar(trailer, 'pr_number') ?? '0';
   const invocations: EmitInvocation[] = [];
 
   for (const finding of parsed) {

--- a/.gaia/cli/src/telemetry/projection.ts
+++ b/.gaia/cli/src/telemetry/projection.ts
@@ -31,10 +31,8 @@ import type {CloudEventType} from '../schemas/index.js';
  * cloud event payloads (Holistic Reviewer, Skill Curator, Package Steward,
  * Custodian) land with their respective Sequel features in v1.x.
  *
- * MUST stay in sync with `CLOUD_ONLY_EVENT_TYPES` in
- * `.gaia/cli/src/telemetry/emit.ts`. Duplicated intentionally so projection
- * and emit can evolve in parallel without coupling. Drift between the two
- * lists is a bug; the smoke harness asserts they match.
+ * This is the single source of truth — `emit.ts` re-exports it as
+ * `CLOUD_ONLY_EVENT_TYPES` so projection and emit share one list.
  */
 const KNOWN_CLOUD_ONLY_TYPES = [
   'pr_opened',
@@ -97,6 +95,17 @@ const firstIssuePath = (issues: z.core.$ZodIssue[]): string => {
   return issue.path.length > 0 ? issue.path.join('.') : '<root>';
 };
 
+/**
+ * Coerce a raw `event_type` to a string for the drift-result field.
+ *
+ * `ProjectionResult.event_type` is typed as a non-optional string, but a
+ * failed envelope parse means the runtime value may be absent or non-string
+ * despite the static type. Guard so a failed parse can never feed
+ * `undefined`-as-string into the result.
+ */
+const safeEventType = (raw: unknown): string =>
+  typeof raw === 'string' ? raw : '<unknown>';
+
 const resolvePayloadSchema = (eventType: string): undefined | z.ZodType => {
   if (MENTORSHIP_TYPE_SET.has(eventType)) {
     return CloudPayloadByType[eventType as CloudEventType];
@@ -146,16 +155,19 @@ export const projectToCloud = (
   const envelopeResult = EnvelopeSchema.safeParse(cloudEvent);
 
   if (!envelopeResult.success) {
+    // Envelope parse failed — `cloudEvent.event_type` is statically typed
+    // `string` but may be absent/non-string at runtime here. Coerce.
     return {
       code: 'cloud_projection_drift',
-      event_type: cloudEvent.event_type,
+      event_type: safeEventType(cloudEvent.event_type),
       field: firstIssuePath(envelopeResult.error.issues),
       ok: false,
     };
   }
 
-  // 3. Resolve cloud payload schema by event_type.
-  const eventType = cloudEvent.event_type;
+  // 3. Resolve cloud payload schema by event_type. The envelope parse
+  //    succeeded, so `event_type` is a validated string.
+  const eventType = envelopeResult.data.event_type;
   const payloadSchema = resolvePayloadSchema(eventType);
 
   if (payloadSchema === undefined) {
@@ -216,10 +228,10 @@ export const projectToCloud = (
 };
 
 /**
- * Re-export so emit-core can reference the same canonical list when
- * deciding whether an unknown event_type is a cloud-only future-Sequel
- * type vs. an outright unknown event. Drift between this list and
- * emit-core's own copy is a bug; smoke harness asserts equality.
+ * Canonical cloud-only event-type list. `emit.ts` re-exports this as
+ * `CLOUD_ONLY_EVENT_TYPES` so emit-core can decide whether an unknown
+ * event_type is a cloud-only future-Sequel type vs. an outright unknown
+ * event — both modules share one list, no drift possible.
  */
 export const KNOWN_CLOUD_ONLY_EVENT_TYPES: readonly KnownCloudOnlyType[] =
   KNOWN_CLOUD_ONLY_TYPES;


### PR DESCRIPTION
## Summary

Remediates pre-release audit findings in the maintainer CLI (`.gaia/cli/`) automation/telemetry/analytics area. TDD for the genuine bugs (failing vitest test first, then fix); surgical changes only.

### Bugs fixed

- **`automation/init-state.ts`** — wrote the automation state file with no schema validation, so a malformed `--at` argument silently corrupted `last_run_at`. Now validates the assembled shape against `AutomationStateFileSchema` before persisting (mirrors `record-run`); bad input fails loud with `state_malformed` and writes nothing.
- **`telemetry/ndjson-writer.ts`** — `appendIdempotent` re-read the entire daily NDJSON file on every emit to dedupe, O(n²) over a day of emits from a long-lived process. Now seeds a process-lifetime in-memory seen-set with a single read per file path, then dedupes purely in memory. Idempotency preserved: cross-process duplicates caught by the one-time read, in-process duplicates by the set.
- **`telemetry/projection.ts`** — a failed `EnvelopeSchema.safeParse` could feed an absent/non-string `event_type` into a `ProjectionResult` field typed as a non-optional `string`. Added a `safeEventType` coercion at the failure site; the post-success read now uses the validated `envelopeResult.data.event_type`.

### Low-risk cleanups (SUGGEST)

- **cron-decide double cast** — narrowed `TOOL_ID_TO_CONFIG_KEY` to a new `ToolConfigKey` value type, so `config[key]` resolves directly to `ToolConfig`. Removed the `as unknown as ToolConfig` double cast.
- **`CLOUD_ONLY_EVENT_TYPES` duplication** — was copy-pasted across `telemetry/emit.ts` and `telemetry/projection.ts`. Consolidated: `projection.ts` is the single source, `emit.ts` re-exports it under the legacy name.
- **`analytics/generator.ts` brittle repo-root reconstruction** — replaced the triple-`path.dirname` strip with a `.gaia`-segment split (keeps the fixed-strip as a fallback).
- **redundant quote-strip** — removed `.replace(/^"|"$/g, '')` on `pr_number` in `telemetry/parse-trailer.ts`; `trailerScalar` already strips surrounding quotes.

### Skipped

None — all four SUGGEST items were clear and low-risk, so all were fixed.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — clean
- [x] `pnpm -C .gaia/cli exec vitest run` — 1123 passed / 107 files (5 new tests added)
- [x] New tests: init-state rejects malformed `--at` and writes nothing; ndjson-writer dedupes a prior-process on-disk id and a repeated id across 25 appends; projection returns a string `event_type` when it is absent / non-string

🤖 Generated with [Claude Code](https://claude.com/claude-code)