### PR TITLE
fix(wiki): recover the un-evaluated window on sync re-anchor

### DIFF
--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -30,7 +30,7 @@ After the upstream lint finishes, run `gaia wiki state --json` and append a `## 
 gaia wiki state --json
 ```
 
-The CLI returns a JSON object with `drift_severity` (`none` | `low` | `medium` | `high`), `head_short`, `state_sha`, `commits_ahead`, `reachable`, and `recent_commits`. If the command exits non-zero with `state_missing` (or equivalent reason), append:
+The CLI returns a JSON object with `drift_severity` (`none` | `low` | `medium` | `high`), `head_short`, `state_sha`, `commits_ahead`, `reachable`, `recent_commits`, and `suggested_base`. If the command exits non-zero with `state_missing` (or equivalent reason), append:
 
 ```markdown
 ## #11: Wiki drift check
@@ -40,15 +40,15 @@ The CLI returns a JSON object with `drift_severity` (`none` | `low` | `medium` |
 
 Then stop the drift check.
 
-If `reachable === false`, append:
+If `reachable === false`, the recorded SHA was orphaned (the squash-merge flow replaces the evaluated branch SHA on every merge). Append — and surface `suggested_base` when the CLI resolved a recovery baseline so the reader knows the window is recoverable, not lost:
 
 ```markdown
 ## #11: Wiki drift check
 
-⚠ `wiki/.state.json` `last_evaluated_sha` (`<state_sha>`) is not reachable from HEAD (history rewritten or shallow clone). Run `/gaia wiki sync` to re-anchor.
+⚠ `wiki/.state.json` `last_evaluated_sha` (`<state_sha>`) is not reachable from HEAD (squashed/rewritten history). Run `/gaia wiki sync` — it resolves a recovery baseline (`<suggested_base>`) and evaluates the un-evaluated window.
 ```
 
-Then stop.
+When `suggested_base` is empty (no recoverable baseline), drop the parenthetical and say `it re-anchors to HEAD.` instead. Then stop.
 
 ### 2b. Classify and append
 

--- a/.claude/skills/gaia/references/wiki/sync.md
+++ b/.claude/skills/gaia/references/wiki/sync.md
@@ -10,12 +10,16 @@ Evaluate every commit between `wiki/.state.json` `last_evaluated_sha` and HEAD. 
 
 ## Step 1: Read state and compute drift
 
-Run `gaia wiki state --json` and parse the result. Use `head_short`, `state_sha`, `commits_ahead`, and `reachable` directly.
+Run `gaia wiki state --json` and parse the result. Use `head_short`, `state_sha`, `commits_ahead`, `reachable`, and `suggested_base` directly.
+
+Throughout this playbook, **the evaluation baseline** is the ref Steps 2, 3, and 8 evaluate from. On the normal path it is `last_evaluated_sha`; on the recovery path (below) it is `suggested_base`. Each branch states which.
 
 - If the command exits non-zero with a `state_missing` (or equivalent) reason, this is a fresh project (no prior sync). Treat the first commit as the baseline. Run `gaia wiki state-init "$(git rev-list --max-parents=0 HEAD | tail -1)"` to create `wiki/.state.json` with `{version, last_evaluated_sha, last_evaluated_at}`, then commit as `wiki: initialize state at {short_sha}`. Stop — no commits to evaluate yet.
 - If `commits_ahead === 0`: skip the evaluation pass (no commits to evaluate) but DO NOT exit yet — fall through to Step 9 (consolidate gate). The gate may still trigger consolidate based on accumulated page-adds since last consolidate run, even when this sync is a no-op. The Step 8 report still prints; just substitute `Wiki already in sync at {short_sha}.` for the regular summary block, then run Step 9.
-- If `reachable === false`: the recorded SHA is not in HEAD's history (rebase scenario). Re-anchor — run `gaia wiki state-bump last_evaluated_sha "$(git rev-parse HEAD)"`, then `gaia wiki log-prepend --sha "$(git rev-parse --short HEAD)" --decision RE_ANCHOR --reason "re-anchored after history rewrite"`, commit, exit. Skip Step 9 — re-anchor wipes drift baseline; running consolidate against an unreachable past makes no sense.
-- Otherwise proceed with the evaluation pass.
+- If `reachable === false`: the recorded `last_evaluated_sha` is not in HEAD's history. GAIA's squash-merge flow orphans it on **every** merge — the evaluated branch SHA is replaced by a new squash commit on `main` — so this is the common case, not just a manual rebase. Recover the un-evaluated window instead of discarding it:
+  - **Recovery path — when `suggested_base` is non-empty.** The CLI resolved `suggested_base` to the newest commit reachable from HEAD at or older than `last_evaluated_at` — a reachable baseline equivalent to where the orphaned SHA left off. Adopt `suggested_base` as the evaluation baseline and run the normal pass (Steps 2–9) from it. Do NOT jump to HEAD and do NOT log a `RE_ANCHOR` line — the window is evaluated, not abandoned. Step 6 advances `last_evaluated_sha` to HEAD as usual.
+  - **Fallback path — when `suggested_base` is empty.** Only when the CLI cannot resolve a baseline (no `last_evaluated_at`, or it predates all history) revert to the lossy-but-safe re-anchor: run `gaia wiki state-bump last_evaluated_sha "$(git rev-parse HEAD)"`, then `gaia wiki log-prepend --sha "$(git rev-parse --short HEAD)" --decision RE_ANCHOR --reason "re-anchored after history rewrite (no recoverable baseline)"`, commit, exit. Skip Step 9 — there is no recovered range to consolidate against.
+- Otherwise proceed with the evaluation pass on the normal baseline (`last_evaluated_sha`).
 
 ## Step 2: Drift cap check
 
@@ -29,13 +33,19 @@ If drift > 30 commits, ASK the user via `AskUserQuestion`:
 
 Only proceed automatically when drift ≤ 30.
 
+The drift count is `commits_ahead` on the normal path. On the recovery path `commits_ahead` is `0` (the recorded SHA is unreachable, so the CLI cannot count from it); use the recovered range size instead — `git rev-list --count <suggested_base>..HEAD` — and apply this same cap to it. A batch that landed since the last sync (worst case, a whole release) shows up here and is gated exactly like normal drift.
+
 ## Step 3: First-pass — classify commits
 
-Run:
+Run, using the evaluation baseline from Step 1 (normal path: `last_evaluated_sha`; recovery path: `suggested_base`):
 
 ```bash
-gaia wiki commit-classify --since $(jq -r .last_evaluated_sha wiki/.state.json) --json
+# Normal path: BASE=$(jq -r .last_evaluated_sha wiki/.state.json)
+# Recovery path: BASE=<suggested_base from `gaia wiki state --json`>
+gaia wiki commit-classify --since "$BASE" --json
 ```
+
+On the recovery path, classify from `suggested_base` — NOT the orphaned `last_evaluated_sha`. The orphaned SHA's `..HEAD` range is topologically unreliable after a squash; `suggested_base` is reachable and time-anchored.
 
 The CLI emits a deterministic `suggestion` field per commit (`WORTHY` or `SKIP`) along with `subject`, `body`, file stats, and `suggestion_reason`. Treat the `WORTHY` subset as candidates for deep-read. Trust the CLI's classification — do not re-derive WORTHY/SKIP rules in prose. Log the `suggestion_reason` verbatim alongside the decision in Step 5.
 
@@ -75,11 +85,16 @@ If a commit's diff turns out NOT to be wiki-worthy on closer inspection (e.g. su
 
 ## Step 5: Append to wiki/log.md
 
-For each commit (worthy or skipped), run:
+For each commit (worthy or skipped), first dedup against the existing ledger, then run:
 
 ```bash
+# Skip commits a prior sync already catalogued — avoids double-logging.
+# Grep the working-tree log so lines this sync already prepended count too.
+grep -qF "<short_sha>" wiki/log.md && continue
 gaia wiki log-prepend --sha <short_sha> --decision <WORTHY|SKIP> --reason "<one-line reason>"
 ```
+
+The dedup guard matters most on the recovery path (Step 1): the resolved `suggested_base` is time-anchored, so it can sit one or two commits behind a boundary a prior sync already logged. Skip any commit whose short SHA is already in `wiki/log.md` rather than appending a duplicate line.
 
 The CLI inserts a single canonical line `- <YYYY-MM-DD> <sha> <decision> — <reason>` at the top of `wiki/log.md` (after frontmatter), atomically, newest entries on top. Examples:
 
@@ -121,7 +136,7 @@ Print a brief summary:
 ```
 Wiki sync complete.
 
-  Range:    {state_sha}..{head_sha}
+  Range:    {baseline}..{head_sha}
   Total:    {N} commits
   Worthy:   {N_worthy}
   Skipped:  {N_skipped}
@@ -129,6 +144,8 @@ Wiki sync complete.
   ADRs created: {list, if any}
   State advanced to {head_sha}.
 ```
+
+`{baseline}` is `state_sha` on the normal path and `suggested_base` on the recovery path — the ref the range was actually evaluated from.
 
 (On the no-op path from Step 1's drift=0 branch: print `Wiki already in sync at {short_sha}.` instead of the block above.)
 
@@ -185,7 +202,8 @@ The router reads the last line and decides whether to invoke consolidate. The ga
 ### 9e. Edge cases
 
 - **Drift=0 sync (no commits since last sync).** Gate still runs. The page-add count is computed against `last_consolidated_sha`, not against the sync's evaluation range, so accumulated adds from earlier syncs may still meet threshold.
-- **Re-anchor (rebase).** Step 1 exits before Step 9. After re-anchor, the next sync's Step 6 will preserve any existing `last_consolidated_sha`; the gate resumes counting from there. If the anchor change put `last_consolidated_sha` upstream of HEAD by an unreachable path, the next gate's `git diff` returns empty → `false`. Acceptable; the maintainer can run consolidate manually.
+- **Recovery re-anchor (Step 1, `suggested_base` resolved).** The run goes through the full pass, so Step 9 executes normally — the recovered range is evaluated and the gate counts page-adds as usual.
+- **Fallback re-anchor (Step 1, `suggested_base` empty).** Step 1 exits before Step 9. After the fallback re-anchor, the next sync's Step 6 will preserve any existing `last_consolidated_sha`; the gate resumes counting from there. If the anchor change put `last_consolidated_sha` upstream of HEAD by an unreachable path, the next gate's `git diff` returns empty → `false`. Acceptable; the maintainer can run consolidate manually.
 - **Consolidate's own commits in the diff.** If a previous consolidate run produced commits that landed (retirements moving pages to `wiki/_archived/`, near-collision renames inside an active domain), those appear in the next gate's diff. `_archived/` is excluded by path. Renames inside an active domain show as added paths and may trigger a redundant consolidate fire. Living with that — the false positive is cheap (consolidate runs, finds nothing new, advances state, returns).
 
 ## Failure modes

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -15201,6 +15201,14 @@ var isReachable = (sha, cwd) => {
     return false;
   }
 };
+var ancestorBefore = (isoTimestamp, cwd) => {
+  const result = tryRunGit(
+    ["rev-list", "-1", `--before=${isoTimestamp}`, "HEAD"],
+    { cwd }
+  );
+  if (result === null) return "";
+  return result.trim();
+};
 var commitsAhead = (sha, cwd) => {
   const result = tryRunGit(["rev-list", "--count", `${sha}..HEAD`], { cwd });
   if (result === null) return 0;
@@ -19136,7 +19144,7 @@ import { existsSync as existsSync17, readdirSync, readFileSync as readFileSync15
 import path19 from "node:path";
 
 // src/schemas/analytics-report.ts
-var AnalyticsReportSchema = external_exports.object({
+var AnalyticsReportSchema = external_exports.strictObject({
   adaptations: external_exports.array(
     external_exports.object({
       adaptation_id: external_exports.string(),
@@ -19183,7 +19191,7 @@ var AnalyticsReportSchema = external_exports.object({
   report_id: external_exports.string(),
   report_window_days: external_exports.literal(30),
   schema_version: external_exports.literal(1)
-}).strict();
+});
 
 // src/mentorship/analytics-dry-run.ts
 var REPORT_GLOB = /^report-\d{4}-\d{2}-\d{2}\.json$/u;
@@ -24240,63 +24248,63 @@ var appendIdempotent = async (args) => {
 };
 
 // src/schemas/cloud-projection.ts
-var UatPassCloudPayload = external_exports.object({
+var UatPassCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   attempts: external_exports.number().int(),
   spec_id: external_exports.string(),
   task_id: external_exports.string(),
   uat_id: external_exports.string()
-}).strict();
-var UatFailCloudPayload = external_exports.object({
+});
+var UatFailCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   attempts: external_exports.number().int(),
   failure_class: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string(),
   uat_id: external_exports.string()
-}).strict();
-var NeedsContextReturnedCloudPayload = external_exports.object({
+});
+var NeedsContextReturnedCloudPayload = external_exports.strictObject({
   agent_type: external_exports.string(),
   area_tags: external_exports.array(external_exports.string()),
   context_request_class: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string()
-}).strict();
-var BlockedReturnedCloudPayload = external_exports.object({
+});
+var BlockedReturnedCloudPayload = external_exports.strictObject({
   agent_type: external_exports.string(),
   area_tags: external_exports.array(external_exports.string()),
   classification: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string()
-}).strict();
-var SpecAmendedCloudPayload = external_exports.object({
+});
+var SpecAmendedCloudPayload = external_exports.strictObject({
   amendment_reason: external_exports.string(),
   fields_changed: external_exports.array(external_exports.string()),
   spec_id: external_exports.string(),
   time_since_close_seconds: external_exports.number().int()
-}).strict();
-var PlanRevisedCloudPayload = external_exports.object({
+});
+var PlanRevisedCloudPayload = external_exports.strictObject({
   items_added: external_exports.number().int(),
   items_removed: external_exports.number().int(),
   plan_id: external_exports.string(),
   revision_class: external_exports.string(),
   spec_id: external_exports.string()
-}).strict();
-var TimeToResolvedSpecCloudPayload = external_exports.object({
+});
+var TimeToResolvedSpecCloudPayload = external_exports.strictObject({
   abandoned: external_exports.boolean(),
   area_tags: external_exports.array(external_exports.string()),
   duration_seconds: external_exports.number().int(),
   question_count: external_exports.number().int(),
   spec_id: external_exports.string()
-}).strict();
-var CodeReviewAuditFindingCloudPayload = external_exports.object({
+});
+var CodeReviewAuditFindingCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   auditor_type: external_exports.string(),
   finding_class: external_exports.string(),
   pr_number: external_exports.number().int(),
   severity: external_exports.string(),
   spec_id: external_exports.string().optional()
-}).strict();
+});
 var CloudPayloadByType = {
   blocked_returned: BlockedReturnedCloudPayload,
   code_review_audit_finding: CodeReviewAuditFindingCloudPayload,
@@ -27510,6 +27518,9 @@ var printHuman12 = (state, write) => {
     `  Reachable:      ${state.reachable ? "yes" : "no"}`,
     `  Drift:          ${state.commits_ahead} commits (${state.drift_severity})`
   ];
+  if (state.suggested_base !== "") {
+    lines.push(`  Recovery base:  ${state.suggested_base}`);
+  }
   if (state.recent_commits.length > 0) {
     lines.push("  Recent unsynced:");
     for (const commit of state.recent_commits) {
@@ -27559,6 +27570,7 @@ var run70 = (argv, options = {}) => {
   const statePath = path44.join(wikiRoot, ".state.json");
   const stateFile = readStateFile2(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? "";
+  const stateAt = stateFile?.last_evaluated_at ?? "";
   const head = headSha(repoRoot2);
   const headShort = shortSha(head, repoRoot2);
   const stateShort = stateSha === "" ? "" : shortSha(stateSha, repoRoot2);
@@ -27567,6 +27579,8 @@ var run70 = (argv, options = {}) => {
   const recent = stateSha === "" || !reachable ? [] : recentCommits(stateSha, repoRoot2, 5);
   const severity = classifySeverity(ahead);
   const counts = countDomainPages(wikiRoot);
+  const suggestedFull = !reachable && stateAt !== "" ? ancestorBefore(stateAt, repoRoot2) : "";
+  const suggestedBase = suggestedFull === "" ? "" : shortSha(suggestedFull, repoRoot2);
   const state = {
     commits_ahead: ahead,
     drift_severity: severity,
@@ -27574,7 +27588,8 @@ var run70 = (argv, options = {}) => {
     per_domain_page_counts: counts,
     reachable,
     recent_commits: recent,
-    state_sha: stateShort
+    state_sha: stateShort,
+    suggested_base: suggestedBase
   };
   if (json2) {
     write(`${JSON.stringify(state)}

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -15200,6 +15200,14 @@ var isReachable = (sha, cwd) => {
     return false;
   }
 };
+var ancestorBefore = (isoTimestamp, cwd) => {
+  const result = tryRunGit(
+    ["rev-list", "-1", `--before=${isoTimestamp}`, "HEAD"],
+    { cwd }
+  );
+  if (result === null) return "";
+  return result.trim();
+};
 var commitsAhead = (sha, cwd) => {
   const result = tryRunGit(["rev-list", "--count", `${sha}..HEAD`], { cwd });
   if (result === null) return 0;
@@ -18353,7 +18361,7 @@ import { existsSync as existsSync16, readdirSync, readFileSync as readFileSync14
 import path17 from "node:path";
 
 // src/schemas/analytics-report.ts
-var AnalyticsReportSchema = external_exports.object({
+var AnalyticsReportSchema = external_exports.strictObject({
   adaptations: external_exports.array(
     external_exports.object({
       adaptation_id: external_exports.string(),
@@ -18400,7 +18408,7 @@ var AnalyticsReportSchema = external_exports.object({
   report_id: external_exports.string(),
   report_window_days: external_exports.literal(30),
   schema_version: external_exports.literal(1)
-}).strict();
+});
 
 // src/mentorship/analytics-dry-run.ts
 var REPORT_GLOB = /^report-\d{4}-\d{2}-\d{2}\.json$/u;
@@ -20311,6 +20319,9 @@ var printHuman = (state, write) => {
     `  Reachable:      ${state.reachable ? "yes" : "no"}`,
     `  Drift:          ${state.commits_ahead} commits (${state.drift_severity})`
   ];
+  if (state.suggested_base !== "") {
+    lines.push(`  Recovery base:  ${state.suggested_base}`);
+  }
   if (state.recent_commits.length > 0) {
     lines.push("  Recent unsynced:");
     for (const commit of state.recent_commits) {
@@ -20360,6 +20371,7 @@ var run36 = (argv, options = {}) => {
   const statePath = path24.join(wikiRoot, ".state.json");
   const stateFile = readStateFile(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? "";
+  const stateAt = stateFile?.last_evaluated_at ?? "";
   const head = headSha(repoRoot2);
   const headShort = shortSha(head, repoRoot2);
   const stateShort = stateSha === "" ? "" : shortSha(stateSha, repoRoot2);
@@ -20368,6 +20380,8 @@ var run36 = (argv, options = {}) => {
   const recent = stateSha === "" || !reachable ? [] : recentCommits(stateSha, repoRoot2, 5);
   const severity = classifySeverity(ahead);
   const counts = countDomainPages(wikiRoot);
+  const suggestedFull = !reachable && stateAt !== "" ? ancestorBefore(stateAt, repoRoot2) : "";
+  const suggestedBase = suggestedFull === "" ? "" : shortSha(suggestedFull, repoRoot2);
   const state = {
     commits_ahead: ahead,
     drift_severity: severity,
@@ -20375,7 +20389,8 @@ var run36 = (argv, options = {}) => {
     per_domain_page_counts: counts,
     reachable,
     recent_commits: recent,
-    state_sha: stateShort
+    state_sha: stateShort,
+    suggested_base: suggestedBase
   };
   if (json3) {
     write(`${JSON.stringify(state)}
@@ -26963,63 +26978,63 @@ var appendIdempotent = async (args) => {
 };
 
 // src/schemas/cloud-projection.ts
-var UatPassCloudPayload = external_exports.object({
+var UatPassCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   attempts: external_exports.number().int(),
   spec_id: external_exports.string(),
   task_id: external_exports.string(),
   uat_id: external_exports.string()
-}).strict();
-var UatFailCloudPayload = external_exports.object({
+});
+var UatFailCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   attempts: external_exports.number().int(),
   failure_class: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string(),
   uat_id: external_exports.string()
-}).strict();
-var NeedsContextReturnedCloudPayload = external_exports.object({
+});
+var NeedsContextReturnedCloudPayload = external_exports.strictObject({
   agent_type: external_exports.string(),
   area_tags: external_exports.array(external_exports.string()),
   context_request_class: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string()
-}).strict();
-var BlockedReturnedCloudPayload = external_exports.object({
+});
+var BlockedReturnedCloudPayload = external_exports.strictObject({
   agent_type: external_exports.string(),
   area_tags: external_exports.array(external_exports.string()),
   classification: external_exports.string(),
   spec_id: external_exports.string(),
   task_id: external_exports.string()
-}).strict();
-var SpecAmendedCloudPayload = external_exports.object({
+});
+var SpecAmendedCloudPayload = external_exports.strictObject({
   amendment_reason: external_exports.string(),
   fields_changed: external_exports.array(external_exports.string()),
   spec_id: external_exports.string(),
   time_since_close_seconds: external_exports.number().int()
-}).strict();
-var PlanRevisedCloudPayload = external_exports.object({
+});
+var PlanRevisedCloudPayload = external_exports.strictObject({
   items_added: external_exports.number().int(),
   items_removed: external_exports.number().int(),
   plan_id: external_exports.string(),
   revision_class: external_exports.string(),
   spec_id: external_exports.string()
-}).strict();
-var TimeToResolvedSpecCloudPayload = external_exports.object({
+});
+var TimeToResolvedSpecCloudPayload = external_exports.strictObject({
   abandoned: external_exports.boolean(),
   area_tags: external_exports.array(external_exports.string()),
   duration_seconds: external_exports.number().int(),
   question_count: external_exports.number().int(),
   spec_id: external_exports.string()
-}).strict();
-var CodeReviewAuditFindingCloudPayload = external_exports.object({
+});
+var CodeReviewAuditFindingCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   auditor_type: external_exports.string(),
   finding_class: external_exports.string(),
   pr_number: external_exports.number().int(),
   severity: external_exports.string(),
   spec_id: external_exports.string().optional()
-}).strict();
+});
 var CloudPayloadByType = {
   blocked_returned: BlockedReturnedCloudPayload,
   code_review_audit_finding: CodeReviewAuditFindingCloudPayload,

--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -11,6 +11,14 @@ import {run} from './state.js';
 type Sandbox = {
   cleanup: () => void;
   commit: (message: string, files: Record<string, string>) => string;
+  // Like `commit`, but pins author + committer date to `isoDate` so tests
+  // can exercise the `--before=<timestamp>` baseline resolution that backs
+  // `suggested_base`. `git rev-list --before` filters on committer date.
+  commitAt: (
+    message: string,
+    files: Record<string, string>,
+    isoDate: string
+  ) => string;
   // Creates N empty commits in a single `git fast-import` spawn. The
   // sandbox `commit()` helper (write, add, commit, rev-parse) costs
   // 3-4 Node→git spawns per call; under full-suite contention each
@@ -47,6 +55,32 @@ const setupSandbox = (): Sandbox => {
     }).trim();
   };
 
+  const commitAt = (
+    message: string,
+    files: Record<string, string>,
+    isoDate: string
+  ): string => {
+    for (const [relativePath, contents] of Object.entries(files)) {
+      const absPath = path.join(root, relativePath);
+      mkdirSync(path.dirname(absPath), {recursive: true});
+      writeFileSync(absPath, contents, 'utf8');
+    }
+    execFileSync('git', ['add', '-A'], {cwd: root});
+    execFileSync('git', ['commit', '-q', '-m', message], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: isoDate,
+        GIT_COMMITTER_DATE: isoDate,
+      },
+    });
+
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+    }).trim();
+  };
+
   const commitEmptyChain = (count: number): void => {
     if (count <= 0) return;
     const lines: string[] = [];
@@ -75,10 +109,17 @@ const setupSandbox = (): Sandbox => {
       rmSync(root, {force: true, recursive: true});
     },
     commit,
+    commitAt,
     commitEmptyChain,
     root,
   };
 };
+
+const shortShaOf = (root: string, sha: string): string =>
+  execFileSync('git', ['rev-parse', '--short=7', sha], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim();
 
 const captureStdio = (): {
   errors: string[];
@@ -120,6 +161,18 @@ const writeStateFile = (root: string, sha: string): void => {
   );
 };
 
+const writeStateFileAt = (root: string, sha: string, at: string): void => {
+  writeFileSync(
+    path.join(root, 'wiki', '.state.json'),
+    `${JSON.stringify(
+      {version: 1, last_evaluated_sha: sha, last_evaluated_at: at},
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+};
+
 describe('wiki state', () => {
   let sandbox: Sandbox;
   let stdio: ReturnType<typeof captureStdio>;
@@ -153,7 +206,75 @@ describe('wiki state', () => {
     expect(json.reachable).toBe(true);
     expect(typeof json.head_short).toBe('string');
     expect((json.head_short as string).length).toBe(7);
+    // suggested_base only fires on the unreachable recovery path.
+    expect(json.suggested_base).toBe('');
   });
+
+  test('suggested_base resolves to newest reachable ancestor at/older than last_evaluated_at when unreachable', () => {
+    // Mirrors the squash-merge orphan: a sync evaluated up to an orphaned
+    // feature-branch SHA, recorded its timestamp, then the squash landed and
+    // replaced that SHA on main. Recovery resolves the baseline by time.
+    sandbox.commitAt('A', {'app/a.ts': 'a\n'}, '2026-01-01T00:00:00Z');
+    const shaB = sandbox.commitAt('B', {'app/b.ts': 'b\n'}, '2026-01-02T00:00:00Z');
+    sandbox.commitAt('C', {'app/c.ts': 'c\n'}, '2026-01-03T00:00:00Z');
+
+    // Orphan an evaluated-up-to SHA off B that never lands on main's history.
+    execFileSync('git', ['checkout', '-q', '-b', 'feat', shaB], {
+      cwd: sandbox.root,
+    });
+    const orphan = sandbox.commitAt(
+      'O',
+      {'app/o.ts': 'o\n'},
+      '2026-01-02T12:00:00Z'
+    );
+    execFileSync('git', ['checkout', '-q', 'main'], {cwd: sandbox.root});
+
+    // Evaluated up to the orphan at 12:00 on Jan 2 — newest reachable ancestor
+    // of HEAD at/older than that is B (Jan 2 00:00); C (Jan 3) is the window.
+    writeStateFileAt(sandbox.root, orphan, '2026-01-02T12:00:00Z');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const json = JSON.parse(stdio.outputs.join('').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(json.reachable).toBe(false);
+    expect(json.suggested_base).toBe(shortShaOf(sandbox.root, shaB));
+  }, 15_000);
+
+  test('suggested_base is empty when last_evaluated_at predates all history', () => {
+    const sha = sandbox.commitAt(
+      'A',
+      {'app/a.ts': 'a\n'},
+      '2026-01-01T00:00:00Z'
+    );
+    sandbox.commitAt('B', {'app/b.ts': 'b\n'}, '2026-01-02T00:00:00Z');
+
+    // Orphan SHA = the root commit, but record a timestamp older than any
+    // commit so `--before` resolves empty → fall back to jump-to-HEAD.
+    execFileSync('git', ['checkout', '-q', '-b', 'feat', sha], {
+      cwd: sandbox.root,
+    });
+    const orphan = sandbox.commitAt(
+      'O',
+      {'app/o.ts': 'o\n'},
+      '2026-01-01T06:00:00Z'
+    );
+    execFileSync('git', ['checkout', '-q', 'main'], {cwd: sandbox.root});
+    writeStateFileAt(sandbox.root, orphan, '2000-01-01T00:00:00Z');
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const json = JSON.parse(stdio.outputs.join('').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(json.reachable).toBe(false);
+    expect(json.suggested_base).toBe('');
+  }, 15_000);
 
   test('reports drift_severity low for 1-5 commits ahead', () => {
     const baseSha = sandbox.commit('initial', {'README.md': '# repo\n'});
@@ -223,6 +344,8 @@ describe('wiki state', () => {
     >;
     expect(json.reachable).toBe(false);
     expect(json.commits_ahead).toBe(0);
+    // No last_evaluated_at to anchor against → no recoverable baseline.
+    expect(json.suggested_base).toBe('');
   });
 
   test('returns per_domain_page_counts shaped object', () => {

--- a/.gaia/cli/src/wiki/state.ts
+++ b/.gaia/cli/src/wiki/state.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {
+  ancestorBefore,
   commitsAhead,
   headSha,
   isReachable,
@@ -44,6 +45,15 @@ export type WikiState = {
   reachable: boolean;
   recent_commits: RecentCommit[];
   state_sha: string;
+  /**
+   * When `reachable` is false, the short SHA of a reachable baseline to resume
+   * evaluation from — the newest ancestor of HEAD at or older than
+   * `last_evaluated_at`. Empty string when reachable, when the state file has
+   * no `last_evaluated_at`, or when the timestamp predates all history. The
+   * sync playbook uses it to recover the un-evaluated window after a squash- or
+   * rebase-merge orphans `last_evaluated_sha`, rather than discarding it.
+   */
+  suggested_base: string;
 };
 
 const classifySeverity = (commitCount: number): DriftSeverity => {
@@ -93,6 +103,7 @@ const countDomainPages = (wikiRoot: string): Record<string, number> => {
 };
 
 type StateFileShape = {
+  last_evaluated_at?: string;
   last_evaluated_sha?: string;
 };
 
@@ -115,6 +126,10 @@ const printHuman = (state: WikiState, write: (chunk: string) => void): void => {
     `  Reachable:      ${state.reachable ? 'yes' : 'no'}`,
     `  Drift:          ${state.commits_ahead} commits (${state.drift_severity})`,
   ];
+
+  if (state.suggested_base !== '') {
+    lines.push(`  Recovery base:  ${state.suggested_base}`);
+  }
 
   if (state.recent_commits.length > 0) {
     lines.push('  Recent unsynced:');
@@ -191,6 +206,7 @@ export const run = (
   const statePath = path.join(wikiRoot, '.state.json');
   const stateFile = readStateFile(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? '';
+  const stateAt = stateFile?.last_evaluated_at ?? '';
   const head = headSha(repoRoot);
   const headShort = shortSha(head, repoRoot);
   const stateShort = stateSha === '' ? '' : shortSha(stateSha, repoRoot);
@@ -201,6 +217,13 @@ export const run = (
     stateSha === '' || !reachable ? [] : recentCommits(stateSha, repoRoot, 5);
   const severity = classifySeverity(ahead);
   const counts = countDomainPages(wikiRoot);
+  // Only the unreachable path needs a recovery baseline. When the recorded SHA
+  // is still in HEAD's history, the normal `last_evaluated_sha..HEAD` range is
+  // correct; suggested_base stays empty so consumers ignore it.
+  const suggestedFull =
+    !reachable && stateAt !== '' ? ancestorBefore(stateAt, repoRoot) : '';
+  const suggestedBase =
+    suggestedFull === '' ? '' : shortSha(suggestedFull, repoRoot);
 
   const state: WikiState = {
     commits_ahead: ahead,
@@ -210,6 +233,7 @@ export const run = (
     reachable,
     recent_commits: recent,
     state_sha: stateShort,
+    suggested_base: suggestedBase,
   };
 
   if (json) {

--- a/.gaia/cli/src/wiki/util/git.ts
+++ b/.gaia/cli/src/wiki/util/git.ts
@@ -69,6 +69,28 @@ export const isReachable = (sha: string, cwd: string): boolean => {
   }
 };
 
+/**
+ * Resolve the newest commit reachable from HEAD whose committer date is at or
+ * older than `isoTimestamp` (`git rev-list -1 --before=<ts> HEAD`).
+ *
+ * Used to recover a reachable evaluation baseline after a squash- or
+ * rebase-merge orphans the recorded `last_evaluated_sha`: the orphaned SHA is
+ * gone from HEAD's history, but the timestamp it was recorded with still maps
+ * to the commit the last sync stopped at. Returns '' when nothing matches (the
+ * timestamp predates all history) or on git failure — the caller falls back to
+ * the lossy jump-to-HEAD re-anchor in that case.
+ */
+export const ancestorBefore = (isoTimestamp: string, cwd: string): string => {
+  const result = tryRunGit(
+    ['rev-list', '-1', `--before=${isoTimestamp}`, 'HEAD'],
+    {cwd}
+  );
+
+  if (result === null) return '';
+
+  return result.trim();
+};
+
 /** Count commits in `<sha>..HEAD`. Returns 0 if `sha` is unreachable. */
 export const commitsAhead = (sha: string, cwd: string): number => {
   const result = tryRunGit(['rev-list', '--count', `${sha}..HEAD`], {cwd});

--- a/wiki/concepts/Wiki Sync.md
+++ b/wiki/concepts/Wiki Sync.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-03
-updated: 2026-05-06
+updated: 2026-06-02
 tags: [concept, claude, workflow, wiki]
 ---
 
@@ -47,6 +47,8 @@ This handles the case that broke the previous design (`wiki-update-evaluator.sh`
 ```
 
 `last_evaluated_sha` is the commit through which `/gaia wiki sync` has fully evaluated. Drift = `git rev-list --count <last_evaluated_sha>..HEAD`.
+
+`last_evaluated_at` is the timestamp of that evaluation, and it anchors recovery. Because a SHA is fragile under squash- and rebase-merge — the recorded commit is replaced and becomes unreachable — the timestamp provides a stable second anchor: `gaia wiki state` resolves the newest commit reachable from HEAD at or older than `last_evaluated_at` and reports it as `suggested_base`, the baseline a recovering sync resumes from.
 
 `last_consolidated_sha` is owned by `/gaia wiki consolidate`. On the first sync that bootstraps this field, it is set to the new HEAD value, giving the consolidate gate a baseline to accumulate from.
 
@@ -106,7 +108,7 @@ You don't need to run it after every commit. The hooks let you defer with full v
 
 - **Mid-sync interruption.** `/gaia wiki sync` does not advance state on partial completion. The next sync resumes from the original `last_evaluated_sha`.
 - **`wiki/.state.json` corrupted.** `/gaia wiki sync` stops and asks — won't auto-rewrite over manual edits.
-- **Rebased history.** If `last_evaluated_sha` is no longer reachable, hooks silently skip; `/gaia wiki sync` re-anchors to HEAD on next run with a log entry.
+- **Orphaned baseline.** GAIA's squash-merge flow replaces the evaluated branch SHA with a new squash commit on every merge, so `last_evaluated_sha` is regularly unreachable from HEAD — not just after a manual rebase. The hooks silently skip while it is unreachable. `/gaia wiki sync` recovers the un-evaluated window: it resolves a reachable baseline (the newest commit at or older than `last_evaluated_at`) and runs the normal evaluation pass from there, cataloguing every commit in between. Only when no baseline resolves — no `last_evaluated_at`, or it predates all history — does it fall back to a lossy re-anchor straight to HEAD with a `RE_ANCHOR` log entry.
 - **Concurrent syncs on different branches.** `wiki/log.md` will conflict on merge. Resolve by keeping both lines, sorted newest-first.
 
 ## Adopters

--- a/wiki/decisions/Wiki Management.md
+++ b/wiki/decisions/Wiki Management.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-05-07
 created: 2026-05-07
-updated: 2026-05-07
+updated: 2026-06-02
 tags: [decision, wiki, cli]
 ---
 
@@ -14,7 +14,7 @@ The wiki is critical infrastructure — it decays when drift between code and do
 
 ## Primitives
 
-**`gaia wiki state`** — Outputs current sync state: `head_sha`, `state_sha`, `commits_ahead` (drift count), and `reachable` (whether recorded SHA is in HEAD's history). Used by hooks and commands to detect when a sync is needed.
+**`gaia wiki state`** — Outputs current sync state: `head_sha`, `state_sha`, `commits_ahead` (drift count), `reachable` (whether recorded SHA is in HEAD's history), and `suggested_base`. When `reachable` is false, `suggested_base` is the newest commit reachable from HEAD at or older than `last_evaluated_at` — a recovery baseline that lets a sync resume the un-evaluated window after a squash- or rebase-merge orphans the recorded SHA, instead of discarding it. It is empty when reachable or when no baseline resolves. Used by hooks and commands to detect when a sync is needed.
 
 **`gaia wiki commit-classify`** — Evaluates commits since a baseline SHA. For each commit, outputs `suggestion` (`WORTHY` or `SKIP`) based on subject and file paths. WORTHY commits warrant deep-read and wiki update; SKIP commits can be logged without wiki edits. The classification is deterministic — same commit always produces the same suggestion.
 


### PR DESCRIPTION
## Problem

`wiki/.state.json`'s `last_evaluated_sha` is a commit SHA. GAIA's PR-only + squash-merge flow orphans it on **every** merge — the recorded branch SHA is replaced by a new squash commit on `main`. sync.md Step 1's `reachable === false` path re-anchored by jumping `last_evaluated_sha` to HEAD and logging a `RE_ANCHOR` line, **silently discarding every commit between the orphaned baseline and HEAD**. Negligible for one small PR; total loss of the window when a batch lands between syncs (worst case: the first sync after a release abandons that whole release's commits).

## Fix

`gaia wiki state` now emits **`suggested_base`** — the newest HEAD-reachable commit at or older than `last_evaluated_at` (new `ancestorBefore` git helper, computed only on the unreachable path). The sync recovery path adopts it as the evaluation baseline and runs the **normal** evaluation pass, cataloguing the window instead of dropping it. It falls back to the lossy jump-to-HEAD re-anchor **only** when no baseline resolves (missing `last_evaluated_at`, or it predates all history). General — covers any squash/rebase orphan, not just releases; no new state field.

- **Step 2** drift cap applies to the recovered range (`git rev-list --count <suggested_base>..HEAD`).
- **Step 5** dedups against `wiki/log.md` so a time-anchored baseline can't double-log a boundary a prior sync already catalogued.
- `commits_ahead`/`recent_commits` semantics **unchanged** → release `preflight` gate unaffected.

## Changed

- `.gaia/cli/src/wiki/util/git.ts` — `ancestorBefore()`
- `.gaia/cli/src/wiki/state.ts` — `suggested_base` field (+ human-readable line)
- `.gaia/cli/src/wiki/state.test.ts` — +3 cases (resolves / empty-no-timestamp / empty-predates-history)
- `.gaia/cli/gaia` + `.gaia/cli/gaia-maintainer` — rebundled binaries
- `.claude/skills/gaia/references/wiki/sync.md` (Steps 1/2/3/5/8/9), `lint.md`
- `wiki/concepts/Wiki Sync.md`, `wiki/decisions/Wiki Management.md`

## Verification

CLI: full `.gaia/cli` vitest **1197 passed / 1 skipped**, typecheck clean. App typecheck + lint clean (zero `app/` files touched).

Live bug fixture (read-only; `.state.json` preserved): `reachable:false` → `suggested_base:45dadb3` → recovered range = 1 commit (`e4a1ca0` #255), classified WORTHY, not in `log.md` → **catalogued, not RE_ANCHOR'd**. Exactly the commit the old path lost.

## Known follow-up (separate PR)

Release `preflight.ts` gates on `commits_ahead === 0`, which is hardcoded to `0` when `reachable === false` — so a release cut while wiki state is orphaned gets a green gate, blind to orphaned drift. Same root cause, different surface. Tracked for its own PR; this change is regression-free to that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)