### PR TITLE
chore(audit-ci): bump max_turns from 30 to 60

### DIFF
--- a/.gaia/audit-ci.yml
+++ b/.gaia/audit-ci.yml
@@ -13,7 +13,7 @@ budget_seconds: 1800
 
 # Maximum number of fix turns the agent is allowed inside CI. Maps to claude_args
 # `--max-turns`. Lower = cheaper. Higher = more chance to self-heal.
-max_turns: 30
+max_turns: 60
 
 # Whether the agent may push self-heal commits to the PR branch. Set false to make
 # the audit advisory-only (it comments findings but does not push).


### PR DESCRIPTION
## Summary

Doubles the audit agent's turn ceiling from 30 to 60. The 30-turn limit was tripping on multi-defect PRs and surfacing as `error_max_turns` → `Status — audit aborted`, which prevents the self-heal commit (and therefore the re-trigger / listener-stamp chain) from running.

`budget_seconds` (1800) still caps total wall-clock cost; this is purely a turn-ceiling adjustment.

## Test plan

- [x] `actionlint` and Quality Gate auto-skip (no TS/JS/CSS touched, only `.gaia/audit-ci.yml`).
- [ ] CI on this branch passes (no new code paths exercised — config-only change).
- [ ] After merge, re-trigger the audit on PR #239 to exercise the stamp-dispatched-checks.yml listener that landed in #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)