### PR TITLE
feat(ci): skip required workflows on chore(deps) PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,9 +30,25 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+      # Pre-verified dep-bump PRs (the /update-deps wrapper runs the full
+      # quality gate locally before pushing) skip Chromatic. This workflow
+      # triggers on `push`, so the gate inspects the HEAD commit subject
+      # rather than the PR title. Pattern is restricted to `chore(deps):`
+      # and `chore(deps-dev):` so other chore commits still run Chromatic.
+      - name: Check chore-deps commit
+        id: chore-deps
+        run: |
+          set -eu
+          subject=$(git log -1 --format=%s HEAD)
+          if printf '%s' "$subject" | grep -qE '^chore\(deps(-dev)?\):'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       # Allowlist of paths that can affect a Storybook build. Anything outside
       # this list reports the required check green without running Chromatic.
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: steps.chore-deps.outputs.skip == 'false'
         id: filter
         with:
           filters: |
@@ -45,22 +61,22 @@ jobs:
               - 'tsconfig*.json'
               - 'vite.config.*'
               - '.github/workflows/chromatic.yml'
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Run Chromatic
         uses: chromaui/action@8d925269a481085d451544f6bd9aa2ab3af55b5d # v16.9.1
         with:

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -90,9 +90,28 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check chore-deps title
+        id: chore-deps
+        if: steps.gate.outputs.gated == 'false'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -eu
+          # Pre-verified dep-bump PRs (the /update-deps wrapper runs the full
+          # quality gate locally before pushing) skip the audit. Pattern is
+          # restricted to `chore(deps):` and `chore(deps-dev):` so other chore
+          # PRs still run.
+          if printf '%s' "$PR_TITLE" | grep -qE '^chore\(deps(-dev)?\):'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for source-code changes
         id: source-changes
-        if: steps.gate.outputs.gated == 'false'
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.chore-deps.outputs.skip == 'false'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -592,6 +611,15 @@ jobs:
           set -eu
           gh pr comment "$PR_NUMBER" \
             --body "code-review-audit skipped: gate_label '$GATE_LABEL' not present on PR"
+
+      - name: Status — skipped (chore-deps PR)
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.chore-deps.outputs.skip == 'true'
+        run: |
+          set -eu
+          gh pr comment "$PR_NUMBER" \
+            --body "code-review-audit skipped: chore(deps) / chore(deps-dev) PRs are pre-verified by the /update-deps wrapper's local quality gate"
 
       - name: Status — skipped (no source changes)
         if: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,29 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+      # Pre-verified dep-bump PRs (the /update-deps wrapper runs the full
+      # quality gate locally before pushing) skip the CI suite. Title-pattern
+      # gate is restricted to `chore(deps):` and `chore(deps-dev):` so other
+      # chore PRs still run normally. Skipped jobs do not satisfy required
+      # checks under classic branch protection, so we gate steps instead.
+      - name: Check chore-deps title
+        id: chore-deps
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+              && printf '%s' "$PR_TITLE" | grep -qE '^chore\(deps(-dev)?\):'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       # Allowlist of paths that affect the test suite. Anything outside this
       # list reports the required check green without running. Skipped jobs do
       # not satisfy required checks under classic branch protection, so we
       # gate steps instead.
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        if: steps.chore-deps.outputs.skip == 'false'
         id: filter
         with:
           filters: |
@@ -48,43 +66,43 @@ jobs:
               - 'eslint.config.*'
               - '.node-version'
               - '.github/workflows/tests.yml'
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b # v1.3.1
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Typecheck
         run: pnpm typecheck
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Lint
         run: pnpm lint-dry
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Run Vitest tests
         run: pnpm test:ci
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           npm_package_version: ${{ steps.package-version.outputs.current-version}}
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
-      - if: steps.filter.outputs.code == 'true'
+      - if: steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true'
         name: Run Playwright tests
         run: pnpm exec playwright test --pass-with-no-tests
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           npm_package_version: ${{ steps.package-version.outputs.current-version}}
-      - if: ${{ failure() && steps.filter.outputs.code == 'true' }}
+      - if: ${{ failure() && steps.chore-deps.outputs.skip == 'false' && steps.filter.outputs.code == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload Playwright failed test traces
         with:

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -35,6 +35,12 @@ Version mismatch (a newer GAIA release shipped) and tree mismatch (HEAD amended 
 
 The trailer is written by `.claude/hooks/audit-stamp-trailer.sh` at the end of a clean local run of the audit agent. Stamp placement is automatic: amend on un-pushed HEADs, an empty `chore: code review audit passed` commit on already-pushed HEADs (never silently rewriting published history), and amend on the audit's own self-heal commits regardless of push state. The full stamp invariant and placement rule live alongside the workflow's frozen contracts at `.gaia/local/plans/code-review-audit-ci/trailer-format.md`.
 
+## Skip rule (chore-deps PRs)
+
+PRs whose title starts with `chore(deps):` or `chore(deps-dev):` skip the audit entirely. These come from the `/update-deps` wrapper, which runs the full quality gate (`pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm pw`, `pnpm build`) locally before pushing — the local pass is equivalent to the audit's CI signal for dep-only changes. The workflow's `Check chore-deps title` step reads `github.event.pull_request.title`, sets `skip=true` when the prefix matches, and the gate cascades through the rest of the steps. The terminal `Status — skipped (chore-deps PR)` step posts the explanation and reports `code-review-audit` as a green skipped check.
+
+Other `chore:` prefixes (e.g. `chore: bump version`, `chore: tidy imports`) still run the audit — only the dep-specific narrowing skips. `tests.yml` and `chromatic.yml` carry the same skip pattern so all three required checks short-circuit on chore-deps PRs.
+
 ## Adopter knobs
 
 The adopter-tunable knobs live at `.gaia/audit-ci.yml`. The workflow reads the file at job start via `.gaia/scripts/read-audit-ci-config.sh`; missing file or missing keys fall back to documented defaults.


### PR DESCRIPTION
## Summary

Adds a title-pattern skip to the three required workflows so `chore(deps):` and `chore(deps-dev):` PRs short-circuit to green skipped checks. These PRs come from the `/update-deps` wrapper, which already runs the full quality gate (typecheck + lint + vitest + playwright + build) locally before pushing — re-running the same gate in CI is redundant on the critical path of dependency hygiene.

## Files

- `.github/workflows/code-review-audit.yml` — new `Check chore-deps title` step; cascades through the existing `if:` chain; new `Status — skipped (chore-deps PR)` terminal step that posts a PR comment.
- `.github/workflows/tests.yml` — new `Check chore-deps title` step; all subsequent steps gated on both `chore-deps.skip == 'false'` and the existing `paths-filter` output.
- `.github/workflows/chromatic.yml` — new `Check chore-deps commit` step that inspects the HEAD commit subject (since chromatic fires on push, not pull_request); gates the remaining steps.
- `wiki/concepts/Code Review Audit CI.md` — new "Skip rule (chore-deps PRs)" section.

## Step-level skip, not job-level

Required checks under classic branch protection are satisfied by SUCCESS conclusions. Job-level `if:` would skip the job and produce a "neutral" conclusion that does NOT satisfy the required check. All gates here are step-level — the job runs, every step body short-circuits, the job ends with `success`.

## Scope narrowing

The pattern is `^chore\(deps(-dev)?\):` — anchored at the start, exact prefix match. Other `chore:` PRs (`chore: bump version`, `chore: tidy`) still run the full suite. An adopter can broaden by editing the grep pattern or remove the skip by deleting the chore-deps step (no orphan references — every gated `if:` falls back to false when the step output is empty).

## Test plan

- [x] `actionlint` clean on all three workflows.
- [x] Wiki-style audit greps clean on the concept page.
- [ ] Once merged, PR #244 (date-fns bump) re-runs and observes the three required checks short-circuit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
