### PR TITLE
feat(test): add axe-core accessibility testing for Vitest and Playwright

### DIFF
--- a/.claude/rules/playwright.md
+++ b/.claude/rules/playwright.md
@@ -110,3 +110,24 @@ await page.setExtraHTTPHeaders({'Accept-Language': 'ja'});
 
 - `trace: 'retain-on-failure'` — traces saved to `.playwright/output/` on failure.
 - No explicit screenshot calls in specs; rely on Playwright trace viewer for debugging.
+
+## Accessibility scans
+
+Use `expectNoSeriousA11yViolations` from `.playwright/a11y.ts` for axe-core
+scans of fully-rendered pages. The fixture in `.playwright/fixtures.ts`
+exposes `makeAxeBuilder` for tests that need to customize tags, includes, or
+disabled rules. Failure threshold is frozen: critical + serious violations
+fail the test; moderate + minor violations attach as `axe-advisory.json` and
+emit `console.warn`.
+
+```ts
+import {test} from '../fixtures';
+import {expectNoSeriousA11yViolations} from '../a11y';
+import {hydration} from '../utils';
+
+test('home page has no serious a11y violations', async ({page}, testInfo) => {
+  await page.goto('/');
+  await hydration(page);
+  await expectNoSeriousA11yViolations(page, testInfo);
+});
+```

--- a/.claude/skills/a11y-fixes/SKILL.md
+++ b/.claude/skills/a11y-fixes/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: a11y-fixes
+description: Resolve axe-core accessibility violations reported by Vitest (test/a11y.ts), Playwright (.playwright/a11y.ts), or the code-review-audit agent's a11y bucket. Use when fixing violations like color-contrast, label, label-title-only, image-alt, button-name, link-name, region, landmark-one-main, heading-order, aria-allowed-attr, aria-required-attr, aria-required-children, aria-required-parent, aria-valid-attr-value, focus-trap, tabindex, html-has-lang, document-title, duplicate-id, listitem, definition-list. Trigger on any axe rule id appearing in test output.
+model: haiku
+---
+
+# Accessibility Fix Patterns
+
+How to resolve specific axe-core violations in this project.
+
+Violations come from `test/a11y.ts` (Vitest), `.playwright/a11y.ts` (Playwright), or the `code-review-audit` agent's a11y bucket. General a11y guidance lives in `.claude/rules/accessibility.md`.
+
+## color-contrast
+
+WCAG AA requires 4.5:1 for normal text, 3:1 for large text. Use the project's semantic Tailwind tokens (see `.claude/rules/tailwind.md`) instead of arbitrary palette colors — they pair light/dark modes correctly.
+
+```tsx
+// BAD — fails contrast in dark mode, raw colors
+<p className="text-gray-400 bg-white">Status</p>
+
+// GOOD — semantic tokens, contrast-safe in both modes
+<p className="text-body bg-body">Status</p>
+```
+
+## label
+
+Form inputs need an associated `<label>`. Use GAIA's `Field` wrapper from `~/components/Form/Field` rather than a bare `<label>` — it wires `htmlFor`, error text, and description automatically. See the `form-components.md` audit extension.
+
+```tsx
+// BAD — bare input with no label association
+<input type="text" name="email" />
+
+// GOOD — Field wraps a project input with the right wiring
+<Field type="input" name="email" label={t('email')}>
+  <InputText name="email" />
+</Field>
+```
+
+## label-title-only
+
+`title` attributes are not labels — screen readers and mobile devices ignore them. Use `aria-label` or a real `<label>`.
+
+```tsx
+// BAD — title is not an accessible name
+<input type="text" title="Search" />
+
+// GOOD — aria-label provides the accessible name
+<input type="text" aria-label={t('search')} />
+```
+
+## image-alt
+
+Every `<img>` needs `alt`. Content images describe the image; decorative images use `alt=""`. See `.claude/rules/accessibility.md`.
+
+```tsx
+// BAD — no alt attribute
+<img src="/logo.png" />
+
+// GOOD — content image
+<img src="/logo.png" alt={t('companyLogo')} />
+
+// GOOD — decorative image, hidden from AT
+<img src="/divider.svg" alt="" />
+```
+
+## button-name
+
+Buttons need an accessible name. Visible text is fine; icon-only buttons need `aria-label`.
+
+```tsx
+// BAD — icon-only button with no name
+<button onClick={onClose}>
+  <CloseIcon />
+</button>
+
+// GOOD — aria-label supplies the name
+<button aria-label={t('close')} onClick={onClose}>
+  <CloseIcon />
+</button>
+
+// GOOD — visible text, no aria-label needed
+<button onClick={onSave}>{t('save')}</button>
+```
+
+## link-name
+
+Same pattern as `button-name` — anchors need an accessible name.
+
+```tsx
+// BAD — icon-only link
+<Link to="/settings"><GearIcon /></Link>
+
+// GOOD — aria-label on the link
+<Link to="/settings" aria-label={t('settings')}>
+  <GearIcon />
+</Link>
+```
+
+## region / landmark-one-main
+
+Page content must live inside a landmark, and there must be exactly one `<main>`. GAIA's Layout component owns the `<main>` landmark — page components render inside it and should not add their own.
+
+```tsx
+// BAD — page component wraps itself in <main>, duplicating Layout's
+const Page = () => (
+  <main>
+    <h1>{t('title')}</h1>
+  </main>
+);
+
+// GOOD — page renders into Layout's <main>
+const Page = () => (
+  <>
+    <h1>{t('title')}</h1>
+  </>
+);
+```
+
+## heading-order
+
+One `<h1>` per page. Levels do not skip — `h2 → h4` is a violation.
+
+```tsx
+// BAD — skips h3
+<h2>{t('section')}</h2>
+<h4>{t('subsection')}</h4>
+
+// GOOD — sequential levels
+<h2>{t('section')}</h2>
+<h3>{t('subsection')}</h3>
+```
+
+## aria-allowed-attr
+
+ARIA attributes are role-scoped. Look up the role; only attrs in its allowed list are valid. Common case: `aria-checked` only on `role="checkbox"`, `role="radio"`, `role="menuitemcheckbox"`, `role="menuitemradio"`, `role="switch"`, `role="treeitem"`.
+
+```tsx
+// BAD — aria-checked is not allowed on a button
+<button aria-checked={selected}>{t('toggle')}</button>
+
+// GOOD — aria-pressed for buttons, aria-checked for checkbox role
+<button aria-pressed={selected}>{t('toggle')}</button>
+```
+
+## aria-required-attr
+
+Some roles require companion attrs. Disclosure widgets (`aria-expanded`) need `aria-controls` pointing at the controlled element's id.
+
+```tsx
+// BAD — aria-expanded with no aria-controls
+<button aria-expanded={open}>{t('menu')}</button>
+
+// GOOD — aria-controls names the panel
+<button aria-expanded={open} aria-controls="menu-panel">
+  {t('menu')}
+</button>
+<div id="menu-panel" hidden={!open}>...</div>
+```
+
+## aria-required-children / aria-required-parent
+
+Composite roles need their child roles, and child roles need the right parent. Prefer semantic HTML (`<ul><li>`, `<select><option>`) over recreating these structures with ARIA.
+
+```tsx
+// BAD — role="listbox" with no role="option" children
+<div role="listbox">
+  <div>{t('one')}</div>
+  <div>{t('two')}</div>
+</div>
+
+// GOOD — semantic <select> with <option> children
+<select aria-label={t('choose')}>
+  <option value="1">{t('one')}</option>
+  <option value="2">{t('two')}</option>
+</select>
+```
+
+## aria-valid-attr-value
+
+`aria-*` attrs that take id refs must point at existing ids; boolean attrs take `true`/`false`, not arbitrary strings.
+
+```tsx
+// BAD — aria-labelledby points at id that does not exist
+<input aria-labelledby="missing-id" />
+
+// GOOD — id exists in the DOM
+<>
+  <span id="email-label">{t('email')}</span>
+  <input aria-labelledby="email-label" />
+</>
+```
+
+## focus-trap (focus management)
+
+Modals must trap focus while open and return focus to the trigger on close. See `.claude/rules/accessibility.md`. Prefer a vetted dialog primitive (Radix, react-aria) over hand-rolled focus logic.
+
+```tsx
+// BAD — open modal leaves focus on body, close drops focus
+{open && (
+  <div role="dialog">
+    <button onClick={() => setOpen(false)}>{t('close')}</button>
+  </div>
+)}
+
+// GOOD — primitive handles focus trap + restore
+<Dialog open={open} onOpenChange={setOpen}>
+  <Dialog.Content>
+    <Dialog.Close>{t('close')}</Dialog.Close>
+  </Dialog.Content>
+</Dialog>
+```
+
+## tabindex
+
+Positive `tabindex` (`tabindex={1}`, `tabindex={2}`, ...) reorders the tab sequence and is always a violation. Use `tabIndex={0}` to insert into natural order, `tabIndex={-1}` for programmatic-only focus.
+
+```tsx
+// BAD — positive tabindex skews tab order
+<div tabIndex={1}>{t('first')}</div>
+<div tabIndex={2}>{t('second')}</div>
+
+// GOOD — natural DOM order, programmatic focus on the panel
+<div tabIndex={0}>{t('first')}</div>
+<div tabIndex={0}>{t('second')}</div>
+<section tabIndex={-1} ref={panelRef}>...</section>
+```
+
+## html-has-lang
+
+`<html>` must have a `lang` attribute. The React Router root sets it from the i18n locale; if a violation appears, the root loader is not threading locale through. Verify the root layout reads locale from the request context and renders `<html lang={locale}>`.
+
+```tsx
+// BAD — hardcoded or missing lang
+<html>...</html>
+
+// GOOD — locale from the loader / i18n
+<html lang={locale}>...</html>
+```
+
+## document-title
+
+Every route needs a `<title>`. Set it via the route's `meta` export, and pull the string from i18n using the loader's `getInstance(context)` pattern (see `.claude/rules/i18n.md`).
+
+```ts
+// BAD — no meta, or hardcoded title
+export const meta = () => [{title: 'Dashboard'}];
+
+// GOOD — i18n-resolved title in the loader
+export const loader = ({context}) => {
+  const i18next = getInstance(context as RouterContextProvider);
+  return {title: i18next.t('dashboard.meta.title', {ns: 'pages'})};
+};
+export const meta = ({data}) => [{title: data.title}];
+```
+
+## duplicate-id
+
+Every `id` in the rendered DOM must be unique. Common Conform pitfall: rendering the same field `name` twice in a fieldset produces duplicate ids. Pass an explicit unique `id`.
+
+```tsx
+// BAD — same field rendered twice, ids collide
+<InputText name="email" />
+<InputText name="email" />
+
+// GOOD — unique ids
+<InputText id="email-primary" name="emailPrimary" />
+<InputText id="email-secondary" name="emailSecondary" />
+```
+
+## listitem
+
+`<li>` must be a direct child of `<ul>` or `<ol>`. A standalone `<li>` is a violation.
+
+```tsx
+// BAD — <li> with no list parent
+<div>
+  <li>{t('one')}</li>
+</div>
+
+// GOOD — wrapped in <ul>
+<ul>
+  <li>{t('one')}</li>
+</ul>
+```
+
+## definition-list
+
+`<dt>` and `<dd>` must live inside `<dl>`. Group related term/description pairs in one `<dl>`.
+
+```tsx
+// BAD — dt/dd outside <dl>
+<div>
+  <dt>{t('term')}</dt>
+  <dd>{t('definition')}</dd>
+</div>
+
+// GOOD — wrapped in <dl>
+<dl>
+  <dt>{t('term')}</dt>
+  <dd>{t('definition')}</dd>
+</dl>
+```

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -20,3 +20,7 @@ Trigger: user asks to create a component, scaffold a card, etc.
 - `--no-story` — skip Storybook story
 - `--parent <dir>` — non-default parent dir (e.g. `app/components/Form`)
 - `--props "a:string,b:number"` — typed props rendered as a Props alias and destructured in the signature
+
+## Accessibility assertion
+
+Scaffolded test files include a `test('a11y')` block that calls `expectNoA11yViolations` from `test/a11y.ts` (axe-core, [WCAG 2.1 AA](https://www.w3.org/TR/WCAG21/) ruleset). Because `axe-core` is incompatible with the project's default `happy-dom` test environment (`Node.prototype.isConnected` is getter-only — capricorn86/happy-dom#978), the scaffolder writes `// @vitest-environment jsdom` as the first line of the test file. The directive is required: `expectNoA11yViolations` throws an actionable error if it detects a non-jsdom runtime. Don't strip the directive when editing the file.

--- a/.gaia/cli/src/scaffold/component.test.ts
+++ b/.gaia/cli/src/scaffold/component.test.ts
@@ -88,6 +88,11 @@ const captureStdio = (): StdioCapture => {
 
 const read = (filePath: string): string => readFileSync(filePath, 'utf8');
 
+// Built from fragments so Vitest's environment scanner does not read the
+// directive text in the assertions below as a real environment pragma for
+// this file — this is a Node CLI test and must not be forced into jsdom.
+const JSDOM_ENV_DIRECTIVE = `// @vitest-${'environment'} jsdom`;
+
 describe('scaffold component', () => {
   let sandbox: Sandbox;
   let stdio: StdioCapture;
@@ -124,7 +129,7 @@ describe('scaffold component', () => {
     expect(indexContents).not.toContain('FooProps');
 
     const testContents = read(testPath);
-    expect(testContents.startsWith('// @vitest-environment jsdom\n')).toBe(true);
+    expect(testContents.startsWith(`${JSDOM_ENV_DIRECTIVE}\n`)).toBe(true);
     expect(testContents).toContain(
       "import {composeStory} from '@storybook/react-vite';"
     );
@@ -161,7 +166,7 @@ describe('scaffold component', () => {
     const testContents = read(
       path.join(sandbox.parent, 'Bar', 'tests', 'index.test.tsx')
     );
-    expect(testContents.startsWith('// @vitest-environment jsdom\n')).toBe(true);
+    expect(testContents.startsWith(`${JSDOM_ENV_DIRECTIVE}\n`)).toBe(true);
     expect(testContents).not.toContain('composeStory');
     expect(testContents).toContain("import Bar from '..'");
     expect(testContents).toContain(

--- a/.gaia/cli/src/scaffold/component.test.ts
+++ b/.gaia/cli/src/scaffold/component.test.ts
@@ -124,11 +124,17 @@ describe('scaffold component', () => {
     expect(indexContents).not.toContain('FooProps');
 
     const testContents = read(testPath);
+    expect(testContents.startsWith('// @vitest-environment jsdom\n')).toBe(true);
     expect(testContents).toContain(
       "import {composeStory} from '@storybook/react-vite';"
     );
+    expect(testContents).toContain(
+      "import {expectNoA11yViolations} from 'test/a11y';"
+    );
     expect(testContents).toContain('const Foo = composeStory(Default, Meta);');
     expect(testContents).toContain("describe('Foo'");
+    expect(testContents).toContain("test('a11y', async () => {");
+    expect(testContents).toContain('await expectNoA11yViolations(container);');
 
     const storyContents = read(storyPath);
     expect(storyContents).toContain("import Foo from '..';");
@@ -155,8 +161,13 @@ describe('scaffold component', () => {
     const testContents = read(
       path.join(sandbox.parent, 'Bar', 'tests', 'index.test.tsx')
     );
+    expect(testContents.startsWith('// @vitest-environment jsdom\n')).toBe(true);
     expect(testContents).not.toContain('composeStory');
     expect(testContents).toContain("import Bar from '..'");
+    expect(testContents).toContain(
+      "import {expectNoA11yViolations} from 'test/a11y';"
+    );
+    expect(testContents).toContain("test('a11y', async () => {");
   });
 
   test('--props renders a typed Props alias and destructured signature', () => {

--- a/.gaia/cli/src/scaffold/templates/component/index.test.tsx.tmpl
+++ b/.gaia/cli/src/scaffold/templates/component/index.test.tsx.tmpl
@@ -1,8 +1,15 @@
+// @vitest-environment jsdom
 {{testImports}}
+import {expectNoA11yViolations} from 'test/a11y';
 
 describe('{{Name}}', () => {
   test('renders', () => {
     const {container} = render(<{{Name}} />);
     expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('a11y', async () => {
+    const {container} = render(<{{Name}} />);
+    await expectNoA11yViolations(container);
   });
 });

--- a/.playwright/a11y.ts
+++ b/.playwright/a11y.ts
@@ -1,0 +1,57 @@
+import AxeBuilder from '@axe-core/playwright';
+import type {Page, TestInfo} from '@playwright/test';
+
+const SEVERITY_FAIL = new Set(['critical', 'serious']);
+
+/**
+ * Scans the current page with axe and asserts no critical/serious
+ * violations. Moderate/minor violations are attached to the test info
+ * and surfaced via console.warn.
+ */
+export const expectNoSeriousA11yViolations = async (
+  page: Page,
+  testInfo: TestInfo,
+  builder?: AxeBuilder
+): Promise<void> => {
+  const axe =
+    builder ??
+    new AxeBuilder({page}).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+    ]);
+
+  const {violations} = await axe.analyze();
+  const blocking = violations.filter((v) =>
+    SEVERITY_FAIL.has(v.impact ?? 'minor')
+  );
+  const advisory = violations.filter(
+    (v) => !SEVERITY_FAIL.has(v.impact ?? 'minor')
+  );
+
+  if (advisory.length > 0) {
+    await testInfo.attach('axe-advisory.json', {
+      body: JSON.stringify(advisory, null, 2),
+      contentType: 'application/json',
+    });
+
+    for (const v of advisory) {
+      // eslint-disable-next-line no-console -- advisory surface for moderate/minor violations
+      console.warn(`a11y advisory (${v.impact}) ${v.id}: ${v.help}`);
+    }
+  }
+
+  if (blocking.length > 0) {
+    await testInfo.attach('axe-violations.json', {
+      body: JSON.stringify(blocking, null, 2),
+      contentType: 'application/json',
+    });
+
+    throw new Error(
+      `Found ${blocking.length} blocking a11y violations: ${blocking
+        .map((v) => `${v.id} (${v.impact})`)
+        .join(', ')}`
+    );
+  }
+};

--- a/.playwright/e2e/home-a11y.spec.ts
+++ b/.playwright/e2e/home-a11y.spec.ts
@@ -1,0 +1,10 @@
+import {expectNoSeriousA11yViolations} from '../a11y';
+import {test} from '../fixtures';
+import {hydration} from '../utils';
+
+// eslint-disable-next-line playwright/expect-expect -- expectNoSeriousA11yViolations is the assertion
+test('home page has no serious a11y violations', async ({page}, testInfo) => {
+  await page.goto('/');
+  await hydration(page);
+  await expectNoSeriousA11yViolations(page, testInfo);
+});

--- a/.playwright/e2e/language-switch-a11y.spec.ts
+++ b/.playwright/e2e/language-switch-a11y.spec.ts
@@ -1,0 +1,20 @@
+import {expectNoSeriousA11yViolations} from '../a11y';
+import {test} from '../fixtures';
+import {hydration} from '../utils';
+
+// eslint-disable-next-line playwright/expect-expect -- expectNoSeriousA11yViolations is the assertion
+test('language switcher has no serious a11y violations', async ({
+  page,
+}, testInfo) => {
+  await page.goto('/');
+  await hydration(page);
+
+  // Smoke-test the switcher in its initial state.
+  await expectNoSeriousA11yViolations(page, testInfo);
+
+  // Re-select the current language to exercise the switch flow.
+  await page.locator('select[name="language"]').selectOption('en');
+  await hydration(page);
+
+  await expectNoSeriousA11yViolations(page, testInfo);
+});

--- a/.playwright/fixtures.ts
+++ b/.playwright/fixtures.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from '@axe-core/playwright';
+import {test as base, expect} from '@playwright/test';
+
+type AxeFixtures = {
+  makeAxeBuilder: () => AxeBuilder;
+};
+
+/**
+ * Extended Playwright test with an axe-core builder fixture.
+ * Default tag set: WCAG 2.0/2.1 A and AA.
+ */
+export const test = base.extend<AxeFixtures>({
+  makeAxeBuilder: async ({page}, use) => {
+    const make = () =>
+      new AxeBuilder({page}).withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+      ]);
+
+    // `use` is the Playwright fixture-API callback parameter, not a React hook.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    await use(make);
+  },
+});
+
+export {expect};

--- a/app/components/Button/tests/index.test.tsx
+++ b/app/components/Button/tests/index.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
 import userEvent from '@testing-library/user-event';
 import {describe, expect, test, vi} from 'vitest';
+import {expectNoA11yViolations} from 'test/a11y';
 import {render, screen} from 'test/rtl';
 import Button from '..';
 
@@ -34,5 +36,10 @@ describe('Button', () => {
     );
     const loader = screen.getByRole('progressbar');
     expect(loader).toBeInTheDocument();
+  });
+
+  test('a11y', async () => {
+    const {container} = render(<Button>Test</Button>);
+    await expectNoA11yViolations(container);
   });
 });

--- a/app/pages/Public/IndexPage/index.tsx
+++ b/app/pages/Public/IndexPage/index.tsx
@@ -36,7 +36,7 @@ const IndexPage: FC = () => {
         className="relative z-10 flex flex-1 flex-col justify-center p-8 sm:px-16 sm:py-12"
       >
         <div className="max-w-3xl">
-          <p className="text-claude-500 dark:text-claude-400 mb-4 font-mono text-xs uppercase tracking-widest sm:text-sm">
+          <p className="text-claude-700 dark:text-claude-400 mb-4 font-mono text-xs uppercase tracking-widest sm:text-sm">
             {t('eyebrow')}
           </p>
 
@@ -55,7 +55,7 @@ const IndexPage: FC = () => {
 
           <div className="flex">
             <LinkButton
-              className="border-claude-500 text-claude-500 hover:bg-claude-500/10 dark:border-claude-400 dark:text-claude-300 dark:hover:bg-claude-500/15"
+              className="border-claude-500 text-claude-700 hover:bg-claude-500/10 dark:border-claude-400 dark:text-claude-300 dark:hover:bg-claude-500/15"
               icon={FaGithub}
               size="lg"
               to="https://github.com/gaia-react/gaia"

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -16,6 +16,7 @@
   --color-claude-400: #e89275;
   --color-claude-500: #d97757;
   --color-claude-600: #c96b4b;
+  --color-claude-700: #b05a3d;
 }
 
 @layer base {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
     "@faker-js/faker": "10.4.0",
     "@gaia-react/lint": "1.1.3",
     "@msw/data": "1.1.5",
@@ -92,11 +93,13 @@
     "@vitest/coverage-v8": "4.1.5",
     "@vueless/storybook-dark-mode": "10.0.8",
     "accept-language-parser": "1.5.0",
+    "axe-core": "4.11.4",
     "chromatic": "16.9.1",
     "eslint": "9.39.4",
     "happy-dom": "20.9.0",
     "husky": "9.1.7",
     "is-ci": "4.1.0",
+    "jsdom": "29.1.1",
     "knip": "6.12.2",
     "lint-staged": "17.0.4",
     "msw": "2.14.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.3
+        version: 4.11.3(playwright-core@1.59.1)
       '@faker-js/faker':
         specifier: 10.4.0
         version: 10.4.0
@@ -186,6 +189,9 @@ importers:
       accept-language-parser:
         specifier: 1.5.0
         version: 1.5.0
+      axe-core:
+        specifier: 4.11.4
+        version: 4.11.4
       chromatic:
         specifier: 16.9.1
         version: 16.9.1
@@ -201,6 +207,9 @@ importers:
       is-ci:
         specifier: 4.1.0
         version: 4.1.0
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       knip:
         specifier: 6.12.2
         version: 6.12.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -263,6 +272,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -5358,7 +5372,6 @@ snapshots:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -5367,13 +5380,15 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1':
-    optional: true
+  '@asamuzakjp/generational-cache@1.0.1': {}
 
-  '@asamuzakjp/nwsapi@2.3.9':
-    optional: true
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.59.1
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5576,7 +5591,6 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
-    optional: true
 
   '@cacheable/memory@2.0.8':
     dependencies:
@@ -5603,8 +5617,7 @@ snapshots:
       '@conform-to/dom': 1.19.2
       zod: 4.4.3
 
-  '@csstools/color-helpers@6.0.2':
-    optional: true
+  '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5617,7 +5630,6 @@ snapshots:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5805,8 +5817,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0':
-    optional: true
+  '@exodus/bytes@1.15.0': {}
 
   '@faker-js/faker@10.4.0': {}
 
@@ -7180,7 +7191,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-    optional: true
 
   body-parser@1.20.5:
     dependencies:
@@ -7411,7 +7421,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -7445,8 +7454,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   decode-uri-component@0.4.1: {}
 
@@ -7531,8 +7539,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  entities@8.0.0:
-    optional: true
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -8480,7 +8487,6 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -8666,8 +8672,7 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-proto-prop@2.0.0:
     dependencies:
@@ -8782,7 +8787,6 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   jsesc@3.0.2: {}
 
@@ -9273,7 +9277,6 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
-    optional: true
 
   parseurl@1.3.3: {}
 
@@ -9692,7 +9695,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.27.0: {}
 
@@ -10073,8 +10075,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   synckit@0.11.12:
     dependencies:
@@ -10138,7 +10139,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -10250,8 +10250,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.25.0:
-    optional: true
+  undici@7.25.0: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -10407,7 +10406,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   wait-for-expect@3.0.2: {}
 
@@ -10415,15 +10413,13 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@8.0.1:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-mimetype@5.0.0:
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
     dependencies:
@@ -10432,7 +10428,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10523,11 +10518,9 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/test/a11y.ts
+++ b/test/a11y.ts
@@ -1,0 +1,48 @@
+import axeCore from 'axe-core';
+import type {AxeResults, RunOptions} from 'axe-core';
+import {expect} from 'vitest';
+
+/**
+ * Runs axe-core against the given container and asserts no violations.
+ * Uses the project-wide axe ruleset; pass `options` to scope or filter
+ * (e.g. exclude rules, restrict tags).
+ *
+ * Test files calling this MUST opt into jsdom via:
+ *   // @vitest-environment jsdom
+ * placed as the first line of the file. happy-dom's Node.prototype.isConnected
+ * (getter-only) breaks axe-core's polyfill (capricorn86/happy-dom#978).
+ */
+
+const assertJsdomEnvironment = (): void => {
+  // jsdom sets navigator.userAgent to a Mozilla string containing "jsdom".
+  // happy-dom does not. The user agent is the canonical signal across both.
+  if (!globalThis.navigator.userAgent.includes('jsdom')) {
+    throw new Error(
+      'expectNoA11yViolations requires the jsdom test environment. ' +
+        'Add `// @vitest-environment jsdom` as the first line of this test file. ' +
+        'happy-dom is incompatible with axe-core (capricorn86/happy-dom#978).'
+    );
+  }
+};
+
+/** Raw axe runner for tests that need to inspect the result manually. */
+export const runAxe = async (
+  container: Document | Element,
+  options?: RunOptions
+): Promise<AxeResults> => {
+  assertJsdomEnvironment();
+
+  // axe.run treats a trailing undefined as callback mode; forward options
+  // only when the caller supplied them so we always get a Promise back.
+  return options === undefined ?
+      axeCore.run(container)
+    : axeCore.run(container, options);
+};
+
+export const expectNoA11yViolations = async (
+  container: Document | Element,
+  options?: RunOptions
+): Promise<void> => {
+  const results = await runAxe(container, options);
+  expect(results.violations).toEqual([]);
+};

--- a/wiki/concepts/Component Testing.md
+++ b/wiki/concepts/Component Testing.md
@@ -34,3 +34,7 @@ Stateful custom form components MUST use `useInputControl` to stay in sync with 
 `app/components/Form/YearMonthDay/tests/` — three Selects driven by a local hidden ISO date input, fully tested via `composeStory` and `useInputControl`.
 
 For the current file pattern (where to put `.stories.tsx` vs `.test.tsx`), Serena and the scaffolders (`/new-component`, `/new-route`) handle it — query Serena rather than maintaining the layout here.
+
+## Accessibility assertions
+
+`test/a11y.ts` exports `expectNoA11yViolations(container, options?)` and `runAxe(container, options?)` — thin wrappers around `axe-core` that fail a test on any WCAG-relevant violation. The scaffolder injects an `a11y` block into every new component test by default. The helper requires the `jsdom` runtime: tests calling it must declare `// @vitest-environment jsdom` as the very first line of the file. The global env stays `happy-dom` for speed; the per-file opt-in exists because `axe-core` mutates `Node.prototype.isConnected`, which `happy-dom` defines as a getter-only property. The helper throws a clear setup error when the env is wrong, so a missing directive surfaces immediately.


### PR DESCRIPTION
## Summary
- Adds `test/a11y.ts` — `expectNoA11yViolations`/`runAxe` wrappers around `axe-core` for component-level a11y assertions
- Adds `.playwright/a11y.ts` + `fixtures.ts` + two e2e specs — page-level axe scans gated to critical/serious severity (moderate/minor attach as advisories)
- The component scaffolder template now injects an `a11y` test block into every new component test
- New `a11y-fixes` skill documents how to resolve each axe rule id
- New deps: `axe-core`, `@axe-core/playwright`, `jsdom`

## Notes
- `axe-core` requires the jsdom runtime (happy-dom's getter-only `Node.prototype.isConnected` breaks its polyfill), so affected test files opt in via a per-file `// @vitest-environment jsdom` directive; `test/a11y.ts` throws an actionable error if the wrong env is detected
- This branch restores in-progress work that `lint-staged` had stashed; the unused `@chialab/vitest-axe` dep the WIP had added was dropped since `test/a11y.ts` uses `axe-core` directly

## Test plan
- [x] typecheck (app + `.gaia/cli`)
- [x] lint
- [x] vitest one-shot — 55 app tests + 1118 `.gaia/cli` tests
- [x] production build
- [ ] run the new Playwright a11y e2e specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
