### PR TITLE
chore(deps): bump date-fns from 4.2.1 to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@react-router/serve": "7.15.1",
     "autosize": "6.0.1",
     "cookie": "1.1.1",
-    "date-fns": "4.2.1",
+    "date-fns": "4.3.0",
     "dotenv": "17.4.2",
     "i18next": "26.2.0",
     "i18next-browser-languagedetector": "8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       date-fns:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 4.3.0
+        version: 4.3.0
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -2782,8 +2782,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@4.2.1:
-    resolution: {integrity: sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==}
+  date-fns@4.3.0:
+    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -7906,7 +7906,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@4.2.1: {}
+  date-fns@4.3.0: {}
 
   debug@2.6.9:
     dependencies:


### PR DESCRIPTION
## Migration Report

### Updated packages

| Group     | Package  | From  | To    | Type  |
| --------- | -------- | ----- | ----- | ----- |
| date-fns  | date-fns | 4.2.1 | 4.3.0 | patch |

### Breaking changes applied

None.

### Overrides audited

None — `pnpm.overrides` is empty.

### Skipped packages

None.

### Quality gate

| Step            | Result |
| --------------- | ------ |
| pnpm typecheck  | pass   |
| pnpm lint       | pass   |
| pnpm test --run | pass (26 files, 120 tests) |
| pnpm pw         | pass (2 playwright tests)  |
| pnpm build      | pass (client + server)     |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
