### PR TITLE
fix(audit-ci): re-trigger required checks on self-heal HEAD

### DIFF
--- a/.gaia/audit-ci.yml
+++ b/.gaia/audit-ci.yml
@@ -18,3 +18,22 @@ max_turns: 30
 # Whether the agent may push self-heal commits to the PR branch. Set false to make
 # the audit advisory-only (it comments findings but does not push).
 push_fixes: true
+
+# Workflows the audit re-dispatches against the PR branch after a self-heal
+# push. GitHub does not fire push / pull_request events for commits made with
+# GITHUB_TOKEN (its recursion guard), so required check runs on the new HEAD
+# would otherwise be absent and branch protection would block the merge. The
+# audit calls `gh workflow run --ref <branch>` for each name, producing fresh
+# check runs on the new HEAD.
+#
+# Each entry is the workflow's `name:` field (top of its YAML file), not the
+# filename. The two entries below match the GAIA template's required-check-
+# producing workflows. Adopters who require additional workflows (e.g. a
+# custom lint or security scan) add them here; adopters who do not require
+# Chromatic / Tests can remove them.
+#
+# Workflows listed here must declare `workflow_dispatch:` in their `on:`
+# triggers. The GAIA template's `chromatic.yml` and `tests.yml` already do.
+retrigger_workflows:
+  - Chromatic
+  - Tests

--- a/.gaia/scripts/read-audit-ci-config.sh
+++ b/.gaia/scripts/read-audit-ci-config.sh
@@ -18,11 +18,19 @@
 # Bash 3.2 compatible (macOS default). No associative arrays, no
 # `mapfile`. No `cd` (per `.claude/rules/shell-cwd.md`).
 #
-# Output shape (always all four lines, always this order):
+# Output shape (always all keys, always this order):
 #   gate_label=<string-or-empty>
 #   budget_seconds=<integer>
 #   max_turns=<integer>
 #   push_fixes=<true|false>
+#   retrigger_workflows<<__GAIA_END__
+#   <name-1>
+#   <name-2>
+#   __GAIA_END__
+#
+# The `retrigger_workflows` value uses GitHub Actions' multiline-output
+# heredoc syntax so consumers receive a newline-separated string (workflow
+# display names may contain spaces — single-line separators are ambiguous).
 #
 # Resilience:
 #   - Missing file        → all defaults.
@@ -32,8 +40,10 @@
 #   - Invalid integer     → default + stderr warning.
 #   - Invalid boolean     → default + stderr warning.
 #   - `null` (any case) for `gate_label` → empty.
+#   - Empty / `null` `retrigger_workflows` → default list.
+#   - Scalar in place of `retrigger_workflows` list → single-item list.
 #
-# Exit code: 0 always. Consumers parse the four output lines.
+# Exit code: 0 always. Consumers parse the output lines.
 
 set -euo pipefail
 
@@ -47,6 +57,13 @@ set -euo pipefail
 DEFAULT_BUDGET_SECONDS="1800"
 DEFAULT_MAX_TURNS="30"
 DEFAULT_PUSH_FIXES="true"
+# `retrigger_workflows` ships defaulted to the GAIA template's required
+# check-producing workflows (matching the `name:` field at the top of each
+# YAML file). Adopters who rename or replace those workflows update the knob
+# to match. Items are newline-separated because workflow display names may
+# contain spaces (e.g. "Code Review Audit").
+DEFAULT_RETRIGGER_WORKFLOWS="Chromatic
+Tests"
 
 # --- Resolve the config file path --------------------------------------------
 
@@ -105,6 +122,76 @@ extract_raw_value() {
       }
       print line
       found = 1
+    }
+  ' "$config_file"
+}
+
+# extract_list_value <key>
+#   Emits one item per line on stdout for a YAML list at the given key.
+#   Supports block style (`- item` lines indented under `key:`) and flow
+#   style (`key: [a, b, c]`). Items are trimmed and unquoted. A scalar
+#   value in place of a list is treated as a single-item list (forward
+#   compatibility for adopters who write `retrigger_workflows: Chromatic`).
+#   Empty / `null` / `~` value with no block items emits nothing → caller
+#   substitutes the default.
+extract_list_value() {
+  local key="$1"
+  [ -f "$config_file" ] || return 0
+  awk -v key="$key" '
+    function strip_quotes(s) {
+      if (s ~ /^".*"$/) return substr(s, 2, length(s) - 2)
+      if (s ~ /^'\''.*'\''$/) return substr(s, 2, length(s) - 2)
+      return s
+    }
+    function trim(s) {
+      sub(/^[[:space:]]+/, "", s)
+      sub(/[[:space:]]+$/, "", s)
+      return s
+    }
+    BEGIN { in_list = 0 }
+    {
+      line = $0
+      if (in_list == 1) {
+        # Block-style list item: `<indent>- <value>`.
+        if (line ~ /^[[:space:]]+-[[:space:]]+/) {
+          item = line
+          sub(/^[[:space:]]+-[[:space:]]+/, "", item)
+          sub(/[[:space:]]+#.*$/, "", item)
+          item = trim(item)
+          item = strip_quotes(item)
+          if (item != "") print item
+          next
+        }
+        # Blank lines and comments are tolerated mid-list.
+        if (line ~ /^[[:space:]]*$/) next
+        if (line ~ /^[[:space:]]*#/) next
+        # Anything else (next key or unrelated content) ends the list.
+        exit
+      }
+      pattern = "^[[:space:]]*" key "[[:space:]]*:"
+      if (line !~ pattern) next
+      sub(pattern, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      line = trim(line)
+      # Flow style: `[a, b, c]`.
+      if (line ~ /^\[.*\]$/) {
+        inside = substr(line, 2, length(line) - 2)
+        n = split(inside, parts, ",")
+        for (i = 1; i <= n; i++) {
+          item = strip_quotes(trim(parts[i]))
+          if (item != "") print item
+        }
+        exit
+      }
+      # Empty / null / ~ → look for block-style items on subsequent lines.
+      lower = tolower(line)
+      if (line == "" || lower == "null" || line == "~") {
+        in_list = 1
+        next
+      }
+      # Scalar where a list was expected — accept as a single-item list.
+      print strip_quotes(line)
+      exit
     }
   ' "$config_file"
 }
@@ -182,11 +269,17 @@ raw_gate_label=$(extract_raw_value "gate_label")
 raw_budget_seconds=$(extract_raw_value "budget_seconds")
 raw_max_turns=$(extract_raw_value "max_turns")
 raw_push_fixes=$(extract_raw_value "push_fixes")
+raw_retrigger_workflows=$(extract_list_value "retrigger_workflows")
 
 gate_label=$(normalize_gate_label "$raw_gate_label")
 budget_seconds=$(normalize_integer "$raw_budget_seconds" "$DEFAULT_BUDGET_SECONDS" "budget_seconds")
 max_turns=$(normalize_integer "$raw_max_turns" "$DEFAULT_MAX_TURNS" "max_turns")
 push_fixes=$(normalize_boolean "$raw_push_fixes" "$DEFAULT_PUSH_FIXES" "push_fixes")
+if [ -z "$raw_retrigger_workflows" ]; then
+  retrigger_workflows="$DEFAULT_RETRIGGER_WORKFLOWS"
+else
+  retrigger_workflows="$raw_retrigger_workflows"
+fi
 
 # --- Emit (deterministic order) -----------------------------------------------
 
@@ -194,3 +287,10 @@ printf 'gate_label=%s\n' "$gate_label"
 printf 'budget_seconds=%s\n' "$budget_seconds"
 printf 'max_turns=%s\n' "$max_turns"
 printf 'push_fixes=%s\n' "$push_fixes"
+# Multiline output: GitHub Actions reads this via the `<<DELIMITER` heredoc
+# syntax and exposes it as a newline-separated string. Workflow display
+# names may contain spaces, so a single-line separator (space, comma) would
+# be ambiguous.
+printf 'retrigger_workflows<<__GAIA_END__\n'
+printf '%s\n' "$retrigger_workflows"
+printf '__GAIA_END__\n'

--- a/.gaia/scripts/tests/read-audit-ci-config.bats
+++ b/.gaia/scripts/tests/read-audit-ci-config.bats
@@ -36,12 +36,19 @@ write_config() {
 
 # Expected default block (one big string, deterministic order).
 default_block() {
-  printf 'gate_label=\nbudget_seconds=1800\nmax_turns=30\npush_fixes=true'
+  printf 'gate_label=\nbudget_seconds=1800\nmax_turns=30\npush_fixes=true\n%s' \
+    "$(default_retrigger_block)"
+}
+
+# The retrigger_workflows default uses GitHub Actions multiline-output
+# heredoc syntax. Helper keeps the delimiter and default list in one place.
+default_retrigger_block() {
+  printf 'retrigger_workflows<<__GAIA_END__\nChromatic\nTests\n__GAIA_END__'
 }
 
 # --- 1. File missing → all defaults -----------------------------------------
 
-@test "missing config file: all four defaults emitted in order" {
+@test "missing config file: all defaults emitted in order" {
   # No write_config — file does not exist.
   run run_in_sandbox
   [ "$status" -eq 0 ]
@@ -131,28 +138,28 @@ push_fixes: true"
   write_config "push_fixes: false"
   run run_in_sandbox
   [ "$status" -eq 0 ]
-  [[ "$output" == *"push_fixes=false" ]]
+  [[ "$output" == *"push_fixes=false"$'\n'* ]]
 }
 
 @test "push_fixes: yes → push_fixes=true (alias normalized)" {
   write_config "push_fixes: yes"
   run run_in_sandbox
   [ "$status" -eq 0 ]
-  [[ "$output" == *"push_fixes=true" ]]
+  [[ "$output" == *"push_fixes=true"$'\n'* ]]
 }
 
 @test "push_fixes: NO → push_fixes=false (alias + case-insensitive)" {
   write_config "push_fixes: NO"
   run run_in_sandbox
   [ "$status" -eq 0 ]
-  [[ "$output" == *"push_fixes=false" ]]
+  [[ "$output" == *"push_fixes=false"$'\n'* ]]
 }
 
 @test "push_fixes: 0 → push_fixes=false" {
   write_config "push_fixes: 0"
   run run_in_sandbox
   [ "$status" -eq 0 ]
-  [[ "$output" == *"push_fixes=false" ]]
+  [[ "$output" == *"push_fixes=false"$'\n'* ]]
 }
 
 @test "push_fixes: bogus → default true + stderr warning" {
@@ -218,7 +225,8 @@ budget_seconds: 60"
   expected="gate_label=
 budget_seconds=60
 max_turns=30
-push_fixes=true"
+push_fixes=true
+$(default_retrigger_block)"
   [ "$output" = "$expected" ]
 }
 
@@ -243,7 +251,8 @@ max_turns: 5
   expected="gate_label=ready-for-review
 budget_seconds=1800
 max_turns=5
-push_fixes=true"
+push_fixes=true
+$(default_retrigger_block)"
   [ "$output" = "$expected" ]
 }
 
@@ -265,7 +274,8 @@ push_fixes: false
   expected="gate_label=needs-review
 budget_seconds=600
 max_turns=10
-push_fixes=false"
+push_fixes=false
+$(default_retrigger_block)"
   [ "$output" = "$expected" ]
 }
 
@@ -290,6 +300,110 @@ gate_label: needs-review"
   expected="gate_label=needs-review
 budget_seconds=60
 max_turns=5
-push_fixes=false"
+push_fixes=false
+$(default_retrigger_block)"
   [ "$output" = "$expected" ]
+}
+
+# --- 16. retrigger_workflows: block-style list parsed in order --------------
+
+@test "retrigger_workflows block-style: items preserved in order, multi-word names allowed" {
+  write_config "retrigger_workflows:
+  - Chromatic
+  - Vitest and Playwright
+  - My Custom Lint"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  expected="gate_label=
+budget_seconds=1800
+max_turns=30
+push_fixes=true
+retrigger_workflows<<__GAIA_END__
+Chromatic
+Vitest and Playwright
+My Custom Lint
+__GAIA_END__"
+  [ "$output" = "$expected" ]
+}
+
+# --- 17. retrigger_workflows: flow-style list -------------------------------
+
+@test "retrigger_workflows flow-style: [a, b, c] parsed and trimmed" {
+  write_config "retrigger_workflows: [Chromatic, Tests, Lint]"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Tests"$'\n'"Lint"$'\n'"__GAIA_END__"* ]]
+}
+
+# --- 18. retrigger_workflows: quoted entries unquoted -----------------------
+
+@test "retrigger_workflows: double-quoted and single-quoted entries unquoted" {
+  write_config "retrigger_workflows:
+  - \"Run Chromatic\"
+  - 'Run Tests'"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Run Chromatic"$'\n'"Run Tests"$'\n'"__GAIA_END__"* ]]
+}
+
+# --- 19. retrigger_workflows: scalar accepted as single-item list -----------
+
+@test "retrigger_workflows: scalar (non-list) value accepted as single item" {
+  write_config "retrigger_workflows: Chromatic"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"__GAIA_END__"* ]]
+}
+
+# --- 20. retrigger_workflows: null + empty fall back to default -------------
+
+@test "retrigger_workflows: null with no items falls back to default" {
+  write_config "retrigger_workflows: null"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$(default_retrigger_block)"* ]]
+}
+
+@test "retrigger_workflows: empty value with no items falls back to default" {
+  write_config "retrigger_workflows:"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$(default_retrigger_block)"* ]]
+}
+
+# --- 21. retrigger_workflows: inline comments stripped from items -----------
+
+@test "retrigger_workflows: trailing # comments stripped from items" {
+  write_config "retrigger_workflows:
+  - Chromatic    # run on PRs only
+  - Tests        # vitest + playwright"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Tests"$'\n'"__GAIA_END__"* ]]
+}
+
+# --- 22. retrigger_workflows: blank lines + comments mid-list tolerated -----
+
+@test "retrigger_workflows: blank lines and comment lines between items tolerated" {
+  write_config "retrigger_workflows:
+  - Chromatic
+
+  # interlude
+  - Tests"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Tests"$'\n'"__GAIA_END__"* ]]
+}
+
+# --- 23. retrigger_workflows: list ends at next top-level key ---------------
+
+@test "retrigger_workflows: list terminates when next top-level key appears" {
+  write_config "retrigger_workflows:
+  - Chromatic
+  - Tests
+push_fixes: false"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"push_fixes=false"* ]]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Tests"$'\n'"__GAIA_END__"* ]]
 }

--- a/.gaia/scripts/tests/read-audit-ci-config.bats
+++ b/.gaia/scripts/tests/read-audit-ci-config.bats
@@ -335,6 +335,13 @@ __GAIA_END__"
   [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Tests"$'\n'"Lint"$'\n'"__GAIA_END__"* ]]
 }
 
+@test "retrigger_workflows flow-style: multi-word names preserved" {
+  write_config "retrigger_workflows: [Chromatic, Vitest and Playwright]"
+  run run_in_sandbox
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retrigger_workflows<<__GAIA_END__"$'\n'"Chromatic"$'\n'"Vitest and Playwright"$'\n'"__GAIA_END__"* ]]
+}
+
 # --- 18. retrigger_workflows: quoted entries unquoted -----------------------
 
 @test "retrigger_workflows: double-quoted and single-quoted entries unquoted" {

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 name: Chromatic
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,7 +23,7 @@ jobs:
   chromatic:
     name: Run Chromatic
     needs: has-chromatic-token
-    if: needs.has-chromatic-token.outputs.present == 'true' && github.event_name == 'push'
+    if: needs.has-chromatic-token.outputs.present == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -41,7 +41,13 @@ jobs:
       pull-requests: write
       statuses: write
       id-token: write
-      actions: read
+      # `actions: write` lets the self-heal re-trigger step dispatch
+      # required workflows on the PR branch after pushing self-heal
+      # commits. `checks: write` lets it stamp a `code-review-audit`
+      # check run on the new HEAD so branch protection accepts the
+      # already-audited tree without re-running this workflow.
+      actions: write
+      checks: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -409,6 +415,69 @@ jobs:
             --field state=success \
             --field context=GAIA-Audit \
             --field description="${version} ${tree_sha}"
+
+      - name: Re-trigger required checks on new HEAD
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
+          steps.workflow-self-mod.outputs.self_modified == 'false' &&
+          steps.trailer.outputs.skip == 'false' &&
+          steps.audit.outcome == 'success' &&
+          steps.push-fixes.outputs.pushed == 'true'
+        env:
+          AUDIT_SHA: ${{ steps.push-fixes.outputs.audit_sha }}
+          RETRIGGER_WORKFLOWS: ${{ steps.config.outputs.retrigger_workflows }}
+        run: |
+          set -eu
+          # When the audit self-heals and pushes a new commit, GitHub does
+          # not fire push / pull_request events for the GITHUB_TOKEN-authored
+          # push (recursion guard). The new HEAD would therefore have zero
+          # check runs and branch protection would block the merge
+          # indefinitely. This step closes that loop in two parts:
+          #
+          # 1. Stamp a `code-review-audit` check run on the new HEAD with
+          #    conclusion=success. The audit just produced the new tree,
+          #    so it is vouching for its own output; the GAIA-Audit commit
+          #    status stamped above records the version+tree binding.
+          # 2. Dispatch every workflow listed in `retrigger_workflows`
+          #    against the PR branch. `workflow_dispatch` IS allowed
+          #    under GITHUB_TOKEN (unlike push), so check runs from these
+          #    workflows attach to the new HEAD SHA and the ruleset
+          #    accepts the PR for merge.
+          #
+          # Each `gh workflow run` failure (workflow not present, lacks
+          # `workflow_dispatch:` trigger, etc.) is logged and tolerated —
+          # an adopter may list a workflow that doesn't exist in their
+          # repo, and the audit should not fail the PR over that.
+
+          if [ -z "${AUDIT_SHA:-}" ]; then
+            echo "code-review-audit: no audit_sha to re-trigger against; skipping." >&2
+            exit 0
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+            --method POST \
+            --field name=code-review-audit \
+            --field head_sha="${AUDIT_SHA}" \
+            --field status=completed \
+            --field conclusion=success \
+            --field 'output[title]=code-review-audit (re-stamped on self-heal HEAD)' \
+            --field 'output[summary]=Audit completed on the parent commit and produced the self-heal changes that advanced HEAD to this SHA. The GAIA-Audit commit status on this SHA records the version + tree binding.' \
+            >/dev/null \
+            || echo "code-review-audit: failed to stamp check run on ${AUDIT_SHA}; continuing." >&2
+
+          if [ -z "${RETRIGGER_WORKFLOWS:-}" ]; then
+            echo "code-review-audit: retrigger_workflows is empty; nothing to dispatch." >&2
+            exit 0
+          fi
+
+          printf '%s\n' "$RETRIGGER_WORKFLOWS" | while IFS= read -r workflow_name; do
+            [ -n "$workflow_name" ] || continue
+            echo "code-review-audit: dispatching '${workflow_name}' on ${PR_BRANCH}" >&2
+            if ! gh workflow run "$workflow_name" --ref "$PR_BRANCH" 2>&1; then
+              echo "code-review-audit: dispatch of '${workflow_name}' failed -- workflow may be absent or missing workflow_dispatch trigger." >&2
+            fi
+          done
 
       # ----------------------------------------------------------------
       # Terminal status steps. Exactly one fires per run; together they

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +14,7 @@ concurrency:
 jobs:
   tests:
     name: Vitest and Playwright
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -37,14 +37,26 @@ The trailer is written by `.claude/hooks/audit-stamp-trailer.sh` at the end of a
 
 ## Adopter knobs
 
-The four adopter-tunable knobs live at `.gaia/audit-ci.yml`. The workflow reads the file at job start via `.gaia/scripts/read-audit-ci-config.sh`; missing file or missing keys fall back to documented defaults.
+The adopter-tunable knobs live at `.gaia/audit-ci.yml`. The workflow reads the file at job start via `.gaia/scripts/read-audit-ci-config.sh`; missing file or missing keys fall back to documented defaults.
 
-| Knob             | Default | Purpose                                                                                                                                                                                     |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gate_label`     | `null`  | Run the audit only when the PR carries this label. `null` runs on every PR. Maintainer recommendation: leave `null` until the audit is stable in CI; flip to `ready-for-review` once it is. |
-| `budget_seconds` | `1800`  | Hard wall-clock budget for the audit invocation. The workflow times out the agent step at this value and reports `audit aborted: budget` rather than failing red.                           |
-| `max_turns`      | `30`    | Maximum fix turns the agent is allowed inside CI. Maps to `claude_args`'s `--max-turns`. Lower = cheaper. Higher = more chance to self-heal.                                                |
-| `push_fixes`     | `true`  | Whether the agent may push self-heal commits to the PR branch. Set `false` to make the audit advisory-only (it comments findings but does not push).                                        |
+| Knob                  | Default                | Purpose                                                                                                                                                                                                                                                                                                          |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gate_label`          | `null`                 | Run the audit only when the PR carries this label. `null` runs on every PR. Maintainer recommendation: leave `null` until the audit is stable in CI; flip to `ready-for-review` once it is.                                                                                                                      |
+| `budget_seconds`      | `1800`                 | Hard wall-clock budget for the audit invocation. The workflow times out the agent step at this value and reports `audit aborted: budget` rather than failing red.                                                                                                                                                |
+| `max_turns`           | `30`                   | Maximum fix turns the agent is allowed inside CI. Maps to `claude_args`'s `--max-turns`. Lower = cheaper. Higher = more chance to self-heal.                                                                                                                                                                     |
+| `push_fixes`          | `true`                 | Whether the agent may push self-heal commits to the PR branch. Set `false` to make the audit advisory-only (it comments findings but does not push).                                                                                                                                                             |
+| `retrigger_workflows` | `[Chromatic, Tests]`   | Workflows the audit re-dispatches against the PR branch after a self-heal push (see [[#Self-heal re-trigger]]). Each entry is the workflow's `name:` field — not the filename. Workflows listed must declare `workflow_dispatch:` in their triggers; the GAIA template's `chromatic.yml` and `tests.yml` do.     |
+
+## Self-heal re-trigger
+
+When the audit's self-heal step pushes a new commit, GitHub does not fire `push` or `pull_request` events for the GITHUB_TOKEN-authored push — its recursion guard. Without intervention, the new HEAD has zero check runs, and branch protection blocks the merge indefinitely. The workflow closes that loop in two parts:
+
+1. **Stamp `code-review-audit` on the new HEAD.** The `Re-trigger required checks on new HEAD` step uses the Checks API to create a `code-review-audit` check run on the self-heal SHA with `conclusion=success`. The audit produced the new tree, so it is vouching for its own output; the `GAIA-Audit` commit status stamped on the same SHA records the version + tree binding.
+2. **Dispatch the rest via `workflow_dispatch`.** The step iterates `retrigger_workflows` and calls `gh workflow run <name> --ref <pr-branch>` for each. `workflow_dispatch` IS allowed under GITHUB_TOKEN, so check runs from those workflows attach to the new HEAD SHA and the ruleset accepts the PR for merge.
+
+A dispatch failure (workflow not present, missing `workflow_dispatch:` trigger) is logged and tolerated — the audit does not fail the PR over an adopter-listed workflow that doesn't exist in their repo.
+
+This mechanism is invisible when `push_fixes: false` — the audit posts comments and never advances HEAD.
 
 ## How to enable as a required check
 
@@ -54,6 +66,7 @@ After the workflow lands on `main`, the maintainer (or an adopter applying the s
 2. Edit the rule for `main` (or add one if none exists).
 3. Enable **Require status checks to pass before merging**.
 4. Add `code-review-audit` to the required checks list. The check name is frozen — do not rename even if the workflow grows internal steps.
+5. If the rule also requires checks from sibling workflows (e.g. `Run Chromatic`, `Vitest and Playwright`), list those workflows in `retrigger_workflows` so the self-heal re-trigger restores them on the new HEAD. Without this, a self-heal push will strand the PR with the sibling checks missing.
 
 ## How to skip an audit run locally
 

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -41,9 +41,11 @@ The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove
 | ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `.gaia/local/audit/<HEAD-sha>.ok`                                         | Local audit agent            | Agent writes it on a clean pass                                                                                   |
 | `GAIA-Audit:` commit-message trailer on HEAD                              | Local audit agent            | `audit-stamp-trailer.sh` writes an empty commit with the trailer                                                  |
-| `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this instead of pushing an empty commit (pushing would re-trigger CI and leave HEAD without check runs) |
+| `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this on the audit SHA (no empty marker commit is pushed — that would strand HEAD on a check-less commit). |
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
+
+When CI self-heals — the audit modifies a file and pushes the fix — the workflow stamps a `code-review-audit` check run on the new HEAD and dispatches the sibling required workflows (e.g. `Chromatic`, `Tests`) via `workflow_dispatch` so their check runs attach to the new SHA. See [[Code Review Audit CI#Self-heal re-trigger]] for the full mechanism and the `retrigger_workflows` knob.
 
 A clean pass requires no Critical Issues, every Important Issue addressed, and every Suggestion either auto-fixed or resolved by the operator. Knip and react-doctor advisories remain advisory and never block signal emission.
 


### PR DESCRIPTION
## Summary

- GITHUB_TOKEN-authored pushes don't fire `push`/`pull_request` events (GitHub's recursion guard), so the audit's self-heal commits left PRs stranded with no check runs on the new HEAD and branch protection blocked the merge indefinitely (current example: #236).
- After a self-heal push, the workflow now stamps a `code-review-audit` check run on the new HEAD and dispatches the sibling required workflows via `workflow_dispatch` so their check runs attach to the new SHA.
- New adopter knob: `retrigger_workflows` in `.gaia/audit-ci.yml` (default `[Chromatic, Tests]`). Workflow display names — not filenames — so multi-word names like `Code Review Audit` are fine.
- `chromatic.yml` and `tests.yml` now declare `workflow_dispatch:` and accept it in their event-name guards.

## Mechanism

1. Audit runs against `PR HEAD`. If it self-heals, the existing logic pushes the fix and stamps a `GAIA-Audit` commit status (content-bound) on the new HEAD.
2. **New step**: when `pushed=true`, the workflow uses the Checks API to create a `code-review-audit` check run on the new HEAD (the audit produced the new tree — it's vouching for its own output), then calls `gh workflow run <name> --ref <pr-branch>` for each entry in `retrigger_workflows`. `workflow_dispatch` IS allowed under GITHUB_TOKEN.
3. Dispatch failures (workflow absent, missing `workflow_dispatch:` trigger) are logged and tolerated — adopter misconfiguration doesn't fail the audit.

## Test plan

- [x] `bats .gaia/scripts/tests/read-audit-ci-config.bats` — 35/35 pass (9 new tests cover the `retrigger_workflows` parser: block-style, flow-style, quoted entries, scalar fallback, `null`/empty defaults, inline comments, blank-line tolerance, list termination at next top-level key).
- [x] `actionlint` clean on new step (pre-existing SC2129/SC2016 notes unrelated).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean on all touched YAML.
- [ ] After merge, force a self-heal on a test PR and observe: new HEAD has fresh `Vitest and Playwright` + `Run Chromatic` check runs plus a stamped `code-review-audit` check run, and branch protection unblocks.
- [ ] After merge, unblock #236 with an empty commit so the new flow runs against its head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)