### PR TITLE
feat(pr-merge): bypass audit-marker requirement on chore(deps) PRs

### DIFF
--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # PreToolUse Bash hook: BLOCK `gh pr merge` until proof of a passing
-# code-review-audit exists for the current HEAD. Three signals are accepted:
+# code-review-audit exists for the current HEAD. Three signals and one
+# bypass are accepted:
 #
 #   1. Local marker file at .gaia/local/audit/<sha>.ok — written by the
 #      audit agent at the end of a clean local review.
@@ -14,6 +15,12 @@
 #      pushing an empty marker commit (pushing it would re-trigger CI and leave
 #      the PR HEAD without check runs). Queried via `gh api` using GH_TOKEN or
 #      the ambient gh auth session.
+#
+#   4. chore(deps) PR bypass: PR title matches `^chore\(deps(-dev)?\):`. The
+#      /update-deps wrapper runs the full quality gate locally before
+#      pushing, so the audit signal is implicit for this PR class. Mirrors
+#      the same narrowing applied to code-review-audit.yml, tests.yml, and
+#      chromatic.yml — all four surfaces skip together on chore(deps) PRs.
 #
 # Any signal proves the audit ran against this content and the agent saw
 # no Critical Issues and no unresolved Important Issues. Without one, the
@@ -158,12 +165,36 @@ if check_github_status; then
   exit 0
 fi
 
+# chore(deps) bypass: PRs whose title matches `^chore\(deps(-dev)?\):` are
+# pre-verified by the /update-deps wrapper's local quality gate (typecheck +
+# lint + vitest + playwright + build), so the audit-marker requirement is
+# waived for this PR class. Same skip narrowing as the CI workflows
+# (code-review-audit.yml, tests.yml, chromatic.yml).
+#
+# Title is queried via `gh pr view`. On any failure (no gh, no auth, no PR
+# for the current branch, network error) the bypass does not fire and the
+# normal deny path runs — the bypass is opt-in proof, not a fallback.
+check_chore_deps_pr() {
+  command -v gh >/dev/null 2>&1 || return 1
+  pr_title=$(gh pr view --json title --jq .title 2>/dev/null || true)
+  [ -n "$pr_title" ] || return 1
+  case "$pr_title" in
+    'chore(deps):'*|'chore(deps-dev):'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if check_chore_deps_pr; then
+  exit 0
+fi
+
 reason="PR merge gate: no code-review-audit signal for HEAD ${sha:0:12}.
 
 None of the accepted signals is present:
   - Local marker:    ${marker} (missing)
   - Commit trailer:  ${trailer_status}
   - GitHub CI status: absent or version/tree mismatch
+  - chore(deps) PR:  PR title does not match \`chore(deps):\` or \`chore(deps-dev):\`
 
 To unblock:
   1. Spawn the code-review-audit agent locally, OR push to the PR branch

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -35,15 +35,18 @@ Task(
 
 ### 3. Marker handshake
 
-The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove the audit ran clean against the content being merged:
+The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove the audit ran clean against the content being merged, plus one bypass for pre-verified PR classes:
 
 | Signal                                                                    | Source                       | How it gets there                                                                                                 |
 | ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `.gaia/local/audit/<HEAD-sha>.ok`                                         | Local audit agent            | Agent writes it on a clean pass                                                                                   |
 | `GAIA-Audit:` commit-message trailer on HEAD                              | Local audit agent            | `audit-stamp-trailer.sh` writes an empty commit with the trailer                                                  |
 | `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this on the audit SHA (no empty marker commit is pushed — that would strand HEAD on a check-less commit). |
+| PR title matches `^chore\(deps(-dev)?\):` (bypass)                        | `/update-deps` wrapper       | Wrapper opens dep-bump PRs with the canonical prefix; the local quality gate stands in for the audit signal.      |
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
+
+The chore(deps) bypass mirrors the same skip narrowing that `code-review-audit.yml`, `tests.yml`, and `chromatic.yml` apply at CI level. All four surfaces — local hook + three required workflows — release together when a `chore(deps):` or `chore(deps-dev):` PR is recognized, so dep-bump PRs from `/update-deps` are turnkey. The bypass requires `gh` to be installed and authenticated; if either is missing the hook falls through to the normal deny path (the bypass is opt-in proof, not a fallback).
 
 When CI self-heals — the audit modifies a file and pushes the fix — the workflow stamps a `code-review-audit` check run on the new HEAD and dispatches the sibling required workflows (e.g. `Chromatic`, `Tests`) via `workflow_dispatch` so their check runs attach to the new SHA. See [[Code Review Audit CI#Self-heal re-trigger]] for the full mechanism and the `retrigger_workflows` knob.
 


### PR DESCRIPTION
## Summary

Adds a chore(deps) bypass to the `pr-merge-audit-check.sh` hook so dep-bump PRs from `/update-deps` are turnkey to merge — no separate audit run required. Mirrors the same skip narrowing already applied to the three required CI workflows in #245.

## Mechanism

`gh pr view --json title --jq .title` reads the current branch's PR title. If it matches `^chore\(deps(-dev)?\):`, the hook exits 0 and the merge proceeds.

The bypass runs only after the three existing signals (local marker, GAIA-Audit trailer, GitHub commit status) have all missed — same pattern as the existing GitHub-status fallback. Any failure to query (no `gh`, no auth, no PR for the current branch, network error) falls through to the normal deny path. The bypass is opt-in proof, not a fallback that softens the gate.

## Why this scope

The /update-deps wrapper runs the full quality gate (typecheck + lint + vitest + playwright + build) locally before pushing. That's equivalent evidence to a separate code-review-audit run. With the three required workflows already skipping on `chore(deps):`, requiring a local audit marker was the last barrier — this PR removes it.

Other `chore:` prefixes (`chore: bump version`, etc.) still require the marker. Pattern is anchored, exact prefix match.

## Test plan

- [x] `bash -n` clean on the modified hook.
- [x] `shellcheck` clean on the modified hook (only pre-existing SC1091 info note remains).
- [x] Wiki-style audit clean on the PR Merge Workflow page.
- [ ] After merge, the next /update-deps run produces a PR that merges without a separate audit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
