### PR TITLE
fix(test): provide fallback env vars in setup for clean-env distribution test

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,4 +4,11 @@ import * as globalStorybookConfig from '../.storybook/preview';
 import '@testing-library/jest-dom/vitest';
 import './test.server';
 
+// Fallback values for required server env vars: env.server.ts parses
+// process.env at import time; tests that import it transitively fail
+// in clean environments (no .env) without these defaults.
+process.env.API_URL ??= 'http://localhost:3001';
+process.env.SESSION_SECRET ??= 'test-secret';
+process.env.SITE_URL ??= 'http://localhost:3000';
+
 setProjectAnnotations(globalStorybookConfig as Preview);


### PR DESCRIPTION
`env.server.ts` calls `schema.parse(process.env)` at module level. Any test that transitively imports it fails in a clean scaffold environment (no `.env`) with a ZodError on `API_URL`, `SESSION_SECRET`, and `SITE_URL`.

Sets `??=` fallbacks in `test/setup.ts` — these run before test files are loaded, so the parse succeeds. Values are ignored in normal development where `.env` already provides them.

Fixes distribution test `04-scaffold-runs.sh` for v1.3.0.