### PR TITLE
fix(cli-ci): revert-ledger lock per-PR scope + stale recovery

### DIFF
--- a/.gaia/cli/src/ci/__tests__/revert.test.ts
+++ b/.gaia/cli/src/ci/__tests__/revert.test.ts
@@ -1,9 +1,19 @@
 import {execFileSync} from 'node:child_process';
-import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import type {RevertLedger} from '../../schemas/revert-ledger.js';
+import {withRevertLedgerLock} from '../../schemas/revert-ledger.js';
 import {run} from '../revert.js';
 import * as runProcess from '../util/run-process.js';
 import type {ProcessResult} from '../util/run-process.js';
@@ -325,8 +335,8 @@ describe('ci-revert', () => {
       expect(() => readFileSync(sandbox.ledgerPath, 'utf8')).toThrow();
     });
 
-    it('refuses when the ledger lock is already held', () => {
-      mkdirSync(`${sandbox.ledgerPath}.lock`, {recursive: true});
+    it('refuses when the per-PR ledger lock is already held', () => {
+      mkdirSync(`${sandbox.ledgerPath}.lock.pr-99`, {recursive: true});
 
       const exit = run(
         ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
@@ -337,6 +347,55 @@ describe('ci-revert', () => {
       // Hard cap: zero gh / git invocations while a revert is in flight.
       expect(ghSpy.mock.calls.length).toBe(0);
       expect(gitSpy.mock.calls.length).toBe(0);
+
+      const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
+      expect(printed.error).toBe('revert_lock_held');
+    });
+
+    it('proceeds when a lock for a different PR is held', () => {
+      // A lock scoped to PR 137 must not block a revert open for PR 99.
+      mkdirSync(`${sandbox.ledgerPath}.lock.pr-137`, {recursive: true});
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    });
+
+    it('reclaims a stale per-PR lock and proceeds', () => {
+      const lockDir = `${sandbox.ledgerPath}.lock.pr-99`;
+      mkdirSync(lockDir, {recursive: true});
+      // Backdate the lock dir's mtime well past the stale threshold
+      // (5 min). 1 h ago is comfortably stale.
+      const stale = new Date(Date.now() - 60 * 60_000);
+      utimesSync(lockDir, stale, stale);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).toBe(0);
+
+      const ledger = JSON.parse(readFileSync(sandbox.ledgerPath, 'utf8')) as RevertLedger;
+      expect(ledger.attempts['99']?.revert_pr).toBe(137);
+    });
+
+    it('refuses when a fresh per-PR lock is held', () => {
+      const lockDir = `${sandbox.ledgerPath}.lock.pr-99`;
+      mkdirSync(lockDir, {recursive: true});
+      // mtime within the threshold — a healthy concurrent revert.
+      const fresh = new Date(Date.now() - 30_000);
+      utimesSync(lockDir, fresh, fresh);
+
+      const exit = run(
+        ['open', '--pr', '99', '--label', 'gaia-ci', '--json'],
+        {cwd: sandbox.root}
+      );
+      expect(exit).not.toBe(0);
 
       const printed = JSON.parse(stdio.out.join('').trim()) as Record<string, unknown>;
       expect(printed.error).toBe('revert_lock_held');
@@ -521,6 +580,95 @@ describe('ci-revert', () => {
       const exit = run(['unknown'], {cwd: sandbox.root});
       expect(exit).not.toBe(0);
       expect(stdio.err.join('')).toContain('unknown');
+    });
+  });
+
+  describe('withRevertLedgerLock', () => {
+    it('propagates a non-EEXIST lock-acquire error', () => {
+      // A read-only lock parent makes the lock-dir `mkdir` fail with
+      // EACCES — a genuine error, not contention. It must propagate
+      // rather than be swallowed into {locked: false}.
+      const ledgerDir = path.join(sandbox.root, '.gaia');
+      chmodSync(ledgerDir, 0o500);
+
+      try {
+        expect(() =>
+          withRevertLedgerLock(sandbox.root, 99, () => 'never-runs')
+        ).toThrow();
+      } finally {
+        // Restore writability so the sandbox cleanup can remove it.
+        chmodSync(ledgerDir, 0o700);
+      }
+    });
+
+    it('does not serialize locks for different PRs', () => {
+      const outer = withRevertLedgerLock(sandbox.root, 99, () =>
+        // While PR 99's lock is held, a revert for PR 100 still acquires.
+        withRevertLedgerLock(sandbox.root, 100, () => 'inner-ran')
+      );
+
+      expect(outer.locked).toBe(true);
+
+      if (outer.locked) {
+        expect(outer.value.locked).toBe(true);
+
+        if (outer.value.locked) {
+          expect(outer.value.value).toBe('inner-ran');
+        }
+      }
+    });
+
+    it('serializes locks for the same PR', () => {
+      const outer = withRevertLedgerLock(sandbox.root, 99, () =>
+        // A second open for the same PR while the first holds a fresh
+        // lock is refused.
+        withRevertLedgerLock(sandbox.root, 99, () => 'inner-ran')
+      );
+
+      expect(outer.locked).toBe(true);
+
+      if (outer.locked) {
+        expect(outer.value.locked).toBe(false);
+      }
+    });
+
+    it('reclaims a stale lock directory', () => {
+      const lockDir = path.join(
+        sandbox.root,
+        '.gaia',
+        'automation.state-revert-attempts.json.lock.pr-99'
+      );
+      mkdirSync(lockDir, {recursive: true});
+      const stale = new Date(Date.now() - 60 * 60_000);
+      utimesSync(lockDir, stale, stale);
+
+      const result = withRevertLedgerLock(sandbox.root, 99, () => 'critical-ran');
+
+      expect(result.locked).toBe(true);
+
+      if (result.locked) {
+        expect(result.value).toBe('critical-ran');
+      }
+
+      // The lock dir is released on the happy path.
+      expect(() => statSync(lockDir)).toThrow();
+    });
+
+    it('refuses when a fresh lock directory exists', () => {
+      const lockDir = path.join(
+        sandbox.root,
+        '.gaia',
+        'automation.state-revert-attempts.json.lock.pr-99'
+      );
+      mkdirSync(lockDir, {recursive: true});
+      const fresh = new Date(Date.now() - 30_000);
+      utimesSync(lockDir, fresh, fresh);
+
+      const result = withRevertLedgerLock(sandbox.root, 99, () => 'never-runs');
+
+      expect(result.locked).toBe(false);
+      // The pre-existing fresh lock is left in place — not reclaimed.
+      expect(() => statSync(lockDir)).not.toThrow();
     });
   });
 });

--- a/.gaia/cli/src/ci/revert.ts
+++ b/.gaia/cli/src/ci/revert.ts
@@ -265,9 +265,10 @@ const handleOpen = (
   if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 
   // Serialize the ledger read-check-write so the "one revert per PR"
-  // hard cap is not defeated by two concurrent `ci-revert open` runs
-  // both passing the existence check before either writes.
-  const locked = withRevertLedgerLock(repoRoot, () =>
+  // hard cap is not defeated by two concurrent `ci-revert open` runs for
+  // the same PR both passing the existence check before either writes.
+  // The lock is scoped to `pr` — reverts of distinct PRs do not block.
+  const locked = withRevertLedgerLock(repoRoot, pr, () =>
     handleOpenLocked({json, label, options, pr, reason, repoRoot})
   );
 

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -16,6 +16,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -99,34 +100,54 @@ export const writeRevertLedger = (
   renameSync(tmpPath, target);
 };
 
+/** A revert-open run does ~6 git/gh calls; a lock older than this is
+ *  presumed orphaned by a killed process and is reclaimed. */
+const STALE_LOCK_MS = 5 * 60_000;
+
 /**
- * Acquire an advisory lock around a ledger read-modify-write.
+ * Acquire an advisory lock around a ledger read-modify-write for one PR.
  *
  * The "one revert per PR" hard cap is a check-then-act on a shared file:
  * `ci-revert open` reads the ledger, confirms no entry exists, then does
  * several slow `git`/`gh` calls before writing the entry back. Two
- * concurrent invocations can both pass the check and both open a revert
- * PR. `mkdir` is atomic on POSIX, so it serves as the lock primitive —
- * exactly one caller wins the directory create.
+ * concurrent invocations targeting the same PR can both pass the check and
+ * both open a revert PR. `mkdir` is atomic on POSIX, so it serves as the
+ * lock primitive — exactly one caller wins the directory create.
  *
- * Returns `true` and runs `critical` under the lock, or returns `false`
- * without running it when the lock is already held (a concurrent revert
- * is in flight — refuse rather than race).
+ * The lock is scoped per `originalPr`: the lock directory carries the PR
+ * number, so reverts of distinct PRs touch disjoint locks and never
+ * serialize against each other.
+ *
+ * A process killed between `mkdir` and the `finally` release leaves the
+ * lock directory orphaned. To recover, an existing lock older than
+ * `STALE_LOCK_MS` (by mtime) is treated as stale and reclaimed.
+ *
+ * Returns `{locked: true}` and runs `critical` under the lock, or returns
+ * `{locked: false}` without running it when a fresh lock for the same PR
+ * is already held (a concurrent revert is in flight — refuse rather than
+ * race). A non-`EEXIST` failure from lock acquisition propagates to the
+ * caller as a genuine error rather than being masked as contention.
  */
 export const withRevertLedgerLock = <T>(
   repoRoot: string,
+  originalPr: number,
   critical: () => T
 ): {locked: false} | {locked: true; value: T} => {
   const target = revertLedgerPath(repoRoot);
   mkdirSync(path.dirname(target), {recursive: true});
-  const lockDir = `${target}.lock`;
+  // `originalPr` is a positive integer (RevertAttemptSchema.original_pr),
+  // so it is filename-safe with no sanitization.
+  const lockDir = `${target}.lock.pr-${originalPr}`;
 
   try {
     // `recursive: false` is the default — fails with EEXIST if the lock
     // directory already exists, which is the contended path.
     mkdirSync(lockDir);
-  } catch {
-    return {locked: false};
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+
+    // EEXIST: a lock already exists. Reclaim it only if it is stale.
+    if (!reclaimStaleLock(lockDir)) return {locked: false};
   }
 
   try {
@@ -134,4 +155,48 @@ export const withRevertLedgerLock = <T>(
   } finally {
     rmSync(lockDir, {force: true, recursive: true});
   }
+};
+
+/**
+ * Attempt to take over a pre-existing lock directory after an `EEXIST`.
+ *
+ * Returns `true` when this caller now holds the lock (the prior lock was
+ * stale and has been reclaimed, or it vanished and was re-created), and
+ * `false` when a fresh lock is still held by a live concurrent revert.
+ */
+const reclaimStaleLock = (lockDir: string): boolean => {
+  let mtimeMs: number;
+
+  try {
+    mtimeMs = statSync(lockDir).mtimeMs;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+
+    // The lock vanished between the failed `mkdir` and the `stat` — retry.
+    return retryLockMkdir(lockDir);
+  }
+
+  // A fresh lock belongs to a healthy concurrent revert — refuse.
+  if (Date.now() - mtimeMs <= STALE_LOCK_MS) return false;
+
+  // Stale: presumed orphaned by a killed process. Reclaim it.
+  rmSync(lockDir, {force: true, recursive: true});
+
+  return retryLockMkdir(lockDir);
+};
+
+/**
+ * Re-create the lock directory once. Returns `false` when another process
+ * won the race and re-created the lock first (`EEXIST`).
+ */
+const retryLockMkdir = (lockDir: string): boolean => {
+  try {
+    mkdirSync(lockDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+
+    return false;
+  }
+
+  return true;
 };


### PR DESCRIPTION
## Summary

Harden `withRevertLedgerLock` (the advisory `mkdir`-based lock around the "one revert per PR" check-then-act) per three gaps deferred from #200:

- **Narrow the catch to EEXIST.** A bare `catch` reported every `mkdirSync` failure as `revert_lock_held`. Genuine errors (EACCES, ENOSPC, ENOENT) now propagate as real failures; only EEXIST falls through to recovery.
- **Per-PR lock scope.** The lock directory now carries the PR number (`.lock.pr-<originalPr>`), so two `ci-revert open` runs for *different* PRs no longer serialize against each other. `withRevertLedgerLock` gains a required `originalPr` parameter; the one caller (`ci/revert.ts`) is updated.
- **Stale-lock recovery.** A lock directory older than `STALE_LOCK_MS` (5 min, by mtime) is presumed orphaned by a killed process and reclaimed, instead of refusing every subsequent revert forever.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck` — clean
- [x] `pnpm -C .gaia/cli exec vitest run` — 109 files, 1177 passed, 1 skipped
- [x] New tests: non-EEXIST propagation, per-PR isolation, same-PR serialization, stale-lock reclaim, fresh-lock refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)