### PR TITLE
docs(hooks): document useDebounce return semantics

### DIFF
--- a/app/hooks/useDebounce.ts
+++ b/app/hooks/useDebounce.ts
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 
+// Returns value only after it stops changing for delay ms; each change resets the timer
 export const useDebounce = <T>(value: T, delay: number): T => {
   const [debouncedValue, setDebouncedValue] = useState(value);
 

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d964864846133bb41e40ce5c34e3194ca8dcba1f",
-  "last_evaluated_at": "2026-05-26T14:40:42.058Z",
+  "last_evaluated_sha": "bc55b59770d72addf2d08100cf63d37a1f8fe54c",
+  "last_evaluated_at": "2026-06-01T21:17:43Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -3,7 +3,7 @@ type: meta
 title: Hot Cache
 status: active
 created: 2026-05-26
-updated: 2026-05-26
+updated: 2026-06-02
 tags: [meta, cache]
 ---
 
@@ -11,8 +11,22 @@ tags: [meta, cache]
 
 ## Last Updated
 
-2026-05-26. Released as GAIA v1.3.4. Fresh slate.
+2026-06-02. Unreleased work sits on top of GAIA v1.3.4.
+
+## Key Recent Facts
+
+- The two expensive required checks (`code-review-audit`, `Vitest and Playwright`) gate on the delta *since that check last passed green*, not the full PR diff — a passing code commit followed by a prose-only commit re-runs neither. `Run Chromatic` stays always-on. See [[Incremental CI Skipping]].
+- Content-Security-Policy ships enforcing (not Report-Only); every streamed script carries a per-request nonce. See [[Content Security Policy]].
+- React Router v8 future flags are enabled for readiness; pnpm supply-chain hardening adds `minimumReleaseAge` + `trustPolicy`. See [[pnpm]].
+
+## Recent Changes
+
+- #254 since-last-green CI gating (`resolve-check-base.sh`).
+- #253 CSP enforcement.
+- #252 incremental `code-review-audit` scope.
+- #251 RR v8 flags + pnpm hardening + react-doctor 100/100.
+- #250 dependency bumps + dev-only CVE overrides.
 
 ## Active Threads
 
-- None.
+- Live-testing the incremental CI skip on PR #255 (code → prose-only sequence).

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,4 +11,13 @@ tags: [meta, log]
 
 ## [v1.3.4] 2026-05-26 | Released
 
+- 2026-06-01 bc55b59 SKIP — one-line hook doc comment; Serena handles hook inventory
+- 2026-06-01 45dadb3 WORTHY — since-last-green CI gating → wiki/concepts/Incremental CI Skipping.md (current)
+- 2026-06-01 632382f WORTHY — CSP enforcement (Report-Only → enforcing) → wiki/decisions/Content Security Policy.md (current)
+- 2026-06-01 912b245 WORTHY — incremental code-review-audit scope → wiki/concepts/Code Review Audit CI.md + Incremental CI Skipping.md (current)
+- 2026-06-01 551d07d WORTHY — pnpm supply-chain hardening → wiki/decisions/pnpm.md; RR v8 future-flag readiness + react-doctor 100/100 (CHANGELOG-tracked)
+- 2026-06-01 ae366b7 SKIP — routine in-range dependency bumps + dev-only CVE overrides; CHANGELOG-tracked
+- 2026-06-01 7267eba SKIP — maintainer-only gaia-release tooling fix; no wiki body
+- 2026-06-01 a2901b0 SKIP — README copy update; no wiki body
+- 2026-06-01 2b1f8c6 SKIP — release semver-required chore; no wiki body
 See CHANGELOG.md for details.


### PR DESCRIPTION
## What

Adds a one-line comment documenting `useDebounce`'s return semantics (returns the value only after it stops changing for `delay` ms; each change resets the timer), matching the existing `//`-comment style on sibling hooks like `useComponentRect`.

## Why

This PR also serves as a live exercise of the incremental "since-last-green" CI gating (#254). The sequence is **code → prose on one branch**:

1. This commit — a small, audit-clean code change under `app/`. `Vitest and Playwright` and `code-review-audit` run in full and (should) go green, anchoring the last-green base.
2. A follow-up **prose-only** commit (`/gaia wiki sync` output: `wiki/**`, `CHANGELOG`) pushed after this commit is green. Both expensive checks should then **skip** — their un-passed delta touches no relevant files — while `Run Chromatic` behaves as before.

Verification of the skip behavior happens on the second push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)