### PR TITLE
fix(knip): cover .playwright/ entry points

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -2,6 +2,7 @@ import type {KnipConfig} from 'knip';
 
 export default {
   entry: [
+    '.playwright/**/*.ts',
     '.storybook/**/*.{ts,tsx}',
     'app/components/**/*.{ts,tsx}',
     'app/hooks/**/*.ts',


### PR DESCRIPTION
## Summary
- knip's `entry` globs in `knip.config.ts` omitted `.playwright/`, so `@axe-core/playwright` — imported only by `.playwright/a11y.ts` and `.playwright/fixtures.ts` — was reported as an unused devDependency.
- Add `.playwright/**/*.ts` to the `entry` array. `pnpm knip` is now clean.

## Test plan
- [x] `pnpm knip` reports no findings
- [x] `pnpm typecheck && pnpm lint && pnpm test --run && pnpm build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)