### PR TITLE
fix(cli): atomic-write deferred writers + crypto temp-path

### DIFF
--- a/.gaia/cli/src/init/configure-i18n.ts
+++ b/.gaia/cli/src/init/configure-i18n.ts
@@ -20,10 +20,11 @@
  *
  * Stdout: nothing on success. Exit codes: 0 / 1 / 2.
  */
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {markStepCompleted} from './util/state.js';
 
 const HELP_TEXT = `Usage: gaia init configure-i18n --locales <list> --strip <bool>
@@ -172,7 +173,7 @@ const updateLanguagesIndex = (cwd: string, locales: readonly string[]): void => 
   const current = readFileSync(target, 'utf8');
 
   if (current === next) return;
-  writeFileSync(target, next, 'utf8');
+  atomicWriteFileSync(target, next);
 };
 
 const updateI18nFallback = (cwd: string, fallback: string): void => {
@@ -187,7 +188,7 @@ const updateI18nFallback = (cwd: string, fallback: string): void => {
   );
 
   if (next !== original) {
-    writeFileSync(target, next, 'utf8');
+    atomicWriteFileSync(target, next);
   }
 };
 

--- a/.gaia/cli/src/mentorship/display-rule-memory.ts
+++ b/.gaia/cli/src/mentorship/display-rule-memory.ts
@@ -17,15 +17,10 @@
  * `MEMORY.md` is treated as plain text. The index line is identified by
  * exact match against `DISPLAY_RULE_INDEX_LINE`.
  */
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync, unlinkSync} from 'node:fs';
 import path from 'node:path';
 import type {StorageRoots} from '../storage/index.js';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {
   DISPLAY_RULE_BODY,
   DISPLAY_RULE_FILE_NAME,
@@ -95,7 +90,7 @@ export const installDisplayRule = (roots: StorageRoots): void => {
   ensureMemoryDirectory(roots.memoryDir);
 
   const bodyPath = path.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
-  writeFileSync(bodyPath, DISPLAY_RULE_BODY, 'utf8');
+  atomicWriteFileSync(bodyPath, DISPLAY_RULE_BODY);
 
   const indexPath = path.join(roots.memoryDir, MEMORY_INDEX_FILE);
   const indexBody = readIndex(indexPath);
@@ -103,7 +98,7 @@ export const installDisplayRule = (roots: StorageRoots): void => {
   if (indexContainsLine(indexBody, DISPLAY_RULE_INDEX_LINE)) return;
 
   const next = appendIndexLine(indexBody, DISPLAY_RULE_INDEX_LINE);
-  writeFileSync(indexPath, next, 'utf8');
+  atomicWriteFileSync(indexPath, next);
 };
 
 /**
@@ -137,7 +132,7 @@ export const removeDisplayRule = (roots: StorageRoots): void => {
     return;
   }
 
-  writeFileSync(indexPath, next, 'utf8');
+  atomicWriteFileSync(indexPath, next);
 };
 
 /**
@@ -169,7 +164,7 @@ export const assertDisplayRule = (
   const bodyChanged = previousBody !== DISPLAY_RULE_BODY;
 
   if (bodyChanged) {
-    writeFileSync(bodyPath, DISPLAY_RULE_BODY, 'utf8');
+    atomicWriteFileSync(bodyPath, DISPLAY_RULE_BODY);
   }
 
   const indexPath = path.join(roots.memoryDir, MEMORY_INDEX_FILE);
@@ -178,7 +173,7 @@ export const assertDisplayRule = (
 
   if (lineMissing) {
     const next = appendIndexLine(indexBody, DISPLAY_RULE_INDEX_LINE);
-    writeFileSync(indexPath, next, 'utf8');
+    atomicWriteFileSync(indexPath, next);
   }
 
   return {

--- a/.gaia/cli/src/scaffold/barrel.ts
+++ b/.gaia/cli/src/scaffold/barrel.ts
@@ -15,7 +15,8 @@
  * inserted into the longest contiguous run of export-from lines that bounds
  * the alphabetically-correct slot.
  */
-import {readFileSync, writeFileSync} from 'node:fs';
+import {readFileSync} from 'node:fs';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 
 const EXPORT_FROM_PATTERN = /^\s*export\s+(?:\*|\{[^}]*\})\s+from\s+/u;
 
@@ -129,5 +130,5 @@ export const insertIntoBarrel = (
       ? insertWhenNoExistingRun(lines, exportLine)
       : insertAt(lines, findInsertIndex(lines, bounds, exportLine), exportLine);
 
-  writeFileSync(barrelPath, buildOutput(next, trailingNewline), 'utf8');
+  atomicWriteFileSync(barrelPath, buildOutput(next, trailingNewline));
 };

--- a/.gaia/cli/src/scaffold/fs.ts
+++ b/.gaia/cli/src/scaffold/fs.ts
@@ -6,8 +6,9 @@
  * file whose contents differ. Identical content is silently treated as a
  * no-op so re-running a scaffolder is idempotent.
  */
-import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 
 /**
  * Create the directory at `absPath` (recursive). No-op when it already
@@ -40,7 +41,7 @@ export const writeFileIfAbsent = (
   }
 
   ensureDir(path.dirname(absPath));
-  writeFileSync(absPath, contents, 'utf8');
+  atomicWriteFileSync(absPath, contents);
 
   return {written: true};
 };

--- a/.gaia/cli/src/scaffold/route.ts
+++ b/.gaia/cli/src/scaffold/route.ts
@@ -11,11 +11,12 @@
  * Templates and the shared scaffold primitives live alongside under
  * `templates/route/` and `template.ts` / `fs.ts` / `barrel.ts`.
  */
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {writeFileIfAbsent} from './fs.js';
 import {renderTemplate, type TemplateVars} from './template.js';
 import type {ScaffoldResult} from './types.js';
@@ -240,7 +241,7 @@ const insertIntoLocaleBarrel = (
     );
   }
 
-  writeFileSync(barrelPath, next, 'utf8');
+  atomicWriteFileSync(barrelPath, next);
 
   return 'inserted';
 };

--- a/.gaia/cli/src/scaffold/service.ts
+++ b/.gaia/cli/src/scaffold/service.ts
@@ -16,11 +16,12 @@
  *   - Endpoint flag drives which request functions, mock files, and the
  *     handlers-array order. The set is closed: get/post/put/delete only.
  */
-import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {fileURLToPath} from 'node:url';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {ensureDir, writeFileIfAbsent} from './fs.js';
 import {renderTemplate, type TemplateVars} from './template.js';
 import type {ScaffoldResult} from './types.js';
@@ -378,7 +379,7 @@ const updateDatabaseBarrel = (
   const next = applyDatabaseEdits(raw, derived, importLine, resetCall);
 
   if (next === raw) return {written: false};
-  writeFileSync(databasePath, next, 'utf8');
+  atomicWriteFileSync(databasePath, next);
 
   return {written: true};
 };

--- a/.gaia/cli/src/util/atomic-write.ts
+++ b/.gaia/cli/src/util/atomic-write.ts
@@ -6,6 +6,7 @@
  * after the rename can leave the target pointing at unflushed (empty or
  * partial) data.
  */
+import {randomBytes} from 'node:crypto';
 import {
   closeSync,
   fsyncSync,
@@ -16,10 +17,11 @@ import {
 } from 'node:fs';
 import {open, rename, unlink} from 'node:fs/promises';
 
-// PID + monotonic high-res clock keeps concurrent writers — same process
-// or different processes — from colliding on the temp file name.
+// A crypto-random suffix keeps concurrent writers — same process or
+// different processes — from colliding on the temp file name, and is
+// portable across platforms.
 const temporaryPath = (filePath: string): string =>
-  `${filePath}.tmp.${process.pid}.${process.hrtime.bigint().toString()}`;
+  `${filePath}.tmp.${randomBytes(8).toString('hex')}`;
 
 export const atomicWriteFileSync = (
   filePath: string,

--- a/.gaia/cli/src/wiki/state-bump.ts
+++ b/.gaia/cli/src/wiki/state-bump.ts
@@ -9,10 +9,11 @@
  * Replaces the prose `jq ... > tmp && mv tmp wiki/.state.json` recipe in
  * `wiki/sync.md` Step 6 and `wiki/consolidate.md` Step 5.
  */
-import {existsSync, readFileSync, renameSync, writeFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {resolveRepoRoot} from './util/git.js';
 
 const HELP_TEXT = `Usage: gaia wiki state-bump <field> <value>
@@ -159,9 +160,7 @@ export const run = (
   const next = reorderObject(source, field, tryParseJson(valueRaw));
   const trailingNewline = raw.endsWith('\n') ? '\n' : '';
   const serialized = `${JSON.stringify(next, null, 2)}${trailingNewline}`;
-  const tmpPath = `${statePath}.tmp`;
-  writeFileSync(tmpPath, serialized, 'utf8');
-  renameSync(tmpPath, statePath);
+  atomicWriteFileSync(statePath, serialized);
 
   return EXIT_CODES.OK;
 };

--- a/.gaia/cli/src/wiki/state-init.ts
+++ b/.gaia/cli/src/wiki/state-init.ts
@@ -11,10 +11,11 @@
  * existing file). `state-init` is the explicit creation primitive.
  */
 import {execFileSync} from 'node:child_process';
-import {existsSync, mkdirSync, renameSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {resolveRepoRoot} from './util/git.js';
 
 const HELP_TEXT = `Usage: gaia wiki state-init <sha>
@@ -143,9 +144,7 @@ export const run = (
   };
 
   const serialized = `${JSON.stringify(payload, null, 2)}\n`;
-  const tmpPath = `${statePath}.tmp`;
-  writeFileSync(tmpPath, serialized, 'utf8');
-  renameSync(tmpPath, statePath);
+  atomicWriteFileSync(statePath, serialized);
 
   return EXIT_CODES.OK;
 };


### PR DESCRIPTION
## Summary

- Route the lower-traffic committed-file writers deferred from the original atomic-write change (#198) through `atomicWriteFileSync` so a crash mid-write cannot corrupt the target: `scaffold/fs.ts`, `scaffold/barrel.ts`, `scaffold/route.ts`, `scaffold/service.ts`, `wiki/state-bump.ts`, `wiki/state-init.ts`, `init/configure-i18n.ts`, `mentorship/display-rule-memory.ts`.
- Replace the hand-rolled temp-file+rename in `state-bump.ts` / `state-init.ts` (which skipped `fsync`) with the helper.
- Switch the helper's temp-filename suffix from `process.pid` + `process.hrtime.bigint()` to `crypto.randomBytes(8)` — robust and portable. Public exports, fsync/rename ordering, and cleanup logic unchanged.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — clean
- [x] `pnpm -C .gaia/cli exec vitest run` — 109 files, 1167 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)