### PR TITLE
Fix critical + important codebase audit findings

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -119,11 +119,11 @@ Performance problems, significant code smells, and architectural concerns that w
 
 ### Suggestions (Must Fix or Escalate)
 
-Refactoring opportunities, maintainability improvements, and minor code quality enhancements. Same format as above.
+Refactoring opportunities, maintainability improvements, and minor code quality enhancements. Same format as above. **Only include actionable items here** — confirmations of correct patterns belong in What's Done Well, not in this section.
 
 Every suggestion must be resolved before the audit passes:
 - **Auto-fix** it in a self-heal commit (preferred), or
-- **Escalate**: document why it cannot be auto-fixed (architectural tradeoff, breaking change, conflicting convention). Escalated suggestions block the marker — the operator must review and address them before merging.
+- **Escalate**: document why it cannot be auto-fixed (architectural tradeoff, breaking change, conflicting convention). Escalated suggestions **always block the marker** — documenting the rationale does not satisfy this condition. The operator must resolve the escalation before the marker is written.
 
 ### What's Done Well (optional)
 
@@ -326,8 +326,8 @@ After producing the report, decide whether to write the marker:
 - **Write the marker** when all of the following are true:
   1. The Critical Issues section is empty.
   2. The Important Issues section is empty, OR every item is already fixed in the working tree (verify by re-reading the relevant file; do not trust prior chat claims).
-  3. The Suggestions section is empty, OR every suggestion is auto-fixed in the working tree (verify by re-reading the relevant file).
-- **Do NOT write the marker** when any Critical Issue exists, any Important Issue remains unaddressed, or any Suggestion remains unaddressed (including escalated suggestions that require human judgment). The operator must address findings, commit, and re-invoke this agent on the new HEAD; the next clean run writes the marker.
+  3. The Suggestions section is empty, OR every suggestion is auto-fixed in the working tree (verify by re-reading the relevant file). **Escalated suggestions do not satisfy this condition** — an escalation is not a resolution.
+- **Do NOT write the marker** when any Critical Issue exists, any Important Issue remains unaddressed, or any Suggestion is either unaddressed or escalated. Escalated suggestions block unconditionally — the operator must fix or explicitly accept the escalation, commit, and re-invoke this agent on the new HEAD before the marker is written.
 
 Knip and react-doctor advisories remain advisory and never block the marker.
 

--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -117,9 +117,13 @@ Security vulnerabilities and bugs that could cause data loss, unauthorized acces
 
 Performance problems, significant code smells, and architectural concerns that will cause problems at scale. Same format as above.
 
-### Suggestions (Consider Fixing)
+### Suggestions (Must Fix or Escalate)
 
-Refactoring opportunities, maintainability improvements, and minor code quality enhancements. Same format.
+Refactoring opportunities, maintainability improvements, and minor code quality enhancements. Same format as above.
+
+Every suggestion must be resolved before the audit passes:
+- **Auto-fix** it in a self-heal commit (preferred), or
+- **Escalate**: document why it cannot be auto-fixed (architectural tradeoff, breaking change, conflicting convention). Escalated suggestions block the marker — the operator must review and address them before merging.
 
 ### What's Done Well (optional)
 
@@ -319,12 +323,13 @@ Both variables travel forward to the marker-write step below.
 
 After producing the report, decide whether to write the marker:
 
-- **Write the marker** when both:
+- **Write the marker** when all of the following are true:
   1. The Critical Issues section is empty.
   2. The Important Issues section is empty, OR every item is already fixed in the working tree (verify by re-reading the relevant file; do not trust prior chat claims).
-- **Do NOT write the marker** when any Critical Issue exists or any Important Issue remains unaddressed in the working tree. The operator must address findings, commit, and re-invoke this agent on the new HEAD; the next clean run writes the marker.
+  3. The Suggestions section is empty, OR every suggestion is auto-fixed in the working tree (verify by re-reading the relevant file).
+- **Do NOT write the marker** when any Critical Issue exists, any Important Issue remains unaddressed, or any Suggestion remains unaddressed (including escalated suggestions that require human judgment). The operator must address findings, commit, and re-invoke this agent on the new HEAD; the next clean run writes the marker.
 
-Knip / react-doctor advisories and Suggestions never block the marker — they are advisory-by-design.
+Knip and react-doctor advisories remain advisory and never block the marker.
 
 When the marker is warranted, the write is a three-step "stamp → mark → push" sequence: first stamp HEAD locally with the `GAIA-Audit:` trailer (the helper picks amend vs empty-commit per the placement rule, but never pushes); then re-read HEAD (it may have moved due to amend / empty-commit) and write the marker file for the *new* HEAD; *then* push. Marker-before-push is load-bearing — it ensures a `chore: code review audit passed` commit never reaches remote history without a corresponding marker, even if the marker write step is interrupted (the un-pushed commit is recoverable via `git reset --hard HEAD~1`). The `[ ! -f "$marker" ]` guard makes the write idempotent — re-running the audit on the same HEAD never overwrites an existing marker:
 

--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -139,6 +139,7 @@ Include only when there are specific, concrete patterns worth reinforcing. Skip 
 6. **Be proportionate** — don't nitpick formatting when there are security holes; focus energy on what matters most
 7. **Respect existing patterns** — if the codebase has an established way of doing something, don't suggest alternatives unless there's a concrete benefit
 8. **Dispatch in parallel** — once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor` and `pnpm knip --reporter json` from a single tool-call message so they run concurrently with your own review
+9. **Resolve suggestions before writing the marker** — after the report is produced and before deciding on the marker, attempt to auto-fix every item in the Suggestions section. For each: if the fix is surgical (touches `app/` source only, ≤10 files, no convention surface), apply it in a self-heal commit and set `AUDIT_SELF_HEALED="true"`. If a suggestion requires a human tradeoff (architectural restructuring, breaking change, conflicting convention), mark it **Escalated** with explicit rationale — escalated suggestions unconditionally block the marker. Never proceed to the marker with any suggestion that is neither fixed in the working tree nor explicitly escalated.
 
 ## Rules-Based Audit (Specialist Subagents + react-doctor + knip)
 

--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -73,6 +73,7 @@ type MaybeIcon = {
 };
 
 type OnlyIcon = {
+  'aria-label': string;
   children?: never;
   classNameIcon?: string;
   icon: IconType;
@@ -102,7 +103,8 @@ const Button: FC<ButtonProps> = ({
   const innerClassName = twJoin(
     icon && 'flex items-center justify-center',
     icon && !children && ICON_ONLY_SIZES[size],
-    icon && children && `gap-1.5 ${ICON_POSITION[iconPosition]}`
+    icon && children && 'gap-1.5',
+    icon && children && ICON_POSITION[iconPosition]
   );
 
   return (

--- a/app/components/Document/index.tsx
+++ b/app/components/Document/index.tsx
@@ -1,7 +1,7 @@
 import type {FC, ReactNode} from 'react';
 import {Links, Scripts, ScrollRestoration} from 'react-router';
 import {twJoin} from 'tailwind-merge';
-import {useOptionalTheme} from '~/routes/resources+/theme-switch';
+import {useOptionalTheme} from '~/hooks/useTheme';
 import {useNonce} from '~/utils/nonce';
 import {useOptionalRequestInfo} from '~/utils/request-info';
 import MetaHydrated from './MetaHydrated';

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -20,13 +20,13 @@ const ErrorStack: FC<ErrorStackProps> = ({
   const {t} = useTranslation('common');
 
   if (stack) {
-    const handleClickCopyStack = async () => {
+    const handleCopyStack = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
     };
 
     const statusDiv =
       status || statusText ?
-        <div className="space-x-1 pl-1 pr-1.5 pt-px font-sans text-xs leading-none text-white">
+        <div className="space-x-1 pt-px pr-1.5 pl-1 font-sans text-xs leading-none text-white">
           {status && <span>{status}</span>}
           {statusText && <span>{statusText}</span>}
         </div>
@@ -49,15 +49,15 @@ const ErrorStack: FC<ErrorStackProps> = ({
         >
           {statusDiv}
           <button
-            className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
-            onClick={handleClickCopyStack}
+            className="flex items-center gap-1 rounded-bl-sm bg-red-700 pt-px pr-1 pb-1 pl-1.5 font-sans text-xs leading-none text-white hover:bg-red-600"
+            onClick={handleCopyStack}
             type="button"
           >
             <IoCopyOutline aria-hidden={true} />
             <span>{t('copyToClipboard')}</span>
           </button>
         </div>
-        <pre className="whitespace-pre-wrap px-4 pb-4 pt-2">{stack}</pre>
+        <pre className="px-4 pt-2 pb-4 whitespace-pre-wrap">{stack}</pre>
       </div>
     );
   }

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -20,7 +20,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
   const {t} = useTranslation('common');
 
   if (stack) {
-    const handleCopyStack = async () => {
+    const handleCopyStackButton = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
     };
 
@@ -50,7 +50,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
           {statusDiv}
           <button
             className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
-            onClick={handleCopyStack}
+            onClick={handleCopyStackButton}
             type="button"
           >
             <IoCopyOutline aria-hidden={true} />
@@ -61,6 +61,8 @@ const ErrorStack: FC<ErrorStackProps> = ({
       </div>
     );
   }
+
+  return null;
 };
 
 export default ErrorStack;

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -20,7 +20,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
   const {t} = useTranslation('common');
 
   if (stack) {
-    const handleCopyStack = async () => {
+    const handleClickCopyButton = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
     };
 
@@ -50,7 +50,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
           {statusDiv}
           <button
             className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
-            onClick={handleCopyStack}
+            onClick={handleClickCopyButton}
             type="button"
           >
             <IoCopyOutline aria-hidden={true} />

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -26,7 +26,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
 
     const statusDiv =
       status || statusText ?
-        <div className="space-x-1 pt-px pr-1.5 pl-1 font-sans text-xs leading-none text-white">
+        <div className="space-x-1 pl-1 pr-1.5 pt-px font-sans text-xs leading-none text-white">
           {status && <span>{status}</span>}
           {statusText && <span>{statusText}</span>}
         </div>
@@ -49,7 +49,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
         >
           {statusDiv}
           <button
-            className="flex items-center gap-1 rounded-bl-sm bg-red-700 pt-px pr-1 pb-1 pl-1.5 font-sans text-xs leading-none text-white hover:bg-red-600"
+            className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
             onClick={handleCopyStack}
             type="button"
           >
@@ -57,7 +57,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
             <span>{t('copyToClipboard')}</span>
           </button>
         </div>
-        <pre className="px-4 pt-2 pb-4 whitespace-pre-wrap">{stack}</pre>
+        <pre className="whitespace-pre-wrap px-4 pb-4 pt-2">{stack}</pre>
       </div>
     );
   }

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -20,7 +20,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
   const {t} = useTranslation('common');
 
   if (stack) {
-    const handleClickCopyButton = async () => {
+    const handleClickCopyStack = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
     };
 
@@ -50,7 +50,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
           {statusDiv}
           <button
             className="flex items-center gap-1 rounded-bl-sm bg-red-700 pb-1 pl-1.5 pr-1 pt-px font-sans text-xs leading-none text-white hover:bg-red-600"
-            onClick={handleClickCopyButton}
+            onClick={handleClickCopyStack}
             type="button"
           >
             <IoCopyOutline aria-hidden={true} />

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -1,4 +1,5 @@
 import type {FC} from 'react';
+import {useTranslation} from 'react-i18next';
 import {IoCopyOutline} from 'react-icons/io5';
 import {twJoin, twMerge} from 'tailwind-merge';
 import {tryCatch} from '~/utils/function';
@@ -16,6 +17,8 @@ const ErrorStack: FC<ErrorStackProps> = ({
   status,
   statusText,
 }) => {
+  const {t} = useTranslation('common');
+
   if (stack) {
     const handleCopyStack = async () => {
       await tryCatch(async () => navigator.clipboard.writeText(stack));
@@ -30,9 +33,9 @@ const ErrorStack: FC<ErrorStackProps> = ({
       : undefined;
 
     return (
-      <pre
+      <div
         className={twMerge(
-          'relative whitespace-pre-wrap border-2 border-red-700 bg-gray-900 text-left text-sm text-white',
+          'relative border-2 border-red-700 bg-gray-900 text-left text-sm text-white',
           className
         )}
       >
@@ -51,11 +54,11 @@ const ErrorStack: FC<ErrorStackProps> = ({
             type="button"
           >
             <IoCopyOutline aria-hidden={true} />
-            <span>Copy to clipboard</span>
+            <span>{t('copyToClipboard')}</span>
           </button>
         </div>
-        <div className="px-4 pb-4 pt-2">{stack}</div>
-      </pre>
+        <pre className="whitespace-pre-wrap px-4 pb-4 pt-2">{stack}</pre>
+      </div>
     );
   }
 };

--- a/app/components/Errors/RootErrorBoundary/index.tsx
+++ b/app/components/Errors/RootErrorBoundary/index.tsx
@@ -2,9 +2,14 @@
 import {isRouteErrorResponse} from 'react-router';
 import Document from '~/components/Document';
 import ErrorStack from '~/components/Errors/ErrorStack';
+import {DEFAULT_LOCALE} from '~/i18n';
 import {canUseDOM} from '~/utils/dom';
 import type {Route} from '../../../../.react-router/types/app/+types/root';
 
+// This boundary intentionally does NOT use useTranslation: it renders when
+// the app (potentially including i18n) has already failed, so its visible
+// strings stay as English literals to avoid a cascade failure. lang is
+// derived from DEFAULT_LOCALE rather than hardcoded.
 const RootErrorBoundary = ({error}: Route.ErrorBoundaryProps) => {
   if (!canUseDOM) {
     // Server-Side log of error
@@ -13,7 +18,7 @@ const RootErrorBoundary = ({error}: Route.ErrorBoundaryProps) => {
 
   if (isRouteErrorResponse(error)) {
     return (
-      <Document lang="en" noIndex={true} title={error.statusText}>
+      <Document lang={DEFAULT_LOCALE} noIndex={true} title={error.statusText}>
         <main className="absolute inset-0 flex items-center justify-center p-4">
           <div className="flex flex-col items-center gap-5 text-center">
             <h1 className="flex items-center gap-4 text-2xl tracking-wide">
@@ -41,7 +46,7 @@ const RootErrorBoundary = ({error}: Route.ErrorBoundaryProps) => {
 
   if (error instanceof Error) {
     return (
-      <Document lang="en" noIndex={true} title="Error">
+      <Document lang={DEFAULT_LOCALE} noIndex={true} title="Error">
         <main className="space-y-4 p-4">
           <h1 className="text-2xl">Error</h1>
           <p>{error.message}</p>
@@ -52,7 +57,7 @@ const RootErrorBoundary = ({error}: Route.ErrorBoundaryProps) => {
   }
 
   return (
-    <Document lang="en" noIndex={true} title="Unexpected error">
+    <Document lang={DEFAULT_LOCALE} noIndex={true} title="Unexpected error">
       <main className="p-4">
         <h1 className="text-2xl">An unexpected error occurred</h1>
       </main>

--- a/app/components/Errors/RootErrorBoundary/index.tsx
+++ b/app/components/Errors/RootErrorBoundary/index.tsx
@@ -13,7 +13,7 @@ import type {Route} from '../../../../.react-router/types/app/+types/root';
 const RootErrorBoundary = ({error}: Route.ErrorBoundaryProps) => {
   if (!canUseDOM) {
     // Server-Side log of error
-    console.log(error);
+    console.error(error);
   }
 
   if (isRouteErrorResponse(error)) {

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -17,7 +17,7 @@ const Footer: FC<FooterProps> = ({className}) => {
       )}
     >
       <div className="flex w-full flex-col items-center justify-between gap-1 sm:flex-row">
-        <span>&copy;2026 GAIA Framework</span>
+        <span>&copy;{new Date().getFullYear()} GAIA Framework</span>
         <a
           className="hover:text-body transition-colors"
           href="https://github.com/gaia-react/gaia?tab=MIT-1-ov-file#readme"

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -17,7 +17,9 @@ const Footer: FC<FooterProps> = ({className}) => {
       )}
     >
       <div className="flex w-full flex-col items-center justify-between gap-1 sm:flex-row">
-        <span>&copy;{new Date().getFullYear()} GAIA Framework</span>
+        <span suppressHydrationWarning={true}>
+          &copy;{new Date().getFullYear()} GAIA Framework
+        </span>
         <a
           className="hover:text-body transition-colors"
           href="https://github.com/gaia-react/gaia?tab=MIT-1-ov-file#readme"

--- a/app/components/Form/Chain/tests/index.stories.tsx
+++ b/app/components/Form/Chain/tests/index.stories.tsx
@@ -43,7 +43,7 @@ export const Default: StoryFn = () => (
         placeholder="Labeled Input"
       />
       <InputText name="bar3" placeholder="Input" />
-      <Button icon={IoSearch} variant="primary" />
+      <Button aria-label="Search" icon={IoSearch} variant="primary" />
       <Select
         label="Choice"
         name="baz1"
@@ -77,7 +77,7 @@ export const FullWidth: StoryFn = () => (
         placeholder="Labeled Input"
       />
       <InputText name="full-baz1" placeholder="Input" />
-      <Button icon={IoSearch} variant="primary" />
+      <Button aria-label="Search" icon={IoSearch} variant="primary" />
       <Select
         label="Choice"
         name="full-bar3"

--- a/app/components/Form/Checkboxes/index.tsx
+++ b/app/components/Form/Checkboxes/index.tsx
@@ -55,7 +55,7 @@ const Checkboxes: FC<CheckboxesProps> = ({
       id={groupId}
       label={label}
       required={isRequired}
-      type="radio"
+      type="checkbox"
     >
       <CheckboxRadioGroup
         className={classNameGroup}

--- a/app/components/Form/Field/FieldStatus/FieldError/index.tsx
+++ b/app/components/Form/Field/FieldStatus/FieldError/index.tsx
@@ -5,10 +5,7 @@ type FieldErrorProps = {
 };
 
 const FieldError: FC<FieldErrorProps> = ({error}) => (
-  <div
-    className="whitespace-pre-wrap text-sm text-red-600 dark:text-red-500"
-    role="alert"
-  >
+  <div className="text-invalid whitespace-pre-wrap text-sm" role="alert">
     {error}
   </div>
 );

--- a/app/components/Form/Field/FieldStatus/MaxLength/index.tsx
+++ b/app/components/Form/Field/FieldStatus/MaxLength/index.tsx
@@ -7,6 +7,7 @@ type MaxLengthProps = {
   maxLength: number;
 };
 
+// index = digit count of maxLength; pixel min-width prevents layout shift as current length changes
 const MIN_WIDTHS = [0, 34, 49, 65, 80, 95, 100, 111];
 
 const MaxLength: FC<MaxLengthProps> = ({className, length, maxLength}) => {

--- a/app/components/Form/Field/FieldStatus/MaxLength/index.tsx
+++ b/app/components/Form/Field/FieldStatus/MaxLength/index.tsx
@@ -14,7 +14,7 @@ const MaxLength: FC<MaxLengthProps> = ({className, length, maxLength}) => {
   const minWidth = MIN_WIDTHS[String(maxLength).length];
 
   return (
-    <div
+    <output
       className={twJoin(
         'flex-initial select-none px-1 pt-0.5 text-right text-xs',
         length < maxLength ? 'text-secondary' : 'text-invalid',
@@ -23,7 +23,7 @@ const MaxLength: FC<MaxLengthProps> = ({className, length, maxLength}) => {
       style={{minWidth}}
     >
       {length} / {maxLength}
-    </div>
+    </output>
   );
 };
 

--- a/app/components/Form/FormError/index.tsx
+++ b/app/components/Form/FormError/index.tsx
@@ -25,7 +25,7 @@ const FormError: FC<FormResultProps> = ({className, hide}) => {
   const result =
     !hide && error !== undefined && actionData !== dismissed ? error : '';
 
-  const handleDismissError = () => {
+  const handleDismissErrorButton = () => {
     setDismissed(actionData);
   };
 
@@ -39,7 +39,7 @@ const FormError: FC<FormResultProps> = ({className, hide}) => {
         'flex w-full items-center justify-between rounded-sm border-red-600 bg-red-500 px-4 py-2 text-white dark:border-red-400',
         className
       )}
-      onClick={handleDismissError}
+      onClick={handleDismissErrorButton}
       type="button"
     >
       <span role="alert">{result}</span>

--- a/app/components/Form/InputRadio/index.tsx
+++ b/app/components/Form/InputRadio/index.tsx
@@ -52,7 +52,6 @@ const InputRadio: FC<InputRadioProps> = ({
     htmlFor={`${id ?? name}-${option.value}`}
   >
     <input
-      aria-label={`${id ?? name}-${option.value}`}
       className={SIZE[size]}
       defaultChecked={defaultValue === option.value}
       disabled={disabled ?? option.disabled ?? readOnly}

--- a/app/components/Form/InputText/index.tsx
+++ b/app/components/Form/InputText/index.tsx
@@ -35,7 +35,7 @@ const InputText: FC<InputProps> = ({
   const length =
     props.value === undefined ? localLength : String(props.value).length;
 
-  const handleUpdateLength = useCallback(
+  const handleUpdateLengthInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (maxLength && props.value === undefined) {
         setLocalLength(event.currentTarget.value.length);
@@ -82,7 +82,7 @@ const InputText: FC<InputProps> = ({
           id={id ?? name}
           maxLength={maxLength}
           name={name}
-          onChange={handleUpdateLength}
+          onChange={handleUpdateLengthInput}
           readOnly={readOnly}
           required={required}
           tabIndex={readOnly ? -1 : undefined}
@@ -92,7 +92,7 @@ const InputText: FC<InputProps> = ({
         {Icon && (
           <Icon
             className={twMerge(
-              'absolute top-[0.825rem] text-gray-400 dark:text-gray-600',
+              'text-placeholder absolute top-[0.825rem]',
               iconPosition === 'left' ? 'left-3' : 'right-3',
               classNameIcon
             )}

--- a/app/components/Form/RadioButtons/tests/index.test.tsx
+++ b/app/components/Form/RadioButtons/tests/index.test.tsx
@@ -13,7 +13,7 @@ describe('Radio', () => {
     render(<Radio />);
 
     const RadioLocoMoco = screen.getByRole('radio', {
-      name: /hawaii-locomoco/i,
+      name: /loco moco/i,
     });
     expect(RadioLocoMoco).toBeInTheDocument();
     expect(RadioLocoMoco).not.toBeChecked();

--- a/app/components/Form/Select/index.tsx
+++ b/app/components/Form/Select/index.tsx
@@ -53,7 +53,7 @@ const Select: FC<SelectProps> = ({
   // `uncontrolledValue` only backs the uncontrolled (defaultValue) case.
   const currentValue = value ?? uncontrolledValue;
 
-  const handleUpdateValue = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleUpdateValueSelect = (event: ChangeEvent<HTMLSelectElement>) => {
     setUncontrolledValue(event.currentTarget.value || '');
     onChange?.(event);
   };
@@ -92,7 +92,7 @@ const Select: FC<SelectProps> = ({
           disabled={disabled}
           id={id ?? name}
           name={name}
-          onChange={handleUpdateValue}
+          onChange={handleUpdateValueSelect}
           required={required}
           value={value}
           {...props}

--- a/app/components/Form/TextArea/index.tsx
+++ b/app/components/Form/TextArea/index.tsx
@@ -61,7 +61,7 @@ const TextArea: FC<TextAreaProps> = ({
   );
   const length = value === undefined ? localLength : String(value).length;
 
-  const handleUpdateLength = useCallback(
+  const handleUpdateLengthInput = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       if (maxLength && value === undefined) {
         setLocalLength(event.currentTarget.value.length);
@@ -118,7 +118,7 @@ const TextArea: FC<TextAreaProps> = ({
         id={id ?? name}
         maxLength={maxLength}
         name={name}
-        onChange={handleUpdateLength}
+        onChange={handleUpdateLengthInput}
         readOnly={readOnly}
         rows={rows}
         tabIndex={readOnly ? -1 : undefined}

--- a/app/components/Form/YearMonthDay/index.tsx
+++ b/app/components/Form/YearMonthDay/index.tsx
@@ -75,20 +75,23 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
     };
   }, []);
 
-  const handleUpdateDate = (event: ChangeEvent<HTMLSelectElement>) => {
-    const newValue =
-      event.currentTarget.name.includes('Date') ?
-        `${year}-${month}-${event.currentTarget.value}`
-      : getSafeValue(value, event.currentTarget);
+  const handleUpdateDateSelect = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const newValue =
+        event.currentTarget.name.includes('Date') ?
+          `${year}-${month}-${event.currentTarget.value}`
+        : getSafeValue(value, event.currentTarget);
 
-    // Sync the hidden input's DOM value before onChange dispatches events,
-    // so Conform reads the correct value during revalidation.
-    if (hiddenRef.current) {
-      hiddenRef.current.value = newValue;
-    }
+      // Sync the hidden input's DOM value before onChange dispatches events,
+      // so Conform reads the correct value during revalidation.
+      if (hiddenRef.current) {
+        hiddenRef.current.value = newValue;
+      }
 
-    onChange(newValue);
-  };
+      onChange(newValue);
+    },
+    [month, onChange, value, year]
+  );
 
   const years = useMemo(
     () =>
@@ -150,7 +153,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Year`}
-          onChange={handleUpdateDate}
+          onChange={handleUpdateDateSelect}
           options={years}
           value={year}
         />
@@ -159,7 +162,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Month`}
-          onChange={handleUpdateDate}
+          onChange={handleUpdateDateSelect}
           options={months}
           value={month}
         />
@@ -168,7 +171,7 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
           className="flex-1"
           classNameSelect={classNameSelect}
           name={`${name}Date`}
-          onChange={handleUpdateDate}
+          onChange={handleUpdateDateSelect}
           options={dates}
           value={date}
         />

--- a/app/components/Form/YearMonthDay/index.tsx
+++ b/app/components/Form/YearMonthDay/index.tsx
@@ -75,23 +75,20 @@ const YearMonthDay: FC<YearMonthDayProps> = ({
     };
   }, []);
 
-  const handleUpdateDateSelect = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      const newValue =
-        event.currentTarget.name.includes('Date') ?
-          `${year}-${month}-${event.currentTarget.value}`
-        : getSafeValue(value, event.currentTarget);
+  const handleUpdateDateSelect = (event: ChangeEvent<HTMLSelectElement>) => {
+    const newValue =
+      event.currentTarget.name.includes('Date') ?
+        `${year}-${month}-${event.currentTarget.value}`
+      : getSafeValue(value, event.currentTarget);
 
-      // Sync the hidden input's DOM value before onChange dispatches events,
-      // so Conform reads the correct value during revalidation.
-      if (hiddenRef.current) {
-        hiddenRef.current.value = newValue;
-      }
+    // Sync the hidden input's DOM value before onChange dispatches events,
+    // so Conform reads the correct value during revalidation.
+    if (hiddenRef.current) {
+      hiddenRef.current.value = newValue;
+    }
 
-      onChange(newValue);
-    },
-    [month, onChange, value, year]
-  );
+    onChange(newValue);
+  };
 
   const years = useMemo(
     () =>

--- a/app/components/Form/YearMonthDay/utils.ts
+++ b/app/components/Form/YearMonthDay/utils.ts
@@ -27,7 +27,11 @@ export const DEFAULT_VALUE = formatISO8601Date(DEFAULT_DATE);
 const iso8601DateSchema = z.iso.date();
 
 export const getValues = (value: string) => {
-  const [year, month, date] = iso8601DateSchema.parse(value).split('-');
+  const result = iso8601DateSchema.safeParse(value);
+  const [year, month, date] = (
+    result.success ?
+      result.data
+    : DEFAULT_VALUE).split('-');
 
   return [year, month, date];
 };

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -4,7 +4,7 @@ import {Link} from 'react-router';
 import {twMerge} from 'tailwind-merge';
 import GaiaLogo from '~/components/GaiaLogo';
 import LanguageSelect from '~/components/LanguageSelect';
-import {ThemeSwitch} from '~/routes/resources+/theme-switch';
+import ThemeSwitch from '~/components/ThemeSwitch';
 import {useRequestInfo} from '~/utils/request-info';
 
 type HeaderProps = {

--- a/app/components/LanguageSelect/index.tsx
+++ b/app/components/LanguageSelect/index.tsx
@@ -3,6 +3,8 @@ import {useTranslation} from 'react-i18next';
 import {useFetcher, useLocation} from 'react-router';
 import {twMerge} from 'tailwind-merge';
 
+const SET_LANGUAGE_ACTION = '/actions/set-language';
+
 const OPTIONS = [{label: 'English', value: 'en'}];
 
 type LanguageSelectProps = {
@@ -21,9 +23,11 @@ const LanguageSelect: FC<LanguageSelectProps> = ({className, onChange}) => {
 
   const redirectUrl = `${location.pathname}${location.search}${location.hash}`;
 
-  const handleChangeLanguage = async (event: ChangeEvent<HTMLFormElement>) => {
+  const handleChangeLanguageForm = async (
+    event: ChangeEvent<HTMLFormElement>
+  ) => {
     await fetcher.submit(event.currentTarget, {
-      action: '/actions/set-language',
+      action: SET_LANGUAGE_ACTION,
       method: 'POST',
     });
 
@@ -32,10 +36,10 @@ const LanguageSelect: FC<LanguageSelectProps> = ({className, onChange}) => {
 
   return (
     <fetcher.Form
-      action="/actions/set-language"
+      action={SET_LANGUAGE_ACTION}
       className={twMerge('relative flex-none text-sm', className)}
       method="POST"
-      onChange={handleChangeLanguage}
+      onChange={handleChangeLanguageForm}
     >
       <input name="redirectUrl" type="hidden" value={redirectUrl} />
       <select

--- a/app/components/LanguageSelect/index.tsx
+++ b/app/components/LanguageSelect/index.tsx
@@ -2,10 +2,16 @@ import type {ChangeEvent, FC} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useFetcher, useLocation} from 'react-router';
 import {twMerge} from 'tailwind-merge';
+import {LANGUAGES} from '~/languages';
 
 const SET_LANGUAGE_ACTION = '/actions/set-language';
 
-const OPTIONS = [{label: 'English', value: 'en'}];
+// Native <select> intentional: this is a non-Conform chrome control, not a form field.
+const LANGUAGE_LABELS: Record<string, string> = {en: 'English'};
+const OPTIONS = LANGUAGES.map((value) => ({
+  label: LANGUAGE_LABELS[value] ?? value,
+  value,
+}));
 
 type LanguageSelectProps = {
   className?: string;

--- a/app/components/LinkButton/index.tsx
+++ b/app/components/LinkButton/index.tsx
@@ -39,9 +39,8 @@ const LinkButton: FC<LinkButtonProps> = ({
   const innerSpan = (
     <span
       className={twJoin(
-        icon &&
-          children &&
-          `flex items-center justify-center gap-1.5 ${ICON_POSITION[iconPosition]}`
+        icon && children && 'flex items-center justify-center gap-1.5',
+        icon && children && ICON_POSITION[iconPosition]
       )}
     >
       {iconComponent}

--- a/app/components/Loaders/Spinner/index.tsx
+++ b/app/components/Loaders/Spinner/index.tsx
@@ -1,10 +1,12 @@
 import type {FC} from 'react';
 import {useId} from 'react';
+import {useTranslation} from 'react-i18next';
 import {twMerge} from 'tailwind-merge';
 import type {Size} from '~/types';
 
 export type SpinnerProps = {
   className?: string;
+  label?: string;
   size?: Size;
 };
 
@@ -16,12 +18,14 @@ const SIZES: Record<Size, string> = {
   xs: 'h-3',
 };
 
-const Spinner: FC<SpinnerProps> = ({className = '', size = 'base'}) => {
+const Spinner: FC<SpinnerProps> = ({className = '', label, size = 'base'}) => {
+  const {t} = useTranslation('common');
   const id = useId();
 
   return (
     <svg
       aria-busy="true"
+      aria-label={label ?? t('loading')}
       aria-live="polite"
       className={twMerge(SIZES[size], className)}
       role="progressbar"

--- a/app/components/ThemeSwitch/index.tsx
+++ b/app/components/ThemeSwitch/index.tsx
@@ -1,0 +1,57 @@
+import type {FC} from 'react';
+import {useTranslation} from 'react-i18next';
+import {IoDesktopOutline, IoMoon, IoSunny} from 'react-icons/io5';
+import {useFetcher} from 'react-router';
+import {useOptimisticThemeMode} from '~/hooks/useTheme';
+import type {action} from '~/routes/resources+/theme-switch';
+import type {Theme} from '~/utils/theme.server';
+
+export type ThemeSwitchProps = {
+  userPreference?: null | Theme;
+};
+
+const NEXT_MODE: Record<
+  'dark' | 'light' | 'system',
+  'dark' | 'light' | 'system'
+> = {
+  dark: 'system',
+  light: 'dark',
+  system: 'light',
+};
+
+const ICONS = {
+  dark: IoMoon,
+  light: IoSunny,
+  system: IoDesktopOutline,
+} as const;
+
+const LABEL_KEYS = {
+  dark: 'useSystemTheme',
+  light: 'enableDarkMode',
+  system: 'enableLightMode',
+} as const;
+
+const ThemeSwitch: FC<ThemeSwitchProps> = ({userPreference}) => {
+  const {t} = useTranslation('common', {keyPrefix: 'theme'});
+  const fetcher = useFetcher<typeof action>();
+  const optimisticMode = useOptimisticThemeMode();
+
+  const mode = optimisticMode ?? userPreference ?? 'system';
+  const next = NEXT_MODE[mode];
+  const ThemeIcon = ICONS[mode];
+
+  return (
+    <fetcher.Form action="/resources/theme-switch" method="POST">
+      <input name="theme" type="hidden" value={next} />
+      <button
+        aria-label={t(LABEL_KEYS[mode])}
+        className="text-body size-4.5 relative flex items-center gap-2"
+        type="submit"
+      >
+        <ThemeIcon />
+      </button>
+    </fetcher.Form>
+  );
+};
+
+export default ThemeSwitch;

--- a/app/components/ThemeSwitch/index.tsx
+++ b/app/components/ThemeSwitch/index.tsx
@@ -48,7 +48,7 @@ const ThemeSwitch: FC<ThemeSwitchProps> = ({userPreference}) => {
         className="text-body size-4.5 relative flex items-center gap-2"
         type="submit"
       >
-        <ThemeIcon />
+        <ThemeIcon aria-hidden={true} />
       </button>
     </fetcher.Form>
   );

--- a/app/components/Toast/ToastNotification/index.tsx
+++ b/app/components/Toast/ToastNotification/index.tsx
@@ -1,5 +1,4 @@
 import type {FC} from 'react';
-import {useEffect, useRef, useState} from 'react';
 import type {IconType} from 'react-icons';
 import {useTranslation} from 'react-i18next';
 import {
@@ -37,10 +36,6 @@ const ICON_COLOR: Record<ToastType, string> = {
   warning: 'text-yellow-300',
 };
 
-const DEFAULT_DURATION = 5000;
-// Error notifications last longer to allow users to read/copy the stack
-const DEFAULT_ERROR_DURATION = 30_000;
-
 type ToastNotificationProps = {
   id: number | string;
   payload: Partial<ToastMessage> | string;
@@ -49,39 +44,12 @@ type ToastNotificationProps = {
 
 const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
   const {t} = useTranslation('common');
-  const [isHovered, setIsHovered] = useState(false);
-  const timeoutRef = useRef(0);
 
-  const {description, duration, message, stack} = parsePayload(payload);
-
-  const toastDuration =
-    duration ?? (type === 'error' ? DEFAULT_ERROR_DURATION : DEFAULT_DURATION);
+  const {description, message, stack} = parsePayload(payload);
 
   const handleCloseButton = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
     toast.dismiss(id);
   };
-
-  useEffect(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    if (!isHovered) {
-      timeoutRef.current = window.setTimeout(
-        () => toast.dismiss(id),
-        toastDuration
-      );
-    }
-
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, [id, isHovered, toastDuration]);
 
   return (
     <div
@@ -89,12 +57,6 @@ const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
         'w-88 relative rounded-sm p-3 text-sm text-white',
         COLOR[type]
       )}
-      onMouseEnter={() => {
-        setIsHovered(true);
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false);
-      }}
     >
       <button
         aria-label={t('close')}

--- a/app/components/Toast/ToastNotification/index.tsx
+++ b/app/components/Toast/ToastNotification/index.tsx
@@ -121,7 +121,7 @@ const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
       )}
       {stack && (
         <details className={twJoin((message ?? description) && 'mt-1.5')}>
-          <summary className="cursor-pointer">Stack trace</summary>
+          <summary className="cursor-pointer">{t('stackTrace')}</summary>
           <ErrorStack
             className="max-h-60 overflow-y-auto text-xs"
             stack={stack}

--- a/app/components/Toast/ToastNotification/index.tsx
+++ b/app/components/Toast/ToastNotification/index.tsx
@@ -1,5 +1,5 @@
 import type {FC} from 'react';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import type {IconType} from 'react-icons';
 import {useTranslation} from 'react-i18next';
 import {
@@ -57,12 +57,12 @@ const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
   const toastDuration =
     duration ?? (type === 'error' ? DEFAULT_ERROR_DURATION : DEFAULT_DURATION);
 
-  const handleClose = useCallback(() => {
+  const handleClose = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
     toast.dismiss(id);
-  }, [id]);
+  };
 
   useEffect(() => {
     if (timeoutRef.current) {

--- a/app/components/Toast/ToastNotification/index.tsx
+++ b/app/components/Toast/ToastNotification/index.tsx
@@ -57,7 +57,7 @@ const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
   const toastDuration =
     duration ?? (type === 'error' ? DEFAULT_ERROR_DURATION : DEFAULT_DURATION);
 
-  const handleClose = () => {
+  const handleCloseButton = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -99,7 +99,7 @@ const ToastNotification: FC<ToastNotificationProps> = ({id, payload, type}) => {
       <button
         aria-label={t('close')}
         className="relative float-end ms-2 size-3 text-sm leading-none opacity-50 transition-transform hover:scale-125 hover:opacity-100"
-        onClick={handleClose}
+        onClick={handleCloseButton}
         type="button"
       >
         <IoClose className="size-4" />

--- a/app/components/Toast/index.tsx
+++ b/app/components/Toast/index.tsx
@@ -3,14 +3,21 @@ import type {ToastMessage} from 'remix-toast';
 import {toast, Toaster} from 'sonner';
 import {md5} from '~/utils/object';
 import ToastNotification from './ToastNotification';
+import {parsePayload} from './ToastNotification/utils';
 
 // Reference
 // https://sonner.emilkowal.ski/toaster
+// Hover-pause: Sonner sets expanded=true on the <ol> onMouseEnter, which pauses all
+// toast timers (including toast.custom) via its internal useEffect. No manual
+// onMouseEnter/onMouseLeave needed in ToastNotification.
+
+const DEFAULT_DURATION = 5000;
+// Error notifications last longer to allow users to read/copy the stack
+const DEFAULT_ERROR_DURATION = 30_000;
 
 const Toast: FC = () => (
   <Toaster
     className="w-90"
-    duration={Number.POSITIVE_INFINITY}
     expand={true}
     offset={8}
     position="top-right"
@@ -22,24 +29,36 @@ const Toast: FC = () => (
 export default Toast;
 
 export const notify = {
-  error: (payload: Partial<ToastMessage> | string) =>
-    toast.custom(
+  error: (payload: Partial<ToastMessage> | string) => {
+    const {duration} = parsePayload(payload);
+
+    return toast.custom(
       (id) => <ToastNotification id={id} payload={payload} type="error" />,
-      {id: md5({payload})}
-    ),
-  info: (payload: Partial<ToastMessage> | string) =>
-    toast.custom(
+      {duration: duration ?? DEFAULT_ERROR_DURATION, id: md5({payload})}
+    );
+  },
+  info: (payload: Partial<ToastMessage> | string) => {
+    const {duration} = parsePayload(payload);
+
+    return toast.custom(
       (id) => <ToastNotification id={id} payload={payload} type="info" />,
-      {id: md5({payload})}
-    ),
-  success: (payload: Partial<ToastMessage> | string) =>
-    toast.custom(
+      {duration: duration ?? DEFAULT_DURATION, id: md5({payload})}
+    );
+  },
+  success: (payload: Partial<ToastMessage> | string) => {
+    const {duration} = parsePayload(payload);
+
+    return toast.custom(
       (id) => <ToastNotification id={id} payload={payload} type="success" />,
-      {id: md5({payload})}
-    ),
-  warning: (payload: Partial<ToastMessage> | string) =>
-    toast.custom(
+      {duration: duration ?? DEFAULT_DURATION, id: md5({payload})}
+    );
+  },
+  warning: (payload: Partial<ToastMessage> | string) => {
+    const {duration} = parsePayload(payload);
+
+    return toast.custom(
       (id) => <ToastNotification id={id} payload={payload} type="warning" />,
-      {id: md5({payload})}
-    ),
+      {duration: duration ?? DEFAULT_DURATION, id: md5({payload})}
+    );
+  },
 };

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -13,6 +13,7 @@ import {ServerRouter} from 'react-router';
 import {createReadableStreamFromReadable} from '@react-router/node';
 import {createInstance} from 'i18next';
 import {isbot} from 'isbot';
+import {setToastCookieOptions} from 'remix-toast';
 import {randomBytes} from 'node:crypto';
 import {PassThrough} from 'node:stream';
 import i18nConfig from '~/i18n';
@@ -21,6 +22,8 @@ import {getContentSecurityPolicy} from '~/utils/http.server';
 import {NonceProvider} from '~/utils/nonce';
 import {env} from './env.server';
 import 'dotenv/config';
+
+setToastCookieOptions({secrets: [env.SESSION_SECRET]});
 
 if (env.NODE_ENV !== 'production' && env.MSW_ENABLED) {
   const {startApiMocks} = await import('../test/msw.server');

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -127,10 +127,12 @@ const handleRequest = async (
           );
 
           // Security response headers
-          responseHeaders.set(
-            'Strict-Transport-Security',
-            'max-age=31536000; includeSubDomains'
-          );
+          if (env.NODE_ENV === 'production') {
+            responseHeaders.set(
+              'Strict-Transport-Security',
+              'max-age=31536000; includeSubDomains'
+            );
+          }
           responseHeaders.set('X-Content-Type-Options', 'nosniff');
           responseHeaders.set('X-Frame-Options', 'DENY');
 

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -43,8 +43,8 @@ const handleRequest = async (
   const url = new URL(request.url);
 
   // disallow www subdomain
-  if (url.host.includes('www.')) {
-    url.host = url.host.replace('www.', '');
+  if (url.host.startsWith('www.')) {
+    url.host = url.host.slice(4);
 
     return Response.redirect(url.toString(), 301);
   }
@@ -123,14 +123,13 @@ const handleRequest = async (
             getContentSecurityPolicy(nonce)
           );
 
-          /* Optional response headers for SEO
+          // Security response headers
           responseHeaders.set(
             'Strict-Transport-Security',
             'max-age=31536000; includeSubDomains'
           );
           responseHeaders.set('X-Content-Type-Options', 'nosniff');
           responseHeaders.set('X-Frame-Options', 'DENY');
-          */
 
           resolve(
             new Response(stream, {

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -19,11 +19,11 @@ import i18nConfig from '~/i18n';
 import {getInstance} from '~/middleware/i18next';
 import {getContentSecurityPolicy} from '~/utils/http.server';
 import {NonceProvider} from '~/utils/nonce';
-import {startApiMocks} from '../test/msw.server';
 import {env} from './env.server';
 import 'dotenv/config';
 
 if (env.NODE_ENV !== 'production' && env.MSW_ENABLED) {
+  const {startApiMocks} = await import('../test/msw.server');
   startApiMocks();
 }
 

--- a/app/hooks/tests/useBreakpoint.test.ts
+++ b/app/hooks/tests/useBreakpoint.test.ts
@@ -3,55 +3,64 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {useBreakpoint} from '../useBreakpoint';
 
 describe('useBreakpoint', () => {
-  const originalInnerWidth = window.innerWidth;
+  let changeListeners: (() => void)[] = [];
+  let mockMatches = false;
+
+  const mockMql = {
+    addEventListener: vi.fn((_event: string, listener: () => void) => {
+      changeListeners.push(listener);
+    }),
+    get matches() {
+      return mockMatches;
+    },
+    removeEventListener: vi.fn((_event: string, listener: () => void) => {
+      changeListeners = changeListeners.filter((l) => l !== listener);
+    }),
+  };
 
   beforeEach(() => {
-    vi.spyOn(window, 'addEventListener');
-    vi.spyOn(window, 'removeEventListener');
+    changeListeners = [];
+    mockMatches = false;
+    vi.spyOn(window, 'matchMedia').mockReturnValue(
+      mockMql as unknown as MediaQueryList
+    );
   });
 
   afterEach(() => {
-    Object.defineProperty(window, 'innerWidth', {
-      value: originalInnerWidth,
-      writable: true,
-    });
     vi.restoreAllMocks();
   });
 
-  test('returns true when innerWidth meets the breakpoint threshold', () => {
-    Object.defineProperty(window, 'innerWidth', {value: 1024, writable: true});
-    const {result} = renderHook(() => useBreakpoint('lg'));
-    expect(result.current).toBe(true);
-  });
-
-  test('returns false when innerWidth is below the breakpoint threshold', () => {
-    Object.defineProperty(window, 'innerWidth', {value: 600, writable: true});
+  test('returns false when media query does not match', () => {
+    mockMatches = false;
     const {result} = renderHook(() => useBreakpoint('lg'));
     expect(result.current).toBe(false);
   });
 
-  test('updates on window resize events', () => {
-    Object.defineProperty(window, 'innerWidth', {value: 600, writable: true});
+  test('returns true when media query matches', () => {
+    mockMatches = true;
+    const {result} = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(true);
+  });
+
+  test('updates when MediaQueryList fires a change event', () => {
+    mockMatches = false;
     const {result} = renderHook(() => useBreakpoint('lg'));
     expect(result.current).toBe(false);
 
     act(() => {
-      Object.defineProperty(window, 'innerWidth', {
-        value: 1200,
-        writable: true,
-      });
-      window.dispatchEvent(new Event('resize'));
+      mockMatches = true;
+      changeListeners.forEach((listener) => listener());
     });
 
     expect(result.current).toBe(true);
   });
 
-  test('removes the resize listener on unmount', () => {
+  test('removes the change listener on unmount', () => {
     const {unmount} = renderHook(() => useBreakpoint('md'));
     unmount();
 
-    expect(window.removeEventListener).toHaveBeenCalledWith(
-      'resize',
+    expect(mockMql.removeEventListener).toHaveBeenCalledWith(
+      'change',
       expect.any(Function)
     );
   });

--- a/app/hooks/tests/useBreakpoint.test.ts
+++ b/app/hooks/tests/useBreakpoint.test.ts
@@ -1,0 +1,58 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {useBreakpoint} from '../useBreakpoint';
+
+describe('useBreakpoint', () => {
+  const originalInnerWidth = window.innerWidth;
+
+  beforeEach(() => {
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: originalInnerWidth,
+      writable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  test('returns true when innerWidth meets the breakpoint threshold', () => {
+    Object.defineProperty(window, 'innerWidth', {value: 1024, writable: true});
+    const {result} = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(true);
+  });
+
+  test('returns false when innerWidth is below the breakpoint threshold', () => {
+    Object.defineProperty(window, 'innerWidth', {value: 600, writable: true});
+    const {result} = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(false);
+  });
+
+  test('updates on window resize events', () => {
+    Object.defineProperty(window, 'innerWidth', {value: 600, writable: true});
+    const {result} = renderHook(() => useBreakpoint('lg'));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        value: 1200,
+        writable: true,
+      });
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  test('removes the resize listener on unmount', () => {
+    const {unmount} = renderHook(() => useBreakpoint('md'));
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function)
+    );
+  });
+});

--- a/app/hooks/tests/useComponentRect.test.ts
+++ b/app/hooks/tests/useComponentRect.test.ts
@@ -1,0 +1,97 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {useComponentRect} from '../useComponentRect';
+
+describe('useComponentRect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'addEventListener');
+    vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('returns a zero-rect before any measurement', () => {
+    const ref = {current: null};
+    const {result} = renderHook(() => useComponentRect(ref));
+
+    expect(result.current).toMatchObject({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  test('calls getBoundingClientRect on the ref element and updates state', () => {
+    const mockRect = {
+      bottom: 100,
+      height: 50,
+      left: 10,
+      right: 110,
+      toJSON: () => {},
+      top: 50,
+      width: 100,
+      x: 10,
+      y: 50,
+    } as DOMRect;
+
+    const element = document.createElement('div');
+    element.getBoundingClientRect = vi.fn().mockReturnValue(mockRect);
+
+    const ref = {current: element};
+
+    const {result} = renderHook(() => useComponentRect(ref));
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(element.getBoundingClientRect).toHaveBeenCalled();
+    expect(result.current).toMatchObject({
+      height: 50,
+      width: 100,
+    });
+  });
+
+  test('removes resize and scroll listeners on unmount', () => {
+    const element = document.createElement('div');
+    element.getBoundingClientRect = vi.fn().mockReturnValue({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      toJSON: () => {},
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    });
+
+    const ref = {current: element};
+    const {unmount} = renderHook(() => useComponentRect(ref));
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function)
+    );
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'scroll',
+      expect.any(Function),
+      expect.objectContaining({passive: true})
+    );
+  });
+});

--- a/app/hooks/tests/useDebounce.test.ts
+++ b/app/hooks/tests/useDebounce.test.ts
@@ -1,0 +1,89 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {useDebounce} from '../useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns the initial value immediately', () => {
+    const {result} = renderHook(() => useDebounce('hello', 300));
+    expect(result.current).toBe('hello');
+  });
+
+  test('does not update until delay elapses after a value change', () => {
+    let value = 'hello';
+    const {rerender, result} = renderHook(() => useDebounce(value, 300));
+
+    value = 'world';
+    rerender();
+
+    // Not updated yet — delay has not elapsed
+    expect(result.current).toBe('hello');
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe('hello');
+  });
+
+  test('updates to the latest value after delay elapses', () => {
+    let value = 'hello';
+    const {rerender, result} = renderHook(() => useDebounce(value, 300));
+
+    value = 'world';
+    rerender();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('world');
+  });
+
+  test('clears the pending timer on unmount — no late state update', () => {
+    let value = 'hello';
+    const {rerender, result, unmount} = renderHook(() =>
+      useDebounce(value, 300)
+    );
+
+    value = 'world';
+    rerender();
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // Still reflects the value at the time of unmount
+    expect(result.current).toBe('hello');
+  });
+
+  test('cancels pending update on rapid value changes and settles on the final value', () => {
+    let value = 'a';
+    const {rerender, result} = renderHook(() => useDebounce(value, 300));
+
+    value = 'b';
+    rerender();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    value = 'c';
+    rerender();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('c');
+  });
+});

--- a/app/hooks/tests/useTimeout.test.ts
+++ b/app/hooks/tests/useTimeout.test.ts
@@ -1,0 +1,64 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {useTimeout} from '../useTimeout';
+
+describe('useTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('complete is false immediately after mount', () => {
+    const {result} = renderHook(() => useTimeout(500));
+    expect(result.current).toBe(false);
+  });
+
+  test('complete becomes true after advancing timers past delay', () => {
+    const {result} = renderHook(() => useTimeout(500));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  test('changing trigger resets complete to false', () => {
+    let trigger = 'a';
+    const {rerender, result} = renderHook(() => useTimeout(200, trigger));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(true);
+
+    trigger = 'b';
+    rerender();
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  test('timeout is cleared on unmount — no late state update', () => {
+    const {result, unmount} = renderHook(() => useTimeout(500));
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // Still false — the timer was cleared before it fired
+    expect(result.current).toBe(false);
+  });
+});

--- a/app/hooks/useBreakpoint.ts
+++ b/app/hooks/useBreakpoint.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useSyncExternalStore} from 'react';
 
 const BREAKPOINTS = {
   '2xl': 1536,
@@ -10,21 +10,25 @@ const BREAKPOINTS = {
 
 type BreakpointType = keyof typeof BREAKPOINTS;
 
+const getServerSnapshot = (): boolean => false;
+
 export const useBreakpoint = (breakpoint: BreakpointType): boolean => {
-  const [isBreakpoint, setIsBreakpoint] = useState(false);
+  const query = `(min-width: ${BREAKPOINTS[breakpoint]}px)`;
 
-  useEffect(() => {
-    const onUpdate = () => {
-      const {innerWidth} = window;
-      setIsBreakpoint(innerWidth >= BREAKPOINTS[breakpoint]);
-    };
-    onUpdate();
-    window.addEventListener('resize', onUpdate);
+  // stable ref required by useSyncExternalStore — re-subscribes only when breakpoint changes
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', callback);
 
-    return () => {
-      window.removeEventListener('resize', onUpdate);
-    };
-  }, [breakpoint]);
+      return () => mql.removeEventListener('change', callback);
+    },
+    [query]
+  );
 
-  return isBreakpoint;
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    getServerSnapshot
+  );
 };

--- a/app/hooks/useBreakpoint.ts
+++ b/app/hooks/useBreakpoint.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import {canUseDOM} from '~/utils/dom';
 
 const BREAKPOINTS = {
   '2xl': 1536,
@@ -11,7 +12,9 @@ const BREAKPOINTS = {
 type BreakpointType = keyof typeof BREAKPOINTS;
 
 export const useBreakpoint = (breakpoint: BreakpointType): boolean => {
-  const [isBreakpoint, setIsBreakpoint] = useState(true);
+  const [isBreakpoint, setIsBreakpoint] = useState(
+    () => canUseDOM && window.innerWidth >= BREAKPOINTS[breakpoint]
+  );
 
   useEffect(() => {
     const onUpdate = () => {

--- a/app/hooks/useBreakpoint.ts
+++ b/app/hooks/useBreakpoint.ts
@@ -1,5 +1,4 @@
 import {useEffect, useState} from 'react';
-import {canUseDOM} from '~/utils/dom';
 
 const BREAKPOINTS = {
   '2xl': 1536,
@@ -12,9 +11,7 @@ const BREAKPOINTS = {
 type BreakpointType = keyof typeof BREAKPOINTS;
 
 export const useBreakpoint = (breakpoint: BreakpointType): boolean => {
-  const [isBreakpoint, setIsBreakpoint] = useState(
-    () => canUseDOM && window.innerWidth >= BREAKPOINTS[breakpoint]
-  );
+  const [isBreakpoint, setIsBreakpoint] = useState(false);
 
   useEffect(() => {
     const onUpdate = () => {

--- a/app/hooks/useComponentRect.ts
+++ b/app/hooks/useComponentRect.ts
@@ -28,8 +28,10 @@ export const useComponentRect = (
         }
       };
 
+      const scrollOptions: AddEventListenerOptions = {passive: true};
+
       window.addEventListener('resize', onUpdate);
-      window.addEventListener('scroll', onUpdate, {passive: true});
+      window.addEventListener('scroll', onUpdate, scrollOptions);
 
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -41,7 +43,7 @@ export const useComponentRect = (
           clearTimeout(timeoutRef.current);
         }
         window.removeEventListener('resize', onUpdate);
-        window.removeEventListener('scroll', onUpdate);
+        window.removeEventListener('scroll', onUpdate, scrollOptions);
       };
     }
 

--- a/app/hooks/useTheme.ts
+++ b/app/hooks/useTheme.ts
@@ -1,0 +1,54 @@
+import {useSyncExternalStore} from 'react';
+import {useFetchers} from 'react-router';
+import {useOptionalRequestInfo} from '~/utils/request-info';
+import type {Theme} from '~/utils/theme.server';
+
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+const subscribeToColorScheme = (onChange: () => void): (() => void) => {
+  const query = window.matchMedia(COLOR_SCHEME_QUERY);
+  query.addEventListener('change', onChange);
+
+  return () => {
+    query.removeEventListener('change', onChange);
+  };
+};
+
+const getColorSchemeSnapshot = (): Theme =>
+  window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
+
+const getColorSchemeServerSnapshot = (): undefined => undefined;
+
+export const useSystemTheme = (): Theme | undefined =>
+  useSyncExternalStore<Theme | undefined>(
+    subscribeToColorScheme,
+    getColorSchemeSnapshot,
+    getColorSchemeServerSnapshot
+  );
+
+export const useOptimisticThemeMode = ():
+  | 'dark'
+  | 'light'
+  | 'system'
+  | undefined => {
+  const fetchers = useFetchers();
+  const themeFetcher = fetchers.find(
+    (f) => f.formAction === '/resources/theme-switch'
+  );
+  const theme = themeFetcher?.formData?.get('theme');
+  if (theme === 'dark' || theme === 'light' || theme === 'system') return theme;
+
+  return undefined;
+};
+
+export const useOptionalTheme = (): Theme | undefined => {
+  const requestInfo = useOptionalRequestInfo();
+  const optimisticMode = useOptimisticThemeMode();
+  const systemTheme = useSystemTheme();
+
+  if (optimisticMode) {
+    return optimisticMode === 'system' ? systemTheme : optimisticMode;
+  }
+
+  return requestInfo?.userPrefs.theme ?? systemTheme;
+};

--- a/app/hooks/useTimeout.ts
+++ b/app/hooks/useTimeout.ts
@@ -10,7 +10,7 @@ export const useTimeout = (delay: number, trigger?: unknown): boolean => {
   }
 
   useEffect(() => {
-    const id = window.setTimeout(() => {
+    const id = setTimeout(() => {
       setComplete(true);
     }, delay);
 

--- a/app/i18n.ts
+++ b/app/i18n.ts
@@ -1,6 +1,8 @@
 import type {FormatFunction} from 'i18next';
 import resources, {LANGUAGES} from '~/languages';
 
+export const DEFAULT_LOCALE = 'en';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const formatFn: FormatFunction = (value: any, format?: string) =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -8,7 +10,7 @@ const formatFn: FormatFunction = (value: any, format?: string) =>
 
 const i18n = {
   defaultNS: 'common',
-  fallbackLng: 'en',
+  fallbackLng: DEFAULT_LOCALE,
   fallbackNS: ['common'],
   interpolation: {
     escapeValue: false,

--- a/app/languages/en/common.ts
+++ b/app/languages/en/common.ts
@@ -1,5 +1,6 @@
 export default {
   close: 'Close',
+  copyToClipboard: 'Copy to clipboard',
   counters: {
     clicks_one: '{{count}} click',
     clicks_other: '{{count}} clicks',
@@ -31,6 +32,7 @@ export default {
   },
   language: 'Language',
   license: 'Released under MIT license',
+  loading: 'Loading',
   meta: {
     siteName: 'GAIA Template',
   },
@@ -38,6 +40,7 @@ export default {
   next: 'Next',
   password: 'Password',
   previous: 'Previous',
+  stackTrace: 'Stack trace',
   theme: {
     dark: 'Dark mode',
     enableDarkMode: 'Enable dark mode',

--- a/app/pages/Legal/PrivacyPage/index.tsx
+++ b/app/pages/Legal/PrivacyPage/index.tsx
@@ -18,9 +18,8 @@ const PrivacyPage: FC<PrivacyPageProps> = ({description, title}) => {
       <meta content={description} name="description" />
       <div className="prose dark:prose-invert p-8 sm:px-16">
         <h1>{title}</h1>
-        {paragraphs.map((paragraph, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <p key={`paragraph-${index}`}>{paragraph}</p>
+        {paragraphs.map((paragraph) => (
+          <p key={paragraph}>{paragraph}</p>
         ))}
       </div>
     </Layout>

--- a/app/pages/Legal/PrivacyPage/index.tsx
+++ b/app/pages/Legal/PrivacyPage/index.tsx
@@ -1,0 +1,30 @@
+import type {FC} from 'react';
+import {useTranslation} from 'react-i18next';
+import Layout from '~/components/Layout';
+
+type PrivacyPageProps = {
+  description: string;
+  title: string;
+};
+
+const PrivacyPage: FC<PrivacyPageProps> = ({description, title}) => {
+  const {t} = useTranslation('pages', {keyPrefix: 'legal.privacy'});
+  const raw = t('paragraphs', {returnObjects: true});
+  const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
+
+  return (
+    <Layout>
+      <title>{title}</title>
+      <meta content={description} name="description" />
+      <div className="prose dark:prose-invert p-8 sm:px-16">
+        <h1>{title}</h1>
+        {paragraphs.map((paragraph, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <p key={`paragraph-${index}`}>{paragraph}</p>
+        ))}
+      </div>
+    </Layout>
+  );
+};
+
+export default PrivacyPage;

--- a/app/pages/Legal/PrivacyPage/index.tsx
+++ b/app/pages/Legal/PrivacyPage/index.tsx
@@ -1,6 +1,7 @@
 import type {FC} from 'react';
 import {useTranslation} from 'react-i18next';
 import Layout from '~/components/Layout';
+import {md5} from '~/utils/object';
 
 type PrivacyPageProps = {
   description: string;
@@ -19,7 +20,7 @@ const PrivacyPage: FC<PrivacyPageProps> = ({description, title}) => {
       <div className="prose dark:prose-invert p-8 sm:px-16">
         <h1>{title}</h1>
         {paragraphs.map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
+          <p key={md5({paragraph})}>{paragraph}</p>
         ))}
       </div>
     </Layout>

--- a/app/pages/Legal/PrivacyPage/index.tsx
+++ b/app/pages/Legal/PrivacyPage/index.tsx
@@ -1,6 +1,5 @@
 import type {FC} from 'react';
 import {useTranslation} from 'react-i18next';
-import Layout from '~/components/Layout';
 import {md5} from '~/utils/object';
 
 type PrivacyPageProps = {
@@ -14,7 +13,7 @@ const PrivacyPage: FC<PrivacyPageProps> = ({description, title}) => {
   const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
   return (
-    <Layout>
+    <>
       <title>{title}</title>
       <meta content={description} name="description" />
       <div className="prose dark:prose-invert p-8 sm:px-16">
@@ -23,7 +22,7 @@ const PrivacyPage: FC<PrivacyPageProps> = ({description, title}) => {
           <p key={md5({paragraph})}>{paragraph}</p>
         ))}
       </div>
-    </Layout>
+    </>
   );
 };
 

--- a/app/pages/Legal/TermsPage/index.tsx
+++ b/app/pages/Legal/TermsPage/index.tsx
@@ -1,6 +1,7 @@
 import type {FC} from 'react';
 import {useTranslation} from 'react-i18next';
 import Layout from '~/components/Layout';
+import {md5} from '~/utils/object';
 
 type TermsPageProps = {
   description: string;
@@ -19,7 +20,7 @@ const TermsPage: FC<TermsPageProps> = ({description, title}) => {
       <div className="prose dark:prose-invert p-8 sm:px-16">
         <h1>{title}</h1>
         {paragraphs.map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
+          <p key={md5({paragraph})}>{paragraph}</p>
         ))}
       </div>
     </Layout>

--- a/app/pages/Legal/TermsPage/index.tsx
+++ b/app/pages/Legal/TermsPage/index.tsx
@@ -1,6 +1,5 @@
 import type {FC} from 'react';
 import {useTranslation} from 'react-i18next';
-import Layout from '~/components/Layout';
 import {md5} from '~/utils/object';
 
 type TermsPageProps = {
@@ -14,7 +13,7 @@ const TermsPage: FC<TermsPageProps> = ({description, title}) => {
   const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
   return (
-    <Layout>
+    <>
       <title>{title}</title>
       <meta content={description} name="description" />
       <div className="prose dark:prose-invert p-8 sm:px-16">
@@ -23,7 +22,7 @@ const TermsPage: FC<TermsPageProps> = ({description, title}) => {
           <p key={md5({paragraph})}>{paragraph}</p>
         ))}
       </div>
-    </Layout>
+    </>
   );
 };
 

--- a/app/pages/Legal/TermsPage/index.tsx
+++ b/app/pages/Legal/TermsPage/index.tsx
@@ -1,0 +1,30 @@
+import type {FC} from 'react';
+import {useTranslation} from 'react-i18next';
+import Layout from '~/components/Layout';
+
+type TermsPageProps = {
+  description: string;
+  title: string;
+};
+
+const TermsPage: FC<TermsPageProps> = ({description, title}) => {
+  const {t} = useTranslation('pages', {keyPrefix: 'legal.terms'});
+  const raw = t('paragraphs', {returnObjects: true});
+  const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
+
+  return (
+    <Layout>
+      <title>{title}</title>
+      <meta content={description} name="description" />
+      <div className="prose dark:prose-invert p-8 sm:px-16">
+        <h1>{title}</h1>
+        {paragraphs.map((paragraph, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <p key={`paragraph-${index}`}>{paragraph}</p>
+        ))}
+      </div>
+    </Layout>
+  );
+};
+
+export default TermsPage;

--- a/app/pages/Legal/TermsPage/index.tsx
+++ b/app/pages/Legal/TermsPage/index.tsx
@@ -18,9 +18,8 @@ const TermsPage: FC<TermsPageProps> = ({description, title}) => {
       <meta content={description} name="description" />
       <div className="prose dark:prose-invert p-8 sm:px-16">
         <h1>{title}</h1>
-        {paragraphs.map((paragraph, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <p key={`paragraph-${index}`}>{paragraph}</p>
+        {paragraphs.map((paragraph) => (
+          <p key={paragraph}>{paragraph}</p>
         ))}
       </div>
     </Layout>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,12 +18,12 @@ import './styles/tailwind.css';
 
 export const middleware = [i18nextMiddleware];
 
-setToastCookieOptions({secrets: [env.SESSION_SECRET]});
-
 export const loader = async ({context, request}: Route.LoaderArgs) => {
   const isProduction = isProductionHost(request);
 
   const language = getLanguage(context);
+
+  setToastCookieOptions({secrets: [env.SESSION_SECRET]});
 
   const {headers, toast} = await getToast(request);
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,7 +2,7 @@ import type {FC} from 'react';
 import {useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
 import {data, Outlet, useLoaderData} from 'react-router';
-import {getToast, setToastCookieOptions} from 'remix-toast';
+import {getToast} from 'remix-toast';
 import Document from '~/components/Document';
 import RootErrorBoundary from '~/components/Errors/RootErrorBoundary';
 import Toast, {notify} from '~/components/Toast';
@@ -13,7 +13,7 @@ import {isProductionHost} from '~/utils/http.server';
 import {useNonce} from '~/utils/nonce';
 import {getTheme} from '~/utils/theme.server';
 import type {Route} from './+types/root';
-import {env, envClient} from './env.server';
+import {envClient} from './env.server';
 import './styles/tailwind.css';
 
 export const middleware = [i18nextMiddleware];
@@ -22,8 +22,6 @@ export const loader = async ({context, request}: Route.LoaderArgs) => {
   const isProduction = isProductionHost(request);
 
   const language = getLanguage(context);
-
-  setToastCookieOptions({secrets: [env.SESSION_SECRET]});
 
   const {headers, toast} = await getToast(request);
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,12 +18,12 @@ import './styles/tailwind.css';
 
 export const middleware = [i18nextMiddleware];
 
+setToastCookieOptions({secrets: [env.SESSION_SECRET]});
+
 export const loader = async ({context, request}: Route.LoaderArgs) => {
   const isProduction = isProductionHost(request);
 
   const language = getLanguage(context);
-
-  setToastCookieOptions({secrets: [env.SESSION_SECRET]});
 
   const {headers, toast} = await getToast(request);
 

--- a/app/routes/_legal+/_layout.tsx
+++ b/app/routes/_legal+/_layout.tsx
@@ -1,0 +1,11 @@
+import type {FC} from 'react';
+import {Outlet} from 'react-router';
+import Layout from '~/components/Layout';
+
+const LegalRoute: FC = () => (
+  <Layout>
+    <Outlet />
+  </Layout>
+);
+
+export default LegalRoute;

--- a/app/routes/_legal+/privacy.tsx
+++ b/app/routes/_legal+/privacy.tsx
@@ -1,3 +1,4 @@
+import type {FC} from 'react';
 import {useLoaderData} from 'react-router';
 import {getInstance} from '~/middleware/i18next';
 import PrivacyPage from '~/pages/Legal/PrivacyPage';
@@ -11,7 +12,7 @@ export const loader = async ({context}: Route.LoaderArgs) => {
   return {description, title};
 };
 
-const PrivacyRoute = () => {
+const PrivacyRoute: FC = () => {
   const {description, title} = useLoaderData<typeof loader>();
 
   return <PrivacyPage description={description} title={title} />;

--- a/app/routes/_legal+/privacy.tsx
+++ b/app/routes/_legal+/privacy.tsx
@@ -1,7 +1,6 @@
-import {useTranslation} from 'react-i18next';
 import {useLoaderData} from 'react-router';
-import Layout from '~/components/Layout';
 import {getInstance} from '~/middleware/i18next';
+import PrivacyPage from '~/pages/Legal/PrivacyPage';
 import type {Route} from './+types/privacy';
 
 export const loader = async ({context}: Route.LoaderArgs) => {
@@ -14,22 +13,8 @@ export const loader = async ({context}: Route.LoaderArgs) => {
 
 const PrivacyRoute = () => {
   const {description, title} = useLoaderData<typeof loader>();
-  const {t} = useTranslation('pages', {keyPrefix: 'legal.privacy'});
-  const raw = t('paragraphs', {returnObjects: true});
-  const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
-  return (
-    <Layout>
-      <title>{title}</title>
-      <meta content={description} name="description" />
-      <div className="prose dark:prose-invert p-8 sm:px-16">
-        <h1>{title}</h1>
-        {paragraphs.map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
-        ))}
-      </div>
-    </Layout>
-  );
+  return <PrivacyPage description={description} title={title} />;
 };
 
 export default PrivacyRoute;

--- a/app/routes/_legal+/terms.tsx
+++ b/app/routes/_legal+/terms.tsx
@@ -1,3 +1,4 @@
+import type {FC} from 'react';
 import {useLoaderData} from 'react-router';
 import {getInstance} from '~/middleware/i18next';
 import TermsPage from '~/pages/Legal/TermsPage';
@@ -11,7 +12,7 @@ export const loader = async ({context}: Route.LoaderArgs) => {
   return {description, title};
 };
 
-const TermsRoute = () => {
+const TermsRoute: FC = () => {
   const {description, title} = useLoaderData<typeof loader>();
 
   return <TermsPage description={description} title={title} />;

--- a/app/routes/_legal+/terms.tsx
+++ b/app/routes/_legal+/terms.tsx
@@ -1,7 +1,6 @@
-import {useTranslation} from 'react-i18next';
 import {useLoaderData} from 'react-router';
-import Layout from '~/components/Layout';
 import {getInstance} from '~/middleware/i18next';
+import TermsPage from '~/pages/Legal/TermsPage';
 import type {Route} from './+types/terms';
 
 export const loader = async ({context}: Route.LoaderArgs) => {
@@ -14,22 +13,8 @@ export const loader = async ({context}: Route.LoaderArgs) => {
 
 const TermsRoute = () => {
   const {description, title} = useLoaderData<typeof loader>();
-  const {t} = useTranslation('pages', {keyPrefix: 'legal.terms'});
-  const raw = t('paragraphs', {returnObjects: true});
-  const paragraphs = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
-  return (
-    <Layout>
-      <title>{title}</title>
-      <meta content={description} name="description" />
-      <div className="prose dark:prose-invert p-8 sm:px-16">
-        <h1>{title}</h1>
-        {paragraphs.map((paragraph) => (
-          <p key={paragraph}>{paragraph}</p>
-        ))}
-      </div>
-    </Layout>
-  );
+  return <TermsPage description={description} title={title} />;
 };
 
 export default TermsRoute;

--- a/app/routes/_public+/_index.tsx
+++ b/app/routes/_public+/_index.tsx
@@ -1,3 +1,4 @@
+import type {FC} from 'react';
 import {useLoaderData} from 'react-router';
 import {getInstance} from '~/middleware/i18next';
 import IndexPage from '~/pages/Public/IndexPage';
@@ -11,7 +12,7 @@ export const loader = async ({context}: Route.LoaderArgs) => {
   return {description, title};
 };
 
-const IndexRoute = () => {
+const IndexRoute: FC = () => {
   const {description, title} = useLoaderData<typeof loader>();
 
   return (

--- a/app/routes/_public+/_layout.tsx
+++ b/app/routes/_public+/_layout.tsx
@@ -1,8 +1,9 @@
+import type {FC} from 'react';
 import {Outlet} from 'react-router';
 import Layout from '~/components/Layout';
 
 // This is where routes that are publicly available go
-const PublicRoute = () => (
+const PublicRoute: FC = () => (
   <Layout>
     <Outlet />
   </Layout>

--- a/app/routes/actions+/set-language.ts
+++ b/app/routes/actions+/set-language.ts
@@ -7,7 +7,7 @@ import type {Route} from './+types/set-language';
 
 const SetLanguageSchema = z.object({
   language: z.string().refine((lang) => LANGUAGES.includes(lang)),
-  redirectUrl: z.string().refine(isLocalRedirect),
+  redirectUrl: z.string().startsWith('/').refine(isLocalRedirect),
 });
 
 export const action = async ({request}: Route.ActionArgs) => {

--- a/app/routes/actions+/set-language.ts
+++ b/app/routes/actions+/set-language.ts
@@ -1,28 +1,27 @@
 import {data, redirect, replace} from 'react-router';
+import {z} from 'zod';
 import {LANGUAGES} from '~/languages';
 import {languageCookie} from '~/sessions.server/language';
 import {isLocalRedirect} from '~/utils/http';
 import type {Route} from './+types/set-language';
 
-export const action = async ({request}: Route.ActionArgs) => {
-  const requestText = await request.text();
-  const form = new URLSearchParams(requestText);
-  const language = form.get('language');
-  const redirectUrl = form.get('redirectUrl');
+const SetLanguageSchema = z.object({
+  language: z.string().refine((lang) => LANGUAGES.includes(lang)),
+  redirectUrl: z.string().refine(isLocalRedirect),
+});
 
-  if (
-    language == null ||
-    !LANGUAGES.includes(language) ||
-    !isLocalRedirect(redirectUrl)
-  ) {
-    return data(
-      {
-        message: `language value of ${language} is not a valid language`,
-        ok: false,
-      },
-      {status: 400}
-    );
+export const action = async ({request}: Route.ActionArgs) => {
+  const formData = await request.formData();
+  const submission = SetLanguageSchema.safeParse({
+    language: formData.get('language'),
+    redirectUrl: formData.get('redirectUrl'),
+  });
+
+  if (!submission.success) {
+    return data(null, {status: 400});
   }
+
+  const {language, redirectUrl} = submission.data;
 
   return replace(redirectUrl, {
     headers: {

--- a/app/routes/resources+/theme-switch.tsx
+++ b/app/routes/resources+/theme-switch.tsx
@@ -1,12 +1,6 @@
-import type {FC} from 'react';
-import {useSyncExternalStore} from 'react';
-import {useTranslation} from 'react-i18next';
-import {IoDesktopOutline, IoMoon, IoSunny} from 'react-icons/io5';
-import {data, redirect, useFetcher, useFetchers} from 'react-router';
+import {data, redirect} from 'react-router';
 import {z} from 'zod';
 import {isLocalRedirect} from '~/utils/http';
-import {useOptionalRequestInfo} from '~/utils/request-info';
-import type {Theme} from '~/utils/theme.server';
 import {setTheme} from '~/utils/theme.server';
 import type {Route} from './+types/theme-switch';
 
@@ -37,105 +31,4 @@ export const action = async ({request}: Route.ActionArgs) => {
   }
 
   return data({result: 'success'} as const, {headers});
-};
-
-const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
-
-const subscribeToColorScheme = (onChange: () => void): (() => void) => {
-  const query = window.matchMedia(COLOR_SCHEME_QUERY);
-  query.addEventListener('change', onChange);
-
-  return () => {
-    query.removeEventListener('change', onChange);
-  };
-};
-
-const getColorSchemeSnapshot = (): Theme =>
-  window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
-
-const getColorSchemeServerSnapshot = (): undefined => undefined;
-
-const useSystemTheme = (): Theme | undefined =>
-  useSyncExternalStore<Theme | undefined>(
-    subscribeToColorScheme,
-    getColorSchemeSnapshot,
-    getColorSchemeServerSnapshot
-  );
-
-export const useOptimisticThemeMode = ():
-  | 'dark'
-  | 'light'
-  | 'system'
-  | undefined => {
-  const fetchers = useFetchers();
-  const themeFetcher = fetchers.find(
-    (f) => f.formAction === '/resources/theme-switch'
-  );
-  const theme = themeFetcher?.formData?.get('theme');
-  if (theme === 'dark' || theme === 'light' || theme === 'system') return theme;
-
-  return undefined;
-};
-
-export const useOptionalTheme = (): Theme | undefined => {
-  const requestInfo = useOptionalRequestInfo();
-  const optimisticMode = useOptimisticThemeMode();
-  const systemTheme = useSystemTheme();
-
-  if (optimisticMode) {
-    return optimisticMode === 'system' ? systemTheme : optimisticMode;
-  }
-
-  return requestInfo?.userPrefs.theme ?? systemTheme;
-};
-
-type ThemeSwitchProps = {
-  userPreference?: null | Theme;
-};
-
-const NEXT_MODE: Record<
-  'dark' | 'light' | 'system',
-  'dark' | 'light' | 'system'
-> = {
-  dark: 'system',
-  light: 'dark',
-  system: 'light',
-};
-
-const ICONS = {
-  dark: IoMoon,
-  light: IoSunny,
-  system: IoDesktopOutline,
-} as const;
-
-const LABEL_KEYS = {
-  dark: 'useSystemTheme',
-  light: 'enableDarkMode',
-  system: 'enableLightMode',
-} as const;
-
-export const ThemeSwitch: FC<ThemeSwitchProps> = ({userPreference}) => {
-  const {t} = useTranslation('common', {keyPrefix: 'theme'});
-  const fetcher = useFetcher<typeof action>();
-  const optimisticMode = useOptimisticThemeMode();
-
-  const mode = optimisticMode ?? userPreference ?? 'system';
-  const next = NEXT_MODE[mode];
-
-  return (
-    <fetcher.Form action="/resources/theme-switch" method="POST">
-      <input name="theme" type="hidden" value={next} />
-      <button
-        aria-label={t(LABEL_KEYS[mode])}
-        className="text-body size-4.5 relative flex items-center gap-2"
-        type="submit"
-      >
-        {(() => {
-          const ThemeIcon = ICONS[mode];
-
-          return <ThemeIcon />;
-        })()}
-      </button>
-    </fetcher.Form>
-  );
 };

--- a/app/routes/resources+/theme-switch.tsx
+++ b/app/routes/resources+/theme-switch.tsx
@@ -6,7 +6,7 @@ import type {Route} from './+types/theme-switch';
 
 export const ThemeFormSchema = z.object({
   redirectTo: z.string().refine(isLocalRedirect).optional(),
-  theme: z.enum(['light', 'dark', 'system']),
+  theme: z.literal(['dark', 'light', 'system']),
 });
 
 export const action = async ({request}: Route.ActionArgs) => {

--- a/app/routes/resources+/theme-switch.tsx
+++ b/app/routes/resources+/theme-switch.tsx
@@ -4,13 +4,14 @@ import {useTranslation} from 'react-i18next';
 import {IoDesktopOutline, IoMoon, IoSunny} from 'react-icons/io5';
 import {data, redirect, useFetcher, useFetchers} from 'react-router';
 import {z} from 'zod';
+import {isLocalRedirect} from '~/utils/http';
 import {useOptionalRequestInfo} from '~/utils/request-info';
 import type {Theme} from '~/utils/theme.server';
 import {setTheme} from '~/utils/theme.server';
 import type {Route} from './+types/theme-switch';
 
 export const ThemeFormSchema = z.object({
-  redirectTo: z.string().optional(),
+  redirectTo: z.string().refine(isLocalRedirect).optional(),
   theme: z.enum(['light', 'dark', 'system']),
 });
 

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -10,7 +10,7 @@ type CreateOptions = Options & {
 
 type RequestOptions = Options & {
   language?: string;
-  pathParams?: Record<string, unknown>;
+  pathParams?: Record<string, number | string>;
   searchParams?: Record<string, unknown>;
   token?: string;
 };

--- a/app/services/api/tests/helpers.test.ts
+++ b/app/services/api/tests/helpers.test.ts
@@ -1,0 +1,63 @@
+import {HTTPError} from 'ky';
+import {describe, expect, test} from 'vitest';
+import type {ZodError} from 'zod';
+import {z} from 'zod';
+import {attempt} from '../helpers';
+
+describe('attempt', () => {
+  test('success — resolves to [undefined, result]', async () => {
+    const result = await attempt(async () => 'ok');
+
+    expect(result).toEqual([undefined, 'ok']);
+  });
+
+  test('HTTPError — resolves to [{status, statusText}, undefined]', async () => {
+    const response = new Response('', {status: 404, statusText: 'Not Found'});
+    const request = new Request('https://example.test');
+    const httpError = new HTTPError(response, request, {} as never);
+
+    const result = await attempt(async () => {
+      throw httpError;
+    });
+
+    expect(result).toEqual([{status: 404, statusText: 'Not Found'}, undefined]);
+  });
+
+  test('ZodError — resolves to [{status: 500, statusText: error.message}, undefined]', async () => {
+    let zodError: ZodError;
+
+    try {
+      z.string().parse(123);
+    } catch (error) {
+      zodError = error as ZodError;
+    }
+
+    const result = await attempt(async () => {
+      throw zodError!;
+    });
+
+    expect(result).toEqual([
+      {status: 500, statusText: zodError!.message},
+      undefined,
+    ]);
+  });
+
+  test('plain Error — rejects (re-thrown)', async () => {
+    await expect(
+      attempt(async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+  });
+
+  test('unknown non-Error throw — resolves to [{status: 500, statusText: "Unknown error"}, undefined]', async () => {
+    const result = await attempt(async () => {
+      throw 'something unexpected';
+    });
+
+    expect(result).toEqual([
+      {status: 500, statusText: 'Unknown error'},
+      undefined,
+    ]);
+  });
+});

--- a/app/services/api/tests/utils.test.ts
+++ b/app/services/api/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import type {BeforeRequestState} from 'ky';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import {
   appendSearchParams,
   buildRequestHeaders,
@@ -102,5 +102,19 @@ describe('api utils', () => {
     expect(headers.get('X-Custom')).toBe('keep');
     expect(headers.get('Authorization')).toBeNull();
     expect(headers.get('Accept-Language')).toBeNull();
+  });
+
+  test('getHooks preserves core interceptors when caller passes custom hooks', () => {
+    const customAfter = vi.fn();
+    const customBefore = vi.fn();
+    const hooks = getHooks(true, {
+      afterResponse: [customAfter],
+      beforeRequest: [customBefore],
+    });
+    // core interceptor is index 0, caller hook is appended after
+    expect(hooks?.afterResponse).toHaveLength(2);
+    expect(hooks?.beforeRequest).toHaveLength(2);
+    expect(hooks?.afterResponse?.[1]).toBe(customAfter);
+    expect(hooks?.beforeRequest?.[1]).toBe(customBefore);
   });
 });

--- a/app/services/api/utils.ts
+++ b/app/services/api/utils.ts
@@ -1,7 +1,6 @@
 import type {AfterResponseState, BeforeRequestState, Hooks, Options} from 'ky';
 import type {StringifyOptions} from 'query-string';
 import queryString from 'query-string';
-import {env} from '~/env.server';
 import {tryCatch} from '~/utils/function';
 import {toCamelCase, toSnakeCase} from '~/utils/object';
 
@@ -79,11 +78,11 @@ export const appendSearchParams = (
 
 export const setPathParams = (
   url: string,
-  pathParams?: Record<string, unknown>
+  pathParams?: Record<string, number | string>
 ): string =>
   pathParams ?
     Object.entries(pathParams).reduce(
-      (acc, [key, value]) => acc.replace(`:${key}`, value as string),
+      (acc, [key, value]) => acc.replace(`:${key}`, String(value)),
       url
     )
   : url;
@@ -95,15 +94,15 @@ export const getUri = (
     ...options
   }: {
     arrayFormat?: StringifyOptions['arrayFormat'];
-    pathParams?: Record<string, unknown>;
+    pathParams?: Record<string, number | string>;
     searchParams?: Record<string, unknown>;
     useSnakeCase?: boolean;
   } = {}
 ): string => appendSearchParams(setPathParams(uri, pathParams), options);
 
 export const getBaseUrl = (): string => {
-  // server api call — validated at startup by env.server
-  if (typeof window === 'undefined') return env.API_URL;
+  // server api call — API_URL is validated at startup in env.server
+  if (typeof window === 'undefined') return process.env.API_URL ?? '';
 
   // client api call
   if (window.process.env.API_URL) return window.process.env.API_URL;

--- a/app/services/api/utils.ts
+++ b/app/services/api/utils.ts
@@ -1,6 +1,7 @@
 import type {AfterResponseState, BeforeRequestState, Hooks, Options} from 'ky';
 import type {StringifyOptions} from 'query-string';
 import queryString from 'query-string';
+import {env} from '~/env.server';
 import {tryCatch} from '~/utils/function';
 import {toCamelCase, toSnakeCase} from '~/utils/object';
 
@@ -39,9 +40,9 @@ export const getHooks = (
 ): Hooks | undefined =>
   useSnakeCase ?
     {
+      ...hooks,
       afterResponse: [responseToCamelCase, ...(hooks?.afterResponse ?? [])],
       beforeRequest: [requestToSnakeCase, ...(hooks?.beforeRequest ?? [])],
-      ...hooks,
     }
   : hooks;
 
@@ -101,15 +102,11 @@ export const getUri = (
 ): string => appendSearchParams(setPathParams(uri, pathParams), options);
 
 export const getBaseUrl = (): string => {
-  if (process.env.API_URL) {
-    // server api call
-    return process.env.API_URL;
-  }
+  // server api call — validated at startup by env.server
+  if (typeof window === 'undefined') return env.API_URL;
 
-  if (typeof window !== 'undefined' && window.process.env.API_URL) {
-    // client api call
-    return window.process.env.API_URL;
-  }
+  // client api call
+  if (window.process.env.API_URL) return window.process.env.API_URL;
 
   // fallback
   return '';

--- a/app/services/gaia/api.ts
+++ b/app/services/gaia/api.ts
@@ -2,7 +2,7 @@ import {create} from '../api';
 
 type GaiaServerResponse = {
   data: unknown;
-  error: Error;
+  error?: Error;
 };
 
 export const api = create<GaiaServerResponse>();

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -1,7 +1,10 @@
-export const range = (start: number, end: number): number[] =>
-  (Array(end - start + 1) as number[])
+export const range = (start: number, end: number): number[] => {
+  if (start > end) return [];
+
+  return (Array(end - start + 1) as number[])
     .fill(start)
     .map((value, index) => value + index);
+};
 
 export const uniqBy = <T, K extends keyof T>(
   array: T[],

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -37,6 +37,7 @@ export const formatISO8601Date = (date: Date): string =>
 export const formatFullDate = (date: Date, language: string): string =>
   format(date, 'PPPP', getLocaleOptions(language));
 
+// locale-insensitive by design: MM/yy is a universal card-expiry format
 export const formatMY = (date = new Date()): string => format(date, 'MM/yy');
 
 export const formatFullYear = (date: Date, language: string): string =>

--- a/app/utils/http.server.ts
+++ b/app/utils/http.server.ts
@@ -1,7 +1,8 @@
 import type {HeadersFunction} from 'react-router';
+import {env} from '~/env.server';
 
 export const isProductionHost = (request: Request): boolean =>
-  request.headers.get('host') === 'domain.tld';
+  request.headers.get('host') === new URL(env.SITE_URL).host;
 
 // No report-uri/report-to directive: a violation-reporting endpoint is
 // adopter-owned infrastructure, intentionally out of scope for the template.

--- a/app/utils/http.server.ts
+++ b/app/utils/http.server.ts
@@ -1,8 +1,10 @@
 import type {HeadersFunction} from 'react-router';
 import {env} from '~/env.server';
 
+const PRODUCTION_HOST = new URL(env.SITE_URL).host;
+
 export const isProductionHost = (request: Request): boolean =>
-  request.headers.get('host') === new URL(env.SITE_URL).host;
+  request.headers.get('host') === PRODUCTION_HOST;
 
 // No report-uri/report-to directive: a violation-reporting endpoint is
 // adopter-owned infrastructure, intentionally out of scope for the template.

--- a/app/utils/tests/array.test.ts
+++ b/app/utils/tests/array.test.ts
@@ -8,6 +8,11 @@ describe('array', () => {
     expect(range(-3, 5)).toEqual([-3, -2, -1, 0, 1, 2, 3, 4, 5]);
   });
 
+  test('range returns empty array when start > end', () => {
+    expect(range(5, 0)).toEqual([]);
+    expect(range(1, 0)).toEqual([]);
+  });
+
   test('sortBy should work', () => {
     const data = [
       {id: 4, name: 'Biz'},

--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -17,8 +17,11 @@ export const getTheme = (request: Request): null | Theme => {
 export const setTheme = (theme: 'system' | Theme): string => {
   if (theme === 'system') {
     return cookie.serialize(COOKIE_NAME, '', {
+      httpOnly: true,
       maxAge: -1,
       path: '/',
+      sameSite: 'lax',
+      secure: env.NODE_ENV === 'production',
     });
   }
 

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -9,11 +9,7 @@
         "files": ["app/components/Document/index.tsx", "app/root.tsx"],
         "rules": ["react-doctor/no-danger"]
       },
-      {
-        "files": ["app/components/Toast/ToastNotification/index.tsx"],
-        "rules": ["react-doctor/rerender-state-only-in-handlers"]
-      },
-      {
+{
         "files": ["app/utils/object.ts"],
         "rules": ["react-doctor/no-full-lodash-import"]
       },

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -7,7 +7,7 @@
       },
       {
         "files": ["app/components/Document/index.tsx", "app/root.tsx"],
-        "rules": ["react/no-danger"]
+        "rules": ["react-doctor/no-danger"]
       },
       {
         "files": ["app/components/Toast/ToastNotification/index.tsx"],
@@ -24,6 +24,22 @@
           "react-doctor/async-await-in-loop",
           "react-doctor/server-sequential-independent-await"
         ]
+      },
+      {
+        "files": ["app/root.tsx", "app/routes/**/*.tsx"],
+        "rules": ["react-doctor/only-export-components"]
+      },
+      {
+        "files": [
+          "app/components/Form/Chain/index.tsx",
+          "app/components/Form/CheckboxRadioGroup/index.tsx",
+          "app/components/Form/Field/FieldLabel/FieldRequiredText/index.tsx"
+        ],
+        "rules": ["react-doctor/prefer-tag-over-role"]
+      },
+      {
+        "files": ["app/**/tests/index.stories.tsx"],
+        "rules": ["react-doctor/anchor-ambiguous-text"]
       }
     ]
   }

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -27,7 +27,8 @@ Task(
 
 ### 2. Fix all issues
 
-- Fix every Critical Issue and every Important Issue the audit identifies.
+- Fix every Critical Issue, every Important Issue, and every Suggestion the audit identifies.
+- If a Suggestion involves an architectural tradeoff, breaking change, or conflicting convention, the agent escalates it with documented rationale rather than auto-fixing — the operator must resolve the escalation before the marker is written.
 - Re-run linting and type checking after fixes.
 - Stage, commit, and push the fixes — HEAD must move so the next audit runs against the fixed tree.
 - Re-spawn the audit agent on the new HEAD until it reports clean.
@@ -44,7 +45,7 @@ The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
 
-A clean pass requires no Critical Issues and every Important Issue addressed. Knip / react-doctor advisories and Suggestions never block signal emission.
+A clean pass requires no Critical Issues, every Important Issue addressed, and every Suggestion either auto-fixed or resolved by the operator. Knip and react-doctor advisories remain advisory and never block signal emission.
 
 If the local agent declines to write the marker, its report names what remains unaddressed; resolve those, commit, push, re-spawn.
 


### PR DESCRIPTION
## Summary

- **Security (Bucket A):** Fix open redirect in `theme-switch` action (CR1); uncomment security headers + fix `www` subdomain check using `startsWith` (IM5, SG14)
- **Data correctness (Bucket B):** Fix `getHooks` spread order that silently dropped core interceptors (CR2); use validated `env.API_URL` in `getBaseUrl` (IM10); make `GaiaServerResponse.error` optional (CR3); guard `range()` against `start > end` RangeError (IM9)
- **Infrastructure (Bucket C, partial):** Fix `isProductionHost` placeholder domain via `env.SITE_URL` (IM2); extract legal routes to page components, thin route files (IM3, SG15)
- **Accessibility + i18n (Bucket D):** Add `aria-label` to `Spinner` progressbar (IM7); fix block elements inside `<pre>` in `ErrorStack` (IM8); replace hardcoded English strings with `t()` in `ErrorStack` and `ToastNotification` (IM13); derive `lang` from `DEFAULT_LOCALE` in `RootErrorBoundary` (CB2); remove misleading `aria-label` slug from `InputRadio` (IM6)
- **SSR + test coverage (Bucket E):** Fix `useBreakpoint` SSR hydration mismatch via lazy initializer (IM1); add symmetric `scrollOptions` to `useComponentRect` (SG19); add test coverage for all four hooks (IM12); add `attempt()` helper test coverage (IM11); add `getHooks` regression test (CR2)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Pre-commit hook: lint-staged + vitest (22 test files, 94 tests) — all passed
- [ ] Manual smoke test: `/terms` and `/privacy` routes render correctly
- [ ] Manual smoke test: theme-switch rejects `redirectTo=https://evil.com`
- [ ] Manual smoke test: security headers present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)