### PR TITLE
refactor(plan): print kickoff prompt instead of copying to clipboard

### DIFF
--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -302,29 +302,6 @@ Read <absolute-path-to>/.gaia/local/plans/{slug}/KICKOFF.md and execute it.
 
 Use `$PLAN_DIR/KICKOFF.md` (the absolute path resolved in step 3). The path MUST be absolute so the cold Claude session has no working-directory ambiguity. Do not include any other instruction — the orchestrator's behavior lives in `KICKOFF.md`.
 
-**Try to copy the prompt to the system clipboard** with the first available tool. Probe in this order — the first match wins; if none exist, skip silently:
+**Print the prompt as a fenced code block** so the user can select and copy it manually.
 
-```bash
-PROMPT='Read {absolute path to KICKOFF.md} and execute it.'
-COPIED=0
-if command -v pbcopy >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | pbcopy && COPIED=1
-elif command -v wl-copy >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | wl-copy && COPIED=1
-elif command -v xclip >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | xclip -selection clipboard && COPIED=1
-elif command -v xsel >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | xsel --clipboard --input && COPIED=1
-elif command -v clip.exe >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | clip.exe && COPIED=1
-elif command -v clip >/dev/null 2>&1; then
-  printf '%s' "$PROMPT" | clip && COPIED=1
-fi
-```
-
-**Always print the prompt as a fenced code block**, regardless of whether the copy succeeded — the user may want to verify or copy manually.
-
-Then print one trailing line, conditional on `$COPIED`:
-
-- Copy succeeded (`COPIED=1`): `Prompt copied to clipboard. Type /clear then paste.`
-- No tool found (`COPIED=0`): `Type /clear and paste the prompt above.`
+Then print one trailing line: `Type /clear and paste the prompt above.`

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -657,7 +657,7 @@ On `Plan another slice`, ask via plain prompt (open-ended, not `AskUserQuestion`
 
 Spawn a fresh Agent with the same template as 11a. Parse its return, append the resolved `PLAN_DIR` to `PLAN_DIRS[]`, print the kickoff prompt as a fenced block, append `plan_dispatched` telemetry with `plan_idx: <next>`. Loop until the user picks `Done`.
 
-**Clipboard caveat.** The plan skill attempts a `pbcopy`-style clipboard write inside each Agent's context. Across multiple plans, the LAST Agent's copy wins (or none, if the Agent's clipboard reach is unreliable). The wrapper-printed fenced blocks are the authoritative source the user copies from — clipboard is convenience only.
+**Output note.** The plan skill prints each kickoff prompt only into its own Agent's context, which the user never sees. The wrapper-printed fenced blocks are the authoritative source the user copies from.
 
 #### 11c. Final confirmation
 


### PR DESCRIPTION
## What

`/gaia plan` no longer copies the kickoff execution prompt to the system clipboard. It now prints the prompt as a fenced code block for the user to select and copy manually.

## Changes

- **`plan.md` step 5** — removed the `pbcopy`/`wl-copy`/`xclip`/`xsel`/`clip.exe` clipboard probe and the `$COPIED`-conditional trailing line. Now: print the prompt as a fenced code block, then `Type /clear and paste the prompt above.`
- **`spec.md` 11b** — the "Clipboard caveat" referenced the now-removed `pbcopy` write; rewrote it as an "Output note" (wrapper-printed fenced blocks remain the authoritative source).

Doc-only change to two skill markdown files; no source or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)