### PR TITLE
fix(cli-init): correctness gaps in init/schemas/storage

### DIFF
--- a/.gaia/cli/src/init/rename.test.ts
+++ b/.gaia/cli/src/init/rename.test.ts
@@ -182,6 +182,54 @@ describe('init rename', () => {
     ).toBe(pageFirst);
   });
 
+  test('does not clobber unrelated `title` properties in diverged _index.ts', () => {
+    sandbox = setupSandbox();
+    // Simulate a user whose _index.ts has diverged from the seed: extra
+    // route data with its own nested `title` properties that are NOT the
+    // project title and must be preserved verbatim.
+    const diverged = `export default {
+  heroTitle: 'Start with something solid.',
+  meta: {
+    description: 'Description of the index page',
+    title: 'Index Page',
+  },
+  title: 'Old Title',
+  routes: {
+    about: {
+      title: 'About Us',
+    },
+    contact: {
+      title: 'Contact',
+    },
+  },
+};
+`;
+    writeFileSync(
+      path.join(sandbox.root, 'app', 'languages', 'en', 'pages', '_index.ts'),
+      diverged,
+      'utf8'
+    );
+
+    const exit = run(['--title', 'Hello World', '--kebab', 'hello-world'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+
+    const page = readFileSync(
+      path.join(sandbox.root, 'app', 'languages', 'en', 'pages', '_index.ts'),
+      'utf8'
+    );
+    // Seed identity keys rewritten.
+    expect(page).toContain("heroTitle: 'Hello World'");
+    expect(page).toContain("title: 'Hello World'");
+    // meta.title rewritten.
+    const helloMatches = page.match(/title: 'Hello World'/gu)?.length ?? 0;
+    expect(helloMatches).toBe(2);
+    // Unrelated route titles preserved.
+    expect(page).toContain("title: 'About Us'");
+    expect(page).toContain("title: 'Contact'");
+  });
+
   test('exit 1 when package.json missing', () => {
     sandbox = setupSandbox();
     rmSync(path.join(sandbox.root, 'package.json'));

--- a/.gaia/cli/src/init/rename.ts
+++ b/.gaia/cli/src/init/rename.ts
@@ -166,6 +166,41 @@ const replaceStringPropertyAll = (
   return source.replace(pattern, `$1$2${escaped}$2`);
 };
 
+/**
+ * Replace a string-literal property's value, but only when the key is
+ * indented at the file's top object level (a single indentation unit).
+ * Nested keys with the same name (e.g. a `title` inside a deeper route
+ * object) are left untouched so a user-diverged file is preserved.
+ */
+const replaceTopLevelStringProperty = (
+  source: string,
+  key: string,
+  newValue: string
+): string => {
+  const escaped = newValue.replaceAll(/[$\\]/gu, '\\$&');
+  const pattern = new RegExp(
+    String.raw`^(\x20\x20${key}\s*:\s*)(['"])(?:[^'"\\]|\\.)*\2`,
+    'gmu'
+  );
+
+  return source.replace(pattern, `$1$2${escaped}$2`);
+};
+
+/**
+ * Replace the `title` string-literal nested directly inside the
+ * top-level `meta: { … }` block. Scopes the rewrite to the seed's
+ * `meta.title` so other `title` keys elsewhere in the file are untouched.
+ */
+const replaceMetaTitle = (source: string, newValue: string): string => {
+  const escaped = newValue.replaceAll(/[$\\]/gu, '\\$&');
+  // Match `meta: {` opened at the top object level, then the first
+  // `title:` string within it before the block closes.
+  const pattern =
+    /^(\x20\x20meta\s*:\s*\{[^}]*?\btitle\s*:\s*)(['"])(?:[^'"\\]|\\.)*\2/mu;
+
+  return source.replace(pattern, `$1$2${escaped}$2`);
+};
+
 const renameCommonTs = (cwd: string, title: string): void => {
   const target = path.join(cwd, COMMON_TS);
 
@@ -187,12 +222,14 @@ const renameIndexPage = (cwd: string, title: string): void => {
   if (!existsSync(target)) return;
   const original = readFileSync(target, 'utf8');
   let next = original;
-  // The seeded `_index.ts` has three identity-bearing keys whose value
-  // is the project title in every location: `heroTitle`, `title`, and
-  // `meta.title`. Both `title` keys (top-level and nested) carry the
-  // project title, so a global rewrite is correct.
-  next = replaceStringPropertyAll(next, 'heroTitle', title);
-  next = replaceStringPropertyAll(next, 'title', title);
+  // The seeded `_index.ts` has exactly three identity-bearing keys whose
+  // value is the project title: top-level `heroTitle`, top-level `title`,
+  // and `meta.title`. Scope the rewrite to those precise locations — a
+  // global `title` rewrite would clobber `title` keys in extra routes a
+  // user may have added (data loss on a diverged file).
+  next = replaceTopLevelStringProperty(next, 'heroTitle', title);
+  next = replaceTopLevelStringProperty(next, 'title', title);
+  next = replaceMetaTitle(next, title);
 
   if (next !== original) {
     writeFileSync(target, next, 'utf8');

--- a/.gaia/cli/src/init/strip-branding.test.ts
+++ b/.gaia/cli/src/init/strip-branding.test.ts
@@ -177,6 +177,37 @@ describe('init strip-branding', () => {
     expect(stripCount).toBe(1);
   });
 
+  test('replaces a paired <GaiaLogo>…</GaiaLogo> element', () => {
+    sandbox = setupSandbox();
+    const pairedHeader = `import GaiaLogo from '~/components/GaiaLogo';
+
+const Header = () => (
+  <header>
+    <GaiaLogo className="h-6 sm:h-7">brand</GaiaLogo>
+  </header>
+);
+
+export default Header;
+`;
+    writeFileSync(
+      path.join(sandbox.root, 'app', 'components', 'Header', 'index.tsx'),
+      pairedHeader,
+      'utf8'
+    );
+
+    const exit = run(['--title', 'Hello World'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const header = readFileSync(
+      path.join(sandbox.root, 'app', 'components', 'Header', 'index.tsx'),
+      'utf8'
+    );
+    expect(header).not.toContain('GaiaLogo');
+    expect(header).toContain(
+      "<span className=\"text-body text-xl font-bold\">{t('meta.siteName')}</span>"
+    );
+  });
+
   test('exit 1 when --title missing', () => {
     sandbox = setupSandbox();
     const exit = run([], {cwd: sandbox.root});

--- a/.gaia/cli/src/init/strip-branding.ts
+++ b/.gaia/cli/src/init/strip-branding.ts
@@ -144,8 +144,12 @@ const stripGaiaLogoFromHeader = (cwd: string): void => {
 
   // Replace the JSX element. The runbook ships a specific instance:
   //   <GaiaLogo className="h-6 sm:h-7" />
-  // but match any self-closing <GaiaLogo … /> to be tolerant of edits.
-  next = next.replaceAll(/<GaiaLogo\b[^>]*\/>/gu, WORDMARK_REPLACEMENT);
+  // Match the self-closing form AND a paired `<GaiaLogo …>…</GaiaLogo>`
+  // form, in case the wordmark was customized into a wrapping element.
+  next = next.replaceAll(
+    /<GaiaLogo\b[^>]*\/>|<GaiaLogo\b[^>]*>[\s\S]*?<\/GaiaLogo>/gu,
+    WORDMARK_REPLACEMENT
+  );
 
   if (next !== original) {
     writeFileSync(target, next, 'utf8');

--- a/.gaia/cli/src/schemas/__tests__/analytics-report.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/analytics-report.test.ts
@@ -152,6 +152,24 @@ describe('schemas/analytics-report', () => {
     ).toThrow();
   });
 
+  it('accepts an ISO-8601 datetime for report_generated_at', () => {
+    expect(() =>
+      AnalyticsReportSchema.parse({
+        ...baseReport,
+        report_generated_at: '2026-05-06T12:34:56.789Z',
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a non-datetime string for report_generated_at', () => {
+    expect(() =>
+      AnalyticsReportSchema.parse({
+        ...baseReport,
+        report_generated_at: 'not-a-timestamp',
+      })
+    ).toThrow();
+  });
+
   it('accepts adaptation with null outcome', () => {
     expect(() =>
       AnalyticsReportSchema.parse({

--- a/.gaia/cli/src/schemas/__tests__/envelope.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/envelope.test.ts
@@ -81,11 +81,19 @@ describe('schemas/envelope', () => {
   });
 
   describe('EnvelopeSchema', () => {
+    const validUatPassPayload = {
+      area_tags: ['react'],
+      attempts: 1,
+      spec_id: 'SPEC-014',
+      task_id: 'TASK-093',
+      uat_id: 'UAT-007',
+    };
+
     const validEnvelope = {
       agent_type: 'Senior',
       event_id: VALID_ULID,
       event_type: 'uat_pass',
-      payload: {anything: 'goes-here'},
+      payload: validUatPassPayload,
       project_id: VALID_HEX_32,
       schema_version: 1,
       session_hash: VALID_HEX_32,
@@ -94,6 +102,39 @@ describe('schemas/envelope', () => {
 
     it('accepts a hand-constructed example matching the SPEC snippet', () => {
       expect(() => EnvelopeSchema.parse(validEnvelope)).not.toThrow();
+    });
+
+    it('rejects a payload that does not match its mentorship event_type', () => {
+      expect(() =>
+        EnvelopeSchema.parse({
+          ...validEnvelope,
+          payload: {anything: 'goes-here'},
+        })
+      ).toThrow();
+    });
+
+    it('reports the drift under the payload path', () => {
+      const result = EnvelopeSchema.safeParse({
+        ...validEnvelope,
+        payload: {...validUatPassPayload, uat_id: 'not-a-uat-id'},
+      });
+      expect(result.success).toBe(false);
+
+      if (result.success) return;
+
+      expect(
+        result.error.issues.some((issue) => issue.path[0] === 'payload')
+      ).toBe(true);
+    });
+
+    it('leaves the payload unconstrained for non-mentorship event_types', () => {
+      expect(() =>
+        EnvelopeSchema.parse({
+          ...validEnvelope,
+          event_type: 'pr_opened',
+          payload: {anything: 'goes-here'},
+        })
+      ).not.toThrow();
     });
 
     it('rejects schema_version != 1', () => {

--- a/.gaia/cli/src/schemas/__tests__/mentorship-config.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/mentorship-config.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest';
+import {MentorshipConfigSchema} from '../mentorship-config.js';
+
+const baseConfig = {
+  analytics: {enabled: false},
+  decided_at: null,
+  decided_via: null,
+  enabled: null,
+};
+
+describe('schemas/mentorship-config', () => {
+  it('accepts the pre-decision default (null decided_at)', () => {
+    expect(() => MentorshipConfigSchema.parse(baseConfig)).not.toThrow();
+  });
+
+  it('accepts an ISO-8601 datetime for decided_at', () => {
+    expect(() =>
+      MentorshipConfigSchema.parse({
+        ...baseConfig,
+        decided_at: '2026-05-06T12:34:56.789Z',
+        decided_via: 'gaia-init',
+        enabled: true,
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects a non-datetime string for decided_at', () => {
+    expect(() =>
+      MentorshipConfigSchema.parse({
+        ...baseConfig,
+        decided_at: '2026-05-06',
+        decided_via: 'gaia-init',
+        enabled: true,
+      })
+    ).toThrow();
+  });
+
+  it('rejects an unknown decided_via value', () => {
+    expect(() =>
+      MentorshipConfigSchema.parse({
+        ...baseConfig,
+        decided_via: 'unknown-source',
+      })
+    ).toThrow();
+  });
+});

--- a/.gaia/cli/src/schemas/analytics-report.ts
+++ b/.gaia/cli/src/schemas/analytics-report.ts
@@ -46,7 +46,7 @@ export const AnalyticsReportSchema = z
         strength_p90: z.number().min(0).max(1),
       })
     ),
-    report_generated_at: z.string(),
+    report_generated_at: z.iso.datetime(),
     report_id: z.string(),
     report_window_days: z.literal(30),
     schema_version: z.literal(1),

--- a/.gaia/cli/src/schemas/automation-config.ts
+++ b/.gaia/cli/src/schemas/automation-config.ts
@@ -10,6 +10,7 @@
 import {existsSync, readFileSync} from 'node:fs';
 import {z} from 'zod';
 import {automationConfigPath} from '../automation/paths.js';
+import {summarizeZodError} from './zod-error.js';
 
 export const TOOL_IDS = ['wiki', 'update-deps', 'pnpm-audit', 'stale-branches'] as const;
 export type ToolId = (typeof TOOL_IDS)[number];
@@ -72,16 +73,6 @@ export type ReadAutomationConfigResult =
   | {config: AutomationConfig; status: 'ok'}
   | {status: 'missing'}
   | {error: string; status: 'malformed'};
-
-const summarizeZodError = (filePath: string, error: z.ZodError): string => {
-  const lines = error.issues.map((issue) => {
-    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
-
-    return `${pathStr}: ${issue.message}`;
-  });
-
-  return `${filePath}: ${lines.join('; ')}`;
-};
 
 export const readAutomationConfig = (
   repoRoot: string

--- a/.gaia/cli/src/schemas/automation-state.ts
+++ b/.gaia/cli/src/schemas/automation-state.ts
@@ -10,6 +10,7 @@ import {existsSync, readFileSync} from 'node:fs';
 import {z} from 'zod';
 import {automationStatePath} from '../automation/paths.js';
 import type {ToolId} from './automation-config.js';
+import {summarizeZodError} from './zod-error.js';
 
 export const TriggerSchema = z.enum(['cron', 'force', 'workflow_dispatch']);
 export type Trigger = z.infer<typeof TriggerSchema>;
@@ -34,16 +35,6 @@ export type ReadAutomationStateResult =
   | {state: AutomationStateFile; status: 'ok'}
   | {status: 'missing'}
   | {error: string; status: 'malformed'};
-
-const summarizeZodError = (filePath: string, error: z.ZodError): string => {
-  const lines = error.issues.map((issue) => {
-    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
-
-    return `${pathStr}: ${issue.message}`;
-  });
-
-  return `${filePath}: ${lines.join('; ')}`;
-};
 
 export const readAutomationState = (
   repoRoot: string,

--- a/.gaia/cli/src/schemas/envelope.ts
+++ b/.gaia/cli/src/schemas/envelope.ts
@@ -1,4 +1,8 @@
 import {z} from 'zod';
+import {
+  MentorshipPayloadByType,
+  type MentorshipEventType,
+} from './mentorship-payloads.js';
 
 export const AgentTypeSchema = z.enum([
   'PO',
@@ -24,15 +28,46 @@ export const Iso8601UtcMsSchema = z.string().regex(ISO8601_UTC_MS_REGEX);
 
 export const Sha256HexHalfSchema = z.string().regex(HEX_32_REGEX);
 
-export const EnvelopeSchema = z.object({
-  agent_type: AgentTypeSchema,
-  event_id: UlidSchema,
-  event_type: z.string(),
-  payload: z.unknown(),
-  project_id: Sha256HexHalfSchema,
-  schema_version: z.literal(1),
-  session_hash: Sha256HexHalfSchema,
-  timestamp: Iso8601UtcMsSchema,
-});
+const isMentorshipEventType = (
+  eventType: string
+): eventType is MentorshipEventType =>
+  Object.hasOwn(MentorshipPayloadByType, eventType);
+
+/**
+ * Universal event envelope. `payload` is `unknown` at the field level
+ * because cloud-only event types (`pr_opened`, etc.) have no per-type
+ * schema in v1. The `superRefine` below cross-validates the payload
+ * against `event_type`: for any known mentorship event type the payload
+ * MUST satisfy that type's schema in `MentorshipPayloadByType`. Unknown
+ * event types keep an unconstrained payload — projection's strict cloud
+ * schemas (`telemetry/projection.ts`) own that boundary.
+ */
+export const EnvelopeSchema = z
+  .object({
+    agent_type: AgentTypeSchema,
+    event_id: UlidSchema,
+    event_type: z.string(),
+    payload: z.unknown(),
+    project_id: Sha256HexHalfSchema,
+    schema_version: z.literal(1),
+    session_hash: Sha256HexHalfSchema,
+    timestamp: Iso8601UtcMsSchema,
+  })
+  .superRefine((envelope, ctx) => {
+    if (!isMentorshipEventType(envelope.event_type)) return;
+
+    const payloadSchema = MentorshipPayloadByType[envelope.event_type];
+    const result = payloadSchema.safeParse(envelope.payload);
+
+    if (result.success) return;
+
+    for (const issue of result.error.issues) {
+      ctx.addIssue({
+        code: 'custom',
+        message: issue.message,
+        path: ['payload', ...issue.path],
+      });
+    }
+  });
 
 export type Envelope = z.infer<typeof EnvelopeSchema>;

--- a/.gaia/cli/src/schemas/local-automation.ts
+++ b/.gaia/cli/src/schemas/local-automation.ts
@@ -9,6 +9,7 @@
 import {existsSync, readFileSync} from 'node:fs';
 import {z} from 'zod';
 import {localAutomationPath} from '../automation/paths.js';
+import {summarizeZodError} from './zod-error.js';
 
 export const LocalAutomationSchema = z.object({
   version: z.literal(1),
@@ -23,16 +24,6 @@ export type ReadLocalAutomationResult =
   | {local: LocalAutomation; status: 'ok'}
   | {status: 'missing'}
   | {error: string; status: 'malformed'};
-
-const summarizeZodError = (filePath: string, error: z.ZodError): string => {
-  const lines = error.issues.map((issue) => {
-    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
-
-    return `${pathStr}: ${issue.message}`;
-  });
-
-  return `${filePath}: ${lines.join('; ')}`;
-};
 
 export const readLocalAutomation = (
   repoRoot: string

--- a/.gaia/cli/src/schemas/mentorship-config.ts
+++ b/.gaia/cli/src/schemas/mentorship-config.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 export const MentorshipConfigSchema = z.object({
   analytics: z.object({enabled: z.boolean()}),
-  decided_at: z.string().nullable(),
+  decided_at: z.iso.datetime().nullable(),
   decided_via: z
     .enum([
       'gaia-init',

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -14,6 +14,7 @@ import {existsSync, mkdirSync, readFileSync, renameSync, writeFileSync} from 'no
 import path from 'node:path';
 import {z} from 'zod';
 import {revertLedgerPath} from '../ci/paths.js';
+import {summarizeZodError} from './zod-error.js';
 
 export const RevertAttemptStatusSchema = z.literal(['failed', 'merged', 'open'] as const);
 export type RevertAttemptStatus = z.infer<typeof RevertAttemptStatusSchema>;
@@ -41,16 +42,6 @@ export type ReadRevertLedgerResult =
   | {ledger: RevertLedger; status: 'ok'}
   | {status: 'missing'}
   | {error: string; status: 'malformed'};
-
-const summarizeZodError = (filePath: string, error: z.ZodError): string => {
-  const lines = error.issues.map((issue) => {
-    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
-
-    return `${pathStr}: ${issue.message}`;
-  });
-
-  return `${filePath}: ${lines.join('; ')}`;
-};
 
 export const readRevertLedger = (repoRoot: string): ReadRevertLedgerResult => {
   const filePath = revertLedgerPath(repoRoot);

--- a/.gaia/cli/src/schemas/zod-error.ts
+++ b/.gaia/cli/src/schemas/zod-error.ts
@@ -1,0 +1,20 @@
+import type {z} from 'zod';
+
+/**
+ * Render a `ZodError` into a single-line, human-readable summary prefixed
+ * with the offending file path. Shared by the schema `read*` helpers
+ * (`automation-config`, `automation-state`, `local-automation`,
+ * `revert-ledger`) so the malformed-file message format stays consistent.
+ */
+export const summarizeZodError = (
+  filePath: string,
+  error: z.ZodError
+): string => {
+  const lines = error.issues.map((issue) => {
+    const pathStr = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+
+    return `${pathStr}: ${issue.message}`;
+  });
+
+  return `${filePath}: ${lines.join('; ')}`;
+};

--- a/.gaia/cli/src/storage/__tests__/project-id.test.ts
+++ b/.gaia/cli/src/storage/__tests__/project-id.test.ts
@@ -97,19 +97,19 @@ describe('readOrCreateProjectId', () => {
     expect(repoRootFromProjectIdPath(projectIdPath)).toBe(root);
   });
 
-  test('repoRootFromProjectIdPath handles Windows backslash separators', () => {
-    // The old implementation used a regex anchored to `/`, so a
-    // backslash-separated path left the `.gaia\local\.project-id` suffix
-    // attached and derived the wrong project id. path.win32.dirname is the
-    // separator-aware operation that path.dirname delegates to on Windows.
-    const root = String.raw`C:\Users\me\project`;
-    const projectIdPath = [root, '.gaia', 'local', '.project-id'].join('\\');
-    const recovered = [projectIdPath]
-      .map((p) => path.win32.dirname(path.win32.dirname(path.win32.dirname(p))))
-      .at(0);
+  // repoRootFromProjectIdPath delegates to path.dirname, which is
+  // separator-aware for the host platform. A backslash-separated path is
+  // only resolvable by the function on Windows — on POSIX, path.dirname does
+  // not treat `\` as a separator — so this case runs natively only.
+  test.runIf(process.platform === 'win32')(
+    'repoRootFromProjectIdPath recovers the root from a Windows backslash path',
+    () => {
+      const root = String.raw`C:\Users\me\project`;
+      const projectIdPath = [root, '.gaia', 'local', '.project-id'].join('\\');
 
-    expect(recovered).toBe(root);
-  });
+      expect(repoRootFromProjectIdPath(projectIdPath)).toBe(root);
+    }
+  );
 
   test('creates the parent .gaia/local/ directory if absent', () => {
     const roots = resolveStorageRoots({homeDir: homeDirectory, repoRoot});

--- a/.gaia/cli/src/storage/__tests__/project-id.test.ts
+++ b/.gaia/cli/src/storage/__tests__/project-id.test.ts
@@ -5,7 +5,10 @@ import {existsSync, mkdtempSync, readFileSync, rmSync, statSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {resolveStorageRoots} from '../paths.js';
-import {readOrCreateProjectId} from '../project-id.js';
+import {
+  readOrCreateProjectId,
+  repoRootFromProjectIdPath,
+} from '../project-id.js';
 
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
@@ -82,6 +85,30 @@ describe('readOrCreateProjectId', () => {
       rmSync(repoA, {force: true, recursive: true});
       rmSync(repoB, {force: true, recursive: true});
     }
+  });
+
+  test('repoRootFromProjectIdPath round-trips a native-separator path', () => {
+    // resolveStorageRoots builds projectIdPath with path.join (native
+    // separators); the helper must recover the exact root via path.dirname
+    // rather than a regex hard-coded to `/`, which breaks on Windows `\`.
+    const root = path.join(repoRoot, 'nested', 'project');
+    const projectIdPath = path.join(root, '.gaia', 'local', '.project-id');
+
+    expect(repoRootFromProjectIdPath(projectIdPath)).toBe(root);
+  });
+
+  test('repoRootFromProjectIdPath handles Windows backslash separators', () => {
+    // The old implementation used a regex anchored to `/`, so a
+    // backslash-separated path left the `.gaia\local\.project-id` suffix
+    // attached and derived the wrong project id. path.win32.dirname is the
+    // separator-aware operation that path.dirname delegates to on Windows.
+    const root = String.raw`C:\Users\me\project`;
+    const projectIdPath = [root, '.gaia', 'local', '.project-id'].join('\\');
+    const recovered = [projectIdPath]
+      .map((p) => path.win32.dirname(path.win32.dirname(path.win32.dirname(p))))
+      .at(0);
+
+    expect(recovered).toBe(root);
   });
 
   test('creates the parent .gaia/local/ directory if absent', () => {

--- a/.gaia/cli/src/storage/project-id.ts
+++ b/.gaia/cli/src/storage/project-id.ts
@@ -30,6 +30,15 @@ const deriveProjectId = (repoRootPath: string): string => {
 };
 
 /**
+ * Recover the repo root from a `projectIdPath`. The path always has the
+ * shape `<repoRoot>/.gaia/local/.project-id`, so the root is three
+ * directory levels up. `path.dirname` handles both `/` and `\` separators,
+ * so this is cross-platform (a regex on `/` would break on Windows).
+ */
+export const repoRootFromProjectIdPath = (projectIdPath: string): string =>
+  path.dirname(path.dirname(path.dirname(projectIdPath)));
+
+/**
  * Read or generate `.gaia/local/.project-id` at the repo root.
  * UUIDv4 derived from sha256(repo_root_path); take first 16 bytes; format per RFC 4122.
  * Mode 644.
@@ -54,9 +63,9 @@ export const readOrCreateProjectId = (roots: StorageRoots): string => {
   }
 
   // The repoRoot the projectIdPath was resolved from is the only stable input
-  // for the derivation. Reconstruct it from the path: projectIdPath ends in
-  // `/.gaia/local/.project-id` — the prefix is the repo root.
-  const repoRoot = filePath.replace(/\/\.gaia\/local\/\.project-id$/u, '');
+  // for the derivation. Recover it from the path — projectIdPath ends in
+  // `<repoRoot>/.gaia/local/.project-id`, so the root is three levels up.
+  const repoRoot = repoRootFromProjectIdPath(filePath);
   const id = deriveProjectId(repoRoot);
   writeFileSync(filePath, `${id}\n`, {mode: 0o644});
 


### PR DESCRIPTION
## Summary

Remediates pre-release audit findings in the `@gaia-react/cli` maintainer CLI (`.gaia/cli/`). Each finding was verified against current source before fixing.

### Fixed

- **`init/rename.ts`** — `replaceStringPropertyAll` rewrote *every* `title` property in `_index.ts`. On a user-diverged file (extra routes carrying their own `title`), this caused data loss. Now scoped to the seed's three identity keys only: top-level `heroTitle`, top-level `title`, and `meta.title`. `replaceStringPropertyAll` is retained for `common.ts` (`siteName`).
- **`schemas/envelope.ts`** — `payload: z.unknown()` had no cross-validation against `event_type`. Added a `superRefine` that validates the payload against `MentorshipPayloadByType[event_type]` for known mentorship event types; cloud-only types keep an unconstrained payload (projection's strict cloud schemas own that boundary). Mentorship payload schemas are non-strict, so the cloud-projection drift tests still behave correctly.
- **`schemas/analytics-report.ts`** / **`schemas/mentorship-config.ts`** — `report_generated_at` and `decided_at` tightened from bare `z.string()` to `z.iso.datetime()`, matching sibling schemas (`revert-ledger`, `automation-state`) and the `.toISOString()` producers.
- **`storage/project-id.ts`** — repo-root recovery from `projectIdPath` used a regex anchored to `/`, breaking on Windows `\` separators and deriving a wrong project id. Replaced with a `path.dirname`-based `repoRootFromProjectIdPath` helper (cross-platform, exported for testing).

### Suggested findings — actioned

- **`init/strip-branding.ts`** — the `GaiaLogo` JSX matcher only matched self-closing `<GaiaLogo … />`. Now also matches a paired `<GaiaLogo>…</GaiaLogo>` element.
- **`summarizeZodError`** — four copy-pasted definitions across schema files consolidated into one shared `schemas/zod-error.ts`.

### Suggested findings — skipped

- **`storage/paths.ts` `cachedRepoRoot` module-level state** — skipped. This is a deliberate per-process memoization of `execSync('git rev-parse …')`, which is deterministic within a process. It is not a correctness bug; removing it only adds repeated subprocess overhead. Tests always pass `repoRoot` explicitly, so the cache is never exercised by the suite.

### Scope note

Per the task brief, `writeFileSync` calls were left as-is — file-write atomicity in `init/` and `storage/` is owned by a separate PR.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — passes, no errors
- [x] `pnpm -C .gaia/cli exec vitest run` — 108 files / 1131 tests passed, 0 failed
- New tests added (TDD): diverged-`_index.ts` preservation; cross-platform `repoRootFromProjectIdPath`; envelope payload/event_type cross-validation; tightened timestamp schemas; paired `<GaiaLogo>` replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)