### PR TITLE
fix(dist): lazy-eval PRODUCTION_HOST; handle DEFAULT_LOCALE in configure-i18n

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -17877,8 +17877,12 @@ var updateI18nFallback = (cwd, fallback) => {
   const target = path13.join(cwd, I18N_FILE);
   if (!existsSync11(target)) return;
   const original = readFileSync9(target, "utf8");
-  const next = original.replace(
-    /fallbackLng:\s*['"][^'"]+['"]/u,
+  let next = original.replace(
+    /DEFAULT_LOCALE\s*=\s*['"][^'"]+['"]/u,
+    `DEFAULT_LOCALE = '${fallback}'`
+  );
+  next = next.replace(
+    /fallbackLng:\s*(?:['"][^'"]+['"]|DEFAULT_LOCALE)/u,
     `fallbackLng: '${fallback}'`
   );
   if (next !== original) {

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -17094,8 +17094,12 @@ var updateI18nFallback = (cwd, fallback) => {
   const target = path11.join(cwd, I18N_FILE);
   if (!existsSync10(target)) return;
   const original = readFileSync8(target, "utf8");
-  const next = original.replace(
-    /fallbackLng:\s*['"][^'"]+['"]/u,
+  let next = original.replace(
+    /DEFAULT_LOCALE\s*=\s*['"][^'"]+['"]/u,
+    `DEFAULT_LOCALE = '${fallback}'`
+  );
+  next = next.replace(
+    /fallbackLng:\s*(?:['"][^'"]+['"]|DEFAULT_LOCALE)/u,
     `fallbackLng: '${fallback}'`
   );
   if (next !== original) {

--- a/.gaia/cli/src/init/configure-i18n.ts
+++ b/.gaia/cli/src/init/configure-i18n.ts
@@ -188,9 +188,14 @@ const updateI18nFallback = (cwd: string, fallback: string): void => {
 
   if (!existsSync(target)) return;
   const original = readFileSync(target, 'utf8');
-  // Replace `fallbackLng: 'xx',` (or "xx") preserving surrounding whitespace.
-  const next = original.replace(
-    /fallbackLng:\s*['"][^'"]+['"]/u,
+  // Update DEFAULT_LOCALE constant if present (keeps the export in sync).
+  let next = original.replace(
+    /DEFAULT_LOCALE\s*=\s*['"][^'"]+['"]/u,
+    `DEFAULT_LOCALE = '${fallback}'`
+  );
+  // Replace `fallbackLng: 'xx'` (or "xx") or `fallbackLng: DEFAULT_LOCALE`.
+  next = next.replace(
+    /fallbackLng:\s*(?:['"][^'"]+['"]|DEFAULT_LOCALE)/u,
     `fallbackLng: '${fallback}'`
   );
 

--- a/app/utils/http.server.ts
+++ b/app/utils/http.server.ts
@@ -1,10 +1,8 @@
 import type {HeadersFunction} from 'react-router';
 import {env} from '~/env.server';
 
-const PRODUCTION_HOST = new URL(env.SITE_URL).host;
-
 export const isProductionHost = (request: Request): boolean =>
-  request.headers.get('host') === PRODUCTION_HOST;
+  request.headers.get('host') === new URL(env.SITE_URL).host;
 
 // No report-uri/report-to directive: a violation-reporting endpoint is
 // adopter-owned infrastructure, intentionally out of scope for the template.


### PR DESCRIPTION
Fixes two distribution test failures that blocked the v1.3.0 release:

**04-scaffold-runs.sh** — `http.server.test.ts` ZodError in clean scaffold
- `PRODUCTION_HOST = new URL(env.SITE_URL).host` ran at module-load time, triggering `env.server.ts`'s Zod parse with no `.env` present
- Fix: evaluate inside `isProductionHost` function body (lazy, no module-level side effect)

**08-gaia-init-cli-sequence.sh** — `configure-i18n` not writing `fallbackLng: 'en'`
- `updateI18nFallback` regex only matched string literals; `app/i18n.ts` uses `fallbackLng: DEFAULT_LOCALE`
- Fix: also update `DEFAULT_LOCALE` constant and replace `fallbackLng: DEFAULT_LOCALE` references