### PR TITLE
refactor(forms): derive controlled counter from value, document latest-ref pattern

### DIFF
--- a/app/components/Form/InputText/index.tsx
+++ b/app/components/Form/InputText/index.tsx
@@ -1,5 +1,5 @@
 import type {ChangeEvent, FC} from 'react';
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useState} from 'react';
 import {twJoin, twMerge} from 'tailwind-merge';
 import Field from '../Field';
 import type {InputProps} from '../types';
@@ -29,21 +29,16 @@ const InputText: FC<InputProps> = ({
   type = 'text',
   ...props
 }) => {
-  const [length, setLength] = useState(
-    () => String(props.value ?? props.defaultValue ?? '').length
+  const [localLength, setLocalLength] = useState(
+    () => String(props.defaultValue ?? '').length
   );
-
-  useEffect(() => {
-    if (props.value !== undefined) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setLength(String(props.value).length);
-    }
-  }, [props.value]);
+  const length =
+    props.value === undefined ? localLength : String(props.value).length;
 
   const handleUpdateLength = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (maxLength) {
-        setLength(event.currentTarget.value.length);
+        setLocalLength(event.currentTarget.value.length);
       }
       onChange?.(event);
     },

--- a/app/components/Form/TextArea/index.tsx
+++ b/app/components/Form/TextArea/index.tsx
@@ -52,24 +52,19 @@ const TextArea: FC<TextAreaProps> = ({
   useImperativeHandle(ref, () => innerRef.current!, []);
 
   const onAutoSizeRef = useRef(onAutoSize);
+  // latest-ref pattern: keeps the autosize listener stable without re-registering on every onAutoSize change
   // eslint-disable-next-line react-hooks/refs
   onAutoSizeRef.current = onAutoSize;
 
-  const [length, setLength] = useState(
-    () => String(value ?? props.defaultValue ?? '').length
+  const [localLength, setLocalLength] = useState(
+    () => String(props.defaultValue ?? '').length
   );
-
-  useEffect(() => {
-    if (value !== undefined) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setLength(String(value).length);
-    }
-  }, [value]);
+  const length = value === undefined ? localLength : String(value).length;
 
   const handleUpdateLength = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       if (maxLength) {
-        setLength(event.currentTarget.value.length);
+        setLocalLength(event.currentTarget.value.length);
       }
       onChange?.(event);
     },


### PR DESCRIPTION
## Summary

- **InputText / TextArea**: removes the `set-state-in-effect` pattern for the character counter. `length` is now derived directly from the controlled `value` prop at render time; `localLength` state is only used in uncontrolled mode. No effect needed, no suppression needed.
- **TextArea `onAutoSizeRef`**: adds a one-line comment explaining the `react-hooks/refs` suppression — this is the intentional latest-ref pattern to keep the autosize event listener stable without re-registering it on every `onAutoSize` prop change.

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean
- [ ] `pnpm test` — 94/94 passed (19 tests directly exercising changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)