### PR TITLE
fix(ci): accept GitHub commit status as merge gate signal

### DIFF
--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 # PreToolUse Bash hook: BLOCK `gh pr merge` until proof of a passing
-# code-review-audit exists for the current HEAD. Two signals are accepted:
+# code-review-audit exists for the current HEAD. Three signals are accepted:
 #
 #   1. Local marker file at .gaia/local/audit/<sha>.ok — written by the
 #      audit agent at the end of a clean local review.
 #
 #   2. GAIA-Audit trailer on HEAD's commit message, when the trailer's
-#      tree-sha matches HEAD's current tree. Stamped by CI's audit run via
-#      .claude/hooks/audit-stamp-trailer.sh and pushed back to the PR
-#      branch. Same tree means the audit reviewed the exact content being
-#      merged, regardless of which SHA carries the trailer commit.
+#      tree-sha matches HEAD's current tree. Written by a local audit run
+#      via .claude/hooks/audit-stamp-trailer.sh.
 #
-# Either signal proves the audit ran against this content and the agent saw
+#   3. GAIA-Audit GitHub commit status on HEAD, description "<version> <tree>",
+#      when both version and tree-sha match. CI stamps this status instead of
+#      pushing an empty marker commit (pushing it would re-trigger CI and leave
+#      the PR HEAD without check runs). Queried via `gh api` using GH_TOKEN or
+#      the ambient gh auth session.
+#
+# Any signal proves the audit ran against this content and the agent saw
 # no Critical Issues and no unresolved Important Issues. Without one, the
 # hook denies the gh pr merge call. To unblock:
-#   1. Spawn the code-review-audit agent on the current branch (or rely on
-#      CI to stamp the trailer — when CI's audit can run; it skips when
-#      the PR modifies the audit workflow file itself).
+#   1. Spawn the code-review-audit agent on the current branch, OR push to the
+#      PR branch and wait for CI's audit to stamp the GitHub commit status (CI
+#      skips when the PR modifies the audit workflow file itself — in that case
+#      only the local audit will satisfy the gate).
 #   2. Address any findings; commit and push.
-#   3. Re-spawn the agent on the new HEAD; let it write the marker
-#      or wait for CI's trailer stamp.
+#   3. Re-spawn the agent on the new HEAD; let it write the marker.
 #   4. Retry gh pr merge.
 #
 # See wiki/concepts/PR Merge Workflow.md for the full contract.
@@ -99,17 +103,76 @@ if [ -n "$trailer_line" ]; then
   trailer_status="present but tree-sha mismatch (audit was for a different tree)"
 fi
 
+# GitHub commit status fallback: CI stamps a GAIA-Audit commit status instead
+# of pushing an empty marker commit (pushing it would re-trigger CI and leave
+# the PR HEAD without check runs). Query the API for a matching status on HEAD.
+# Description shape: "<version> <40-hex-tree>". Both must match .gaia/VERSION
+# and HEAD's tree. Falls through silently on any error (no gh, no token, no
+# GITHUB_REPOSITORY, API failure) — the deny path below fires as normal.
+check_github_status() {
+  command -v gh >/dev/null 2>&1 || return 1
+
+  # Derive repo slug. GITHUB_REPOSITORY is set inside Actions; derive from the
+  # origin remote URL for local runs.
+  repo="${GITHUB_REPOSITORY:-}"
+  if [ -z "$repo" ]; then
+    origin_url=$(git remote get-url origin 2>/dev/null || true)
+    [ -n "$origin_url" ] || return 1
+    repo=$(printf '%s' "$origin_url" \
+      | sed -E 's|.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
+    # sed produces the full URL when no pattern matches — reject it.
+    [ "$repo" != "$origin_url" ] || return 1
+    case "$repo" in
+      */*) ;;  # must contain exactly one slash (owner/name)
+      *) return 1 ;;
+    esac
+  fi
+
+  # Read .gaia/VERSION (same "no stamp without VERSION" invariant as CI).
+  cur_version=""
+  if [ -f ".gaia/VERSION" ]; then
+    cur_version=$(tr -d '\r' < ".gaia/VERSION" | awk 'NF{print; exit}')
+    cur_version="${cur_version#"${cur_version%%[![:space:]]*}"}"
+    cur_version="${cur_version%"${cur_version##*[![:space:]]}"}"
+  fi
+  [ -n "$cur_version" ] || return 1
+
+  cur_tree=$(git rev-parse "HEAD^{tree}" 2>/dev/null || true)
+  [ -n "$cur_tree" ] || return 1
+
+  status_desc=$(gh api \
+    "repos/${repo}/commits/${sha}/statuses" \
+    --jq 'map(select(.context == "GAIA-Audit")) | last | .description' \
+    2>/dev/null || true)
+
+  [ -n "$status_desc" ] && [ "$status_desc" != "null" ] || return 1
+
+  status_version=$(printf '%s' "$status_desc" | awk '{print $1}')
+  status_tree=$(printf '%s' "$status_desc" | awk '{print $2}')
+
+  [ -n "$status_version" ] && [ -n "$status_tree" ] || return 1
+  [ "$status_version" = "$cur_version" ] || return 1
+  [ "$status_tree" = "$cur_tree" ] || return 1
+
+  return 0
+}
+
+if check_github_status; then
+  exit 0
+fi
+
 reason="PR merge gate: no code-review-audit signal for HEAD ${sha:0:12}.
 
-Neither accepted signal is present:
-  - Local marker:  ${marker} (missing)
-  - Commit trailer: ${trailer_status}
+None of the accepted signals is present:
+  - Local marker:    ${marker} (missing)
+  - Commit trailer:  ${trailer_status}
+  - GitHub CI status: absent or version/tree mismatch
 
 To unblock:
   1. Spawn the code-review-audit agent locally, OR push to the PR branch
-     and wait for CI's audit to stamp the trailer (CI skips when the PR
-     modifies the audit workflow file itself — in that case only the
-     local audit will satisfy the gate).
+     and wait for CI's audit to stamp the GitHub commit status (CI skips
+     when the PR modifies the audit workflow file itself — in that case
+     only the local audit will satisfy the gate).
   2. Address any Critical/Important findings; commit and push.
   3. Re-spawn the agent on the new HEAD; let it write the marker.
   4. Retry gh pr merge.

--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -142,7 +142,7 @@ check_github_status() {
 
   status_desc=$(gh api \
     "repos/${repo}/commits/${sha}/statuses" \
-    --jq 'map(select(.context == "GAIA-Audit")) | last | .description' \
+    --jq 'map(select(.context == "GAIA-Audit")) | first | .description' \
     2>/dev/null || true)
 
   [ -n "$status_desc" ] && [ "$status_desc" != "null" ] || return 1

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-19
+updated: 2026-05-22
 tags: [concept, ci, review]
 ---
 

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -34,9 +34,19 @@ Task(
 
 ### 3. Marker handshake
 
-The audit agent writes `.gaia/local/audit/<HEAD-sha>.ok` only on a clean pass (no Critical Issues, every Important Issue addressed in the working tree). The hook gates `gh pr merge` on the presence of that marker for the exact commit being merged. Knip / react-doctor advisories and Suggestions never block marker emission.
+The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove the audit ran clean against the content being merged:
 
-If the agent declines to write the marker, the report names what remains unaddressed; resolve those, commit, push, re-spawn.
+| Signal | Source | How it gets there |
+|---|---|---|
+| `.gaia/local/audit/<HEAD-sha>.ok` | Local audit agent | Agent writes it on a clean pass |
+| `GAIA-Audit:` commit-message trailer on HEAD | Local audit agent | `audit-stamp-trailer.sh` writes an empty commit with the trailer |
+| `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this instead of pushing an empty commit (pushing would re-trigger CI and leave HEAD without check runs) |
+
+Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
+
+A clean pass requires no Critical Issues and every Important Issue addressed. Knip / react-doctor advisories and Suggestions never block signal emission.
+
+If the local agent declines to write the marker, its report names what remains unaddressed; resolve those, commit, push, re-spawn.
 
 ### 4. Merge
 


### PR DESCRIPTION
## Summary

- **Root cause:** CI stamps a `GAIA-Audit` GitHub commit status on the PR HEAD instead of pushing an empty marker commit (pushing would re-trigger CI and leave the branch HEAD with no check runs). The local `pr-merge-audit-check.sh` hook never queried the Commit Status API, so CI's stamp was invisible — every PR required a redundant local audit run even after CI already passed.
- **Fix:** Added `check_github_status()` to the hook, mirroring the fallback logic already in `check-trailer.sh`. Derives `owner/repo` from `git remote get-url origin` when `GITHUB_REPOSITORY` isn't set (local runs). Falls through silently on any error so the deny path still fires when no signal is present.
- **Docs:** Updated hook header, deny message, and `wiki/concepts/PR Merge Workflow.md` to document all three accepted signals (local marker, commit-message trailer, GitHub commit status).

## Test plan

- [ ] Bash syntax: `bash -n .claude/hooks/pr-merge-audit-check.sh` — passes (verified locally)
- [ ] CI will post "skipped: no audit-relevant files changed" on this PR (`.claude/hooks/` and `wiki/` are out of CI audit scope) — expected, not a regression
- [ ] **Smoke test after merge:** on the next PR touching `app/` or `test/`, CI runs the full audit and stamps the `GAIA-Audit` status; `gh pr merge` should pass locally without requiring a separate local audit run

🤖 Generated with [Claude Code](https://claude.com/claude-code)