### PR TITLE
fix(forensics,update-gaia): seed missing files; round-trip GH issues; drop UAT leaks

### DIFF
--- a/.claude/skills/gaia/references/forensics.md
+++ b/.claude/skills/gaia/references/forensics.md
@@ -77,7 +77,7 @@ Do not pass frontmatter through redaction. Frontmatter is written after the body
 
 ### 6. Render
 
-Emit the strict-schema body. The frontmatter heads the body, and the same body is posted to the GH issue verbatim — the local file and the GH issue are byte-identical so downstream triage can parse either with the same parser.
+Emit the strict-schema body. The frontmatter heads the body, and the same body is posted to the GH issue verbatim — at creation time (before `gh_issue_url` is back-filled into the local file in step 8) the local file and the GH issue are byte-identical, so downstream triage parses either with the same parser.
 
 Body layout (frontmatter + sections):
 
@@ -165,7 +165,7 @@ command -v gh
       --body-file <tempfile>
     ```
 
-    Use `--body-file` so multiline bodies survive shell escaping intact. The GH-issue body must be byte-identical to the local file body (frontmatter included) so the deterministic parser at `.github/forensics/parse-issue-body.sh` extracts the same `class` from either input.
+    Use `--body-file` so multiline bodies survive shell escaping intact. At this point — before `gh_issue_url` is added back to the local frontmatter — the GH-issue body must be byte-identical to the local file body (frontmatter included) so the deterministic parser at `.github/forensics/parse-issue-body.sh` extracts the same `class` from either input.
     - On success: capture the issue URL printed by `gh`. Record it in the frontmatter `gh_issue_url` field of the already-saved local file (update the file in place). Continue to step 9.
     - On non-zero `gh` exit: surface `gh`'s stderr verbatim. Leave the local report in place. Exit non-zero. Do not retry or partially file.
 

--- a/.claude/skills/gaia/references/forensics.md
+++ b/.claude/skills/gaia/references/forensics.md
@@ -77,9 +77,9 @@ Do not pass frontmatter through redaction. Frontmatter is written after the body
 
 ### 6. Render
 
-Emit the strict-schema body. The frontmatter wraps the local file only; the GH issue body is the post-frontmatter portion.
+Emit the strict-schema body. The frontmatter heads the body, and the same body is posted to the GH issue verbatim — the local file and the GH issue are byte-identical so downstream triage can parse either with the same parser.
 
-Local file layout (frontmatter + body):
+Body layout (frontmatter + sections):
 
 ```markdown
 ---
@@ -115,7 +115,7 @@ class_state_files:
 <plain prose: what the user was doing, what they expected, what happened>
 ```
 
-The body posted to the GH issue is the post-frontmatter portion (`## Symptom` through the end), byte-identical to the local file body.
+The body posted to the GH issue is the full body — frontmatter and all sections — byte-identical to the local file body. The `gh_issue_url` frontmatter key is set after the issue is created (step 8) so the initial GH-issue render omits it; the local file is rewritten with the URL once known.
 
 ### 7. Save
 
@@ -155,7 +155,7 @@ command -v gh
 
   - **On `No`:** exit zero. Print the local path. Do not invoke `gh`.
 
-  - **On `Yes`:** write the post-frontmatter body to a temp file, then invoke:
+  - **On `Yes`:** write the full body — frontmatter and all four sections — to a temp file, then invoke:
 
     ```bash
     gh issue create \
@@ -165,7 +165,7 @@ command -v gh
       --body-file <tempfile>
     ```
 
-    Use `--body-file` so multiline bodies survive shell escaping intact.
+    Use `--body-file` so multiline bodies survive shell escaping intact. The GH-issue body must be byte-identical to the local file body (frontmatter included) so the deterministic parser at `.github/forensics/parse-issue-body.sh` extracts the same `class` from either input.
     - On success: capture the issue URL printed by `gh`. Record it in the frontmatter `gh_issue_url` field of the already-saved local file (update the file in place). Continue to step 9.
     - On non-zero `gh` exit: surface `gh`'s stderr verbatim. Leave the local report in place. Exit non-zero. Do not retry or partially file.
 
@@ -218,7 +218,7 @@ class_state_files:
 <plain prose: what the user was doing, what they expected, what happened>
 ```
 
-The local file carries the frontmatter block. The GH issue body is the post-frontmatter portion only — from `## Symptom` through the end — byte-identical to the local file body.
+The GH issue body is byte-identical to the local file body — frontmatter and all four sections — so the deterministic parser sees the same input from either source. `gh_issue_url` is added to the local file only, after the issue is created.
 
 ## Hardcoded constants
 

--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -196,8 +196,11 @@ Track six lists internally (`UpdateMergeReport`):
 
 Let `A` = working-tree `<path>`, `B` = `$BASELINE_DIR/<path>`, `L` = `$LATEST_DIR/<path>`. Use `cmp -s` for equality; `mkdir -p` before writing.
 
+**Match in declared order — first matching row wins.** The first row applies to every class and runs before any class-specific check; it closes the silent-skip gap where the manifest declares a file but the adopter's tree never had it (in particular, the `shared` / `wiki-owned` `B` ≅ `L` row below would otherwise short-circuit and leave the file missing on disk).
+
 | Class | Condition | Action | List |
 |---|---|---|---|
+| any | `A` missing and `L` exists | Copy `L` → `<path>` | `add[]` |
 | `owned` | `B` missing (new file) | Copy `L` → `<path>` | `add[]` |
 | `owned` | `A` ≅ `B` (no adopter drift) | Back up `A` to `$BACKUP_DIR/<path>`; copy `L` → `<path>` | `overwrite[]` |
 | `owned` | `A` ≅ `L` (adopter already current) | No-op | `skip[]` |

--- a/.github/forensics/handlers/handle-malformed-body.sh
+++ b/.github/forensics/handlers/handle-malformed-body.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# handle-malformed-body.sh — UAT-013 short-circuit handler.
+# handle-malformed-body.sh — short-circuit handler for issues whose
+# body cannot be parsed deterministically.
 #
 # The body parser flagged the issue as `valid:false`. Without invoking
-# the LLM (UAT-013 forbids LLM fallback for parse failures), label the
-# issue `needs-human` and post a comment naming the missing/malformed
-# sections. Issue stays open. No fix attempt.
+# the LLM (parser failures never fall through to an LLM fallback —
+# downstream tooling parses the structured sections deterministically),
+# label the issue `needs-human` and post a comment naming the
+# missing/malformed sections. Issue stays open. No fix attempt.
 #
 # Usage:
 #   handle-malformed-body.sh <issue-num> <parser-output-file>
@@ -21,8 +23,7 @@
 # Exit code: 0 on success. 2 on bad usage / missing input. gh-level
 # failures propagate.
 #
-# Contract: SPEC-002 UAT-013. Idempotency key (`gaia-triaged`) is the
-# final mutation.
+# `gaia-triaged` is the idempotency key and is the final mutation.
 
 set -euo pipefail
 
@@ -49,16 +50,16 @@ trap 'rm -rf "$work_dir"' EXIT
 
 comment_file="$work_dir/comment.md"
 {
-  printf 'verdict: needs-human (malformed body — UAT-013).\n\n'
-  printf 'The forensics issue body did not match the SPEC-001 strict schema, so triage stopped before classification (no LLM fallback per UAT-013).\n\n'
+  printf 'verdict: needs-human (malformed body).\n\n'
+  printf 'Auto-triage parses the body deterministically without an LLM fallback, and this body does not match the expected schema. Triage stopped before classification.\n\n'
   printf 'parser error: `%s`\n\n' "$error_code"
   if [ -n "$missing_csv" ]; then
-    printf 'missing sections: `%s`\n\n' "$missing_csv"
+    printf 'missing or unparseable sections: `%s`\n\n' "$missing_csv"
   fi
   if [ -n "$malformed_csv" ]; then
     printf 'malformed sections: `%s`\n\n' "$malformed_csv"
   fi
-  printf 'Required schema: `## Symptom`, `## Classification`, `## Capture`, `## Reproduction context` plus YAML frontmatter (`class`, `gaia_version`, `created`).\n'
+  printf 'Required schema: four `##` headers — `## Symptom`, `## Classification`, `## Capture`, `## Reproduction context` — each with non-empty content. `## Classification` must include a `class: <tag>` line whose tag is one of: `init`, `update`, `wiki-sync`, `quality-gate`, `hook`, `scaffold`, `dev-server`, `other`. The forensics skill (`/gaia forensics`) emits this shape automatically.\n'
 } > "$comment_file"
 
 # Order:

--- a/.github/forensics/handlers/handle-needs-human.sh
+++ b/.github/forensics/handlers/handle-needs-human.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# handle-needs-human.sh — UAT-003 / UAT-005 / UAT-007 / UAT-014 action handler.
+# handle-needs-human.sh — needs-human triage handler.
 #
 # Labels a forensics-triaged issue as `needs-human` and posts a comment
 # that mentions the maintainer (@stevensacks), names the reason-code, and
@@ -13,8 +13,6 @@
 #
 # Exit code: 0 on success. Non-zero on bad usage, missing file, or unknown
 # reason-code. gh-level failures propagate.
-#
-# Contract: SPEC-002 UAT-003 / UAT-005 / UAT-007 / UAT-014.
 
 set -euo pipefail
 
@@ -33,20 +31,20 @@ reason_code="$3"
 
 [ -f "$reasoning_file" ] || { echo "handle-needs-human.sh: reasoning file not found: $reasoning_file" >&2; exit 2; }
 
-# Map reason-code → one-line UAT summary. The summary names which UAT
-# branch fired so the maintainer can locate the trigger condition fast.
+# Map reason-code → one-line summary describing why auto-triage handed
+# the issue back to the maintainer.
 case "$reason_code" in
   out-of-scope)
-    summary="proposed fix touches paths outside the auto-fix allowlist (UAT-007 / UAT-014)."
+    summary="proposed fix touches paths outside the auto-fix allowlist."
     ;;
   ambiguous-verdict)
-    summary="classifier verdict was missing or self-conflicting (UAT-003 case b)."
+    summary="classifier verdict was missing or self-conflicting."
     ;;
   malformed-body)
-    summary="issue body is missing or malformed against the SPEC-001 strict schema (UAT-013)."
+    summary="issue body does not match the expected forensics schema; the deterministic parser could not extract the required sections."
     ;;
   gate-failure)
-    summary="auto-fix branch failed the Quality Gate; branch was discarded (UAT-005)."
+    summary="auto-fix branch failed the Quality Gate; branch was discarded."
     ;;
   deviation)
     summary="the auto-fix model touched in-allowlist paths that were not declared in its proposed scope; the diff deviates from the classifier's intent."
@@ -78,8 +76,8 @@ comment_file="$work_dir/comment.md"
 #   1. Apply `needs-human` (the classification label).
 #   2. Post the comment.
 #   3. Apply `gaia-triaged` LAST (idempotency key).
-# The issue is NOT closed (UAT-003 / UAT-005 / UAT-007 / UAT-014 all
-# specify "issue stays open").
+# The issue is NOT closed — every needs-human path keeps the issue open
+# so the maintainer can triage by hand.
 gh issue edit "$issue_num" --add-label "needs-human"
 gh issue comment "$issue_num" --body-file "$comment_file"
 gh issue edit "$issue_num" --add-label "gaia-triaged"

--- a/.github/forensics/parse-issue-body.sh
+++ b/.github/forensics/parse-issue-body.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
-# parse-issue-body.sh — deterministic parser for the SPEC-001 strict
-# forensics issue body schema. Emits JSON to stdout.
+# parse-issue-body.sh — deterministic parser for the forensics issue
+# body. Emits JSON to stdout.
 #
 # Exit code: 0 always (consumers inspect the JSON `valid` field). Exit 2
 # is reserved for genuine script errors (missing input file, bad usage).
 #
 # POSIX-tools only: awk, sed, grep, bash. No jq, no yq, no python.
 #
-# Contract: SPEC-002 (UAT-009, UAT-013, UAT-015) and the body-parser
-# task spec at
-# `.gaia/local/plans/spec-002-forensics-triage-action/task-body-parser.md`.
+# Body schema:
+#   - Four `##` section headers, in any order, exactly matching:
+#     `## Symptom`, `## Classification`, `## Capture`, `## Reproduction context`.
+#   - Each section non-empty.
+#   - The `## Classification` section content includes a `class: <tag>` line
+#     whose value is one of the eight forensics taxonomy classes
+#     (`init|update|wiki-sync|quality-gate|hook|scaffold|dev-server|other`).
+#
+# The body may optionally lead with a YAML frontmatter block (`---` …
+# `---`). When present it supplies `class`, `gaia_version`, `created`,
+# and `gh_issue_url`. When absent — the shape `gh issue create` posts —
+# `class` is derived from the `## Classification` section content, and
+# the parser still emits the same JSON shape with empty / null values
+# for any frontmatter-only field.
 
 set -uo pipefail
 
@@ -43,76 +54,74 @@ work_dir=$(mktemp -d 2>/dev/null) || { echo "parse-issue-body.sh: mktemp failed"
 trap 'rm -rf "$work_dir"' EXIT
 
 # ---------------------------------------------------------------------------
-# Step 1: validate frontmatter shape and extract the required keys.
+# Step 1: opportunistically extract a YAML frontmatter block. Frontmatter
+# is optional — the GitHub-issue body shape ships without one, and the
+# parser derives `class` from `## Classification` later. The local file
+# shape (saved at `.gaia/local/forensics/<timestamp>-<class>.md`) keeps
+# the frontmatter, so the parser still picks up its values when present.
 # ---------------------------------------------------------------------------
-
-# First non-blank line (well, first line — SPEC-001 emits `---` as line 1)
-# must be the frontmatter sentinel.
-first_line=$(awk 'NR==1{print; exit}' "$input_file")
-awk_status=$?
-[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
-if [ "$first_line" != "---" ]; then
-  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
-  exit 0
-fi
-
-# Closing `---` line number (must be > 1, exact match).
-fm_end=$(awk 'NR>1 && $0=="---"{print NR; exit}' "$input_file")
-awk_status=$?
-[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
-if [ -z "${fm_end:-}" ]; then
-  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
-  exit 0
-fi
-
-# Frontmatter content lines (between line 2 and fm_end-1).
-awk -v end="$fm_end" 'NR>1 && NR<end' "$input_file" > "$work_dir/frontmatter.txt"
-awk_status=$?
-[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
 
 fm_class=""
 fm_gaia_version=""
 fm_created=""
 fm_gh_issue_url=""
+body_start=1
 
-# YAML-shaped key/value pairs. Accept `key: value` lines (first `: `
-# splits). Strip surrounding single or double quotes from value.
-while IFS= read -r line; do
-  case "$line" in
-    ''|'#'*) continue ;;
-  esac
-  key=$(printf '%s' "$line" | awk -F': ' '{print $1}')
-  value=$(printf '%s' "$line" | sed -n 's/^[^:]*:[[:space:]]*//p')
-  case "$value" in
-    \"*\") value=$(printf '%s' "$value" | sed -e 's/^"//' -e 's/"$//') ;;
-    \'*\') value=$(printf '%s' "$value" | sed -e "s/^'//" -e "s/'$//") ;;
-  esac
-  case "$key" in
-    class) fm_class="$value" ;;
-    gaia_version) fm_gaia_version="$value" ;;
-    created) fm_created="$value" ;;
-    gh_issue_url) fm_gh_issue_url="$value" ;;
-  esac
-done < "$work_dir/frontmatter.txt"
+first_line=$(awk 'NR==1{print; exit}' "$input_file")
+awk_status=$?
+[ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
 
-if [ -z "$fm_class" ] || [ -z "$fm_gaia_version" ] || [ -z "$fm_created" ]; then
-  printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
-  exit 0
+if [ "$first_line" = "---" ]; then
+  # Closing `---` line number (must be > 1, exact match). A frontmatter
+  # open without a matching close is still malformed — emit the same
+  # error as before so a hand-edited local file with a typo doesn't
+  # silently drop frontmatter values.
+  fm_end=$(awk 'NR>1 && $0=="---"{print NR; exit}' "$input_file")
+  awk_status=$?
+  [ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
+  if [ -z "${fm_end:-}" ]; then
+    printf '{"valid":false,"error":"malformed-frontmatter","missing":[],"malformed":["frontmatter"]}\n'
+    exit 0
+  fi
+
+  awk -v end="$fm_end" 'NR>1 && NR<end' "$input_file" > "$work_dir/frontmatter.txt"
+  awk_status=$?
+  [ "$awk_status" -ne 0 ] && emit_internal_error "frontmatter-extract" "$awk_status"
+
+  # YAML-shaped key/value pairs. Accept `key: value` lines (first `: `
+  # splits). Strip surrounding single or double quotes from value.
+  while IFS= read -r line; do
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+    key=$(printf '%s' "$line" | awk -F': ' '{print $1}')
+    value=$(printf '%s' "$line" | sed -n 's/^[^:]*:[[:space:]]*//p')
+    case "$value" in
+      \"*\") value=$(printf '%s' "$value" | sed -e 's/^"//' -e 's/"$//') ;;
+      \'*\') value=$(printf '%s' "$value" | sed -e "s/^'//" -e "s/'$//") ;;
+    esac
+    case "$key" in
+      class) fm_class="$value" ;;
+      gaia_version) fm_gaia_version="$value" ;;
+      created) fm_created="$value" ;;
+      gh_issue_url) fm_gh_issue_url="$value" ;;
+    esac
+  done < "$work_dir/frontmatter.txt"
+
+  body_start=$((fm_end + 1))
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: split the post-frontmatter body into per-section files. Detect
-# malformed `## ` headers (anything not in the canonical four).
+# Step 2: split the body into per-section files. Detect malformed `## `
+# headers (anything not in the canonical four).
 # ---------------------------------------------------------------------------
-
-body_start=$((fm_end + 1))
 
 # Single awk pass: route lines into per-section files; record the first
 # malformed header (if any) into a sentinel file.
 #
 # A section starts at `^## (Symptom|Classification|Capture|Reproduction context)$`
 # and ends at the next `^## ` line or EOF. Lines BEFORE the first valid
-# `## ` header are dropped (the SPEC-001 schema places the four sections
+# `## ` header are dropped (the schema places the four sections
 # back-to-back; nothing precedes them). Lines under a malformed header
 # are also dropped — the malformed header itself is reported.
 awk -v start="$body_start" -v out_dir="$work_dir" '
@@ -207,12 +216,11 @@ if [ -n "$missing_list" ]; then
 fi
 
 # Trim a single leading and a single trailing blank line per section.
-# (UAT-015 wants verbatim section *content*; the blank line that
-# typically separates a `## ` header from the first content line, and
-# the blank line that typically precedes the next `## ` header, are
-# markdown structure, not content. Stripping at most one such blank
-# line on each end keeps redaction tokens byte-identical while not
-# emitting trailing-newline noise.)
+# The blank line that typically separates a `## ` header from the
+# first content line, and the blank line that typically precedes the
+# next `## ` header, are markdown structure, not content. Stripping at
+# most one such blank line on each end keeps redaction tokens
+# byte-identical while not emitting trailing-newline noise.
 trim_one_blank_each_end() {
   local file="$1"
   awk '
@@ -258,6 +266,34 @@ if [ -n "$empty_list" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Step 3b: derive missing frontmatter values from body sections. Only
+# `class` is load-bearing downstream (the workflow uses it as the fix
+# branch slug). `gaia_version` is informational; left empty when not in
+# frontmatter and not declared as `gaia_version: <ver>` in `## Capture`.
+# ---------------------------------------------------------------------------
+
+if [ -z "$fm_class" ]; then
+  fm_class=$(awk -F':[[:space:]]*' '
+    /^class:[[:space:]]/ { print $2; exit }
+  ' "$work_dir/sec-classification.txt")
+  awk_status=$?
+  [ "$awk_status" -ne 0 ] && emit_internal_error "class-derive" "$awk_status"
+fi
+
+if [ -z "$fm_class" ]; then
+  printf '{"valid":false,"error":"missing-class","missing":["class"],"malformed":[]}\n'
+  exit 0
+fi
+
+if [ -z "$fm_gaia_version" ]; then
+  fm_gaia_version=$(awk -F':[[:space:]]*' '
+    /^gaia_version:[[:space:]]/ { print $2; exit }
+  ' "$work_dir/sec-capture.txt")
+  awk_status=$?
+  [ "$awk_status" -ne 0 ] && emit_internal_error "gaia-version-derive" "$awk_status"
+fi
+
+# ---------------------------------------------------------------------------
 # Step 4: emit success JSON. Every string value must be JSON-escaped.
 # ---------------------------------------------------------------------------
 
@@ -290,7 +326,7 @@ json_escape_file() {
         } else if (ord[c] < 32) {
           # Strip remaining 0x01–0x1f control bytes; not valid in JSON
           # strings without \uXXXX escaping, never expected from the
-          # SPEC-001 issue-body schema.
+          # issue-body schema.
         } else {
           printf "%s", c
         }

--- a/.github/forensics/tests/handlers.bats
+++ b/.github/forensics/tests/handlers.bats
@@ -227,24 +227,24 @@ first_captured_body() {
   grep -qF '@stevensacks' "$body_path"
 }
 
-@test "needs-human: comment names the reason-code out-of-scope (UAT-007/UAT-014)" {
+@test "needs-human: comment names the reason-code out-of-scope" {
   reasoning="$BATS_TEST_TMPDIR/r.md"
   printf 'x\n' > "$reasoning"
   run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" out-of-scope
   [ "$status" -eq 0 ]
   body_path="$(first_captured_body)"
   grep -qF 'out-of-scope' "$body_path"
-  grep -qF 'UAT-007' "$body_path"
+  grep -qF 'outside the auto-fix allowlist' "$body_path"
 }
 
-@test "needs-human: comment names the reason-code gate-failure (UAT-005)" {
+@test "needs-human: comment names the reason-code gate-failure" {
   reasoning="$BATS_TEST_TMPDIR/r.md"
   printf 'gate failure detail\n' > "$reasoning"
   run "$HANDLERS/handle-needs-human.sh" 42 "$reasoning" gate-failure
   [ "$status" -eq 0 ]
   body_path="$(first_captured_body)"
   grep -qF 'gate-failure' "$body_path"
-  grep -qF 'UAT-005' "$body_path"
+  grep -qF 'failed the Quality Gate' "$body_path"
 }
 
 @test "needs-human: comment names the reason-code ambiguous-verdict (UAT-003b)" {
@@ -411,7 +411,9 @@ first_captured_body() {
   grep -qF 'symptom' "$body_path"
   grep -qF 'capture' "$body_path"
   grep -qF 'missing-section' "$body_path"
-  grep -qF 'UAT-013' "$body_path"
+  # User-facing comment must not surface internal UAT identifiers — they
+  # rot as UATs are renumbered and confuse adopters who file issues by hand.
+  ! grep -qE 'UAT-[0-9]+' "$body_path"
 }
 
 @test "malformed-body: comment names malformed sections from parser output" {

--- a/.github/forensics/tests/parse-issue-body.bats
+++ b/.github/forensics/tests/parse-issue-body.bats
@@ -1,11 +1,13 @@
 #!/usr/bin/env bats
 # Tests for `.github/forensics/parse-issue-body.sh`.
 #
-# Coverage targets the SPEC-002 UATs that touch body-parsing:
-#   UAT-009  deterministic regex extraction (no LLM)
-#   UAT-013  malformed body → needs-human signal (script returns
-#            valid=false with a precise error code)
-#   UAT-015  redaction tokens pass through verbatim
+# Coverage:
+#   - deterministic regex extraction (no LLM)
+#   - malformed body → needs-human signal (script returns
+#     valid=false with a precise error code)
+#   - redaction tokens pass through verbatim
+#   - frontmatter is optional; when absent, `class` is derived from
+#     the `## Classification` section content
 
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
@@ -90,11 +92,14 @@ setup() {
   [[ "$output" == *'"symptom"'* ]]
 }
 
-@test "missing frontmatter returns malformed-frontmatter" {
+@test "missing frontmatter still parses; class is derived from Classification" {
+  # Frontmatter is optional. The GH-issue body shape ships without one
+  # in some workflows; `class` is derived from the `class: <tag>` line
+  # inside the `## Classification` section instead.
   run "$PARSER" "$FIX/missing-frontmatter.md"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'"valid":false'* ]]
-  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+  [[ "$output" == *'"valid":true'* ]]
+  [[ "$output" == *'"class":"other"'* ]]
 }
 
 @test "malformed section header returns malformed-section-header" {
@@ -138,7 +143,11 @@ EOF
   [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
 }
 
-@test "frontmatter missing required key returns malformed-frontmatter" {
+@test "frontmatter missing class falls through to Classification derivation" {
+  # When the frontmatter doesn't carry `class:` and the `## Classification`
+  # section also lacks a `class: <tag>` line, the parser reports the
+  # missing class explicitly rather than treating it as a frontmatter
+  # problem — `class` is the one load-bearing field downstream.
   body_file="$BATS_TEST_TMPDIR/no-class.md"
   cat > "$body_file" <<'EOF'
 ---
@@ -165,7 +174,35 @@ EOF
   run "$PARSER" "$body_file"
   [ "$status" -eq 0 ]
   [[ "$output" == *'"valid":false'* ]]
-  [[ "$output" == *'"error":"malformed-frontmatter"'* ]]
+  [[ "$output" == *'"error":"missing-class"'* ]]
+}
+
+@test "frontmatterless body with class in Classification parses cleanly" {
+  body_file="$BATS_TEST_TMPDIR/no-fm.md"
+  cat > "$body_file" <<'EOF'
+## Symptom
+
+`/update-gaia` skipped a file even though the manifest declared it owned.
+
+## Classification
+
+class: update
+evidence: "three-way merge" + .gaia/manifest.json
+
+## Capture
+
+gaia_version: 1.4.2
+node: v22.0.0
+
+## Reproduction context
+
+Routine /update-deps run; downstream CI broke because a file was missing.
+EOF
+  run "$PARSER" "$body_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+  [[ "$output" == *'"class":"update"'* ]]
+  [[ "$output" == *'"gaia_version":"1.4.2"'* ]]
 }
 
 @test "empty section body returns empty-section" {


### PR DESCRIPTION
Closes #237

## Summary

Three coupled fixes — the `/update-gaia` bug that issue #237 names, plus two fixes to `/gaia forensics` itself so future forensics tickets land in a triage-able shape and stop leaking internal UAT identifiers to issue authors.

### 1. `/update-gaia` silent skip (the bug #237 reports)

Added a top-priority row to the three-way merge decision table in `.claude/skills/update-gaia/SKILL.md`:

| Class | Condition | Action | List |
|---|---|---|---|
| any | `A` missing and `L` exists | Copy `L` → `<path>` | `add[]` |

This runs before every class-specific row. It closes the silent-skip gap where `shared` / `wiki-owned` files with no upstream change (`B ≅ L`) short-circuited to no-op even though the adopter tree never had them — leaving manifest-declared files missing on disk and breaking downstream consumers (CI workflows, helper scripts) with no diagnostic.

### 2. Forensics writer / triage parser mismatch

`/gaia forensics` used to post the GH-issue body as "the post-frontmatter portion only", but the triage parser at `.github/forensics/parse-issue-body.sh` strictly required the `---` frontmatter block. Every filed issue (including #237) tripped the malformed-body short-circuit before classification.

- `.claude/skills/gaia/references/forensics.md` — writer now posts the full body (frontmatter + four sections), byte-identical to the local file.
- `.github/forensics/parse-issue-body.sh` — frontmatter is now optional as defense in depth. When absent, `class` is derived from the `class: <tag>` line in `## Classification`, and `gaia_version` from `## Capture`. The unused `created` field is no longer required. Same output JSON shape, so the workflow's `frontmatter.class` lookup is unchanged.

### 3. UAT identifiers leaking to user-facing comments

The triage comment on #237 read `verdict: needs-human (malformed body — UAT-013)` and `(no LLM fallback per UAT-013)`. UAT identifiers are internal SPEC fragments that rot as tests get renumbered; surfacing them in user comments adds noise without information.

- `.github/forensics/handlers/handle-malformed-body.sh` — replaced UAT references with plain-English explanation and a complete schema description (including the closed taxonomy set for `class:`).
- `.github/forensics/handlers/handle-needs-human.sh` — stripped UAT-003 / 005 / 007 / 013 / 014 from the reason-code summaries.
- Added a regression test that fails the malformed-body comment if any `UAT-N+` token reappears.

## Test plan

- [x] `bats .github/forensics/tests/parse-issue-body.bats` — 28/28 pass
- [x] `bats .github/forensics/tests/handlers.bats` — 37/37 pass
- [x] `bats .github/forensics/tests/*.bats` — all green
- [x] `bash .gaia/tests/forensics/run-all.sh` — only pre-existing redaction-roundtrip failures on main (verified by stash + re-run on main; unrelated to this change)
- [ ] Post-merge: file a fresh forensics ticket via `/gaia forensics` and confirm the triage workflow classifies cleanly without a malformed-body comment