### PR TITLE
fix(forms): a11y/perf follow-ups for Checkboxes, FieldDescription, TextArea

### DIFF
--- a/app/components/Form/Checkboxes/index.tsx
+++ b/app/components/Form/Checkboxes/index.tsx
@@ -1,4 +1,5 @@
 import type {FC, ReactNode} from 'react';
+import {useId} from 'react';
 import type {Size} from '~/types';
 import Checkbox from '../Checkbox';
 import CheckboxRadioGroup from '../CheckboxRadioGroup';
@@ -37,6 +38,8 @@ const Checkboxes: FC<CheckboxesProps> = ({
   required,
   ...rest
 }) => {
+  const groupId = useId();
+
   const isDisabled =
     disabled ??
     (options.length > 0 && options.every((option) => option.disabled));
@@ -49,6 +52,7 @@ const Checkboxes: FC<CheckboxesProps> = ({
       description={description}
       disabled={isDisabled}
       error={error}
+      id={groupId}
       label={label}
       required={isRequired}
       type="radio"
@@ -60,6 +64,9 @@ const Checkboxes: FC<CheckboxesProps> = ({
         {options.map((option) => (
           <Checkbox
             key={option.name}
+            aria-describedby={
+              description ? `${groupId}-description` : undefined
+            }
             disabled={isDisabled || option.disabled}
             label={option.label}
             name={option.name}

--- a/app/components/Form/Checkboxes/tests/index.test.tsx
+++ b/app/components/Form/Checkboxes/tests/index.test.tsx
@@ -23,4 +23,47 @@ describe('Checkboxes', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', {name: 'One'})).toBeInTheDocument();
   });
+
+  test('associates the group description with every checkbox via aria-describedby', () => {
+    render(
+      <Checkboxes
+        description="Choose at least one"
+        label="Pick some"
+        options={[
+          {label: 'One', name: 'one'},
+          {label: 'Two', name: 'two'},
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByRole('checkbox', {name: 'One'})
+    ).toHaveAccessibleDescription('Choose at least one');
+    expect(
+      screen.getByRole('checkbox', {name: 'Two'})
+    ).toHaveAccessibleDescription('Choose at least one');
+  });
+
+  test('omits aria-describedby when there is no description', () => {
+    render(
+      <Checkboxes label="Pick some" options={[{label: 'One', name: 'one'}]} />
+    );
+
+    expect(screen.getByRole('checkbox', {name: 'One'})).not.toHaveAttribute(
+      'aria-describedby'
+    );
+  });
+
+  test('does not wrap the group label in a label element', () => {
+    render(
+      <Checkboxes
+        description="Choose at least one"
+        label="Pick some"
+        options={[{label: 'One', name: 'one'}]}
+      />
+    );
+
+    const groupLabel = screen.getByText('Pick some');
+    expect(groupLabel.closest('label')).toBeNull();
+  });
 });

--- a/app/components/Form/Field/FieldStatus/FieldDescription/index.tsx
+++ b/app/components/Form/Field/FieldStatus/FieldDescription/index.tsx
@@ -21,7 +21,6 @@ const FieldDescription: FC<FieldDescriptionProps> = ({
       disabled ? 'text-disabled' : 'text-secondary'
     )}
     id={id ? `${id}-description` : undefined}
-    role="note"
   >
     {description}
   </div>

--- a/app/components/Form/Field/index.tsx
+++ b/app/components/Form/Field/index.tsx
@@ -80,7 +80,7 @@ const Field: FC<FieldProps> = ({
         disabled={disabled}
         error={error}
         extra={extra}
-        htmlFor={id ?? name}
+        htmlFor={name ? (id ?? name) : undefined}
         required={required}
       >
         {label}

--- a/app/components/Form/TextArea/index.tsx
+++ b/app/components/Form/TextArea/index.tsx
@@ -51,6 +51,11 @@ const TextArea: FC<TextAreaProps> = ({
   const innerRef = useRef<HTMLTextAreaElement | null>(null);
   useImperativeHandle(ref, () => innerRef.current!, []);
 
+  const onAutoSizeRef = useRef(onAutoSize);
+  useEffect(() => {
+    onAutoSizeRef.current = onAutoSize;
+  });
+
   const [length, setLength] = useState(
     () => String(value ?? props.defaultValue ?? '').length
   );
@@ -71,17 +76,14 @@ const TextArea: FC<TextAreaProps> = ({
 
       autosize(textArea);
 
-      if (onAutoSize) {
-        textArea.addEventListener('autosize:resized', onAutoSize);
-      }
+      const listener = () => onAutoSizeRef.current?.();
+      textArea.addEventListener('autosize:resized', listener);
 
       return () => {
-        if (onAutoSize) {
-          textArea.removeEventListener('autosize:resized', onAutoSize);
-        }
+        textArea.removeEventListener('autosize:resized', listener);
       };
     }
-  }, [onAutoSize, resize]);
+  }, [resize]);
 
   return (
     <Field

--- a/app/components/Form/TextArea/tests/index.test.tsx
+++ b/app/components/Form/TextArea/tests/index.test.tsx
@@ -1,5 +1,5 @@
-import {describe, expect, test} from 'vitest';
-import {render, screen} from 'test/rtl';
+import {describe, expect, test, vi} from 'vitest';
+import {fireEvent, render, screen} from 'test/rtl';
 import TextArea from '..';
 
 describe('TextArea', () => {
@@ -38,5 +38,43 @@ describe('TextArea', () => {
     expect(
       screen.getByRole('textbox', {name: 'Bio'})
     ).toHaveAccessibleDescription('Markdown supported');
+  });
+
+  test('does not give the field description a redundant note role', () => {
+    render(
+      <TextArea description="Markdown supported" label="Bio" name="bio" />
+    );
+
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  test('invokes onAutoSize when the textarea reports a resize', () => {
+    const onAutoSize = vi.fn();
+    render(<TextArea label="Bio" name="bio" onAutoSize={onAutoSize} />);
+    const textArea = screen.getByRole('textbox', {name: 'Bio'});
+
+    onAutoSize.mockClear();
+    fireEvent(textArea, new Event('autosize:resized'));
+
+    expect(onAutoSize).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not resubscribe the resize listener when re-rendered', () => {
+    const removeListener = vi.spyOn(
+      HTMLTextAreaElement.prototype,
+      'removeEventListener'
+    );
+
+    const {rerender} = render(
+      <TextArea label="Bio" name="bio" onAutoSize={() => {}} />
+    );
+    rerender(<TextArea label="Bio" name="bio" onAutoSize={() => {}} />);
+
+    expect(removeListener).not.toHaveBeenCalledWith(
+      'autosize:resized',
+      expect.any(Function)
+    );
+
+    removeListener.mockRestore();
   });
 });

--- a/wiki/components/Form Choices.md
+++ b/wiki/components/Form Choices.md
@@ -8,7 +8,7 @@ depends_on:
   - "[[Form Components]]"
   - "[[Form Field]]"
 created: 2026-04-20
-updated: 2026-05-04
+updated: 2026-05-22
 tags: [component, forms, checkbox, radio]
 ---
 
@@ -29,6 +29,7 @@ Checkboxes and radios share a layout primitive (`CheckboxRadioGroup`) and a `Siz
 
 - `Checkboxes` derives `disabled` and `isRequired` by inspecting every option (`every(disabled)`, `every(required)`) — a single non-required option opts the group out of required
 - `Checkbox` only wraps in `FieldStatus` when `description` or `error` is present — keeps the bare-input case clean
+- `Checkboxes` gives the group a `useId` id and points every checkbox's `aria-describedby` at the shared `${id}-description` element, so a screen reader announces the group description on each option
 
 ## Decision tree
 

--- a/wiki/components/Form Field.md
+++ b/wiki/components/Form Field.md
@@ -6,7 +6,7 @@ language: typescript
 purpose: Label + input + status wrapper used by every GAIA Form component
 depends_on: [[Form Components]]
 created: 2026-04-20
-updated: 2026-05-04
+updated: 2026-05-22
 tags: [component, forms, wrapper]
 ---
 
@@ -36,9 +36,10 @@ This means a `type='button'` Field doesn't accept a `maxLength` — the type sys
 
 Other behaviours worth knowing:
 
-- `FieldLabel` switches between `<label htmlFor>`, `<div>`, and `<legend>` based on whether a target id exists and whether `isLegend` is set ([[Form YearMonthDay]] uses the `<legend>` mode for its fieldset)
+- `FieldLabel` renders `<label htmlFor>` only when the field wraps a single named input; group and display-only fields (`button` / `checkbox` / `radio` / `value`) have no input to point at and render a `<div>` instead, and `isLegend` switches it to `<legend>` ([[Form YearMonthDay]] uses the `<legend>` mode for its fieldset)
 - `FieldRequiredText` flips colour on error state — visual cue that a required field failed
 - `FieldStatus` is `role="status"` so screen readers announce description / error changes live
+- `FieldDescription` renders with id `${id}-description` and carries no ARIA role; inputs announce it by pointing `aria-describedby` at that id, which is the sole screen-reader association — a redundant role like `role="note"` adds nothing and risks a double announcement
 
 For full prop signatures, query Serena (`.claude/rules/code-search.md`).
 


### PR DESCRIPTION
## Summary

Non-blocking Suggestions from the PR #212 code-review-audit, each with failing-first tests.

- **Checkboxes — `aria-describedby`**: the group renders a `Field type="radio"` with no id, so `FieldDescription` rendered with `id={undefined}` and the description had no referenceable id. The group now gets a `useId()` id; every `Checkbox` in the group points `aria-describedby` at `${groupId}-description` (only when a `description` is present), so a screen reader announces the group description on each option.
- **Field — `htmlFor`**: `FieldLabel`'s `htmlFor` now derives from the input `name`, so no-name (`button`/`checkbox`/`radio`/`value`) group fields render a `<div>` instead of a `<label>` with a dangling `for`. Named single-input fields are unchanged (`htmlFor` = `id ?? name`).
- **FieldDescription — drop `role="note"`**: `role="note"` is poorly supported and, with `aria-describedby` as the primary announcement mechanism, risked a double announcement. The `id` + `aria-describedby` link is sufficient.
- **TextArea — stable `onAutoSize` listener**: `onAutoSize` is held in a ref synced each render; the `autosize:resized` effect depends only on `resize`, so the subscription no longer churns when a parent passes a new function reference (pre-existing react-doctor advisory).

Wiki: `Form Field.md` and `Form Choices.md` updated to match.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean, zero warnings
- [x] Vitest one-shot — 90 passed (3 new red→green tests + a regression guard)
- [x] `pnpm pw` — Playwright a11y suite passes
- [x] `pnpm build` — production build succeeds
- [x] Dev smoke test — HTTP 200
- [x] react-doctor — 99/100, the TextArea effect advisory is resolved, no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
