### PR TITLE
fix(cli-release): correctness gaps in release/scaffold

### DIFF
--- a/.gaia/cli/src/release/commit-and-tag.test.ts
+++ b/.gaia/cli/src/release/commit-and-tag.test.ts
@@ -162,6 +162,30 @@ describe('release commit-and-tag --commit', () => {
     // a release file. If it remains the path will succeed. Adjust:
     expect([0, 1]).toContain(exit);
   });
+
+  test('rolls back the release commit when the state-SHA amend fails', () => {
+    sandbox = setupSandbox('1.4.0');
+    const recorded: RecordedCall[] = [];
+    const runner = buildRecordingRunner(
+      [
+        {argv: ['rev-parse', 'HEAD'], result: okResult('abc1234def\n')},
+        {
+          argv: ['commit', '--amend', '--no-edit'],
+          result: failResult(1, 'fatal: amend blocked by hook'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run(['--commit'], {cwd: sandbox.root, runner});
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('amend blocked by hook');
+
+    // The release commit must be unwound after the amend failure.
+    const calls = recorded.map((call) => `${call.command} ${call.args.join(' ')}`);
+    expect(calls).toContain('git reset --soft HEAD~1');
+    expect(stdio.errors.join('')).toContain('rolled back the release commit');
+  });
 });
 
 const okResult = (stdout = ''): SpawnSyncReturns<string> => ({
@@ -268,6 +292,30 @@ describe('release commit-and-tag --tag', () => {
     expect(stdio.errors.join('')).toContain('tag exists');
     // Push must NOT run after tag failure.
     expect(recorded.find((c) => c.args[0] === 'push')).toBeUndefined();
+  });
+
+  test('rolls back the local tag when the push fails', () => {
+    sandbox = setupSandbox('2.5.1');
+    const recorded: RecordedCall[] = [];
+    const runner = buildRecordingRunner(
+      [
+        {
+          argv: ['push', 'origin', 'v2.5.1'],
+          result: failResult(1, 'fatal: unable to access remote'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run(['--tag'], {cwd: sandbox.root, runner});
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('unable to access remote');
+
+    // The created tag must be deleted after the failed push.
+    const calls = recorded.map((call) => `${call.command} ${call.args.join(' ')}`);
+    expect(calls).toContain('git tag -a v2.5.1 -m Release v2.5.1');
+    expect(calls).toContain('git tag -d v2.5.1');
+    expect(stdio.errors.join('')).toContain('deleted the local tag v2.5.1');
   });
 });
 

--- a/.gaia/cli/src/release/commit-and-tag.ts
+++ b/.gaia/cli/src/release/commit-and-tag.ts
@@ -264,7 +264,29 @@ const runCommitMode = (ctx: CommitContext): number => {
     for (const step of amendSequence) {
       const result = ctx.runner(step.command, step.args, {cwd: ctx.cwd});
 
-      if (!stepSucceeded(result)) return passthroughFailure(result, step);
+      if (!stepSucceeded(result)) {
+        // The release commit already landed but the state-SHA amend failed,
+        // leaving a partial release commit. Undo it (`reset --soft` keeps
+        // the staged files) so the maintainer can retry from a clean state
+        // instead of carrying a half-finished commit forward.
+        const rollback = ctx.runner('git', ['reset', '--soft', 'HEAD~1'], {
+          cwd: ctx.cwd,
+        });
+
+        if (!stepSucceeded(rollback)) {
+          process.stderr.write(
+            'commit-and-tag: amend failed AND rollback (git reset --soft HEAD~1) failed; '
+              + 'the release commit is left in place — undo it manually before retrying\n'
+          );
+        } else {
+          process.stderr.write(
+            'commit-and-tag: amend failed; rolled back the release commit '
+              + '(git reset --soft HEAD~1) — fix the cause and retry\n'
+          );
+        }
+
+        return passthroughFailure(result, step);
+      }
     }
   }
 
@@ -285,18 +307,46 @@ type TagContext = {
 const runTagMode = (ctx: TagContext): number => {
   const tagName = `v${ctx.version}`;
   const message = `Release v${ctx.version}`;
-  const sequence: Step[] = [
-    {args: ['tag', '-a', tagName, '-m', message], command: 'git'},
-  ];
+
+  const tagStep: Step = {
+    args: ['tag', '-a', tagName, '-m', message],
+    command: 'git',
+  };
+  const tagResult = ctx.runner(tagStep.command, tagStep.args, {cwd: ctx.cwd});
+
+  if (!stepSucceeded(tagResult)) return passthroughFailure(tagResult, tagStep);
 
   if (!ctx.noPush) {
-    sequence.push({args: ['push', 'origin', tagName], command: 'git'});
-  }
+    const pushStep: Step = {
+      args: ['push', 'origin', tagName],
+      command: 'git',
+    };
+    const pushResult = ctx.runner(pushStep.command, pushStep.args, {
+      cwd: ctx.cwd,
+    });
 
-  for (const step of sequence) {
-    const result = ctx.runner(step.command, step.args, {cwd: ctx.cwd});
+    if (!stepSucceeded(pushResult)) {
+      // The tag was created locally but never reached origin. Delete the
+      // local tag so a retry re-tags cleanly instead of failing on an
+      // already-existing tag.
+      const rollback = ctx.runner('git', ['tag', '-d', tagName], {
+        cwd: ctx.cwd,
+      });
 
-    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+      if (!stepSucceeded(rollback)) {
+        process.stderr.write(
+          `commit-and-tag: push failed AND rollback (git tag -d ${tagName}) failed; `
+            + `the local tag ${tagName} is left in place — delete it manually before retrying\n`
+        );
+      } else {
+        process.stderr.write(
+          `commit-and-tag: push failed; deleted the local tag ${tagName} `
+            + '— fix the cause and retry\n'
+        );
+      }
+
+      return passthroughFailure(pushResult, pushStep);
+    }
   }
 
   process.stdout.write(

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -469,6 +469,41 @@ describe('run --check', () => {
     expect(out).toContain('1.0.0');
   });
 
+  test('malformed manifest (not an object): exits 2 with a parse error', () => {
+    seedAndGenerate();
+
+    const manifestPath = path.join(sandbox.root, '.gaia/manifest.json');
+    writeFileSync(manifestPath, '["not", "a", "manifest"]\n', 'utf8');
+
+    const exit = run(['--check'], {
+      cwd: sandbox.root,
+      generatedAt: '2026-05-07T00:00:00.000Z',
+    });
+
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('manifest_parse_failed');
+    expect(stdio.errors.join('')).toContain('malformed');
+  });
+
+  test('malformed manifest (bad class value): exits 2 with a parse error', () => {
+    seedAndGenerate();
+
+    const manifestPath = path.join(sandbox.root, '.gaia/manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      files: Record<string, string>;
+    };
+    manifest.files['app/foo.ts'] = 'bogus-class';
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    const exit = run(['--check'], {
+      cwd: sandbox.root,
+      generatedAt: '2026-05-07T00:00:00.000Z',
+    });
+
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('manifest_parse_failed');
+  });
+
   test('missing manifest file: exits non-zero with manifest_missing error', () => {
     sandbox.commit('seed', {
       '.gaia/VERSION': '1.0.0\n',

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -116,7 +116,7 @@ export const classifyPath = (relativePath: string): ManifestClass | null => {
   return 'owned';
 };
 
-const ManifestClassSchema = z.enum(['owned', 'shared', 'wiki-owned']);
+const ManifestClassSchema = z.literal(['owned', 'shared', 'wiki-owned'] as const);
 
 /**
  * Runtime shape of `.gaia/manifest.json`. The committed manifest is

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -20,6 +20,7 @@
 import {execFileSync} from 'node:child_process';
 import {existsSync, readFileSync, writeFileSync} from 'node:fs';
 import path from 'node:path';
+import {z} from 'zod';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 
@@ -52,7 +53,13 @@ const UNEXPECTED_EXIT = 2;
 // LICENSE, README.md, SUPPORTERS.md) are handled by `.gaia/release-exclude`
 // category 11 (maintainer-only project governance) and never reach this
 // classifier. Don't add them to the sets below.
-const ADOPTER_OWNED_SENTINELS = new Set([
+//
+// Canonical source of the git-tracked adopter-owned sentinels. `release
+// runtime-deps` imports this set and extends it with its own runtime-only
+// sentinels (paths created on the adopter side that are never git-tracked,
+// so they can't appear here). Keeping one shared base prevents the two
+// allowlists silently drifting apart.
+export const ADOPTER_OWNED_SENTINELS: ReadonlySet<string> = new Set([
   '.gaia/manifest.json',
   '.gaia/VERSION',
   'wiki/hot.md',
@@ -108,11 +115,21 @@ export const classifyPath = (relativePath: string): ManifestClass | null => {
   return 'owned';
 };
 
-type ManifestShape = {
-  files: Record<string, ManifestClass>;
-  generated: string;
-  version: string;
-};
+const ManifestClassSchema = z.enum(['owned', 'shared', 'wiki-owned']);
+
+/**
+ * Runtime shape of `.gaia/manifest.json`. The committed manifest is
+ * untrusted input (hand-edits, merge conflicts, a stale schema), so
+ * `--check` validates it against this schema before diffing rather than
+ * blindly casting `as ManifestShape`.
+ */
+const ManifestSchema = z.object({
+  files: z.record(z.string(), ManifestClassSchema),
+  generated: z.string(),
+  version: z.string(),
+});
+
+type ManifestShape = z.infer<typeof ManifestSchema>;
 
 type BuildOptions = {
   /** Override the timestamp for deterministic tests / snapshots. */
@@ -384,11 +401,18 @@ const runCheck = (
   let actual: ManifestShape;
 
   try {
-    actual = JSON.parse(readFileSync(manifestPath, 'utf8')) as ManifestShape;
+    const rawJson: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    actual = ManifestSchema.parse(rawJson);
   } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? `committed manifest is malformed: ${z.prettifyError(error)}`
+        : error instanceof Error
+          ? error.message
+          : String(error);
     structuredError({
       code: 'manifest_parse_failed',
-      message: error instanceof Error ? error.message : String(error),
+      message,
       path: manifestPath,
       subcommand: 'release manifest',
     });

--- a/.gaia/cli/src/release/preflight.ts
+++ b/.gaia/cli/src/release/preflight.ts
@@ -124,26 +124,16 @@ type WikiState = {commits_ahead: number; state_sha: string};
 type WikiStateProbe = (cwd: string) => WikiState | null;
 
 const runWikiStateJson: WikiStateProbe = (cwd) => {
-  // Capture stdout from the wiki state subcommand by replacing
-  // process.stdout.write for the duration of the call, then parse JSON.
+  // Capture stdout from the wiki state subcommand via an injected sink —
+  // `wiki/state.ts` writes through `options.write` — so the global
+  // `process.stdout` is never mutated.
   const chunks: string[] = [];
-  const originalWrite = process.stdout.write.bind(process.stdout);
-  // The handler is synchronous; restoration is bounded.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime patch
-  (process.stdout as any).write = (chunk: unknown): boolean => {
-    chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
-
-    return true;
-  };
-
-  let exit: number;
-
-  try {
-    exit = runWikiState(['--json'], {cwd});
-  } finally {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime patch
-    (process.stdout as any).write = originalWrite;
-  }
+  const exit = runWikiState(['--json'], {
+    cwd,
+    write: (chunk) => {
+      chunks.push(chunk);
+    },
+  });
 
   if (exit !== EXIT_CODES.OK) return null;
   const raw = chunks.join('').trim();

--- a/.gaia/cli/src/release/runtime-deps.ts
+++ b/.gaia/cli/src/release/runtime-deps.ts
@@ -32,6 +32,7 @@
 import {readdirSync, readFileSync, statSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
+import {ADOPTER_OWNED_SENTINELS as GIT_TRACKED_SENTINELS} from './manifest.js';
 import {structuredError} from '../stderr.js';
 
 const HELP_TEXT = `Usage: gaia-maintainer release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
@@ -60,14 +61,16 @@ const SCAN_GLOBS = ['.gaia/statusline', '.claude/hooks'] as const;
 /**
  * Sentinels that ship in the tarball but are intentionally absent from
  * `.gaia/manifest.json` because adopters take ownership at first install.
- * See `.gaia/cli/src/release/manifest.ts` ADOPTER_OWNED_SENTINELS.
+ *
+ * The git-tracked subset is the single canonical set exported by
+ * `manifest.ts` (`classifyPath` maps those to `null`). This scan adds
+ * `.gaia/automation.json` — a runtime file created on the adopter side,
+ * never git-tracked, so it cannot live in the manifest's set — to cover
+ * references found in the extracted staging tree.
  */
 const ADOPTER_OWNED_SENTINELS: ReadonlySet<string> = new Set([
-  '.gaia/VERSION',
+  ...GIT_TRACKED_SENTINELS,
   '.gaia/automation.json',
-  '.gaia/manifest.json',
-  'wiki/hot.md',
-  'wiki/log.md',
 ]);
 
 /**

--- a/.gaia/cli/src/release/scrub.test.ts
+++ b/.gaia/cli/src/release/scrub.test.ts
@@ -11,7 +11,7 @@ import {
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {globToRegex, run} from './scrub.js';
+import {globToRegex, parseKeyPath, run} from './scrub.js';
 
 const JSON_STRIP_CONFIG = `
 transforms:
@@ -516,5 +516,63 @@ describe('json-strip transform', () => {
     };
     expect(report.json_strip.keys_removed).toBe(0);
     expect(report.json_strip.files_touched).toHaveLength(0);
+  });
+
+  test('removes a key whose name contains a literal dot via \\. escape', () => {
+    // YAML double-quote turns `\\.` into `\.`, which parseKeyPath reads as
+    // a literal dot inside the key name. Key path: ['exports', './secret'].
+    const dottedKeyConfig = `
+transforms:
+  - type: json-strip
+    paths:
+      - "package.json"
+    keys:
+      - "exports.\\\\./secret"
+`;
+    sandbox = setupSandbox({config: dottedKeyConfig});
+    sandbox.writeStaged(
+      'package.json',
+      JSON.stringify(
+        {exports: {'./public': './a.js', './secret': './b.js'}, name: 'app'},
+        null,
+        2
+      )
+    );
+
+    const exit = run([sandbox.stagingDir], {cwd: sandbox.rootDir});
+    expect(exit).toBe(0);
+
+    const after = JSON.parse(
+      readFileSync(path.join(sandbox.stagingDir, 'package.json'), 'utf8')
+    );
+    expect(after.exports).not.toHaveProperty('./secret');
+    expect(after.exports).toHaveProperty('./public');
+  });
+});
+
+describe('parseKeyPath', () => {
+  test('splits on unescaped dots', () => {
+    expect(parseKeyPath('scripts.test:forensics')).toEqual([
+      'scripts',
+      'test:forensics',
+    ]);
+  });
+
+  test('treats an escaped dot as a literal in the key name', () => {
+    expect(parseKeyPath(String.raw`scripts.foo\.bar`)).toEqual([
+      'scripts',
+      'foo.bar',
+    ]);
+  });
+
+  test('handles a leading escaped-dot segment', () => {
+    expect(parseKeyPath(String.raw`exports.\./feature`)).toEqual([
+      'exports',
+      './feature',
+    ]);
+  });
+
+  test('returns a single segment for a plain key', () => {
+    expect(parseKeyPath('bin')).toEqual(['bin']);
   });
 });

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -11,7 +11,7 @@
  *
  *   2. json-strip — delete maintainer-only keys from structured JSON files
  *      using dot-notation paths (e.g. "scripts.test:forensics"). Dots are
- *      path separators; key names must not contain literal dots.
+ *      path separators; a literal dot inside a key name is escaped as `\.`.
  *
  *   3. leak-check — run codified audit patterns from
  *      `.claude/rules/wiki-style.md` Audit section + the distribution-
@@ -277,6 +277,43 @@ export type JsonStripResult = {
   keysRemoved: number;
 };
 
+/**
+ * Split a dot-notation key path into segments. A literal `.` inside a key
+ * name is expressed with a backslash escape (`\.`), so a package.json key
+ * that contains a dot — e.g. `exports.\.\/feature` — stays addressable.
+ *
+ * `scripts.test:forensics` → `['scripts', 'test:forensics']`
+ * String.raw`scripts.foo\.bar` → `['scripts', 'foo.bar']`
+ *
+ * A trailing lone backslash is treated literally.
+ */
+export const parseKeyPath = (key: string): string[] => {
+  const segments: string[] = [];
+  let current = '';
+
+  for (let index = 0; index < key.length; index += 1) {
+    const char = key[index];
+
+    if (char === '\\' && key[index + 1] === '.') {
+      current += '.';
+      index += 1;
+      continue;
+    }
+
+    if (char === '.') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  segments.push(current);
+
+  return segments;
+};
+
 const deleteKeyPath = (
   obj: Record<string, unknown>,
   segments: readonly string[]
@@ -309,7 +346,7 @@ const applyJsonStrip = (
 ): JsonStripResult => {
   const filesTouched: string[] = [];
   let keysRemoved = 0;
-  const keySegments = transform.keys.map((k) => k.split('.'));
+  const keySegments = transform.keys.map((k) => parseKeyPath(k));
 
   for (const relativePath of files) {
     if (!matchesAnyGlob(relativePath, transform.paths)) continue;

--- a/.gaia/cli/src/scaffold/hook.ts
+++ b/.gaia/cli/src/scaffold/hook.ts
@@ -119,29 +119,6 @@ const sentinelForType = (type: string): string => {
 const formatCallArgs = (params: readonly Param[]): string =>
   params.map((param) => sentinelForType(param.type)).join(', ');
 
-const REACT_HOOK_KEYWORDS = [
-  'useCallback',
-  'useEffect',
-  'useMemo',
-  'useRef',
-  'useState',
-] as const;
-
-const detectReactImports = (
-  paramsString: string,
-  returnsAnnotation: string
-): string => {
-  // The default body (`// TODO: implement`) doesn't reference any React
-  // hooks, so we keep imports empty by default. We surface this as a
-  // separate function to leave a clear extension point if a future flag
-  // (e.g. --uses "useState") wants to seed imports.
-  void paramsString;
-  void returnsAnnotation;
-  void REACT_HOOK_KEYWORDS;
-
-  return '';
-};
-
 const resolveTemplateFile = (filename: string): string => {
   const here = fileURLToPath(import.meta.url);
 
@@ -173,10 +150,11 @@ const emitFiles = (options: EmitOptions): ScaffoldResult => {
   const {hookFilePath, name, params, returns, testFilePath} = options;
   const paramsString = formatParamsString(params);
   const returnsAnnotation = returns === undefined ? '' : `: ${returns}`;
-  const imports = detectReactImports(paramsString, returnsAnnotation);
 
   const hookContents = renderTemplate(resolveTemplateFile(HOOK_TEMPLATE_FILE), {
-    imports,
+    // The default body (`// TODO: implement`) references no React hooks,
+    // so the import block is empty.
+    imports: '',
     name,
     paramsString,
     returnsAnnotation,

--- a/.gaia/cli/src/scaffold/index.ts
+++ b/.gaia/cli/src/scaffold/index.ts
@@ -1,14 +1,10 @@
 /**
- * `gaia scaffold` subcommand router (Phase 2 setup).
+ * `gaia scaffold` subcommand router.
  *
  * This file ships:
  *   1. The public re-exports of the scaffold shared API.
- *   2. The router that dispatches to per-kind handlers.
- *
- * In this task, the four handlers (component/hook/route/service) are
- * stubbed to a "not yet implemented" stderr line + exit 1. The four
- * follow-up scaffolder tasks replace each stub with a real implementation
- * by editing this file.
+ *   2. The router that dispatches to per-kind handlers
+ *      (component/hook/route/service).
  *
  * Object-map dispatch (no `switch`) per the project's typescript skill rules.
  */
@@ -27,25 +23,13 @@ export type {ScaffoldResult} from './types.js';
 
 const HELP_TEXT = `Usage: gaia scaffold <subcommand> [args]
 
-  component <Name>         Scaffold a new React component (Phase 2).
-  hook <useFoo>            Scaffold a new custom hook (Phase 2).
-  route <name>             Scaffold a new route + page (Phase 2).
-  service <name>           Scaffold a new API service (Phase 2).
+  component <Name>         Scaffold a new React component.
+  hook <useFoo>            Scaffold a new custom hook.
+  route <name>             Scaffold a new route + page.
+  service <name>           Scaffold a new API service.
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
-
-const STUBBED_KINDS = new Set<string>();
-
-const printNotImplemented = (kind: string): number => {
-  structuredError({
-    code: 'not_implemented',
-    message: `scaffold ${kind}: not yet implemented (Phase 2)`,
-    subcommand: `scaffold ${kind}`,
-  });
-
-  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-};
 
 /**
  * Entry point invoked by the top-level CLI router (`src/index.ts`).
@@ -80,10 +64,6 @@ export const run = (argv: readonly string[]): number => {
 
   if (subcommand === 'service') {
     return runService(argv.slice(1));
-  }
-
-  if (STUBBED_KINDS.has(subcommand)) {
-    return printNotImplemented(subcommand);
   }
 
   structuredError({

--- a/.gaia/cli/src/scaffold/route.ts
+++ b/.gaia/cli/src/scaffold/route.ts
@@ -219,7 +219,28 @@ const insertIntoLocaleBarrel = (
     }
   }
 
-  writeFileSync(barrelPath, lines.join('\n'), 'utf8');
+  const next = lines.join('\n');
+
+  // Diff-safety net: the splice logic above is regex-driven and can
+  // mis-target a barrel whose shape drifted from the expected
+  // import-then-default-export form. Before writing, prove the result
+  // actually contains both the new import line and a matching entry in
+  // the default-export block. A non-matching edit fails loudly here
+  // instead of silently corrupting the barrel.
+  const entryAdded = new RegExp(
+    String.raw`^\s+${importName},?\s*$`,
+    'mu'
+  ).test(next);
+
+  if (!next.includes(importLine) || !entryAdded) {
+    throw new Error(
+      `locale barrel edit did not apply cleanly to ${barrelPath}: `
+        + `expected import "${importName}" and a matching default-export entry. `
+        + 'Add the entries by hand or fix the barrel shape.'
+    );
+  }
+
+  writeFileSync(barrelPath, next, 'utf8');
 
   return 'inserted';
 };

--- a/.gaia/cli/src/scaffold/service.test.ts
+++ b/.gaia/cli/src/scaffold/service.test.ts
@@ -302,6 +302,39 @@ describe('gaia scaffold service', () => {
     expect(after).toContain('export default {apples, mangoes, zebras}');
   });
 
+  test('fails loudly when the database barrel is missing the Promise.all region', () => {
+    // A barrel whose `resetTestData` lost its `Promise.all([...])` region:
+    // the import insert applies but the reset-call insert can no longer
+    // match. The diff-safety net must reject this instead of writing a
+    // half-applied barrel.
+    const databasePath = path.join(sandbox.dir, 'test', 'mocks', 'database.ts');
+    writeFileSync(
+      databasePath,
+      [
+        "import {apples, resetApples} from './apples/data';",
+        '',
+        'export const resetTestData = async (): Promise<void> => {',
+        '  // resetting disabled',
+        '};',
+        '',
+        'export default {apples};',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    const code = run(
+      ['mangoes', '--endpoints', 'get', '--schema', 'id:string', '--mocks'],
+      {cwd: sandbox.dir}
+    );
+
+    expect(code).toBe(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+
+    // The barrel must be left untouched — no partial write.
+    const after = read(databasePath);
+    expect(after).not.toContain('mangoes');
+  });
+
   test('--json emits a single ScaffoldResult JSON line', () => {
     let captured = '';
     const originalWrite = process.stdout.write.bind(process.stdout);

--- a/.gaia/cli/src/scaffold/service.ts
+++ b/.gaia/cli/src/scaffold/service.ts
@@ -511,6 +511,30 @@ const applyDatabaseEdits = (
   }
   next = insertCollectionExportAlphabetically(next, derived);
 
+  // Diff-safety net: each of the three inserts is regex-driven and
+  // returns `source` unchanged when its target region is missing. A
+  // partial application (e.g. the import landed but the `Promise.all`
+  // region didn't match) would otherwise be written out as a silently
+  // broken barrel. Verify all three regions actually carry the new
+  // entries before the caller writes the file; fail loudly otherwise.
+  const collectionEntry = new RegExp(
+    String.raw`export default \{[^}]*\b${derived.plural}\b`,
+    'u'
+  ).test(next);
+
+  if (
+    !next.includes(importLine) ||
+    !next.includes(resetCall) ||
+    !collectionEntry
+  ) {
+    throw new Error(
+      `database barrel edit did not apply cleanly: expected import, `
+        + `${resetCall} in the resetTestData Promise.all, and `
+        + `"${derived.plural}" in the default export. `
+        + 'Register the collection by hand or fix test/mocks/database.ts.'
+    );
+  }
+
   return next;
 };
 

--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -280,4 +280,23 @@ describe('wiki state', () => {
     expect(out).toContain('Wiki state');
     expect(out).toContain('Drift:');
   });
+
+  test('routes output to an injected write sink, not process.stdout', () => {
+    const sha = sandbox.commit('initial', {'README.md': '# repo\n'});
+    writeStateFile(sandbox.root, sha);
+
+    const chunks: string[] = [];
+    const exit = run(['--json'], {
+      cwd: sandbox.root,
+      write: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+    expect(exit).toBe(0);
+
+    // The injected sink receives the payload; the global stdout spy does not.
+    const json = JSON.parse(chunks.join('').trim()) as Record<string, unknown>;
+    expect(json.commits_ahead).toBe(0);
+    expect(stdio.outputs.join('')).toBe('');
+  });
 });

--- a/.gaia/cli/src/wiki/state.ts
+++ b/.gaia/cli/src/wiki/state.ts
@@ -107,7 +107,10 @@ const readStateFile = (statePath: string): StateFileShape | null => {
   }
 };
 
-const printHuman = (state: WikiState): void => {
+const printHuman = (
+  state: WikiState,
+  write: (chunk: string) => void
+): void => {
   const lines = [
     'Wiki state',
     `  HEAD:           ${state.head_short}`,
@@ -127,22 +130,32 @@ const printHuman = (state: WikiState): void => {
   for (const [domain, count] of Object.entries(state.per_domain_page_counts)) {
     lines.push(`    ${domain}: ${count}`);
   }
-  process.stdout.write(`${lines.join('\n')}\n`);
+  write(`${lines.join('\n')}\n`);
 };
 
 type RunOptions = {
   cwd?: string;
+  /**
+   * Sink for the handler's stdout. Defaults to `process.stdout.write`.
+   * Callers that need to capture the output (e.g. `release preflight`
+   * parsing the `--json` payload) pass a collector instead of patching
+   * the global stream.
+   */
+  write?: (chunk: string) => void;
 };
 
 export const run = (
   argv: readonly string[],
   options: RunOptions = {}
 ): number => {
+  const write = options.write ?? ((chunk: string) => {
+    process.stdout.write(chunk);
+  });
   let json = false;
 
   for (const token of argv) {
     if (HELP_TOKENS.has(token)) {
-      process.stdout.write(HELP_TEXT);
+      write(HELP_TEXT);
 
       return EXIT_CODES.OK;
     }
@@ -201,9 +214,9 @@ export const run = (
   };
 
   if (json) {
-    process.stdout.write(`${JSON.stringify(state)}\n`);
+    write(`${JSON.stringify(state)}\n`);
   } else {
-    printHuman(state);
+    printHuman(state, write);
   }
 
   return EXIT_CODES.OK;

--- a/.gaia/release-scrub.yml
+++ b/.gaia/release-scrub.yml
@@ -8,9 +8,10 @@
 #
 #   2. json-strip — delete maintainer-only keys from structured JSON files.
 #      Keys use dot-notation to address nested paths (e.g. "scripts.foo").
-#      Dots are path separators; key names themselves must not contain dots.
-#      Missing keys are silently skipped (no error). Runs after marker-strip
-#      so leak-check sees the already-clean JSON.
+#      Dots are path separators; a literal dot inside a key name is escaped
+#      as `\.` (e.g. "exports.\./feature"). Missing keys are silently skipped
+#      (no error). Runs after marker-strip so leak-check sees the already-
+#      clean JSON.
 #
 #   3. leak-check — run codified audit patterns against the post-strip
 #      staging tree. Non-empty match = build failure with a leak report.


### PR DESCRIPTION
## Summary

Remediates pre-release audit findings in the `@gaia-react/cli` maintainer CLI (`.gaia/cli/`). Each finding was verified against the live code before fixing; logic bugs got a failing test first (TDD).

### Logic fixes

- **`release/scrub.ts` — json-strip literal-dot keys.** Key paths were split on *every* `.`, so a `package.json` key containing a literal dot (e.g. `exports."./feature"`) was unaddressable — a maintainer-only field could be silently left in the adopter bundle. Added `parseKeyPath`, which splits on unescaped dots and treats `\.` as a literal dot. Config doc (`.gaia/release-scrub.yml`) updated.
- **`release/preflight.ts` — stdout monkey-patch removed.** `runWikiStateJson` replaced `process.stdout.write` globally to capture the `wiki state --json` payload. `wiki/state.ts` now takes an optional `write` sink (defaults to `process.stdout.write`); preflight injects a collector. No global mutation.
- **`release/commit-and-tag.ts` — rollback on partial-release failure.** A failed state-SHA amend left a half-finished release commit; a failed tag push left an un-pushed local tag. Added rollback: `git reset --soft HEAD~1` on amend failure, `git tag -d` on push failure, with a clear stderr message (and a louder message if the rollback itself fails).
- **`release/manifest.ts` — validate the committed manifest.** `--check` cast the committed `.gaia/manifest.json` `as ManifestShape` with no validation. Added a zod `ManifestSchema`; a malformed manifest now exits 2 with a structured parse error.
- **`scaffold/route.ts` + `scaffold/service.ts` — barrel-edit diff-safety nets.** The regex-driven barrel inserts could silently produce a wrong/partial result. Both now verify the post-edit content actually carries the new entries and throw loudly otherwise (the throw is caught by the handler's existing error path).

### Cleanups

- Removed dead code: `scaffold/index.ts` `STUBBED_KINDS` + `printNotImplemented` (all four kinds are wired); `scaffold/hook.ts` no-op `detectReactImports` + unused `REACT_HOOK_KEYWORDS`.
- Reconciled the two `ADOPTER_OWNED_SENTINELS` sets: `manifest.ts` exports the canonical git-tracked set; `runtime-deps.ts` imports and extends it with its runtime-only sentinel (`.gaia/automation.json`, never git-tracked), removing the silent-drift risk.

### Skipped findings

- **Duplicated glob-escape helper** — `scrub.ts` `globToRegex` and `manifest.ts` `escapeRegExp`/`parseExcludePatterns` implement *different* glob dialects (`**` support + full-match anchoring vs. `*`-only + `^P(/|$)` prefix anchoring). Merging would change the manifest classifier's matching contract.
- **`index.ts` / `index.maintainer.ts` duplication** — the file headers document this mirroring as deliberate ("a shared abstraction would obscure the contract more than it would save lines").
- **`takeValue` `--`-prefix inconsistency** — the three copies are byte-identical; the finding is vague and rejecting `--`-prefixed values would change flag parsing across three release commands without a demonstrated failure.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — clean, no errors
- [x] `pnpm -C .gaia/cli exec vitest run` — 1129 passed / 0 failed (107 files)
- [x] New tests: `parseKeyPath` unit + literal-dot integration; `wiki state` injected-sink test; commit-and-tag amend-rollback + tag-push-rollback; manifest malformed-input (bad shape + bad class value); service barrel diff-safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)