### PR TITLE
fix(release): detect orphaned wiki drift in preflight via suggested_base

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -28,7 +28,7 @@ The CLI surface is the source of truth. The classification rules for `.gaia/mani
 .gaia/cli/gaia-maintainer release preflight
 ```
 
-Verifies: on `main`, clean working tree, `wiki/.state.json` matches HEAD (per the `gaia wiki state --json` `commits_ahead === 0` contract). Exits non-zero with an explanation on any failure. STOP and report; the maintainer fixes (commit, push, run `/gaia wiki sync`) and re-runs `/gaia-release`.
+Verifies: on `main`, clean working tree, and `wiki/.state.json` is current. The wiki check reads `gaia wiki state --json`: a reachable state passes on `commits_ahead === 0`; an orphaned state (`reachable:false` — the normal post-squash-merge condition, where `commits_ahead` is hardcoded `0`) is re-evaluated over `suggested_base..HEAD` so an un-evaluated window isn't read as a silent zero. Either way, drift that is only wiki-sync squash artifacts passes; substantive drift exits non-zero with an explanation. STOP and report; the maintainer fixes (commit, push, run `/gaia wiki sync`) and re-runs `/gaia-release`.
 
 ### 2. Apply the bump
 

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20476,25 +20476,32 @@ var runWikiStateJson = (cwd) => {
     const parsed = JSON.parse(raw);
     const commitsAhead2 = parsed.commits_ahead;
     const stateSha = parsed.state_sha;
+    const reachable = parsed.reachable;
+    const suggestedBase = parsed.suggested_base;
     if (typeof commitsAhead2 !== "number") return null;
     return {
       commits_ahead: commitsAhead2,
-      state_sha: typeof stateSha === "string" ? stateSha : ""
+      // Default reachable to true on a malformed payload so the orphaned-state
+      // recovery never fires off bad input — the gate falls back to today's
+      // `commits_ahead` reading.
+      reachable: typeof reachable === "boolean" ? reachable : true,
+      state_sha: typeof stateSha === "string" ? stateSha : "",
+      suggested_base: typeof suggestedBase === "string" ? suggestedBase : ""
     };
   } catch {
     return null;
   }
 };
-var readDriftSubjects = (runner, cwd, stateSha) => {
-  if (stateSha === "") return null;
-  const resolved = runner(
-    "git",
-    ["rev-parse", "--verify", `${stateSha}^{commit}`],
-    { cwd }
-  );
-  if (resolved.error !== void 0 || (resolved.status ?? -1) !== 0)
-    return null;
-  const fullSha = (resolved.stdout ?? "").trim();
+var resolveCommit = (runner, cwd, sha) => {
+  if (sha === "") return "";
+  const resolved = runner("git", ["rev-parse", "--verify", `${sha}^{commit}`], {
+    cwd
+  });
+  if (resolved.error !== void 0 || (resolved.status ?? -1) !== 0) return "";
+  return (resolved.stdout ?? "").trim();
+};
+var readDriftSubjects = (runner, cwd, base) => {
+  const fullSha = resolveCommit(runner, cwd, base);
   if (fullSha === "") return null;
   const result = runner("git", ["log", "--format=%s", `${fullSha}..HEAD`], {
     cwd
@@ -20504,6 +20511,16 @@ var readDriftSubjects = (runner, cwd, stateSha) => {
     const trimmed = line.trim();
     return trimmed.length > 0 ? [trimmed] : [];
   });
+};
+var countDriftCommits = (runner, cwd, base) => {
+  const fullSha = resolveCommit(runner, cwd, base);
+  if (fullSha === "") return null;
+  const result = runner("git", ["rev-list", "--count", `${fullSha}..HEAD`], {
+    cwd
+  });
+  if (result.error !== void 0 || (result.status ?? -1) !== 0) return null;
+  const parsed = Number.parseInt((result.stdout ?? "").trim(), 10);
+  return Number.isInteger(parsed) ? parsed : null;
 };
 var run37 = (argv, options = {}) => {
   if (argv.length > 0 && HELP_TOKENS26.has(argv[0])) {
@@ -20556,19 +20573,31 @@ var run37 = (argv, options = {}) => {
       "preflight: failed to read wiki state via `gaia wiki state --json`"
     );
   }
-  if (wikiState.commits_ahead !== 0) {
-    const driftSubjects = readDriftSubjects(runner, cwd, wikiState.state_sha);
-    const benign = driftSubjects !== null && // Guards the vacuous-truth case: zero subjects with `commits_ahead > 0`
+  let driftCount = wikiState.commits_ahead;
+  let driftBase = wikiState.state_sha;
+  if (!wikiState.reachable && wikiState.suggested_base !== "") {
+    const recovered = countDriftCommits(runner, cwd, wikiState.suggested_base);
+    if (recovered === null) {
+      return refuse(
+        `preflight: cannot determine wiki drift from recovery base ${wikiState.suggested_base}; run /gaia wiki sync first`
+      );
+    }
+    driftCount = recovered;
+    driftBase = wikiState.suggested_base;
+  }
+  if (driftCount !== 0) {
+    const driftSubjects = readDriftSubjects(runner, cwd, driftBase);
+    const benign = driftSubjects !== null && // Guards the vacuous-truth case: zero subjects with `driftCount > 0`
     // means the range count disagrees with `git log` — a broken state, not
     // a benign one.
     driftSubjects.length > 0 && driftSubjects.every((subject) => subject.startsWith("wiki:"));
     if (!benign) {
       return refuse(
-        `preflight: wiki is ${wikiState.commits_ahead} commits behind HEAD; run /gaia wiki sync first`
+        `preflight: wiki is ${driftCount} commits behind HEAD; run /gaia wiki sync first`
       );
     }
     process.stderr.write(
-      `preflight: wiki drift is ${wikiState.commits_ahead} wiki-sync squash artifact(s); proceeding (content current)
+      `preflight: wiki drift is ${driftCount} wiki-sync squash artifact(s); proceeding (content current)
 `
     );
   }

--- a/.gaia/cli/src/release/preflight.test.ts
+++ b/.gaia/cli/src/release/preflight.test.ts
@@ -107,6 +107,22 @@ const DRIFT_RANGE = `${STATE_SHA}..HEAD`;
 /** `git rev-parse --verify` argument that resolves the state SHA. */
 const REVPARSE_ARGS = ['rev-parse', '--verify', `${STATE_SHA}^{commit}`];
 
+/**
+ * The recovery baseline `gaia wiki state` reports as `suggested_base` when the
+ * recorded SHA is orphaned (`reachable:false`) — an abbreviated SHA, like
+ * `state_sha`.
+ */
+const SUGGESTED_BASE = 'f6e5d4c3';
+/** `rev-parse --verify` resolves the abbreviated recovery base to a full SHA. */
+const SUGGESTED_FULL = 'f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5';
+const SUGGESTED_REVPARSE = [
+  'rev-parse',
+  '--verify',
+  `${SUGGESTED_BASE}^{commit}`,
+];
+const SUGGESTED_COUNT = ['rev-list', '--count', `${SUGGESTED_FULL}..HEAD`];
+const SUGGESTED_RANGE = `${SUGGESTED_FULL}..HEAD`;
+
 describe('release preflight', () => {
   let sandbox: Sandbox;
   let stdio: ReturnType<typeof captureStdio>;
@@ -138,7 +154,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(0);
     // Success: no stdout, no stderr.
@@ -162,7 +183,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('must be on main');
@@ -187,7 +213,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('working tree is dirty');
@@ -214,7 +245,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 2, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 2,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('wiki is 2 commits behind HEAD');
@@ -241,7 +277,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 1, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 1,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(0);
     expect(stdio.errors.join('')).toContain('wiki-sync squash artifact');
@@ -268,7 +309,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 2, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 2,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('wiki is 2 commits behind HEAD');
@@ -301,7 +347,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 1, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 1,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('wiki is 1 commits behind HEAD');
@@ -335,10 +386,204 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 1, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 1,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('wiki is 1 commits behind HEAD');
+  });
+
+  test('exit 1 when orphaned state recovers a window with substantive drift', () => {
+    // reachable:false is the normal post-squash-merge condition. `gaia wiki
+    // state` hardcodes commits_ahead:0 there, so the gate must recover the
+    // un-evaluated window from suggested_base..HEAD instead of reading the zero.
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {argv: ['status', '--porcelain=v1', '-uall'], result: okResult('')},
+        {argv: SUGGESTED_REVPARSE, result: okResult(`${SUGGESTED_FULL}\n`)},
+        {argv: SUGGESTED_COUNT, result: okResult('2\n')},
+        {
+          argv: ['log', '--format=%s', SUGGESTED_RANGE],
+          result: okResult('feat: a real change\nwiki: sync through abc1234\n'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runner,
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: false,
+        state_sha: STATE_SHA,
+        suggested_base: SUGGESTED_BASE,
+      }),
+    });
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('wiki is 2 commits behind HEAD');
+    // The orphaned state_sha range is topologically unreliable after a squash —
+    // the gate inspects suggested_base..HEAD, never state_sha..HEAD.
+    expect(recorded.some((call) => call.args.includes(SUGGESTED_RANGE))).toBe(
+      true
+    );
+    expect(recorded.some((call) => call.args.includes(DRIFT_RANGE))).toBe(false);
+  });
+
+  test('exit 0 when orphaned recovered window is only wiki-sync artifacts', () => {
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {argv: ['status', '--porcelain=v1', '-uall'], result: okResult('')},
+        {argv: SUGGESTED_REVPARSE, result: okResult(`${SUGGESTED_FULL}\n`)},
+        {argv: SUGGESTED_COUNT, result: okResult('1\n')},
+        {
+          argv: ['log', '--format=%s', SUGGESTED_RANGE],
+          result: okResult('wiki: sync through abc1234 (#173)\n'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runner,
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: false,
+        state_sha: STATE_SHA,
+        suggested_base: SUGGESTED_BASE,
+      }),
+    });
+    expect(exit).toBe(0);
+    expect(stdio.errors.join('')).toContain('wiki-sync squash artifact');
+  });
+
+  test('exit 0 when orphaned state has no recoverable baseline', () => {
+    // suggested_base empty means the timestamp predates all history — there is
+    // nothing un-evaluated to recover, so today's pass is preserved.
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {argv: ['status', '--porcelain=v1', '-uall'], result: okResult('')},
+      ],
+      recorded
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runner,
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: false,
+        state_sha: '',
+        suggested_base: '',
+      }),
+    });
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('')).toBe('');
+    expect(stdio.errors.join('')).toBe('');
+    // No recovery probe: no rev-list count, no drift log.
+    expect(recorded.every((call) => call.args[0] !== 'rev-list')).toBe(true);
+    expect(recorded.every((call) => call.args[0] !== 'log')).toBe(true);
+  });
+
+  test('exit 1 when the orphaned recovery count cannot be read', () => {
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {argv: ['status', '--porcelain=v1', '-uall'], result: okResult('')},
+        {argv: SUGGESTED_REVPARSE, result: okResult(`${SUGGESTED_FULL}\n`)},
+        {
+          argv: SUGGESTED_COUNT,
+          result: {
+            output: ['', '', ''] as never,
+            pid: 0,
+            signal: null,
+            status: 128,
+            stderr: 'fatal: bad revision',
+            stdout: '',
+          },
+        },
+      ],
+      recorded
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runner,
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: false,
+        state_sha: STATE_SHA,
+        suggested_base: SUGGESTED_BASE,
+      }),
+    });
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('cannot determine wiki drift');
+  });
+
+  test('reachable path ignores suggested_base and uses state_sha', () => {
+    // Defensive regression: the recovery branch is gated on `!reachable`. Even
+    // if a payload carried suggested_base while reachable, the count must come
+    // from the JSON's commits_ahead and the range from state_sha — byte
+    // identical to the pre-recovery behavior.
+    const recorded: RecordedCall[] = [];
+    const runner = buildRunner(
+      [
+        {
+          argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+          result: okResult('main\n'),
+        },
+        {argv: ['status', '--porcelain=v1', '-uall'], result: okResult('')},
+        {argv: REVPARSE_ARGS, result: okResult(`${STATE_SHA}\n`)},
+        {
+          argv: ['log', '--format=%s', DRIFT_RANGE],
+          result: okResult('wiki: sync through abc1234\n'),
+        },
+      ],
+      recorded
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runner,
+      wikiStateProbe: () => ({
+        commits_ahead: 1,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: SUGGESTED_BASE,
+      }),
+    });
+    expect(exit).toBe(0);
+    expect(stdio.errors.join('')).toContain('wiki-sync squash artifact');
+    expect(recorded.some((call) => call.args.includes(DRIFT_RANGE))).toBe(true);
+    expect(recorded.some((call) => call.args.includes(SUGGESTED_RANGE))).toBe(
+      false
+    );
+    // Count comes from the JSON, so the reachable path never runs rev-list.
+    expect(recorded.every((call) => call.args[0] !== 'rev-list')).toBe(true);
   });
 
   test('exit 2 when git rev-parse fails', () => {
@@ -360,7 +605,12 @@ describe('release preflight', () => {
     const exit = run([], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(2);
     expect(stdio.errors.join('')).toContain('preflight:');
@@ -382,7 +632,12 @@ describe('release preflight', () => {
     const exit = run(['--branch', 'release/v1'], {
       cwd: sandbox.root,
       runner,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(0);
   });
@@ -390,7 +645,12 @@ describe('release preflight', () => {
   test('rejects unknown flags', () => {
     const exit = run(['--bogus'], {
       cwd: sandbox.root,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(1);
     expect(stdio.errors.join('')).toContain('unknown flag');
@@ -399,7 +659,12 @@ describe('release preflight', () => {
   test('--help prints usage', () => {
     const exit = run(['--help'], {
       cwd: sandbox.root,
-      wikiStateProbe: () => ({commits_ahead: 0, state_sha: STATE_SHA}),
+      wikiStateProbe: () => ({
+        commits_ahead: 0,
+        reachable: true,
+        state_sha: STATE_SHA,
+        suggested_base: '',
+      }),
     });
     expect(exit).toBe(0);
     expect(stdio.outputs.join('')).toContain('Usage:');

--- a/.gaia/cli/src/release/preflight.ts
+++ b/.gaia/cli/src/release/preflight.ts
@@ -123,7 +123,12 @@ const refuse = (message: string): number => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-type WikiState = {commits_ahead: number; state_sha: string};
+type WikiState = {
+  commits_ahead: number;
+  reachable: boolean;
+  state_sha: string;
+  suggested_base: string;
+};
 type WikiStateProbe = (cwd: string) => WikiState | null;
 
 const runWikiStateJson: WikiStateProbe = (cwd) => {
@@ -145,12 +150,19 @@ const runWikiStateJson: WikiStateProbe = (cwd) => {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const commitsAhead = parsed.commits_ahead;
     const stateSha = parsed.state_sha;
+    const reachable = parsed.reachable;
+    const suggestedBase = parsed.suggested_base;
 
     if (typeof commitsAhead !== 'number') return null;
 
     return {
       commits_ahead: commitsAhead,
+      // Default reachable to true on a malformed payload so the orphaned-state
+      // recovery never fires off bad input — the gate falls back to today's
+      // `commits_ahead` reading.
+      reachable: typeof reachable === 'boolean' ? reachable : true,
       state_sha: typeof stateSha === 'string' ? stateSha : '',
+      suggested_base: typeof suggestedBase === 'string' ? suggestedBase : '',
     };
   } catch {
     return null;
@@ -158,29 +170,40 @@ const runWikiStateJson: WikiStateProbe = (cwd) => {
 };
 
 /**
- * Subjects of the commits in `<stateSha>..HEAD`, newest first. `null` if the
- * range can't be read (e.g. `stateSha` is empty, ambiguous, or git fails) —
- * callers treat `null` as "can't prove the drift is benign" and refuse.
+ * Resolve a (possibly abbreviated) SHA to a full commit SHA. `''` when `sha`
+ * is empty or git can't verify it.
  *
- * `gaia wiki state --json` reports `state_sha` abbreviated; resolve it to a
- * full SHA via `git rev-parse` before the range query so `git log` never has
- * to disambiguate a short prefix (which it can fail to do in large repos).
+ * `gaia wiki state --json` reports both `state_sha` and `suggested_base`
+ * abbreviated; resolving to a full SHA before any range query keeps `git log` /
+ * `git rev-list` from having to disambiguate a short prefix (which they can fail
+ * to do in large repos).
+ */
+const resolveCommit = (
+  runner: CommandRunner,
+  cwd: string,
+  sha: string
+): string => {
+  if (sha === '') return '';
+  const resolved = runner('git', ['rev-parse', '--verify', `${sha}^{commit}`], {
+    cwd,
+  });
+
+  if (resolved.error !== undefined || (resolved.status ?? -1) !== 0) return '';
+
+  return (resolved.stdout ?? '').trim();
+};
+
+/**
+ * Subjects of the commits in `<base>..HEAD`, newest first. `null` if the range
+ * can't be read (e.g. `base` is empty, ambiguous, or git fails) — callers treat
+ * `null` as "can't prove the drift is benign" and refuse.
  */
 const readDriftSubjects = (
   runner: CommandRunner,
   cwd: string,
-  stateSha: string
+  base: string
 ): string[] | null => {
-  if (stateSha === '') return null;
-  const resolved = runner(
-    'git',
-    ['rev-parse', '--verify', `${stateSha}^{commit}`],
-    {cwd}
-  );
-
-  if (resolved.error !== undefined || (resolved.status ?? -1) !== 0)
-    return null;
-  const fullSha = (resolved.stdout ?? '').trim();
+  const fullSha = resolveCommit(runner, cwd, base);
 
   if (fullSha === '') return null;
   const result = runner('git', ['log', '--format=%s', `${fullSha}..HEAD`], {
@@ -194,6 +217,29 @@ const readDriftSubjects = (
 
     return trimmed.length > 0 ? [trimmed] : [];
   });
+};
+
+/**
+ * Count the commits in `<base>..HEAD`. `null` if `base` can't be resolved or
+ * `git rev-list` fails. Used to recover the drift count on the orphaned-state
+ * path, where `gaia wiki state` reports a hardcoded `commits_ahead:0`.
+ */
+const countDriftCommits = (
+  runner: CommandRunner,
+  cwd: string,
+  base: string
+): number | null => {
+  const fullSha = resolveCommit(runner, cwd, base);
+
+  if (fullSha === '') return null;
+  const result = runner('git', ['rev-list', '--count', `${fullSha}..HEAD`], {
+    cwd,
+  });
+
+  if (result.error !== undefined || (result.status ?? -1) !== 0) return null;
+  const parsed = Number.parseInt((result.stdout ?? '').trim(), 10);
+
+  return Number.isInteger(parsed) ? parsed : null;
 };
 
 type RunOptions = {
@@ -269,7 +315,34 @@ export const run = (
     );
   }
 
-  if (wikiState.commits_ahead !== 0) {
+  // Resolve the effective drift window. On the reachable path the wiki-state
+  // JSON's `commits_ahead`/`state_sha` are authoritative. On the orphaned path
+  // (`reachable:false` — the normal post-squash-merge condition) the JSON
+  // hardcodes `commits_ahead:0`, blind to any un-evaluated window; recover the
+  // window from `suggested_base..HEAD`, the reachable baseline `gaia wiki state`
+  // reports for exactly this case. `suggested_base` is `''` on the reachable
+  // path, so the recovery branch is inert there and behavior is unchanged.
+  let driftCount = wikiState.commits_ahead;
+  let driftBase = wikiState.state_sha;
+
+  if (!wikiState.reachable && wikiState.suggested_base !== '') {
+    const recovered = countDriftCommits(runner, cwd, wikiState.suggested_base);
+
+    // A git failure counting the recovered window can't prove the wiki is
+    // current — refuse rather than green-light a release on an unknown window.
+    if (recovered === null) {
+      return refuse(
+        `preflight: cannot determine wiki drift from recovery base ${wikiState.suggested_base}; run /gaia wiki sync first`
+      );
+    }
+
+    driftCount = recovered;
+    // Inspect `suggested_base..HEAD` — NOT the orphaned `state_sha`, whose
+    // `..HEAD` range is topologically unreliable after a squash rewrites the SHA.
+    driftBase = wikiState.suggested_base;
+  }
+
+  if (driftCount !== 0) {
     // Documented bypass (wiki/concepts/Release Workflow.md): drift made up
     // entirely of wiki-sync squash artifacts is benign. A PR squash-merge
     // rewrites the commit SHA, so `/gaia wiki sync` → merge leaves the state
@@ -278,10 +351,10 @@ export const run = (
     // uses to flag self-referential sync commits. Without this the gate is
     // unsatisfiable for the standard release flow. Substantive (non-`wiki:`)
     // drift still STOPs — the wiki is genuinely stale.
-    const driftSubjects = readDriftSubjects(runner, cwd, wikiState.state_sha);
+    const driftSubjects = readDriftSubjects(runner, cwd, driftBase);
     const benign =
       driftSubjects !== null &&
-      // Guards the vacuous-truth case: zero subjects with `commits_ahead > 0`
+      // Guards the vacuous-truth case: zero subjects with `driftCount > 0`
       // means the range count disagrees with `git log` — a broken state, not
       // a benign one.
       driftSubjects.length > 0 &&
@@ -289,12 +362,12 @@ export const run = (
 
     if (!benign) {
       return refuse(
-        `preflight: wiki is ${wikiState.commits_ahead} commits behind HEAD; run /gaia wiki sync first`
+        `preflight: wiki is ${driftCount} commits behind HEAD; run /gaia wiki sync first`
       );
     }
 
     process.stderr.write(
-      `preflight: wiki drift is ${wikiState.commits_ahead} wiki-sync squash artifact(s); proceeding (content current)\n`
+      `preflight: wiki drift is ${driftCount} wiki-sync squash artifact(s); proceeding (content current)\n`
     );
   }
 

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -36,7 +36,7 @@ How GAIA cuts a public release. Two surfaces — the template repo (`gaia-react/
 Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 
 1. Verify clean working tree + on `main`.
-2. Verify `wiki/.state.json` is current — either `last_evaluated_sha == HEAD`, or the only drift commits are wiki-sync squash artifacts (subjects starting with `wiki:`). Substantive non-wiki drift STOPs the release; the wiki is stale and would ship out-of-date adopter docs. Maintainer runs `/gaia wiki sync` first. The `wiki:`-prefix bypass exists because PR squash-merging always rewrites the SHA, so the standard flow (`/gaia wiki sync` → merge → `/gaia-release`) leaves the state pointer one squash-commit behind even when content is current; without the bypass the gate is unsatisfiable. See [[Wiki Sync]].
+2. Verify `wiki/.state.json` is current — either `last_evaluated_sha == HEAD`, or the only drift commits are wiki-sync squash artifacts (subjects starting with `wiki:`). Substantive non-wiki drift STOPs the release; the wiki is stale and would ship out-of-date adopter docs. Maintainer runs `/gaia wiki sync` first. The `wiki:`-prefix bypass exists because PR squash-merging always rewrites the SHA, so the standard flow (`/gaia wiki sync` → merge → `/gaia-release`) leaves the state pointer one squash-commit behind even when content is current; without the bypass the gate is unsatisfiable. When a squash orphans `last_evaluated_sha` outright (`reachable:false`), `gaia wiki state` reports a hardcoded `commits_ahead:0` — a silent zero that would hide the un-evaluated window. Preflight catches this: it re-derives the drift over `suggested_base..HEAD` (the newest HEAD-reachable commit at or before `last_evaluated_at`) and applies the same wiki-artifact classification, so an orphaned state still blocks on substantive drift instead of green-lighting on the zero. See [[Wiki Sync]].
 3. Auto-determine bump by analyzing commits since last tag. `patch`/`minor` proceed automatically; `major` stops and asks.
 4. Run the [[Quality Gate]]. Stop on failure.
 5. Create `release/vX.Y.Z` branch.
@@ -51,8 +51,8 @@ Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 
 The tag push triggers [`release.yml`](../../.github/workflows/release.yml), which produces the scrubbed tarball.
 
-> [!note] `state_sha` is abbreviated
-> `gaia wiki state --json` reports `state_sha` in short form. A caller that feeds it into a git range query (`<state_sha>..HEAD`) resolves it to a full SHA first via `git rev-parse --verify` — the `release preflight` subcommand does this before its wiki-sync drift scan (Step 2). Skipping the resolution makes the range query fail or silently return the wrong set on repos where the short SHA is ambiguous.
+> [!note] Abbreviated SHAs are resolved before range queries
+> `gaia wiki state --json` reports `state_sha` and `suggested_base` in short form. A caller that feeds either into a git range query (`<sha>..HEAD`) resolves it to a full SHA first via `git rev-parse --verify` — the `release preflight` subcommand does this before its wiki-sync drift scan (Step 2), for both the reachable `state_sha` range and the orphaned-recovery `suggested_base` range. Skipping the resolution makes the range query fail or silently return the wrong set on repos where the short SHA is ambiguous.
 
 ## Tarball scrubbing
 


### PR DESCRIPTION
## Problem

`release preflight` gates the wiki check on `gaia wiki state --json`'s `commits_ahead === 0`. But `commits_ahead` is hardcoded to `0` whenever the recorded `last_evaluated_sha` is unreachable (`state.ts`: `stateSha === '' || !reachable ? 0`). Since `reachable:false` is the **normal** post-squash-merge condition, a maintainer running `/gaia-release` while wiki state is orphaned got a **green wiki gate — blind to any un-evaluated window**. Same root cause as #256 (SHA-anchored state orphaned by squash), different surface (release gate vs. sync). The existing squash-artifact passthrough never fired here because it was gated behind `commits_ahead !== 0`.

## Fix

Extend the preflight wiki-state probe to also read `reachable` and `suggested_base` (the recovery baseline #256 added). When the state is orphaned (`reachable:false`) and a `suggested_base` resolves, treat `suggested_base..HEAD` as the drift range:

- `N = git rev-list --count suggested_base..HEAD`
- Run the **existing** `readDriftSubjects` + wiki-artifact verdict against `suggested_base` — **not** the orphaned `state_sha`, whose `..HEAD` range is topologically unreliable after a squash.
- Same policy: drift that is only wiki-sync squash artifacts passes (`content current`); substantive drift blocks (`wiki is N commits behind HEAD; run /gaia wiki sync first`).
- Empty `suggested_base` (no recoverable baseline) keeps today's pass.

**The reachable path is byte-identical** — `suggested_base` is `''` there, so the recovery branch is inert (asserted in tests).

## Verification

- **Unit** (`preflight.test.ts`): orphaned + substantive drift → blocks; orphaned + only wiki-sync artifacts → passes; orphaned + empty `suggested_base` → today's pass; orphaned + count git-failure → conservative refuse; reachable path ignores `suggested_base` and uses `state_sha` (regression). Full `.gaia/cli` suite: 1202 passed.
- **Live** (against the orphaned fixture this repo's wiki state currently is): new binary blocks with `wiki is 4 commits behind HEAD`; old binary green-lights (`exit 0`). `wiki/.state.json` untouched.

Rebuilt the maintainer binary; the adopter binary is unchanged (release is tree-shaken out of it).

Out of CI audit scope (`.gaia/cli` + markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)