### PR TITLE
wiki: sync through 75a8ba3 + consolidate rename

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "fbac2bba95e029fab6c6ff2ab9724f764a56ce37",
-  "last_evaluated_at": "2026-05-22T20:01:38Z",
+  "last_evaluated_sha": "b26276e23e142faf3d12c0def95023189f740497",
+  "last_evaluated_at": "2026-05-22T20:03:41Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "last_evaluated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
+  "last_evaluated_sha": "fbac2bba95e029fab6c6ff2ab9724f764a56ce37",
   "last_evaluated_at": "2026-05-22T20:01:38Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "75a8ba37a5a335bc0f63bb07283f3c6081ab0e5a",
-  "last_evaluated_at": "2026-05-22T19:53:23Z",
-  "last_consolidated_sha": "70a4708f9a8a8c5cb23bc8d82256d609f4d1b0f9",
-  "last_consolidated_at": "2026-05-08T13:33:30Z"
+  "last_evaluated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
+  "last_evaluated_at": "2026-05-22T20:01:38Z",
+  "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
+  "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/concepts/GAIA Init Workflow.md
+++ b/wiki/concepts/GAIA Init Workflow.md
@@ -4,10 +4,9 @@ status: active
 created: 2026-05-07
 updated: 2026-05-07
 tags: [concept, claude, cli, workflow]
-consolidation_ack: [Git Workflow]
 ---
 
-# Init Workflow
+# GAIA Init Workflow
 
 The `/gaia init` namespace provides subcommands for on-boarding a cloned GAIA template into a new project. Each subcommand handles a distinct phase of the setup process.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -139,7 +139,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[GAIA Audit]] — `/gaia audit`: two-stage knowledge-store hygiene sweep.
 - [[Wiki Sync]] — `/gaia wiki sync` + drift hooks: keep the wiki convergent with code without spawned sub-Claudes.
 - [[Wiki Consolidate]] — `/gaia wiki consolidate`: cross-SPEC redundancy and contradiction audit; surfaces supersession candidates, reversed decisions, near-collision slugs, and subject-orphans.
-- [[Init Workflow]] — `/gaia init` subcommands: strip-branding, configure-i18n, rename, wire-statusline, finalize, resume.
+- [[GAIA Init Workflow]] — `/gaia init` subcommands: strip-branding, configure-i18n, rename, wire-statusline, finalize, resume.
 - [[Update Merge]] — `gaia update merge`: three-way file comparison with manifest-driven inventory.
 - [[Telemetry]] — three-stream telemetry (mentorship, cloud projection, analytics), `.gaia/cli/` workspace, `.gaia/cli/gaia` bundled binary, profile computation, adaptation injection.
 - [[Serena Integration]] — Serena handles live code; the wiki handles institutional memory.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [v1.2.3] 2026-05-20 | Released
 
+- 2026-05-22 59de542 SKIP — wiki: self-referential
 - 2026-05-22 75a8ba3 SKIP — test-only: timeout fix for slow git-sandbox test
 - 2026-05-22 aa3ff7f WORTHY — fixed dead wiki links: app/utils/client-hints.tsx → app/hooks/useTheme.ts in Dark Mode Modernization and Styles
 - 2026-05-22 9464757 SKIP — wiki: self-referential

--- a/wiki/meta/lint-report-2026-05-08.md
+++ b/wiki/meta/lint-report-2026-05-08.md
@@ -20,3 +20,15 @@ status: developing
 ## #13: UAT/SPEC narrative-ref drift
 
 ✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.
+
+## #11: Wiki drift check
+
+ℹ 1 commits behind HEAD. Run /gaia wiki sync at next opportunity.
+
+## #12: Dead repo-relative paths
+
+✓ No dead repo-relative paths detected in wiki body prose.
+
+## #13: UAT/SPEC narrative-ref drift
+
+✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.


### PR DESCRIPTION
Wiki sync and consolidate:
- Synced 3 commits (1 worthy: Dark Mode Modernization decision, Styles module update)
- Consolidated `Init Workflow` → `GAIA Init Workflow` (resolves near-collision slug with `Git Workflow`)
- Updated `wiki/index.md` entry accordingly