### PR TITLE
chore: react-doctor full triage — fixes, suppressions, handler-naming convention

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -290,7 +290,9 @@ If no violations are found for a rule, don't mention it. If no violations are fo
 - Read related files only as needed for context (e.g., verifying authorization); keep the review focused on the target code
 - Prioritize ruthlessly — 5 important issues beats 50 trivial ones
 - Work within the project's existing patterns when suggesting fixes; don't introduce new dependencies
-- **Self-heal scope is fix-only, not restore-only.** Do NOT recreate files the PR explicitly deleted, do NOT add files you think "should" exist (deprecation aliases, restored renames, templates the PR removed). The PR's intent is authoritative; if a removal looks wrong, raise it as a finding for human review rather than reverting it via a self-heal commit. The push gate refuses self-heal diffs that touch >10 files — a sprawling self-heal indicates the agent is undoing intentional work.
+- **Self-heal scope is fix-only, not restore-only.** Do NOT recreate files the PR explicitly deleted, do NOT add files you think "should" exist (deprecation aliases, restored renames, templates the PR removed). The PR's intent is authoritative; if a removal looks wrong, raise it as a finding for human review rather than reverting it via a self-heal commit.
+- **Self-heal never touches instruction or convention surfaces.** Files under `.claude/`, `.specify/`, and `wiki/` define the project's conventions, skills, and this agent's own definition — they are never code defects to auto-fix, and editing them risks reverting deliberate work or rewriting the very rules the audit enforces. If one looks wrong, raise a finding for human review. The push gate refuses any self-heal that edits them.
+- The push gate also refuses self-heal diffs that touch >10 files — a sprawling self-heal indicates the agent is undoing intentional work.
 
 ## Audit-run env (capture before any edits)
 

--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -186,7 +186,7 @@ Component structure:
 - Named React imports: `import {useState} from 'react'`; never `React.useState()` or `React.FC`
 - Type-only imports: `import type {ChangeEventHandler} from 'react'`
 - Event handler typing: prefer `ChangeEventHandler<HTMLInputElement>` over inline `(e: ChangeEvent<HTMLInputElement>)`
-- Event handler naming: `handle{Action}{Element}` — e.g. `handleClickSave`, `handleChangeInput`
+- Event handler naming: `handle{Action}{Element}` — the `{Element}` is required; flag bare event names (`handleClick`, `handleChange`, `handleSubmit`), which trip `react-doctor/no-generic-handler-names`
 - One component per file
 
 Component extraction:

--- a/.claude/skills/eslint-fixes/SKILL.md
+++ b/.claude/skills/eslint-fixes/SKILL.md
@@ -14,12 +14,12 @@ Don't use the `void` operator in event listener functions. Instead, make the fun
 
 ```tsx
 // BAD
-const handleClick = () => {
+const handleClickNavigate = () => {
   void navigate('/path');
 };
 
 // GOOD
-const handleClick = async () => {
+const handleClickNavigate = async () => {
   await navigate('/path');
 };
 ```

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -89,7 +89,7 @@ See `references/translation-patterns.md` for edge cases (keyPrefix, Trans compon
 - **Named React imports:** `import {useState} from 'react'` — never `React.useState()` — avoids the React namespace and makes tree-shaking explicit
 - **Type imports:** `import type {ChangeEventHandler} from 'react'` — never `React.FC`
 - **Event handler types:** Prefer `ChangeEventHandler<HTMLInputElement>` over inline event typing
-- **Event handler naming:** `handle{Action}{Element}` — e.g. `handleClickSave`, `handleChangeInput`
+- **Event handler naming:** `handle{Action}{Element}` — the `{Element}` is required so the name says *what it does*, not just *when it fires*; e.g. `handleClickSave`, `handleChangeInput`, `handleCopyStack`. A bare event name (`handleClick`, `handleChange`, `handleSubmit`) trips `react-doctor/no-generic-handler-names`.
 
 ### Component Extraction
 

--- a/.claude/skills/react-code/references/hook-patterns.md
+++ b/.claude/skills/react-code/references/hook-patterns.md
@@ -180,10 +180,10 @@ The same principle applies to any subscription, timer, or third-party widget: if
 
 ```tsx
 // ✅ Passed to memo-wrapped child — prevents unnecessary child re-renders
-const handleSubmit = useCallback((data: FormData) => {
+const handleSubmitForm = useCallback((data: FormData) => {
   post('/api/submit', data);
 }, []);
-return <MemoizedForm onSubmit={handleSubmit} />;
+return <MemoizedForm onSubmit={handleSubmitForm} />;
 
 // ✅ Used in useEffect dependency array — keeps a stable reference
 const fetchData = useCallback(async () => {
@@ -196,7 +196,7 @@ useEffect(() => {
 }, [fetchData]);
 
 // ❌ Not passed to a memo child, not in any hook deps — skip useCallback
-const handleClick = () => {
+const handleClickIncrement = () => {
   setCount(count + 1);
 };
 ```
@@ -207,12 +207,12 @@ const handleClick = () => {
 // BAD — premature optimization; every render still allocates the deps array,
 // so if deps change often useCallback saves nothing. An empty deps array is
 // a stale closure waiting to happen if the handler ever needs to read state or props.
-const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+const handleChangeName = useCallback((e: ChangeEvent<HTMLInputElement>) => {
   setName(e.target.value);
-}, []); // looks safe now — breaks the moment handleChange needs to read other state
+}, []); // looks safe now — breaks the moment handleChangeName needs to read other state
 
 // GOOD — plain function is the right default
-const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+const handleChangeName = (e: ChangeEvent<HTMLInputElement>) => {
   setName(e.target.value);
 };
 ```

--- a/.claude/skills/tdd/references/tests-react.md
+++ b/.claude/skills/tdd/references/tests-react.md
@@ -156,11 +156,11 @@ When using custom form components (like `YearMonthDay`, `TimePicker`, etc.) that
 ```tsx
 // BAD - Local state conflicts with Conform's validation
 const [value, setValue] = useState(savedData?.field ?? DEFAULT);
-const handleChange = useCallback((newValue) => {
+const handleChangeValue = useCallback((newValue) => {
   setValue(newValue);
 }, []);
 
-<CustomComponent onChange={handleChange} value={value} />;
+<CustomComponent onChange={handleChangeValue} value={value} />;
 
 // GOOD - useInputControl keeps component synced with Conform
 const fieldControl = useInputControl(fields.fieldName);

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -35,8 +35,9 @@ Follow Apple's Swift API Design Guidelines: names should be clear at the point o
 - **No redundant words** — `availableExercises` not `exerciseArray`, but don't sacrifice clarity for brevity
 
 > **Exception — React event handlers** follow `handle{Action}{Element}` from the react-code skill
-> (e.g. `handleClickSave`, `handleChangeInput`). The descriptive naming guidelines above apply
-> to utilities, hooks, callbacks, and non-event-handler functions.
+> (e.g. `handleClickSave`, `handleChangeInput`) — the `{Element}` is required, since a bare
+> `handleClick` or `handleChange` trips `react-doctor/no-generic-handler-names`. The descriptive
+> naming guidelines above apply to utilities, hooks, callbacks, and non-event-handler functions.
 
 Read `references/naming-conventions.md` for extended BAD/GOOD examples of each naming pattern.
 

--- a/.claude/skills/typescript/references/naming-conventions.md
+++ b/.claude/skills/typescript/references/naming-conventions.md
@@ -16,7 +16,7 @@ const processUserOnboardingProfile = (user: User) => { ... }
 const calculateProgressPercentageFromCompletedSets = (completedSets: number, totalSets: number) => { ... }
 ```
 
-> React event handlers are the exception — they follow `handle{Action}{Element}` (e.g. `handleClickSave`, `handleChangeInput`). The descriptive guidelines above apply to utilities, hooks, callbacks, and non-event-handler functions.
+> React event handlers are the exception — they follow `handle{Action}{Element}` (e.g. `handleClickSave`, `handleChangeInput`); the `{Element}` is required, since a bare `handleClick` or `handleChange` trips `react-doctor/no-generic-handler-names`. The descriptive guidelines above apply to utilities, hooks, callbacks, and non-event-handler functions.
 
 ## Parameters and Arguments
 

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -227,6 +227,11 @@ jobs:
                do NOT restore them. Intentional deletions are not defects.
             3. Never add content that references a library, tool, or pattern that this
                PR removed. The PR diff is the source of truth for intent.
+            4. NEVER edit files under `.claude/`, `.specify/`, or `wiki/` as part of
+               a self-heal. These define the project's conventions, skills, and this
+               agent's own definition — not code defects. If one looks wrong, raise
+               it as a finding for human review. The workflow's self-heal scope gate
+               refuses any self-heal that touches them.
           claude_args: |
             --max-turns ${{ steps.config.outputs.max_turns }}
             --allowedTools Edit,Write,Bash(git:*),Bash(pnpm:*),Bash(node:*),Bash(npm:*)
@@ -258,6 +263,34 @@ jobs:
             git ls-files --others --exclude-standard | head -20 >&2
           fi
 
+          # Self-heal scope gate. Instruction / convention surfaces
+          # (.claude/**, .specify/**, wiki/**) are the rules this audit
+          # enforces and the agent's own definition -- never code defects
+          # it should auto-fix. A self-heal that edits them is almost
+          # always reverting an intentional convention change. Inspect
+          # both committed self-heal commits and uncommitted edits; if any
+          # touch those surfaces, refuse the whole self-heal and surface
+          # it for human review (mirrors the >10-file gate below). The
+          # early `exit 0` runs before the commit/push logic, so nothing
+          # the audit changed reaches origin.
+          self_heal_paths="$(
+            {
+              git diff --name-only
+              git diff --name-only "origin/${PR_BRANCH}..HEAD" 2>/dev/null || true
+            } | sort -u
+          )"
+          if printf '%s\n' "$self_heal_paths" \
+              | grep -qE '^(\.claude|\.specify|wiki)/'; then
+            echo "code-review-audit: self-heal touched instruction/convention surfaces -- refusing." >&2
+            printf '%s\n' "$self_heal_paths" \
+              | grep -E '^(\.claude|\.specify|wiki)/' >&2 || true
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "marker_only=false" >> "$GITHUB_OUTPUT"
+            echo "refused=true" >> "$GITHUB_OUTPUT"
+            echo "refused_reason=instruction-surface" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if ! git diff --quiet; then
             # Stage modifications and deletions to TRACKED files only -- never
             # `git add -A`, which would sweep audit runtime artifacts.
@@ -276,6 +309,7 @@ jobs:
               echo "pushed=false" >> "$GITHUB_OUTPUT"
               echo "marker_only=false" >> "$GITHUB_OUTPUT"
               echo "refused=true" >> "$GITHUB_OUTPUT"
+              echo "refused_reason=file-count" >> "$GITHUB_OUTPUT"
               echo "refused_count=$files_changed" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -461,13 +495,18 @@ jobs:
           PUSHED: ${{ steps.push-fixes.outputs.pushed }}
           REFUSED: ${{ steps.push-fixes.outputs.refused }}
           REFUSED_COUNT: ${{ steps.push-fixes.outputs.refused_count }}
+          REFUSED_REASON: ${{ steps.push-fixes.outputs.refused_reason }}
           PUSH_FIXES: ${{ steps.config.outputs.push_fixes }}
         run: |
           set -eu
           if [ "$PUSH_FIXES" = "false" ]; then
             mode="advisory (push_fixes=false)"
           elif [ "$REFUSED" = "true" ]; then
-            mode="self-heal REFUSED — diff exceeded the 10-file safety threshold (touched $REFUSED_COUNT files); see workflow logs and review manually"
+            if [ "$REFUSED_REASON" = "instruction-surface" ]; then
+              mode="self-heal REFUSED — edited instruction/convention surfaces (.claude/**, .specify/**, or wiki/**), which are off-limits to self-heal; see workflow logs and review manually"
+            else
+              mode="self-heal REFUSED — diff exceeded the 10-file safety threshold (touched $REFUSED_COUNT files); see workflow logs and review manually"
+            fi
           elif [ "$PUSHED" = "true" ]; then
             mode="self-heal pushed"
           else

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -17,7 +17,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
   statusText,
 }) => {
   if (stack) {
-    const handleClick = async () => {
+    const handleCopyStack = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
     };
 
@@ -47,7 +47,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
           {statusDiv}
           <button
             className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
-            onClick={handleClick}
+            onClick={handleCopyStack}
             type="button"
           >
             <IoCopyOutline />

--- a/app/components/Form/FormError/index.tsx
+++ b/app/components/Form/FormError/index.tsx
@@ -25,7 +25,7 @@ const FormError: FC<FormResultProps> = ({className, hide}) => {
   const result =
     !hide && error !== undefined && actionData !== dismissed ? error : '';
 
-  const handleClick = () => {
+  const handleDismissError = () => {
     setDismissed(actionData);
   };
 
@@ -39,7 +39,7 @@ const FormError: FC<FormResultProps> = ({className, hide}) => {
         'flex w-full items-center justify-between rounded-sm border-red-600 bg-red-500 px-4 py-2 text-white dark:border-red-400',
         className
       )}
-      onClick={handleClick}
+      onClick={handleDismissError}
       type="button"
     >
       <span role="alert">{result}</span>

--- a/app/components/Form/InputText/index.tsx
+++ b/app/components/Form/InputText/index.tsx
@@ -33,7 +33,7 @@ const InputText: FC<InputProps> = ({
     () => String(props.value ?? props.defaultValue ?? '').length
   );
 
-  const handleChange = useCallback(
+  const handleUpdateLength = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (maxLength) {
         setLength(event.currentTarget.value.length);
@@ -80,7 +80,7 @@ const InputText: FC<InputProps> = ({
           id={id ?? name}
           maxLength={maxLength}
           name={name}
-          onChange={handleChange}
+          onChange={handleUpdateLength}
           readOnly={readOnly}
           required={required}
           tabIndex={readOnly ? -1 : undefined}

--- a/app/components/Form/Select/index.tsx
+++ b/app/components/Form/Select/index.tsx
@@ -53,7 +53,7 @@ const Select: FC<SelectProps> = ({
   // `uncontrolledValue` only backs the uncontrolled (defaultValue) case.
   const currentValue = value ?? uncontrolledValue;
 
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleUpdateValue = (event: ChangeEvent<HTMLSelectElement>) => {
     setUncontrolledValue(event.currentTarget.value || '');
     onChange?.(event);
   };
@@ -92,7 +92,7 @@ const Select: FC<SelectProps> = ({
           disabled={disabled}
           id={id ?? name}
           name={name}
-          onChange={handleChange}
+          onChange={handleUpdateValue}
           required={required}
           value={value}
           {...props}

--- a/app/components/Form/TextArea/index.tsx
+++ b/app/components/Form/TextArea/index.tsx
@@ -60,7 +60,7 @@ const TextArea: FC<TextAreaProps> = ({
     () => String(value ?? props.defaultValue ?? '').length
   );
 
-  const handleChange = useCallback(
+  const handleUpdateLength = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       if (maxLength) {
         setLength(event.currentTarget.value.length);
@@ -117,7 +117,7 @@ const TextArea: FC<TextAreaProps> = ({
         id={id ?? name}
         maxLength={maxLength}
         name={name}
-        onChange={handleChange}
+        onChange={handleUpdateLength}
         readOnly={readOnly}
         rows={rows}
         tabIndex={readOnly ? -1 : undefined}

--- a/app/components/Form/YearMonthDay/index.tsx
+++ b/app/components/Form/YearMonthDay/index.tsx
@@ -75,7 +75,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
     };
   }, []);
 
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleUpdateDate = (event: ChangeEvent<HTMLSelectElement>) => {
     const newValue =
       event.currentTarget.name.includes('Date') ?
         `${year}-${month}-${event.currentTarget.value}`
@@ -150,7 +150,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Year`}
-          onChange={handleChange}
+          onChange={handleUpdateDate}
           options={years}
           value={year}
         />
@@ -159,7 +159,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Month`}
-          onChange={handleChange}
+          onChange={handleUpdateDate}
           options={months}
           value={month}
         />
@@ -168,7 +168,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Date`}
-          onChange={handleChange}
+          onChange={handleUpdateDate}
           options={dates}
           value={date}
         />

--- a/app/components/Toast/tests/index.stories.tsx
+++ b/app/components/Toast/tests/index.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta = {
 
 export default meta;
 
-const handleClick = (type: string) => {
+const handleShowToast = (type: string) => {
   if (type === 'error') {
     notify.error({
       message: JSON.stringify({
@@ -53,7 +53,7 @@ export const Default: StoryFn = () => (
   >
     <Button
       onClick={() => {
-        handleClick('error');
+        handleShowToast('error');
       }}
       size="sm"
       variant="tertiary"
@@ -62,7 +62,7 @@ export const Default: StoryFn = () => (
     </Button>
     <Button
       onClick={() => {
-        handleClick('success');
+        handleShowToast('success');
       }}
       size="sm"
       variant="tertiary"
@@ -71,7 +71,7 @@ export const Default: StoryFn = () => (
     </Button>
     <Button
       onClick={() => {
-        handleClick('warning');
+        handleShowToast('warning');
       }}
       size="sm"
       variant="tertiary"
@@ -80,7 +80,7 @@ export const Default: StoryFn = () => (
     </Button>
     <Button
       onClick={() => {
-        handleClick('info');
+        handleShowToast('info');
       }}
       size="sm"
       variant="tertiary"

--- a/app/hooks/useComponentRect.ts
+++ b/app/hooks/useComponentRect.ts
@@ -29,7 +29,7 @@ export const useComponentRect = (
       };
 
       window.addEventListener('resize', onUpdate);
-      window.addEventListener('scroll', onUpdate);
+      window.addEventListener('scroll', onUpdate, {passive: true});
 
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);

--- a/app/utils/nonce.ts
+++ b/app/utils/nonce.ts
@@ -1,7 +1,7 @@
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 const NonceContext = createContext<string>('');
 
 export const NonceProvider = NonceContext.Provider;
 
-export const useNonce = (): string => useContext(NonceContext);
+export const useNonce = (): string => use(NonceContext);

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -4,6 +4,26 @@
       {
         "files": ["app/components/**/tests/index.test.tsx"],
         "rules": ["react-doctor/no-barrel-import"]
+      },
+      {
+        "files": ["app/components/Document/index.tsx", "app/root.tsx"],
+        "rules": ["react/no-danger"]
+      },
+      {
+        "files": ["app/components/Toast/ToastNotification/index.tsx"],
+        "rules": ["react-doctor/rerender-state-only-in-handlers"]
+      },
+      {
+        "files": ["app/utils/object.ts"],
+        "rules": ["react-doctor/no-full-lodash-import"]
+      },
+      {
+        "files": [".gaia/cli/**"],
+        "rules": [
+          "react-doctor/js-set-map-lookups",
+          "react-doctor/async-await-in-loop",
+          "react-doctor/server-sequential-independent-await"
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Full triage of all 29 findings from a repo-wide react-doctor scan (`93 → 99/100`). Every finding was reviewed and either fixed, or recorded as a reviewed false-positive / intentional case in `react-doctor.config.json`.

The one remaining finding (`TextArea` `onAutoSize` listener) is fixed by the PR #212 follow-up branch — once that lands, a full scan reads clean.

### Genuine fixes

- **Rename 6 bare-event handlers** to `handle{Action}{Element}`: `handleCopyStack` (ErrorStack), `handleDismissError` (FormError), `handleUpdateValue` (Select), `handleUpdateLength` (InputText, TextArea), `handleUpdateDate` (YearMonthDay), plus a Toast story helper. Pure renames — no behavior change.
- **`useComponentRect`** — the `scroll` listener is marked `{passive: true}` (the handler never calls `preventDefault`).
- **`nonce.ts`** — `useContext` → `use()` (React 19).

### Handler-naming convention

react-doctor's `no-generic-handler-names` and the skills' `handle{Action}{Element}` rule are now aligned: the convention statements in the **react-code** / **typescript** skills, **naming-conventions** reference, and the **code-review-audit** agent now make explicit that the descriptive `{Element}` is **required** — a bare `handleClick` / `handleChange` / `handleSubmit` trips the lint rule. Skill code examples were realigned to match. (`handleChangeLanguage`, `handleClickButton` etc. are fine — they already carry a descriptive target.)

### Reviewed false-positives / intentional — recorded in `react-doctor.config.json`

- `react/no-danger` ×2 — `dangerouslySetInnerHTML` for the SSR nonce/theme inline scripts.
- `rerender-state-only-in-handlers` — `ToastNotification`'s `isHovered` useState **must** stay state: it drives an effect re-run that pauses the auto-dismiss timer on hover. A ref would break that.
- `no-full-lodash-import` — the import is `lodash-es` (ESM), which tree-shakes; the rule's advice targets CJS `lodash`.
- `.gaia/cli` `js-set-map-lookups` ×7 / `async-await-in-loop` ×5 / `server-sequential-independent-await` ×3 — `String.indexOf/includes` misclassified as array lookups, intentional sequential IO (polling loops, ordered writes), and idempotency-ordering tests.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean, zero warnings
- [x] Vitest one-shot — 84 passed
- [x] `pnpm pw` — Playwright a11y suite passes
- [x] `pnpm build` — production build succeeds
- [x] Dev smoke test — HTTP 200
- [x] react-doctor — 99/100 (was 93); the last finding is resolved by the #212 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
