### PR TITLE
fix(merge-gate/knip): macOS sed portability + +types ignore bucket

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -164,6 +164,8 @@ Parse the JSON output from `pnpm knip --reporter json` (an `issues[]` array keye
 
 Knip findings are **advisory, not blocking** — like react-doctor's. Surface them in the audit summary with the recommended bucket and action so the user can decide. Do not auto-delete or auto-edit `knip.config.ts` during the review.
 
+When reporting knip in the Tooling table: if `issues` is an empty array, write **No issues** — do not paste the raw `{"issues":[]}` JSON.
+
 ### Subagent 1: React Patterns & Accessibility Audit
 
 Scope: `.tsx` files only.

--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -112,16 +112,13 @@ fi
 check_github_status() {
   command -v gh >/dev/null 2>&1 || return 1
 
-  # Derive repo slug. GITHUB_REPOSITORY is set inside Actions; derive from the
-  # origin remote URL for local runs.
+  # Derive repo slug. GITHUB_REPOSITORY is set inside Actions; derive from
+  # the current directory's git remote for local runs via `gh repo view`
+  # (avoids BSD-vs-GNU sed portability issues with lazy quantifiers).
   repo="${GITHUB_REPOSITORY:-}"
   if [ -z "$repo" ]; then
-    origin_url=$(git remote get-url origin 2>/dev/null || true)
-    [ -n "$origin_url" ] || return 1
-    repo=$(printf '%s' "$origin_url" \
-      | sed -E 's|.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-    # sed produces the full URL when no pattern matches — reject it.
-    [ "$repo" != "$origin_url" ] || return 1
+    repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+    [ -n "$repo" ] || return 1
     case "$repo" in
       */*) ;;  # must contain exactly one slash (owner/name)
       *) return 1 ;;

--- a/app/utils/object.ts
+++ b/app/utils/object.ts
@@ -92,7 +92,7 @@ export const mapKeys = (
  */
 export const mapValues = (
   obj: Record<string, unknown>,
-  fn: (p: unknown) => unknown
+  fn: (value: unknown) => unknown
 ): Record<string, unknown> =>
   Object.entries(obj).reduce<Record<string, unknown>>(
     (accumulated, [key, value]) => {
@@ -107,7 +107,7 @@ export const mapValues = (
   Case Conversion Utilities
  */
 export const convertCase = (
-  fn: (s: string) => string,
+  fn: (text: string) => string,
   obj: unknown
 ): unknown => {
   if (obj === undefined) {

--- a/app/utils/tests/function.test.ts
+++ b/app/utils/tests/function.test.ts
@@ -58,7 +58,7 @@ describe('compose', () => {
   });
 
   test('handles a single function', () => {
-    const spy = vi.fn((x: number) => x * 3);
+    const spy = vi.fn((inputValue: number) => inputValue * 3);
     const composed = compose(spy);
     expect(composed(4)).toBe(12);
     expect(spy).toHaveBeenCalledWith(4);

--- a/app/utils/tests/function.test.ts
+++ b/app/utils/tests/function.test.ts
@@ -42,8 +42,8 @@ describe('function utils', () => {
   });
 });
 
-const double = (x: number) => x * 2;
-const addOne = (x: number) => x + 1;
+const double = (value: number) => value * 2;
+const addOne = (value: number) => value + 1;
 
 describe('noop', () => {
   test('is callable without throwing', () => {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -14,7 +14,6 @@ export default {
   ],
   ignoreBinaries: ['bats'],
   ignoreDependencies: [
-    '/\\+types/',
     '@epic-web/invariant',
     '@msw/data',
     '@playwright-testing-library/test',
@@ -33,5 +32,6 @@ export default {
     'stylelint-order',
     'tailwindcss',
   ],
+  ignoreUnresolved: [/\/\+types\//],
   project: ['app/**/*.{ts,tsx}', 'test/**/*.{ts,tsx}'],
 } satisfies KnipConfig;


### PR DESCRIPTION
## Summary

- **`pr-merge-audit-check.sh`**: Replace BSD-incompatible `sed -E` lazy-quantifier URL parsing with `gh repo view --json nameWithOwner`. The broken `sed` silently produced an empty `repo` slug, short-circuiting `check_github_status()` on every local macOS run — the smoke test for PR #219 exposed this.
- **`knip.config.ts`**: Move React Router generated-types pattern from `ignoreDependencies` (wrong bucket — only matches package.json entries) to `ignoreUnresolved` (correct bucket — matches unresolved file import paths). Locally typegen has run so the rule shows as an advisory hint; in CI (fresh checkout) it suppresses the 6 `./+types/*` unresolved entries the audit kept flagging.
- **`app/utils/tests/function.test.ts`**: Rename `x` → `value` in module-scope test helpers per TypeScript naming convention (PR #220 audit suggestion).

## Test plan

- [ ] CI `code-review-audit` runs (touches `app/` file, in scope)
- [ ] `pnpm knip` exits 0 locally (config hint only, advisory)
- [ ] After merge, CI audit on a subsequent PR with `app/` changes should show 0 unresolved `./+types/*` entries in knip output

🤖 Generated with [Claude Code](https://claude.com/claude-code)