### PR TITLE
fix(audit-ci): stamp dispatched check runs into PR rollup

### DIFF
--- a/.gaia/audit-ci.yml
+++ b/.gaia/audit-ci.yml
@@ -34,6 +34,25 @@ push_fixes: true
 #
 # Workflows listed here must declare `workflow_dispatch:` in their `on:`
 # triggers. The GAIA template's `chromatic.yml` and `tests.yml` already do.
+#
+# Two-part mechanism: this audit step dispatches each workflow via
+# `workflow_dispatch`, and the companion listener
+# `.github/workflows/stamp-dispatched-checks.yml` mirrors the dispatched
+# run's job results back into the PR's check rollup once each run
+# completes. Without the listener, the dispatched run executes and lands
+# on the PR's head SHA, but the PR's `statusCheckRollup` (the data
+# structure branch protection evaluates) excludes check suites whose
+# `event` is `workflow_dispatch`, so the runs never count toward the
+# required-checks tally and the merge stays blocked.
+#
+# Static-list sync requirement: the listener declares the same workflow
+# names under `on.workflow_run.workflows`. GitHub Actions does not allow
+# dynamic interpolation in that field, so the list there must be edited
+# by hand to match this one. Adding a workflow here without adding it to
+# `stamp-dispatched-checks.yml` (or removing it from one side only) causes
+# silent drift: the dispatched run still executes, but the listener never
+# fires for it, its check runs never enter the PR rollup, and branch
+# protection blocks the merge with no obvious cause.
 retrigger_workflows:
   - Chromatic
   - Tests

--- a/.github/workflows/stamp-dispatched-checks.yml
+++ b/.github/workflows/stamp-dispatched-checks.yml
@@ -65,10 +65,9 @@ jobs:
         run: |
           set -eu
 
-          if [ -z "${CONCLUSION:-}" ]; then
-            echo "stamp-dispatched-checks: source run has no conclusion (still in progress?); refusing to stamp." >&2
-            exit 1
-          fi
+          # CONCLUSION is always non-empty here: this listener only fires on
+          # `workflow_run: completed`, which guarantees a conclusion value.
+          # The field is still validated defensively below at the per-job level.
 
           # `gh api .../jobs` failure is a genuine error — without the job
           # list there is nothing to stamp. Allow `set -e` to surface it.

--- a/.github/workflows/stamp-dispatched-checks.yml
+++ b/.github/workflows/stamp-dispatched-checks.yml
@@ -1,0 +1,104 @@
+# Stamp Dispatched Checks — listener that mirrors workflow_dispatch-triggered
+# check suites as check runs on the PR head SHA, so branch protection's
+# statusCheckRollup can see them.
+#
+# Why this exists:
+#   The code-review-audit workflow's self-heal step (.github/workflows/
+#   code-review-audit.yml) pushes a new HEAD with GITHUB_TOKEN and then
+#   dispatches each workflow in `.gaia/audit-ci.yml`'s `retrigger_workflows`
+#   list via `gh workflow run` (workflow_dispatch is the only re-trigger path
+#   permitted under GITHUB_TOKEN — push and pull_request are blocked by the
+#   recursion guard). The resulting check suites land on the new HEAD SHA and
+#   are visible via `pr.commits.checkSuites`, but the PR's
+#   `statusCheckRollup` — the data structure branch protection evaluates —
+#   excludes suites whose `event` is `workflow_dispatch`. The PR therefore
+#   reports BLOCKED even when every dispatched run passes.
+#
+#   This listener closes that gap by POSTing a check run to the Checks API
+#   for each job in the dispatched workflow run, with `head_sha` set to the
+#   dispatched run's head SHA. Check runs created via the API DO appear in
+#   the rollup, regardless of the source run's event. The audit's
+#   check-run-stamping half (the `code-review-audit` check it stamps on the
+#   self-heal HEAD) already works for the same reason.
+#
+# Static-list constraint:
+#   `on.workflow_run.workflows` does not support dynamic interpolation —
+#   GitHub requires literal workflow names. The two entries below must be
+#   kept in sync with `retrigger_workflows` in `.gaia/audit-ci.yml`.
+#   Adopters who add a workflow to `retrigger_workflows` MUST also add it
+#   here, or dispatched runs of that workflow will not be stamped and
+#   branch protection will continue to block.
+#
+# Default-branch guard:
+#   The job-level `if:` also requires `head_branch != default_branch`.
+#   Stamps on `main` produce noise and serve no purpose (no PR is gated on
+#   a `main` SHA), and a dispatched run on `main` is almost always a
+#   maintainer-initiated manual run that should not double as a PR check.
+
+name: Stamp Dispatched Checks
+
+on:
+  workflow_run:
+    workflows: [Chromatic, Tests]
+    types: [completed]
+
+permissions:
+  checks: write
+  actions: read
+
+jobs:
+  stamp:
+    name: Stamp dispatched check runs
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'workflow_dispatch'
+      && github.event.workflow_run.head_branch != github.event.repository.default_branch
+    steps:
+      - name: Stamp check runs for each job in the dispatched run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -eu
+
+          if [ -z "${CONCLUSION:-}" ]; then
+            echo "stamp-dispatched-checks: source run has no conclusion (still in progress?); refusing to stamp." >&2
+            exit 1
+          fi
+
+          # `gh api .../jobs` failure is a genuine error — without the job
+          # list there is nothing to stamp. Allow `set -e` to surface it.
+          jobs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" --paginate)"
+
+          # Iterate jobs. A single job's POST failure is logged and skipped;
+          # the listener does not fail the dispatched run over a transient
+          # Checks API hiccup on one job out of many.
+          printf '%s' "$jobs_json" \
+            | jq -c '.jobs[]' \
+            | while IFS= read -r job; do
+                job_name="$(printf '%s' "$job" | jq -r '.name')"
+                started_at="$(printf '%s' "$job" | jq -r '.started_at')"
+                completed_at="$(printf '%s' "$job" | jq -r '.completed_at')"
+                details_url="$(printf '%s' "$job" | jq -r '.html_url // empty')"
+                [ -n "$details_url" ] || details_url="$RUN_HTML_URL"
+
+                echo "stamp-dispatched-checks: stamping '${job_name}' on ${HEAD_SHA} (conclusion=${CONCLUSION})" >&2
+                if ! gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+                    --method POST \
+                    --field name="$job_name" \
+                    --field head_sha="$HEAD_SHA" \
+                    --field status=completed \
+                    --field conclusion="$CONCLUSION" \
+                    --field started_at="$started_at" \
+                    --field completed_at="$completed_at" \
+                    --field details_url="$details_url" \
+                    --field "output[title]=${job_name} (stamped from dispatched run)" \
+                    --field "output[summary]=Mirror of dispatched workflow '${WORKFLOW_NAME}' run #${RUN_ID}. See ${RUN_HTML_URL}." \
+                    >/dev/null; then
+                  echo "stamp-dispatched-checks: failed to stamp '${job_name}' on ${HEAD_SHA}; continuing." >&2
+                fi
+              done

--- a/.github/workflows/stamp-dispatched-checks.yml
+++ b/.github/workflows/stamp-dispatched-checks.yml
@@ -77,6 +77,13 @@ jobs:
           # Iterate jobs. A single job's POST failure is logged and skipped;
           # the listener does not fail the dispatched run over a transient
           # Checks API hiccup on one job out of many.
+          #
+          # Conclusion is read PER JOB (not from the workflow-level
+          # CONCLUSION env var) so that a `skipped` or `failure` job inside
+          # an overall-`success` workflow is stamped honestly. Falls back to
+          # the workflow-level value only when a job has no conclusion of
+          # its own (e.g. a job that never started before workflow
+          # cancellation).
           printf '%s' "$jobs_json" \
             | jq -c '.jobs[]' \
             | while IFS= read -r job; do
@@ -85,14 +92,16 @@ jobs:
                 completed_at="$(printf '%s' "$job" | jq -r '.completed_at')"
                 details_url="$(printf '%s' "$job" | jq -r '.html_url // empty')"
                 [ -n "$details_url" ] || details_url="$RUN_HTML_URL"
+                job_conclusion="$(printf '%s' "$job" | jq -r '.conclusion // empty')"
+                [ -n "$job_conclusion" ] || job_conclusion="$CONCLUSION"
 
-                echo "stamp-dispatched-checks: stamping '${job_name}' on ${HEAD_SHA} (conclusion=${CONCLUSION})" >&2
+                echo "stamp-dispatched-checks: stamping '${job_name}' on ${HEAD_SHA} (conclusion=${job_conclusion})" >&2
                 if ! gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
                     --method POST \
                     --field name="$job_name" \
                     --field head_sha="$HEAD_SHA" \
                     --field status=completed \
-                    --field conclusion="$CONCLUSION" \
+                    --field conclusion="$job_conclusion" \
                     --field started_at="$started_at" \
                     --field completed_at="$completed_at" \
                     --field details_url="$details_url" \

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -45,16 +45,24 @@ The adopter-tunable knobs live at `.gaia/audit-ci.yml`. The workflow reads the f
 | `budget_seconds`      | `1800`                 | Hard wall-clock budget for the audit invocation. The workflow times out the agent step at this value and reports `audit aborted: budget` rather than failing red.                                                                                                                                                |
 | `max_turns`           | `30`                   | Maximum fix turns the agent is allowed inside CI. Maps to `claude_args`'s `--max-turns`. Lower = cheaper. Higher = more chance to self-heal.                                                                                                                                                                     |
 | `push_fixes`          | `true`                 | Whether the agent may push self-heal commits to the PR branch. Set `false` to make the audit advisory-only (it comments findings but does not push).                                                                                                                                                             |
-| `retrigger_workflows` | `[Chromatic, Tests]`   | Workflows the audit re-dispatches against the PR branch after a self-heal push (see [[#Self-heal re-trigger]]). Each entry is the workflow's `name:` field — not the filename. Workflows listed must declare `workflow_dispatch:` in their triggers; the GAIA template's `chromatic.yml` and `tests.yml` do.     |
+| `retrigger_workflows` | `[Chromatic, Tests]`   | Workflows the audit re-dispatches against the PR branch after a self-heal push (see [[#Self-heal re-trigger]]). Each entry is the workflow's `name:` field — not the filename. Workflows listed must declare `workflow_dispatch:` in their triggers; the GAIA template's `chromatic.yml` and `tests.yml` do. The listener at `.github/workflows/stamp-dispatched-checks.yml` carries a matching static `workflows:` list that adopters must keep in sync when they edit this knob. |
 
 ## Self-heal re-trigger
 
-When the audit's self-heal step pushes a new commit, GitHub does not fire `push` or `pull_request` events for the GITHUB_TOKEN-authored push — its recursion guard. Without intervention, the new HEAD has zero check runs, and branch protection blocks the merge indefinitely. The workflow closes that loop in two parts:
+When the audit's self-heal step pushes a new commit, GitHub does not fire `push` or `pull_request` events for the GITHUB_TOKEN-authored push — its recursion guard. Without intervention, the new HEAD has zero check runs, and branch protection blocks the merge indefinitely. The workflow closes that loop with a two-part response inside `.github/workflows/code-review-audit.yml`:
 
 1. **Stamp `code-review-audit` on the new HEAD.** The `Re-trigger required checks on new HEAD` step uses the Checks API to create a `code-review-audit` check run on the self-heal SHA with `conclusion=success`. The audit produced the new tree, so it is vouching for its own output; the `GAIA-Audit` commit status stamped on the same SHA records the version + tree binding.
-2. **Dispatch the rest via `workflow_dispatch`.** The step iterates `retrigger_workflows` and calls `gh workflow run <name> --ref <pr-branch>` for each. `workflow_dispatch` IS allowed under GITHUB_TOKEN, so check runs from those workflows attach to the new HEAD SHA and the ruleset accepts the PR for merge.
+2. **Dispatch each `retrigger_workflows` entry.** The step iterates the configured list and calls `gh workflow run <name> --ref <pr-branch>` for each. `workflow_dispatch` IS allowed under GITHUB_TOKEN, so the dispatched runs execute against the new HEAD.
 
-A dispatch failure (workflow not present, missing `workflow_dispatch:` trigger) is logged and tolerated — the audit does not fail the PR over an adopter-listed workflow that doesn't exist in their repo.
+There is a rollup subtlety here: `workflow_dispatch`-triggered check suites are excluded from the PR's `statusCheckRollup` — the projection branch protection evaluates. The dispatched runs land on the SHA and pass, but their results never reach the rollup on their own. Without a second step, the PR stays blocked even after every dispatched workflow goes green.
+
+The listener at `.github/workflows/stamp-dispatched-checks.yml` closes that gap. It triggers on `workflow_run: completed` for each workflow named in its static `workflows:` list, fetches the source run's jobs via the Actions API, and POSTs a matching check run per job to the head SHA via the Checks API. Those POSTed check runs enter the `statusCheckRollup` and unblock the merge.
+
+The listener's `workflows:` list is **static** — GitHub does not allow dynamic interpolation in `workflow_run.workflows`. Adopters who edit `retrigger_workflows` in `.gaia/audit-ci.yml` must mirror the change in `.github/workflows/stamp-dispatched-checks.yml`; a workflow named in `retrigger_workflows` but absent from the listener's list dispatches and runs, but its result never enters the rollup.
+
+The listener guards against stamping on the default branch (`head_branch != default_branch`) because no PR is gated on a `main` SHA — stamping there would create orphan check runs.
+
+A dispatch failure in step 2 (workflow not present, missing `workflow_dispatch:` trigger) is logged and tolerated — the audit does not fail the PR over an adopter-listed workflow that doesn't exist in their repo.
 
 This mechanism is invisible when `push_fixes: false` — the audit posts comments and never advances HEAD.
 
@@ -83,6 +91,7 @@ Editing HEAD between the local stamp and `gh pr merge` invalidates the trailer (
 
 - Agent definition: `.claude/agents/code-review-audit.md`
 - Workflow: `.github/workflows/code-review-audit.yml`
+- Dispatched-check rollup listener: `.github/workflows/stamp-dispatched-checks.yml`
 - Stamp helper (local): `.claude/hooks/audit-stamp-trailer.sh`
 - Skip-logic helper (CI): `.github/audit/check-trailer.sh`
 - Config reader: `.gaia/scripts/read-audit-ci-config.sh`

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -45,7 +45,7 @@ The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
 
-When CI self-heals — the audit modifies a file and pushes the fix — the workflow stamps a `code-review-audit` check run on the new HEAD and dispatches the sibling required workflows (e.g. `Chromatic`, `Tests`) via `workflow_dispatch` so their check runs attach to the new SHA. See [[Code Review Audit CI#Self-heal re-trigger]] for the full mechanism and the `retrigger_workflows` knob.
+When CI self-heals — the audit modifies a file and pushes the fix — the workflow stamps a `code-review-audit` check run on the new HEAD and dispatches the sibling required workflows (e.g. `Chromatic`, `Tests`) via `workflow_dispatch`. A separate listener (`.github/workflows/stamp-dispatched-checks.yml`) then mirrors each dispatched run's jobs back as check runs on the head SHA so they enter the rollup branch protection evaluates. See [[Code Review Audit CI#Self-heal re-trigger]] for the full mechanism and the `retrigger_workflows` knob.
 
 A clean pass requires no Critical Issues, every Important Issue addressed, and every Suggestion either auto-fixed or resolved by the operator. Knip and react-doctor advisories remain advisory and never block signal emission.
 


### PR DESCRIPTION
## Summary

Close the latent bug in PR #238's self-heal re-trigger mechanism: `workflow_dispatch`-triggered check suites are excluded from a PR's `statusCheckRollup`, which is the data structure GitHub branch protection evaluates. The audit step correctly dispatches the sibling workflows and they pass on the new HEAD, but their results never enter the rollup, so branch protection blocks the merge indefinitely (live on PR #239).

## What ships

- **`.github/workflows/stamp-dispatched-checks.yml`** (new) — listener that fires on `workflow_run: completed` for each workflow in `retrigger_workflows` (default `Chromatic`, `Tests`), fetches the source run's jobs via the Actions API, and POSTs a matching check run per job to the head SHA via the Checks API. Stamped check runs DO enter the rollup, regardless of the source run's `event`, which is the same mechanism that already makes the audit's own `code-review-audit` stamp visible to branch protection.
- **`.gaia/audit-ci.yml`** — comment block above `retrigger_workflows` now documents the two-part mechanism (dispatch + listener-stamp), the static-list sync requirement (`on.workflow_run.workflows` does not support dynamic interpolation), and the silent-drift failure mode if the lists drift.

The listener job guard is `event == 'workflow_dispatch' && head_branch != default_branch` — only dispatched runs on non-default branches get stamped, so `push` / `pull_request` runs do not double-stamp and stamps on `main` are suppressed.

## Untouched

- `.github/workflows/code-review-audit.yml` — the existing re-trigger step stays as-is. The listener complements it; it does not replace it.
- `.gaia/scripts/read-audit-ci-config.sh` — already handles `retrigger_workflows`; no change needed.
- All application source (`app/`, `test/`).

## Test plan

- [x] `actionlint .github/workflows/stamp-dispatched-checks.yml` — clean locally.
- [ ] Branch CI passes (Chromatic, Tests, GAIA-Audit, code-review-audit).
- [ ] After merge: force a fresh self-heal on PR #239 (`test/verify-audit-retrigger`), watch the dispatched runs land + listener fire, and confirm `Run Chromatic` / `Vitest and Playwright` appear in PR #239's `statusCheckRollup` with `mergeStateStatus` flipping from `BLOCKED` to `CLEAN`. Close #239 without merging on success.

Context: PR #238 (the self-heal re-trigger work), PR #239 (verification fixture, currently `BLOCKED` for exactly this reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)