### PR TITLE
wiki: sync through 75a8ba3

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "cb4b4c41f50bcccc84ba03bb0c9fa1ce0f931c78",
-  "last_evaluated_at": "2026-05-20T07:41:30.132Z",
+  "last_evaluated_sha": "75a8ba37a5a335bc0f63bb07283f3c6081ab0e5a",
+  "last_evaluated_at": "2026-05-22T19:53:23Z",
   "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
   "last_consolidated_at": "2026-05-08T13:33:30Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,5 +11,8 @@ tags: [meta, log]
 
 ## [v1.2.3] 2026-05-20 | Released
 
+- 2026-05-22 75a8ba3 SKIP — test-only: timeout fix for slow git-sandbox test
+- 2026-05-22 aa3ff7f WORTHY — fixed dead wiki links: app/utils/client-hints.tsx → app/hooks/useTheme.ts in Dark Mode Modernization and Styles
+- 2026-05-22 9464757 SKIP — wiki: self-referential
 - 2026-05-22 cb4b4c4 RE_ANCHOR — re-anchored after history rewrite
 See CHANGELOG.md for details.


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 75a8ba3.