### PR TITLE
feat(csp): enforce Content-Security-Policy for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Changed
 
+- enforce the Content Security Policy in production — ship it under `Content-Security-Policy` instead of `Content-Security-Policy-Report-Only`. The react-router#15083 nonce gap that forced Report-Only is resolved; every streamed script now carries the per-request nonce (#253)
 - enable React Router v8 future flags for early v8 readiness: `v8_passThroughRequests`, `v8_splitRouteModules`, `v8_trailingSlashAwareDataRequests`, `v8_viteEnvironmentApi` (#251)
   - **Migration (`v8_passThroughRequests`):** loaders/actions now receive the raw `request`, so `request.url` keeps the `.data` suffix and `?index`/`?_routes` params on data requests. If you customized `app/root.tsx` (or any loader) and call `new URL(request.url)` for normalized routing, switch to the new normalized `url` arg (a `URL` instance) — e.g. `({request, url}) => url.pathname`. `/update-gaia` delivers the updated `app/root.tsx` as a conflict patch for customized files, so apply this by hand when resolving it.
 - `code-review-audit` CI reviews only the diff since the last clean audit instead of the full `origin/main...HEAD` diff on every push, cutting wall-clock on multi-push PRs. A new `.github/audit/resolve-audit-base.sh` resolves the most recent ancestor that passed a clean audit under the current `.gaia/VERSION`; it falls back to full scope when none exists, so it never skips uncleared code (#252)

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -117,12 +117,8 @@ const handleRequest = async (
 
           responseHeaders.set('Content-Type', 'text/html');
 
-          // Report-Only: React Router's production build does not apply the nonce
-          // to its single-fetch stream scripts, so enforcing would block
-          // hydration. Tracking: https://github.com/remix-run/react-router/issues/15083
-          // Switch the header name to 'Content-Security-Policy' to enforce once fixed.
           responseHeaders.set(
-            'Content-Security-Policy-Report-Only',
+            'Content-Security-Policy',
             getContentSecurityPolicy(nonce)
           );
 

--- a/wiki/decisions/Content Security Policy.md
+++ b/wiki/decisions/Content Security Policy.md
@@ -4,7 +4,7 @@ status: active
 priority: 2
 date: 2026-05-21
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-06-02
 tags: [decision, security, csp]
 ---
 
@@ -15,15 +15,15 @@ GAIA serves a per-request nonce-based Content Security Policy. `handleRequest`
 it through `NonceProvider` and `ServerRouter`; `getContentSecurityPolicy`
 (`app/utils/http.server.ts`) builds the policy string with that nonce.
 
-## Report-Only, not enforced
+## Enforced
 
-In production the policy ships under the `Content-Security-Policy-Report-Only`
-header rather than `Content-Security-Policy`. React Router's production build
-does not apply the nonce to its single-fetch stream scripts, so enforcing the
-policy blocks hydration. The constraint is upstream and tracked at
-https://github.com/remix-run/react-router/issues/15083. Enforcement is a
-one-line change — swap the header name in `app/entry.server.tsx` — once the
-upstream nonce gap closes.
+The policy ships under the enforcing `Content-Security-Policy` header. Every
+server-rendered and streamed script carries the per-request nonce — React
+Router's single-fetch stream scripts and post-shell chunks included — so
+enforcement does not block hydration. App-authored inline scripts read the
+nonce through `useNonce()`: the `window.process` ENV bootstrap in
+`app/root.tsx`, and the dark-mode probe plus `ScrollRestoration` / `Scripts` in
+`app/components/Document`.
 
 ## Trade-offs
 
@@ -35,8 +35,7 @@ upstream nonce gap closes.
   CSP protection becomes a requirement.
 - **No reporting endpoint.** The policy carries no `report-uri` / `report-to`
   directive. A violation-reporting pipeline is adopter-owned infrastructure,
-  out of scope for the template. Report-Only here is a parked state forced by
-  the upstream nonce gap, not a staging phase for collecting violation reports.
+  out of scope for the template.
 
 ## Code review
 


### PR DESCRIPTION
## What

Flip the CSP from **Report-Only** to **enforcing** for scripts: `Content-Security-Policy-Report-Only` → `Content-Security-Policy` in `app/entry.server.tsx`, and drop the now-stale comment block referencing [react-router#15083](https://github.com/remix-run/react-router/issues/15083).

## Why

The react-router#15083 workaround is resolved. On react-router 7.16.0 (prod build via `react-router-serve`), every `streamController.enqueue/close` script — including post-shell streamed chunks — carries the nonce and matches the CSP header. The workaround is no longer needed.

## Out of scope (intentionally untouched)

`getContentSecurityPolicy()` in `app/utils/http.server.ts` keeps `'unsafe-inline'` in `style-src` — the Google Fonts stylesheet injects an un-nonceable inline `<style>`. That's a deliberate, unrelated trade-off.

## Verification

- `pnpm build` ✅
- `PORT=3939 NODE_ENV=production pnpm start`, then curl `/` and `/privacy`:
  - response header is now `content-security-policy:` (not report-only) ✅
  - every `<script>` tag (7 per route, including post-shell streamed chunks) carries a nonce matching the per-request header nonce ✅
- Real Chromium load of `/` and `/privacy`: **0 console errors/warnings → 0 CSP violations**, hydration intact ✅

### Quality Gate

| Step | Result |
| --- | --- |
| Type checking | ✅ |
| Linting | ✅ zero warnings |
| Unit tests | ✅ 120/120 |
| E2E tests | ✅ 2/2 |
| Build | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)