### PR TITLE
fix(gaia-ci): dedupe audit issues, scope pre-run-skip per-tool, set git identity

### DIFF
--- a/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
+++ b/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
@@ -52,12 +52,17 @@ jobs:
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix \`gaia-ci/pnpm-audit/\` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \\
             --search 'author:app/github-actions' \\
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \\
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/pnpm-audit/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for pnpm-audit; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0
@@ -94,7 +99,8 @@ jobs:
             echo "no high/critical findings"
             exit 0
           fi
-          # For each high/critical advisory, open one security issue and one targeted single-package bump PR.
+          # For each high/critical advisory, open one security issue (deduped
+          # by exact title) and one targeted single-package bump PR.
           printf '%s' "$audit_json" \\
             | jq -c '.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")' \\
             | while read -r advisory; do
@@ -102,15 +108,31 @@ jobs:
                 severity=$(printf '%s' "$advisory" | jq -r '.severity')
                 cve=$(printf '%s' "$advisory" | jq -r '.cves[0] // .id')
                 url=$(printf '%s' "$advisory" | jq -r '.url')
-                # Issue
-                gh issue create \\
-                  --title "[GAIA CI] $severity: $pkg ($cve)" \\
-                  --label gaia-ci,security \\
-                  --body "Severity: $severity\\nPackage: $pkg\\nAdvisory: $url"
-                # Targeted single-package security PR
-                branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
+                # Issue (dedupe by exact title against open gaia-ci+security
+                # issues — daily cron must not stack duplicates while a
+                # vulnerability remains unpatched).
+                TITLE="[GAIA CI] $severity: $pkg ($cve)"
+                existing_issue=$(TITLE="$TITLE" gh issue list \\
+                  --state open --label gaia-ci --label security \\
+                  --json number,title \\
+                  --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty')
+                if [ -z "$existing_issue" ]; then
+                  gh issue create \\
+                    --title "$TITLE" \\
+                    --label gaia-ci,security \\
+                    --body "Severity: $severity\\nPackage: $pkg\\nAdvisory: $url"
+                else
+                  echo "issue #$existing_issue already open for $pkg ($cve); skipping create"
+                fi
+                # Targeted single-package security PR. Branch prefix is
+                # \`gaia-ci/pnpm-audit/security/\` so pre-run-skip's
+                # branch-prefix scope blocks the next daily run only while
+                # this workflow's own PR is open.
+                branch="gaia-ci/pnpm-audit/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
                 git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
+                git config user.name 'github-actions[bot]'
+                git config user.email 'github-actions[bot]@users.noreply.github.com'
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"
                 git push origin "$branch"
@@ -137,6 +159,8 @@ jobs:
             echo "no changes; nothing to PR"
             exit 0
           fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore(pnpm-audit): GAIA CI run"
           git push origin "$branch"
@@ -230,12 +254,17 @@ jobs:
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix \`gaia-ci/stale-branches/\` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \\
             --search 'author:app/github-actions' \\
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \\
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/stale-branches/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for stale-branches; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0
@@ -373,12 +402,17 @@ jobs:
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix \`gaia-ci/update-deps/\` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \\
             --search 'author:app/github-actions' \\
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \\
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/update-deps/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for update-deps; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0
@@ -490,6 +524,8 @@ jobs:
             echo "no changes; nothing to PR"
             exit 0
           fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore(update-deps): GAIA CI run"
           git push origin "$branch"
@@ -706,12 +742,17 @@ jobs:
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix \`gaia-ci/wiki/\` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \\
             --search 'author:app/github-actions' \\
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \\
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/wiki/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for wiki; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0
@@ -790,6 +831,8 @@ jobs:
             echo "no changes; nothing to PR"
             exit 0
           fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore(wiki): GAIA CI run"
           git push origin "$branch"

--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -30,7 +30,8 @@ jobs:
             echo "no high/critical findings"
             exit 0
           fi
-          # For each high/critical advisory, open one security issue and one targeted single-package bump PR.
+          # For each high/critical advisory, open one security issue (deduped
+          # by exact title) and one targeted single-package bump PR.
           printf '%s' "$audit_json" \
             | jq -c '.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")' \
             | while read -r advisory; do
@@ -38,15 +39,31 @@ jobs:
                 severity=$(printf '%s' "$advisory" | jq -r '.severity')
                 cve=$(printf '%s' "$advisory" | jq -r '.cves[0] // .id')
                 url=$(printf '%s' "$advisory" | jq -r '.url')
-                # Issue
-                gh issue create \
-                  --title "[GAIA CI] $severity: $pkg ($cve)" \
-                  --label gaia-ci,security \
-                  --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
-                # Targeted single-package security PR
-                branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
+                # Issue (dedupe by exact title against open gaia-ci+security
+                # issues — daily cron must not stack duplicates while a
+                # vulnerability remains unpatched).
+                TITLE="[GAIA CI] $severity: $pkg ($cve)"
+                existing_issue=$(TITLE="$TITLE" gh issue list \
+                  --state open --label gaia-ci --label security \
+                  --json number,title \
+                  --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty')
+                if [ -z "$existing_issue" ]; then
+                  gh issue create \
+                    --title "$TITLE" \
+                    --label gaia-ci,security \
+                    --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
+                else
+                  echo "issue #$existing_issue already open for $pkg ($cve); skipping create"
+                fi
+                # Targeted single-package security PR. Branch prefix is
+                # `gaia-ci/{{tool_id}}/security/` so pre-run-skip's
+                # branch-prefix scope blocks the next daily run only while
+                # this workflow's own PR is open.
+                branch="gaia-ci/{{tool_id}}/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
                 git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
+                git config user.name 'github-actions[bot]'
+                git config user.email 'github-actions[bot]@users.noreply.github.com'
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"
                 git push origin "$branch"

--- a/.gaia/cli/src/automation/templates/workflows/partials/auto-merge.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/partials/auto-merge.yml.tmpl
@@ -12,6 +12,8 @@
             echo "no changes; nothing to PR"
             exit 0
           fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore({{tool_id}}): GAIA CI run"
           git push origin "$branch"

--- a/.gaia/cli/src/automation/templates/workflows/partials/pre-run-skip.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/partials/pre-run-skip.yml.tmpl
@@ -2,12 +2,17 @@
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix `gaia-ci/{{tool_id}}/` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \
             --search 'author:app/github-actions' \
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/{{tool_id}}/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for {{tool_id}}; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl
@@ -30,7 +30,8 @@ jobs:
             echo "no high/critical findings"
             exit 0
           fi
-          # For each high/critical advisory, open one security issue and one targeted single-package bump PR.
+          # For each high/critical advisory, open one security issue (deduped
+          # by exact title) and one targeted single-package bump PR.
           printf '%s' "$audit_json" \
             | jq -c '.advisories | to_entries[] | .value | select(.severity == "high" or .severity == "critical")' \
             | while read -r advisory; do
@@ -38,15 +39,31 @@ jobs:
                 severity=$(printf '%s' "$advisory" | jq -r '.severity')
                 cve=$(printf '%s' "$advisory" | jq -r '.cves[0] // .id')
                 url=$(printf '%s' "$advisory" | jq -r '.url')
-                # Issue
-                gh issue create \
-                  --title "[GAIA CI] $severity: $pkg ($cve)" \
-                  --label gaia-ci,security \
-                  --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
-                # Targeted single-package security PR
-                branch="gaia-ci/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
+                # Issue (dedupe by exact title against open gaia-ci+security
+                # issues — daily cron must not stack duplicates while a
+                # vulnerability remains unpatched).
+                TITLE="[GAIA CI] $severity: $pkg ($cve)"
+                existing_issue=$(TITLE="$TITLE" gh issue list \
+                  --state open --label gaia-ci --label security \
+                  --json number,title \
+                  --jq '[.[] | select(.title == env.TITLE)] | .[0].number // empty')
+                if [ -z "$existing_issue" ]; then
+                  gh issue create \
+                    --title "$TITLE" \
+                    --label gaia-ci,security \
+                    --body "Severity: $severity\nPackage: $pkg\nAdvisory: $url"
+                else
+                  echo "issue #$existing_issue already open for $pkg ($cve); skipping create"
+                fi
+                # Targeted single-package security PR. Branch prefix is
+                # `gaia-ci/{{tool_id}}/security/` so pre-run-skip's
+                # branch-prefix scope blocks the next daily run only while
+                # this workflow's own PR is open.
+                branch="gaia-ci/{{tool_id}}/security/$pkg-$(date -u +%Y%m%d-%H%M%S)"
                 git checkout -b "$branch" "$default"
                 pnpm update "$pkg"
+                git config user.name 'github-actions[bot]'
+                git config user.email 'github-actions[bot]@users.noreply.github.com'
                 git add -A
                 git commit -m "chore(security): bump $pkg ($cve)"
                 git push origin "$branch"

--- a/.gaia/cli/templates/workflows/partials/auto-merge.yml.tmpl
+++ b/.gaia/cli/templates/workflows/partials/auto-merge.yml.tmpl
@@ -12,6 +12,8 @@
             echo "no changes; nothing to PR"
             exit 0
           fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore({{tool_id}}): GAIA CI run"
           git push origin "$branch"

--- a/.gaia/cli/templates/workflows/partials/pre-run-skip.yml.tmpl
+++ b/.gaia/cli/templates/workflows/partials/pre-run-skip.yml.tmpl
@@ -2,12 +2,17 @@
         id: pre_run
         run: |
           set -euo pipefail
-          # Skip if an open gaia-ci PR by github-actions[bot] already exists.
+          # Skip only if an open gaia-ci PR for THIS tool already exists.
+          # Scope by branch prefix `gaia-ci/{{tool_id}}/` so a wiki PR does
+          # not block the audit, etc. Each workflow branches under its own
+          # tool_id prefix (see partials/auto-merge and the audit/update-deps
+          # templates).
           existing_pr=$(gh pr list --state open --label gaia-ci \
             --search 'author:app/github-actions' \
-            --json number --jq '.[0].number // empty')
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("gaia-ci/{{tool_id}}/"))] | .[0].number // empty')
           if [ -n "$existing_pr" ]; then
-            echo "open gaia-ci PR #$existing_pr; skipping"
+            echo "open gaia-ci PR #$existing_pr for {{tool_id}}; skipping"
             echo "decision=skip" >> "$GITHUB_OUTPUT"
             echo "reason=open_pr" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

Three audit findings against the GAIA CI workflows (surfaced by an adopter who updated to 1.3.0 and ran `/gaia-setup-ci`).

### 1. Daily audit cron stacks duplicate GitHub issues
`gaia-ci-pnpm-audit.yml` called `gh issue create` unconditionally inside the per-advisory loop. One unpatched high/critical vuln = one new issue every 24h.

Fix: look up open `gaia-ci`+`security` issues by exact title (`[GAIA CI] $severity: $pkg ($cve)`) before creating. Echo and skip on hit.

### 2. Pre-run skip was cross-workflow
`partials/pre-run-skip.yml.tmpl` skipped any workflow when *any* `gaia-ci`-labeled bot PR was open. A wiki PR could block the security audit (or update-deps) for up to 24h.

Fix: filter open PRs by `headRefName` starting with `gaia-ci/{tool_id}/` so each workflow only self-blocks. Side-fix in the audit template: security PR branches now use `gaia-ci/pnpm-audit/security/...` (was `gaia-ci/security/...`) so they fall under the same scope and still keep the next daily run from re-PR-ing the same package.

### 3. Commits without git identity
The auto-merge partial (used by wiki, update-deps wave-A, audit's auto-merge tail) and the audit's per-advisory security commit ran `git commit` without `user.name`/`user.email`. Fails on self-hosted runners, inconsistent on GitHub-hosted ones. Wave-B already set it correctly.

Fix: add `git config user.name 'github-actions[bot]'` + `user.email 'github-actions[bot]@users.noreply.github.com'` before each `git commit`.

## Files changed

Source templates (edited):
- `.gaia/cli/src/automation/templates/workflows/partials/pre-run-skip.yml.tmpl`
- `.gaia/cli/src/automation/templates/workflows/partials/auto-merge.yml.tmpl`
- `.gaia/cli/src/automation/templates/workflows/gaia-ci-pnpm-audit.yml.tmpl`

Adopter bundle (regenerated via `pnpm bundle:adopter`):
- `.gaia/cli/templates/workflows/...` (same three files mirrored)

Snapshot:
- `.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap`

## Test plan

- [x] CLI suite green: `pnpm -C .gaia/cli test --run` → 1185 pass / 1 skip / 0 fail
- [x] `pnpm bundle:adopter` succeeds, src and bundle templates `diff`-clean
- [x] Rendered audit YAML wraps `gh issue create` in dedup guard and uses scoped branch prefix
- [x] Rendered wiki / update-deps (wave A) / audit auto-merge all set git identity before commit
- [ ] Smoke: an adopter on next `/update-gaia` sees clean three-way merge (all 4 affected files are manifest class `owned`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)