### PR TITLE
feat(audit-ci): stamp GAIA-Audit status on out-of-scope skips

### DIFF
--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -465,6 +465,39 @@ jobs:
             --field context=GAIA-Audit \
             --field description="${version} ${tree_sha}"
 
+      - name: Write GAIA-Audit commit status (out-of-scope skip)
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.chore-deps.outputs.skip == 'false' &&
+          steps.source-changes.outputs.has_source == 'false'
+        run: |
+          set -eu
+          # Out-of-scope skip path: the un-audited delta touches no
+          # audit-relevant files, so the agent never runs and a local audit
+          # would find nothing in scope. Stamp a GAIA-Audit commit status on
+          # HEAD anyway so the merge hook (.claude/hooks/pr-merge-audit-check.sh)
+          # is satisfied without a ceremonial local run. has_source=='false'
+          # structurally excludes the already-audited path (has_source=='true'
+          # && trailer.skip) and the self-modification path (has_source=='true'
+          # && self_modified) — both require has_source=='true' — so neither
+          # auto-stamps. The description carries HEAD's tree (the merge hook
+          # checks tree equality against the content being merged), not a
+          # base/audit-sha tree.
+          version="$(tr -d '\r' < .gaia/VERSION | awk 'NF{print; exit}')"
+          version="${version#"${version%%[![:space:]]*}"}"
+          version="${version%"${version##*[![:space:]]}"}"
+          if [ -z "$version" ]; then
+            echo "code-review-audit: .gaia/VERSION missing/empty; skipping status." >&2
+            exit 0
+          fi
+          head_sha="$(git rev-parse HEAD)"
+          tree_sha="$(git rev-parse "HEAD^{tree}")"
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
+            --method POST \
+            --field state=success \
+            --field context=GAIA-Audit \
+            --field description="${version} ${tree_sha}"
+
       - name: Re-trigger and stamp required checks on new HEAD
         if: |
           steps.gate.outputs.gated == 'false' &&
@@ -658,7 +691,7 @@ jobs:
         run: |
           set -eu
           gh pr comment "$PR_NUMBER" \
-            --body "code-review-audit skipped: no audit-relevant files changed in the un-audited delta (since the last clean audit)"
+            --body "code-review-audit skipped: no audit-relevant files changed in the un-audited delta (since the last clean audit); GAIA-Audit commit status stamped on HEAD so the merge gate is satisfied with no local audit run"
 
       - name: Status — skipped (trailer matches)
         if: |

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -45,6 +45,10 @@ Other `chore:` prefixes (e.g. `chore: bump version`, `chore: tidy imports`) stil
 
 The `Check for source-code changes` step diffs only the **un-audited delta** — `<audit-base>...HEAD`, where `<audit-base>` is the most recent ancestor that already passed a clean audit (resolved by `.github/audit/resolve-audit-base.sh`, the same base the agent reviews). When that delta touches no audit-relevant files (TS/TSX/CSS under `app/`, tests, `.storybook`, workflow files, or root-level build/lint/test configs), the gate short-circuits and reports `code-review-audit` green. Because the base is the last clean-audited commit, a PR that audits clean and then adds a prose-only commit (wiki, CHANGELOG, instruction files) reviews an empty auditable delta and skips — it does not re-run on a tree whose code was already cleared. With no audited ancestor the base is `origin/main`, so the delta is the full PR diff and first-audit behavior is unchanged.
 
+On this skip path the `Write GAIA-Audit commit status (out-of-scope skip)` step stamps a `GAIA-Audit` commit status (`<version> <tree>`) on HEAD, mirroring the full-audit path's status. An out-of-scope PR (CLI-only, docs-only, wiki-only, `.claude`-only) therefore satisfies the [[PR Merge Workflow]] merge hook with no local audit run — the agent would find nothing in scope to review. The description carries HEAD's own tree, since the hook checks tree equality against the content being merged.
+
+The stamp fires on the out-of-scope reason only. The already-audited reason (the `GAIA-Audit:` trailer already matches, so a status is redundant) and the workflow-self-modification reason (auto-approving a change to the audit gate itself would be a security hole) do not stamp. The `has_source == 'false'` condition structurally enforces this: both other reasons require `has_source == 'true'`. A self-modifying PR — including one editing `code-review-audit.yml` — gets no auto-stamp and still needs a local marker to merge.
+
 This is the audit's instance of the cross-workflow mechanism in [[Incremental CI Skipping]].
 
 ## Adopter knobs

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-22
+updated: 2026-06-02
 tags: [concept, ci, review]
 ---
 
@@ -41,7 +41,7 @@ The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove
 | ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `.gaia/local/audit/<HEAD-sha>.ok`                                         | Local audit agent            | Agent writes it on a clean pass                                                                                   |
 | `GAIA-Audit:` commit-message trailer on HEAD                              | Local audit agent            | `audit-stamp-trailer.sh` writes an empty commit with the trailer                                                  |
-| `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this on the audit SHA (no empty marker commit is pushed — that would strand HEAD on a check-less commit). |
+| `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this after a full audit (on the audit SHA) and on HEAD when the un-audited delta is entirely out of audit scope. No empty marker commit is pushed — that would strand HEAD on a check-less commit. |
 | PR title matches `^chore\(deps(-dev)?\):` (bypass)                        | `/update-deps` wrapper       | Wrapper opens dep-bump PRs with the canonical prefix; the local quality gate stands in for the audit signal.      |
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.


### PR DESCRIPTION
## What

When the `code-review-audit` CI skips a PR because its **un-audited delta is entirely out of audit scope** (`has_source == 'false'`), stamp a `GAIA-Audit` commit status (`<version> <tree>`) on HEAD — mirroring the full-audit path's status. Out-of-scope PRs (CLI-only, docs-only, wiki-only, `.claude`-only) now merge hands-off instead of forcing a ceremonial local audit run that finds nothing in scope.

## Why

The merge gate (`.claude/hooks/pr-merge-audit-check.sh`) already accepts a CI `GAIA-Audit` commit status as a valid merge signal. But CI only emitted that status on the full-audit-ran path (`Write GAIA-Audit commit status`, gated on `trailer.skip == 'false'`). On the out-of-scope skip path it set the `code-review-audit` check green in ~7s yet stamped nothing — so every out-of-scope PR still required a local audit run to produce a marker. Pure ceremony.

## How

One new terminal step, `Write GAIA-Audit commit status (out-of-scope skip)`, stamps the status when **and only when**:

```
steps.gate.outputs.gated == 'false' &&
steps.chore-deps.outputs.skip == 'false' &&
steps.source-changes.outputs.has_source == 'false'
```

It mirrors the existing status step's API call and `.gaia/VERSION` derivation, but stamps HEAD's sha with HEAD's tree (`git rev-parse HEAD^{tree}`) — the equality the merge hook checks against the content being merged.

`has_source == 'false'` **structurally** excludes the other two skip reasons, both of which require `has_source == 'true'`:
- **already-audited** (`trailer.skip == 'true'`) — a matching trailer already exists; a status would be redundant.
- **self-modifies workflow** (`self_modified == 'true'`) — auto-approving a change to the audit gate itself is a security hole; it stays manual.

The merge hook (`pr-merge-audit-check.sh`) is **not** touched — it already accepts this signal. The existing terminal check behavior is intact: every code path still sets the `code-review-audit` check.

## Bootstrap wrinkle (expected, not a bug)

This PR edits `code-review-audit.yml`, so its own CI run hits the **self-mod** reason (`self_modified == 'true'`) and will **not** auto-stamp — it needs a local audit marker to merge. That is the built-in negative test confirming the self-mod reason does not auto-stamp.

## Verify

- **Negative (this PR):** its own merge requires a local marker — confirms self-mod stays manual.
- **Positive (next out-of-scope PR after this lands):** its CI run writes a `GAIA-Audit` status on HEAD, and `gh pr merge` is allowed with no local audit.

## Files

- `.github/workflows/code-review-audit.yml` — new out-of-scope-path stamp step + truthful skip comment.
- `wiki/concepts/PR Merge Workflow.md` — marker-signals table now notes the status is emitted on out-of-scope skips too.
- `wiki/concepts/Code Review Audit CI.md` — documents the new stamp and why the other two skip reasons don't fire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)