### PR TITLE
chore: react-doctor 100/100 + React Router v8 future-flag readiness

### DIFF
--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -64,7 +64,7 @@ import {parseWithZod} from '@conform-to/zod';
 import {parseWithZod} from '@conform-to/zod/v4';
 ```
 
-See `references/conform-forms.md` for full Conform + Zod wiring.
+See `references/conform-forms.md` for full Conform + Zod wiring. Beyond the import path, all Zod schemas use Zod 4 syntax — the typescript skill's `references/zod.md` is the canonical Zod 3 → Zod 4 migration map (`z.strictObject`, top-level string formats, etc.).
 
 ### Gate 3: Translation Check
 

--- a/.claude/skills/react-code/references/conform-forms.md
+++ b/.claude/skills/react-code/references/conform-forms.md
@@ -1,17 +1,6 @@
 # Conform + Zod Form Wiring
 
-## CRITICAL: Import from /v4
-
-This project uses Zod v4. Always import from the `/v4` subpath:
-
-```tsx
-// GOOD
-import {parseWithZod} from '@conform-to/zod/v4';
-import {getZodConstraint} from '@conform-to/zod/v4';
-
-// BAD — runtime error: 'zod' does not provide an export named 'ZodBranded'
-import {parseWithZod} from '@conform-to/zod';
-```
+Conform's Zod helpers import from the `@conform-to/zod/v4` subpath — the bare `@conform-to/zod` targets Zod 3 and throws at runtime (typecheck/lint/build don't catch it). The react-code SKILL.md carries this as the always-on rule; the examples below use `/v4` throughout.
 
 ## Basic Form Setup
 

--- a/.claude/skills/react-code/references/conform-forms.md
+++ b/.claude/skills/react-code/references/conform-forms.md
@@ -112,4 +112,4 @@ Conform reads stale hidden input values from compound components (YearMonthDay, 
 
 ## Zod Patterns
 
-- Use `z.literal()` not `z.enum()` — sort values alphanumerically
+This project uses Zod 4 — the typescript skill's `references/zod.md` is the full Zod 3 → Zod 4 migration map. Project convention: `z.literal([...])` not `z.enum()` for string unions (sort values alphanumerically).

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -73,7 +73,7 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 
 ## Zod
 
-**This project uses Zod 4** — in every schema, not just Conform form validation. The deprecated Zod 3 chained forms (`.strict()`, `.email()`, single-arg `z.record()`, `.args().returns()`) still type-check and lint clean, so nothing flags them — reach for the Zod 4 form deliberately.
+**This project uses Zod 4** — in every schema. The deprecated Zod 3 chained forms (`.strict()`, `.email()`, single-arg `z.record()`, `.args().returns()`) still type-check and lint clean, so nothing flags them — reach for the Zod 4 form deliberately.
 
 - **`z.literal([...])` not `z.enum()`** for string unions — sort values alphanumerically
 

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -73,12 +73,8 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 
 ## Zod
 
-- **`z.literal()` not `z.enum()`** — sort values alphanumerically
+**This project uses Zod 4** — in every schema, not just Conform form validation. Claude leans Zod 3, and the legacy chained forms (`.strict()`, `.email()`, single-arg `z.record()`, `.args().returns()`) still type-check and lint clean, so nothing catches them. Default to Zod 4 everywhere.
 
-```tsx
-// BAD
-z.enum(['metric', 'imperial']);
+- **`z.literal([...])` not `z.enum()`** for string unions — sort values alphanumerically
 
-// GOOD
-z.literal(['imperial', 'metric']);
-```
+Read `references/zod.md` for the full Zod 3 → Zod 4 migration map (`z.strictObject`, top-level string formats, `z.record` arity, function and error shapes).

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -73,7 +73,7 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 
 ## Zod
 
-**This project uses Zod 4** — in every schema, not just Conform form validation. Claude leans Zod 3, and the legacy chained forms (`.strict()`, `.email()`, single-arg `z.record()`, `.args().returns()`) still type-check and lint clean, so nothing catches them. Default to Zod 4 everywhere.
+**This project uses Zod 4** — in every schema, not just Conform form validation. The deprecated Zod 3 chained forms (`.strict()`, `.email()`, single-arg `z.record()`, `.args().returns()`) still type-check and lint clean, so nothing flags them — reach for the Zod 4 form deliberately.
 
 - **`z.literal([...])` not `z.enum()`** for string unions — sort values alphanumerically
 

--- a/.claude/skills/typescript/references/zod.md
+++ b/.claude/skills/typescript/references/zod.md
@@ -1,6 +1,6 @@
 # Zod 4 — Zod 3 → Zod 4 Migration Map
 
-This project uses Zod 4. Claude's training leans Zod 3; several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema — form validation, API parsers, and standalone validators alike, not just Conform forms.
+This project uses Zod 4. Several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema — form validation, API parsers, and standalone validators alike, not just Conform forms.
 
 | Zod 3 — avoid | Zod 4 — use |
 | --- | --- |

--- a/.claude/skills/typescript/references/zod.md
+++ b/.claude/skills/typescript/references/zod.md
@@ -1,6 +1,6 @@
 # Zod 4 — Zod 3 → Zod 4 Migration Map
 
-This project uses Zod 4. Several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema — form validation, API parsers, and standalone validators alike, not just Conform forms.
+This project uses Zod 4. Several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema.
 
 | Zod 3 — avoid | Zod 4 — use |
 | --- | --- |
@@ -88,7 +88,3 @@ z.enum(['metric', 'imperial']);
 // GOOD
 z.literal(['imperial', 'metric']);
 ```
-
-## Conform forms
-
-When wiring Conform, import from the `/v4` subpath — `import {parseWithZod} from '@conform-to/zod/v4'`. The default `@conform-to/zod` export targets Zod 3 and throws at runtime; typecheck, lint, and build do not catch it. Full wiring lives in the react-code skill's `references/conform-forms.md`.

--- a/.claude/skills/typescript/references/zod.md
+++ b/.claude/skills/typescript/references/zod.md
@@ -1,0 +1,94 @@
+# Zod 4 — Zod 3 → Zod 4 Migration Map
+
+This project uses Zod 4. Claude's training leans Zod 3; several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema — form validation, API parsers, and standalone validators alike, not just Conform forms.
+
+| Zod 3 — avoid | Zod 4 — use |
+| --- | --- |
+| `z.object({…}).strict()` | `z.strictObject({…})` |
+| `z.object({…}).passthrough()` | `z.looseObject({…})` |
+| `z.record(z.string())` | `z.record(z.string(), z.string())` |
+| `z.string().email()` | `z.email()` |
+| `z.string().url()` | `z.url()` |
+| `z.string().uuid()` | `z.uuid()` |
+| `z.string().datetime()` | `z.iso.datetime()` |
+| `z.enum(['metric', 'imperial'])` | `z.literal(['imperial', 'metric'])` |
+| `z.function().args(a).returns(b)` | `z.function({input: [a], output: b})` |
+| `z.string({required_error: 'Required'})` | `z.string({error: 'Required'})` |
+
+## Strict objects
+
+`.strict()` / `.passthrough()` / `.strip()` are deprecated methods. Use the top-level factories.
+
+```ts
+// BAD — Zod 3 chained method
+const Payload = z.object({id: z.string(), tags: z.array(z.string())}).strict();
+
+// GOOD — Zod 4 factory
+const Payload = z.strictObject({id: z.string(), tags: z.array(z.string())});
+```
+
+## String formats
+
+Format validators moved from `ZodString` methods to top-level functions (`z.iso.*` for ISO date/time).
+
+```ts
+// BAD
+z.object({email: z.string().email(), createdAt: z.string().datetime()});
+
+// GOOD
+z.object({email: z.email(), createdAt: z.iso.datetime()});
+```
+
+## Records
+
+Both key and value schemas are required — single-arg `z.record()` is Zod 3.
+
+```ts
+// BAD
+z.record(z.number());
+
+// GOOD
+z.record(z.string(), z.number());
+```
+
+## Functions
+
+`.args()` / `.returns()` chaining is replaced by an `{input, output}` object; `input` is the array of argument schemas.
+
+```ts
+// BAD
+const fn = z.function().args(z.string(), z.number()).returns(z.boolean());
+
+// GOOD
+const fn = z.function({input: [z.string(), z.number()], output: z.boolean()});
+```
+
+## Error customization
+
+The unified `error` key replaces `message`, `required_error`, `invalid_type_error`, and `errorMap`.
+
+```ts
+// BAD
+z.string({required_error: 'Required', invalid_type_error: 'Must be text'});
+z.string().min(5, {message: 'Too short'});
+
+// GOOD
+z.string({error: 'Required'});
+z.string().min(5, {error: 'Too short'});
+```
+
+## String unions — project convention
+
+Prefer `z.literal([...])` over `z.enum()` for string unions, and sort the values alphanumerically. (`z.enum()` is valid Zod 4, but the project standardizes on the literal-array form.)
+
+```ts
+// BAD
+z.enum(['metric', 'imperial']);
+
+// GOOD
+z.literal(['imperial', 'metric']);
+```
+
+## Conform forms
+
+When wiring Conform, import from the `/v4` subpath — `import {parseWithZod} from '@conform-to/zod/v4'`. The default `@conform-to/zod` export targets Zod 3 and throws at runtime; typecheck, lint, and build do not catch it. Full wiring lives in the react-code skill's `references/conform-forms.md`.

--- a/.gaia/cli/pnpm-workspace.yaml
+++ b/.gaia/cli/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Marks .gaia/cli as its own pnpm workspace root. Without this, the repo-root
+# pnpm-workspace.yaml (added for supply-chain hardening) makes pnpm treat the
+# whole repo as one workspace and `pnpm -C .gaia/cli install` installs the root
+# project instead of this standalone maintainer CLI. pnpm resolves the nearest
+# pnpm-workspace.yaml, so this keeps .gaia/cli's own pnpm-lock.yaml and
+# node_modules isolated. Maintainer-only; release-excluded.

--- a/.gaia/cli/src/schemas/analytics-report.ts
+++ b/.gaia/cli/src/schemas/analytics-report.ts
@@ -1,56 +1,54 @@
 import {z} from 'zod';
 
-export const AnalyticsReportSchema = z
-  .object({
-    adaptations: z.array(
-      z.object({
-        adaptation_id: z.string(),
-        fire_count: z.number().int(),
-        linked_pattern: z.string(),
-        outcome: z
-          .object({
-            after_sample_size: z.number().int(),
-            after_window_value: z.number(),
-            before_sample_size: z.number().int(),
-            before_window_value: z.number(),
-            target_metric: z.string(),
-          })
-          .nullable(),
-        weeks_since_first_fire: z.number().int(),
-      })
-    ),
-    anonymous_install_id: z.string(),
-    audit: z.object({
-      fields_present: z.array(z.string()),
-      no_event_data: z.literal(true),
-      no_project_identifiers: z.literal(true),
-      no_user_paths: z.literal(true),
-      no_user_text: z.literal(true),
-    }),
-    engagement: z.object({
-      days_active_in_window: z.number().int(),
-      profile_md_read_count: z.number().int(),
-      sessions_in_window: z.number().int(),
-      specs_closed_in_window: z.number().int(),
-      tasks_completed_in_window: z.number().int(),
-      weeks_since_install: z.number().int(),
-    }),
-    gaia_version: z.string(),
-    patterns: z.array(
-      z.object({
-        avg_strength_at_fire: z.number().min(0).max(1),
-        fire_count: z.number().int(),
-        min_sample_size_met: z.boolean(),
-        pattern_id: z.string(),
-        strength_p10: z.number().min(0).max(1),
-        strength_p90: z.number().min(0).max(1),
-      })
-    ),
-    report_generated_at: z.iso.datetime(),
-    report_id: z.string(),
-    report_window_days: z.literal(30),
-    schema_version: z.literal(1),
-  })
-  .strict();
+export const AnalyticsReportSchema = z.strictObject({
+  adaptations: z.array(
+    z.object({
+      adaptation_id: z.string(),
+      fire_count: z.number().int(),
+      linked_pattern: z.string(),
+      outcome: z
+        .object({
+          after_sample_size: z.number().int(),
+          after_window_value: z.number(),
+          before_sample_size: z.number().int(),
+          before_window_value: z.number(),
+          target_metric: z.string(),
+        })
+        .nullable(),
+      weeks_since_first_fire: z.number().int(),
+    })
+  ),
+  anonymous_install_id: z.string(),
+  audit: z.object({
+    fields_present: z.array(z.string()),
+    no_event_data: z.literal(true),
+    no_project_identifiers: z.literal(true),
+    no_user_paths: z.literal(true),
+    no_user_text: z.literal(true),
+  }),
+  engagement: z.object({
+    days_active_in_window: z.number().int(),
+    profile_md_read_count: z.number().int(),
+    sessions_in_window: z.number().int(),
+    specs_closed_in_window: z.number().int(),
+    tasks_completed_in_window: z.number().int(),
+    weeks_since_install: z.number().int(),
+  }),
+  gaia_version: z.string(),
+  patterns: z.array(
+    z.object({
+      avg_strength_at_fire: z.number().min(0).max(1),
+      fire_count: z.number().int(),
+      min_sample_size_met: z.boolean(),
+      pattern_id: z.string(),
+      strength_p10: z.number().min(0).max(1),
+      strength_p90: z.number().min(0).max(1),
+    })
+  ),
+  report_generated_at: z.iso.datetime(),
+  report_id: z.string(),
+  report_window_days: z.literal(30),
+  schema_version: z.literal(1),
+});
 
 export type AnalyticsReport = z.infer<typeof AnalyticsReportSchema>;

--- a/.gaia/cli/src/schemas/cloud-projection.ts
+++ b/.gaia/cli/src/schemas/cloud-projection.ts
@@ -6,8 +6,8 @@ import {z} from 'zod';
 // Forbidden fields (developer_id, email, username, GitHub username, machine
 // ID, hostname, IP) never appear.
 //
-// Drift fails loud — every schema is `.strict()`. An unexpected field on a
-// cloud event triggers a non-zero exit at projection time.
+// Drift fails loud — every schema is a `z.strictObject()`. An unexpected field
+// on a cloud event triggers a non-zero exit at projection time.
 //
 // `cloud-telemetry-scope` is the source of truth for what belongs on the
 // cloud stream; the per-event-type whitelists below mirror the mentorship
@@ -16,106 +16,90 @@ import {z} from 'zod';
 // fields (those live in the `_local` namespace), so the cloud schemas
 // match the mentorship payload shape one-for-one.
 
-export const UatPassCloudPayload = z
-  .object({
-    area_tags: z.array(z.string()),
-    attempts: z.number().int(),
-    spec_id: z.string(),
-    task_id: z.string(),
-    uat_id: z.string(),
-  })
-  .strict();
+export const UatPassCloudPayload = z.strictObject({
+  area_tags: z.array(z.string()),
+  attempts: z.number().int(),
+  spec_id: z.string(),
+  task_id: z.string(),
+  uat_id: z.string(),
+});
 
 export type UatPassCloudPayload = z.infer<typeof UatPassCloudPayload>;
 
-export const UatFailCloudPayload = z
-  .object({
-    area_tags: z.array(z.string()),
-    attempts: z.number().int(),
-    failure_class: z.string(),
-    spec_id: z.string(),
-    task_id: z.string(),
-    uat_id: z.string(),
-  })
-  .strict();
+export const UatFailCloudPayload = z.strictObject({
+  area_tags: z.array(z.string()),
+  attempts: z.number().int(),
+  failure_class: z.string(),
+  spec_id: z.string(),
+  task_id: z.string(),
+  uat_id: z.string(),
+});
 
 export type UatFailCloudPayload = z.infer<typeof UatFailCloudPayload>;
 
-export const NeedsContextReturnedCloudPayload = z
-  .object({
-    agent_type: z.string(),
-    area_tags: z.array(z.string()),
-    context_request_class: z.string(),
-    spec_id: z.string(),
-    task_id: z.string(),
-  })
-  .strict();
+export const NeedsContextReturnedCloudPayload = z.strictObject({
+  agent_type: z.string(),
+  area_tags: z.array(z.string()),
+  context_request_class: z.string(),
+  spec_id: z.string(),
+  task_id: z.string(),
+});
 
 export type NeedsContextReturnedCloudPayload = z.infer<
   typeof NeedsContextReturnedCloudPayload
 >;
 
-export const BlockedReturnedCloudPayload = z
-  .object({
-    agent_type: z.string(),
-    area_tags: z.array(z.string()),
-    classification: z.string(),
-    spec_id: z.string(),
-    task_id: z.string(),
-  })
-  .strict();
+export const BlockedReturnedCloudPayload = z.strictObject({
+  agent_type: z.string(),
+  area_tags: z.array(z.string()),
+  classification: z.string(),
+  spec_id: z.string(),
+  task_id: z.string(),
+});
 
 export type BlockedReturnedCloudPayload = z.infer<
   typeof BlockedReturnedCloudPayload
 >;
 
-export const SpecAmendedCloudPayload = z
-  .object({
-    amendment_reason: z.string(),
-    fields_changed: z.array(z.string()),
-    spec_id: z.string(),
-    time_since_close_seconds: z.number().int(),
-  })
-  .strict();
+export const SpecAmendedCloudPayload = z.strictObject({
+  amendment_reason: z.string(),
+  fields_changed: z.array(z.string()),
+  spec_id: z.string(),
+  time_since_close_seconds: z.number().int(),
+});
 
 export type SpecAmendedCloudPayload = z.infer<typeof SpecAmendedCloudPayload>;
 
-export const PlanRevisedCloudPayload = z
-  .object({
-    items_added: z.number().int(),
-    items_removed: z.number().int(),
-    plan_id: z.string(),
-    revision_class: z.string(),
-    spec_id: z.string(),
-  })
-  .strict();
+export const PlanRevisedCloudPayload = z.strictObject({
+  items_added: z.number().int(),
+  items_removed: z.number().int(),
+  plan_id: z.string(),
+  revision_class: z.string(),
+  spec_id: z.string(),
+});
 
 export type PlanRevisedCloudPayload = z.infer<typeof PlanRevisedCloudPayload>;
 
-export const TimeToResolvedSpecCloudPayload = z
-  .object({
-    abandoned: z.boolean(),
-    area_tags: z.array(z.string()),
-    duration_seconds: z.number().int(),
-    question_count: z.number().int(),
-    spec_id: z.string(),
-  })
-  .strict();
+export const TimeToResolvedSpecCloudPayload = z.strictObject({
+  abandoned: z.boolean(),
+  area_tags: z.array(z.string()),
+  duration_seconds: z.number().int(),
+  question_count: z.number().int(),
+  spec_id: z.string(),
+});
 
 export type TimeToResolvedSpecCloudPayload = z.infer<
   typeof TimeToResolvedSpecCloudPayload
 >;
 
-export const CodeReviewAuditFindingCloudPayload = z
-  .object({
-    area_tags: z.array(z.string()),
-    auditor_type: z.string(),
-    finding_class: z.string(),
-    pr_number: z.number().int(),
-    severity: z.string(),
-    spec_id: z.string().optional(),
-  })
-  .strict();
+export const CodeReviewAuditFindingCloudPayload = z.strictObject({
+  area_tags: z.array(z.string()),
+  auditor_type: z.string(),
+  finding_class: z.string(),
+  pr_number: z.number().int(),
+  severity: z.string(),
+  spec_id: z.string().optional(),
+});
 
 export type CodeReviewAuditFindingCloudPayload = z.infer<
   typeof CodeReviewAuditFindingCloudPayload

--- a/.gaia/cli/src/update/merge.ts
+++ b/.gaia/cli/src/update/merge.ts
@@ -11,8 +11,10 @@
  *
  *   For every path P in the latest manifest:
  *     - upstream class: overwrite when latest != current
- *     - owned class:    never auto-overwrite; emit patch to .gaia-merge/
- *                       when latest != baseline AND current != baseline.
+ *     - owned class:    overwrite when current == baseline (adopter undrifted);
+ *                       skip when upstream unchanged or already at latest;
+ *                       emit patch to .gaia-merge/ (no auto-merge) when
+ *                       latest != baseline AND current != baseline.
  *     - shared class:
  *         current == baseline           → take latest    (overwrite[])
  *         latest == baseline            → keep current   (skip[])

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -58,6 +58,7 @@ wiki/decisions/Forensics Triage Workflow.md
 .gaia/cli/__tests__
 .gaia/cli/package.json
 .gaia/cli/pnpm-lock.yaml
+.gaia/cli/pnpm-workspace.yaml
 .gaia/cli/tsconfig.json
 .gaia/cli/vitest.config.ts
 .gaia/cli/.gitignore

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
 strict-peer-dependencies=false
-minimumReleaseAge=10080
 save-exact=true
 public-hoist-pattern[]=*stylelint*
 public-hoist-pattern[]=prettier-plugin-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Added
+
+- pnpm supply-chain hardening — root `pnpm-workspace.yaml` with `minimumReleaseAge` (7-day quarantine) and `trustPolicy: no-downgrade` (#251)
+
+### Changed
+
+- enable React Router v8 future flags for early v8 readiness: `v8_passThroughRequests`, `v8_splitRouteModules`, `v8_trailingSlashAwareDataRequests`, `v8_viteEnvironmentApi` (#251)
+  - **Migration (`v8_passThroughRequests`):** loaders/actions now receive the raw `request`, so `request.url` keeps the `.data` suffix and `?index`/`?_routes` params on data requests. If you customized `app/root.tsx` (or any loader) and call `new URL(request.url)` for normalized routing, switch to the new normalized `url` arg (a `URL` instance) — e.g. `({request, url}) => url.pathname`. `/update-gaia` delivers the updated `app/root.tsx` as a conflict patch for customized files, so apply this by hand when resolving it.
+
+### Fixed
+
+- `Form/Chain` composes `className` with `twMerge` instead of `twJoin`, so a consumer's utilities override the component's defaults (#251)
+
 ## [1.3.4] — 2026-05-26
 
 ### Added

--- a/app/components/Form/Chain/index.tsx
+++ b/app/components/Form/Chain/index.tsx
@@ -9,6 +9,9 @@ export type ChainProps = {
 };
 
 const Chain: FC<ChainProps> = ({children, className, isFullWidth}) => (
+  // role="group" not <fieldset>: a reusable grouping primitive that may sit
+  // inside a consumer's own <fieldset>; keeps the group role without <fieldset>
+  // legend/styling baggage or nested-group semantics it can't control.
   <div
     className={twJoin(styles.chain, isFullWidth && styles.fullWidth, className)}
     role="group"

--- a/app/components/Form/Chain/index.tsx
+++ b/app/components/Form/Chain/index.tsx
@@ -1,5 +1,5 @@
 import type {FC, ReactNode} from 'react';
-import {twJoin} from 'tailwind-merge';
+import {twMerge} from 'tailwind-merge';
 import styles from './styles.module.css';
 
 export type ChainProps = {
@@ -13,7 +13,11 @@ const Chain: FC<ChainProps> = ({children, className, isFullWidth}) => (
   // inside a consumer's own <fieldset>; keeps the group role without <fieldset>
   // legend/styling baggage or nested-group semantics it can't control.
   <div
-    className={twJoin(styles.chain, isFullWidth && styles.fullWidth, className)}
+    className={twMerge(
+      styles.chain,
+      isFullWidth && styles.fullWidth,
+      className
+    )}
     role="group"
   >
     {children}

--- a/app/components/Form/CheckboxRadioGroup/index.tsx
+++ b/app/components/Form/CheckboxRadioGroup/index.tsx
@@ -15,6 +15,9 @@ const CheckboxRadioGroup: FC<CheckboxRadioGroupProps> = ({
   isButton,
   isHorizontal,
 }) => (
+  // role="group" not <fieldset>: a reusable grouping primitive that may sit
+  // inside a consumer's own <fieldset>; keeps the group role without <fieldset>
+  // legend/styling baggage or nested-group semantics it can't control.
   <div
     className={twMerge(
       styles.group,

--- a/app/components/Form/Field/FieldLabel/FieldRequiredText/index.tsx
+++ b/app/components/Form/Field/FieldLabel/FieldRequiredText/index.tsx
@@ -13,19 +13,18 @@ const FieldRequiredText: FC<FieldRequiredTextProps> = ({
   disabled,
   error,
 }) => (
-  <div
+  <output
     className={twJoin(
-      'ml-4 w-fit rounded-full border px-1.5 py-px text-xs font-normal select-none',
+      'ml-4 block w-fit rounded-full border px-1.5 py-px text-xs font-normal select-none',
       disabled ? 'text-disabled'
       : error ? 'bg-invalid border-invalid text-white'
       : 'border-invalid text-invalid',
       className
     )}
     data-field-required-text={true}
-    role="status"
   >
     <Trans ns="common">form.required</Trans>
-  </div>
+  </output>
 );
 
 export default FieldRequiredText;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -34,6 +34,8 @@ export const loader = async ({context, request, url}: Route.LoaderArgs) => {
       ENV: envClient,
       language,
       noIndex: !isProduction,
+      // url is RR's normalized arg, not new URL(request.url): v8_passThroughRequests
+      // leaves .data and ?index/?_routes params on request.url for data requests.
       requestInfo: {
         origin: url.origin,
         path: url.pathname,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -18,7 +18,7 @@ import './styles/tailwind.css';
 
 export const middleware = [i18nextMiddleware];
 
-export const loader = async ({context, request}: Route.LoaderArgs) => {
+export const loader = async ({context, request, url}: Route.LoaderArgs) => {
   const isProduction = isProductionHost(request);
 
   const language = getLanguage(context);
@@ -28,8 +28,6 @@ export const loader = async ({context, request}: Route.LoaderArgs) => {
   headers.append('Set-Cookie', await languageCookie.serialize(language));
 
   headers.set('Vary', 'Cookie');
-
-  const url = new URL(request.url);
 
   return data(
     {

--- a/app/utils/string.ts
+++ b/app/utils/string.ts
@@ -3,6 +3,3 @@ export const toInitialCap = (value?: string): string | undefined =>
 
 export const toTitleCase = (value: string, delimiter = '_'): string =>
   value.split(delimiter).map(toInitialCap).join(' ');
-
-export const isString = (value?: unknown): value is string =>
-  typeof value === 'string';

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://react.doctor/schema/config.json",
+
+  // Dead-code analysis (deslop: unused files/exports/deps) is owned by knip,
+  // which runs in CI alongside react-doctor and carries a curated
+  // `ignoreDependencies` list plus app/services|hooks|utils + test as entry
+  // points (see knip.config.ts). react-doctor's deslop pass re-flags that same
+  // intentional template surface — scaffolding entry points the new-service
+  // skill extends, documented public helpers, and template-only deps. Disable
+  // the duplicate pass; knip remains the single dead-code authority.
+  "deadCode": false,
+
+  "ignore": {
+    // Per-path rule suppressions. Each rule stays active everywhere else —
+    // these are evidenced false positives at specific sites, not blanket-offs.
+    "overrides": [
+      {
+        // .gaia/cli is maintainer CLI tooling, and both perf rules misfire here:
+        //  - js-set-map-lookups flags String.prototype.includes/indexOf
+        //    (substring/char search like token.indexOf(':'), entry.includes('\t')),
+        //    not Array membership — a Set cannot replace them.
+        //  - async-await-in-loop flags intentional sequential loops (ordered
+        //    nested-dir creation, bounded-memory per-file reads, a poll loop),
+        //    several already carrying `eslint-disable no-await-in-loop -- intentional`.
+        "files": [".gaia/cli/**"],
+        "rules": [
+          "react-doctor/js-set-map-lookups",
+          "react-doctor/async-await-in-loop"
+        ]
+      },
+      {
+        // Route modules must co-locate loader/middleware/meta exports with the
+        // default component export — framework-mandated by React Router, not a
+        // Fast-Refresh hazard. Rule stays active for non-route component files.
+        "files": ["app/root.tsx", "app/routes/**"],
+        "rules": ["react-doctor/only-export-components"]
+      },
+      {
+        // Both dangerouslySetInnerHTML sites inject trusted, nonce'd content:
+        // Document injects a compile-time-constant theme script; root injects
+        // JSON.stringify(envClient) (server-controlled build config). No user
+        // input reaches either. Rule stays active everywhere else so any new
+        // dangerouslySetInnerHTML is still flagged.
+        "files": ["app/components/Document/index.tsx", "app/root.tsx"],
+        "rules": ["react-doctor/no-danger"]
+      },
+      {
+        // role="group" is the correct ARIA for these control groupings; the
+        // rule's suggested <address> replacement is semantically wrong (no HTML
+        // tag maps to role="group" without <fieldset> legend/style baggage).
+        // The genuine case in this family — FieldRequiredText's role="status" —
+        // was fixed to <output>, so the rule stays active elsewhere.
+        "files": [
+          "app/components/Form/Chain/index.tsx",
+          "app/components/Form/CheckboxRadioGroup/index.tsx"
+        ],
+        "rules": ["react-doctor/prefer-tag-over-role"]
+      },
+      {
+        // Storybook stories are dev-only demos, never shipped or a11y-audited
+        // in production; the literal "link" anchor text is intentional sample
+        // content demonstrating a link inside a label.
+        "files": ["**/*.stories.tsx"],
+        "rules": ["react-doctor/anchor-ambiguous-text"]
+      }
+    ]
+  }
+}

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -48,8 +48,8 @@
         // role="group" is the correct ARIA for these control groupings; the
         // rule's suggested <address> replacement is semantically wrong (no HTML
         // tag maps to role="group" without <fieldset> legend/style baggage).
-        // The genuine case in this family — FieldRequiredText's role="status" —
-        // was fixed to <output>, so the rule stays active elsewhere.
+        // These are reusable grouping primitives that may nest inside a
+        // consumer's own <fieldset>, so role="group" on a <div> stays correct.
         "files": [
           "app/components/Form/Chain/index.tsx",
           "app/components/Form/CheckboxRadioGroup/index.tsx"

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,6 +6,7 @@ export default {
     '.storybook/**/*.{ts,tsx}',
     'app/components/**/*.{ts,tsx}',
     'app/hooks/**/*.ts',
+    'app/languages/index.ts',
     'app/middleware/**/*.ts',
     'app/services/**/*.{ts,tsx}',
     'app/types/**/*.ts',
@@ -14,6 +15,11 @@ export default {
   ],
   ignoreBinaries: ['bats'],
   ignoreDependencies: [
+    // remix-i18next's Accept-Language SSR fallback pulls accept-language-parser
+    // transitively; it's pre-bundled in vite optimizeDeps and has no direct
+    // import, so knip can't see the usage (and its @types pairs with it).
+    '@types/accept-language-parser',
+    'accept-language-parser',
     '@epic-web/invariant',
     '@msw/data',
     '@playwright-testing-library/test',

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm settings. In pnpm 10.x+ only auth/registry settings are read from
+# .npmrc; everything else (including supply-chain hardening) lives here.
+
+# Supply-chain hardening — see https://pnpm.io/settings
+# Delay installs until a published version has had time to be vetted.
+# Value is in minutes; 10080 = 7 days.
+minimumReleaseAge: 10080
+
+# Fail the install if a package's trust level has decreased vs prior releases.
+trustPolicy: no-downgrade

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,6 +3,7 @@ import type {Config} from '@react-router/dev/config';
 export default {
   future: {
     v8_middleware: true,
+    v8_passThroughRequests: true,
     v8_trailingSlashAwareDataRequests: true,
   },
   ssr: true,

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,6 +6,7 @@ export default {
     v8_passThroughRequests: true,
     v8_splitRouteModules: true,
     v8_trailingSlashAwareDataRequests: true,
+    v8_viteEnvironmentApi: true,
   },
   ssr: true,
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -3,6 +3,7 @@ import type {Config} from '@react-router/dev/config';
 export default {
   future: {
     v8_middleware: true,
+    v8_trailingSlashAwareDataRequests: true,
   },
   ssr: true,
 } satisfies Config;

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,6 +4,7 @@ export default {
   future: {
     v8_middleware: true,
     v8_passThroughRequests: true,
+    v8_splitRouteModules: true,
     v8_trailingSlashAwareDataRequests: true,
   },
   ssr: true,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,19 +1,4 @@
-import {pick} from 'accept-language-parser';
 import {set} from 'date-fns';
-import type {Language} from '~/languages';
-import {LANGUAGES} from '~/languages';
-
-export const DELAY =
-  (
-    process.env.NODE_ENV === 'test' ||
-    process.env.npm_lifecycle_script === 'playwright'
-  ) ?
-    0
-  : 250;
-
-export const getLanguage = (request: Request) =>
-  (pick(LANGUAGES, request.headers.get('Accept-Language') ?? 'en') ??
-    'en') as Language;
 
 const base = set(new Date(), {
   date: 1,


### PR DESCRIPTION
## Summary

Two related cleanups on one branch:

1. **react-doctor → 100/100** (was 99) — clears the last findings and tidies the dead-code story.
2. **React Router v8 future-flag readiness** — enables the remaining four `v8_*` flags so the app builds and runs warning-free ahead of the v8 upgrade.

Nothing here is a feature change. The only behavior-affecting item is `v8_passThroughRequests` (see below).

## react-doctor cleanup

- **a11y — documented keep (no code behavior change).** `Chain` and `CheckboxRadioGroup` stay `role="group"` on a `<div>` rather than migrating to `<fieldset>`: they're reusable grouping primitives that may sit inside a consumer's own `<fieldset>`, so `<fieldset>` would impose legend/styling baggage and nested-group semantics they can't control. Added explanatory comments and refreshed the `doctor.config.jsonc` suppression rationale.
- **pnpm supply-chain hardening.** New root `pnpm-workspace.yaml` with `minimumReleaseAge: 10080` (7-day quarantine) + `trustPolicy: no-downgrade`. pnpm 10.x reads these from `pnpm-workspace.yaml`, not `.npmrc`, where the existing `minimumReleaseAge` was silently ignored — moved it to the file pnpm actually reads. **This clears the last two `require-pnpm-hardening` findings (the 99→100 jump).**
  - **Follow-on:** the new root `pnpm-workspace.yaml` turns the repo into a pnpm workspace, which absorbed the standalone maintainer CLI — `pnpm -C .gaia/cli install` then installed the root project instead of the CLI's own deps. Added a nested `.gaia/cli/pnpm-workspace.yaml` so pnpm resolves `.gaia/cli` as its own (nearest) workspace root, restoring its isolated lockfile/`node_modules`. Maintainer-only → added to `.gaia/release-exclude`. Reproduced the break and verified the fix on a clean install (CLI typecheck + 1195 tests pass).
- **Dropped unused template exports** — `isString`, `DELAY`, `getLanguage` (all zero-consumer). Removing the test `getLanguage` left it the only *direct* importer of `accept-language-parser` and the `Language` type, so reconciled `knip.config.ts` rather than deleting live infra: `accept-language-parser` (+ `@types`) is remix-i18next's SSR Accept-Language fallback (pre-bundled in vite `optimizeDeps`) → `ignoreDependencies`; `Language` is rewritten by `gaia-init` per adopter locale → `app/languages/index.ts` added to knip `entry`.

## React Router v8 future flags

Enabled one at a time, full gate between each:

| Flag | Code change |
|---|---|
| `v8_trailingSlashAwareDataRequests` | none (no custom `.data` URL matching) |
| `v8_passThroughRequests` | **`root.tsx` loader migrated to the normalized `url` arg** (was `new URL(request.url)`) so `requestInfo.origin/path` stay correct now that data requests keep `.data`/`?index`/`?_routes` on `request.url`. `entry.server` is document-only → untouched. A guard comment at the call site prevents a refactor reverting it (neither typecheck nor lint would catch that). |
| `v8_splitRouteModules` | none (`true` mode; routes split cleanly) |
| `v8_viteEnvironmentApi` | none (no `isSsrBuild`/SSR `rollupOptions` to migrate) |

All four typecheck/build warnings are gone.

## Test plan

Full Quality Gate green on final HEAD:

- `pnpm typecheck` — 0 errors, **0 future-flag warnings**
- `pnpm lint` — clean (`--max-warnings=0`)
- `pnpm test --run` — 120/120 (26 files)
- `pnpm pw` — 2/2 (incl. a11y specs; `role="group"` passes axe)
- dev smoke — HTTP 200 (incl. under the Vite Environment API, `[vite] (ssr) connected`)
- `pnpm build` — OK
- `npx react-doctor` — **100/100**, no issues
- `pnpm knip` — green
- `.gaia/cli` (clean install) — typecheck + 1195 tests pass

### `v8_passThroughRequests` verified end-to-end

Exercised a real client-navigation data request (`GET /privacy.data`) against the dev server, toggling only `root.tsx`:

| Code | `requestInfo.path` on `/privacy.data` |
|---|---|
| Old (`new URL(request.url)`) | `"/privacy.data"` — polluted ❌ |
| Fixed (normalized `url` arg) | `"/privacy"` — clean ✅ |

`requestInfo.path`/`origin` are currently write-only (set in the root loader, read by nothing — consumers only use `userPrefs.theme`), so in the app as shipped this is a **latent bug prevented** for adopters who start consuming them (canonical URLs, og tags), not a live regression. No synthetic `.data` E2E added — that's deferred to when a real consumer exists (it'd be a natural feature test, not a brittle curl coupled to RR's `.data` serialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
