### PR TITLE
fix(cli-wiki): add 15_000ms timeout to per_domain_page_counts test

### DIFF
--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -244,7 +244,7 @@ describe('wiki state', () => {
     expect(counts.concepts).toBe(2);
     expect(counts.decisions).toBe(1);
     expect(counts.modules).toBe(0);
-  });
+  }, 15_000);
 
   test('rejects unknown flags', () => {
     sandbox.commit('initial', {'README.md': '# repo\n'});


### PR DESCRIPTION
## Summary

- Adds explicit `15_000`ms timeout to the `per_domain_page_counts` shaped-object test in `state.test.ts`
- This test spawns a real git sandbox and was missed when cb4b4c4 added explicit 15s timeouts to the other slow git-sandbox-based tests in the same file
- Caught by the pre-release health audit (Cycle 1)

## Test plan

- [ ] `pnpm -C .gaia/cli test --run` — all 109 test files pass, no timeout failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)