### PR TITLE
docs: clarify the gate owns formatting; make PR merge marker-first

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -32,3 +32,5 @@ When building new features or fixing bugs, follow the TDD workflow described in 
 ## 6. Always Verify Your Work
 
 Run the Quality Gate Process defined in `.claude/rules/quality-gate.md` (always-loaded as a rule; no `@`-import needed).
+
+Don't hand-polish formatting or auto-fixable lint while authoring — the gate's `pnpm lint` (`eslint --fix`, with Prettier wired in as an `eslint` rule) normalizes it in one terminal pass. Spend tokens only on non-auto-fixable lint.

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -12,11 +12,22 @@ Mandatory before any `gh pr merge`. Machine-enforced by `.claude/hooks/pr-merge-
 
 The gate is **repo-scoped** via `.claude/hooks/lib/repo-scope.sh`: it enforces this repo's audit contract only. A `gh pr merge` positively aimed at a different repo (`-R owner/other`, or `cd <other> &&`) is allowed — this repo's audit markers have no bearing on a sibling repo's merge. Scoping is fail-closed: any ambiguity still enforces.
 
+## Marker-first: check before you audit
+
+The hook requires a **marker to exist** for HEAD — not that you personally run the audit. CI runs `code-review-audit.yml` on every PR and stamps the `GAIA-Audit` status: a full audit on in-scope changes, and an automatic stamp when the un-audited delta is entirely out of audit scope (e.g. markdown-only). So the first action is always a marker check, never an agent spawn:
+
+```bash
+gh pr checks <N> | grep GAIA-Audit   # pass → marker present for HEAD
+git rev-parse HEAD                   # the SHA the marker must match
+```
+
+If the marker is already `pass`/`success` for HEAD, skip straight to **step 4**. The four-step protocol below is the path for when no marker exists yet — an in-scope delta whose CI audit is still pending and you want to merge without waiting, or CI is unavailable. Spawning the local agent when CI has already stamped the marker is redundant work.
+
 ## Four-step protocol
 
-### 1. Run code-review-audit
+### 1. Run code-review-audit (only when no marker exists)
 
-Spawn the agent on the PR's changes:
+When the marker check above comes back empty, spawn the agent on the PR's changes:
 
 ```
 Task(
@@ -91,8 +102,8 @@ If `state == "MERGED"`, do NOT retry the merge. Treat it as merged, run any post
 
 ## No exceptions
 
-- Never skip the audit, even for "small" PRs. The hook denies the merge.
-- Never hand-write a marker file to bypass the gate. The agent owns marker emission.
-- If a doc-only PR genuinely does not warrant an audit, run the agent anyway — it will report no findings and write the marker quickly.
+- Never merge without a marker for HEAD. The hook denies it. The audit must cover the merged content — but CI runs it for you, so "the audit must run" rarely means "spawn the agent locally."
+- Never hand-write a marker file to bypass the gate. The agent (local or CI) owns marker emission.
+- For a doc-only or out-of-scope PR, let CI stamp the marker — don't spawn the local agent redundantly. Run it locally only when no marker exists for HEAD and you don't want to wait for CI.
 
 See [[Code Review Audit Agent]], [[Quality Gate]], [[Git Workflow]].

--- a/wiki/decisions/Quality Gate.md
+++ b/wiki/decisions/Quality Gate.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-04-20
 created: 2026-04-20
-updated: 2026-05-01
+updated: 2026-06-02
 tags: [decision, ci, quality]
 ---
 
@@ -17,7 +17,7 @@ Every change must pass the Quality Gate. Pre-commit hooks enforce a subset; Clau
 1. **Simplify** — run `simplify` skill; apply all endorsed changes.
 2. **Localization check** — no hardcoded user-facing strings or unfilled keys.
 3. `pnpm typecheck` — zero errors.
-4. `pnpm lint` — zero errors, zero warnings.
+4. `pnpm lint` — zero errors, zero warnings. Runs `eslint --fix`, so it auto-fixes every fixable lint rule **and** Prettier formatting (Prettier is wired in as an `eslint` rule via `prettier/prettier`); only non-auto-fixable issues need manual attention. Hand-formatting while authoring is wasted effort — this step normalizes it.
 5. `pnpm test --run` — all tests pass with **zero console warnings** (missing keys, HydrateFallback, etc. count as failures).
 6. `pnpm pw` — all Playwright E2E tests pass.
 7. **Dev smoke test** — start `pnpm dev`, curl a route, verify HTTP 200.


### PR DESCRIPTION
## What

Two related documentation fixes, no source touched.

**1. The Quality Gate owns formatting & auto-fixable lint**
- `.claude/rules/coding-guidelines.md` §6 — adds a nudge: don't hand-polish formatting or auto-fixable lint while authoring; `pnpm lint` (`eslint --fix`, Prettier wired in as an `eslint` rule) normalizes it in one terminal pass. Spend tokens only on non-auto-fixable lint.
- `wiki/decisions/Quality Gate.md` step 4 — records the supporting fact: `pnpm lint` runs `eslint --fix` and auto-fixes both lint and Prettier formatting (via the `prettier/prettier` rule), so only non-auto-fixable issues need manual attention.

**2. PR merge workflow is marker-first, not audit-first**
- `wiki/concepts/PR Merge Workflow.md` — the merge hook requires a `GAIA-Audit` marker to *exist* for HEAD; it does not require running the audit locally. CI stamps the marker automatically (full audit on in-scope changes, auto-stamp when the delta is entirely out of audit scope). Adds a marker-first check as the first action, reframes the local agent run as the fallback for when no marker exists, and drops the stale "run the agent anyway for doc-only PRs" line.

## Why

`pnpm lint` is `eslint --fix`, and `@gaia-react/lint`'s config loads `eslint-plugin-prettier` with `"prettier/prettier": ["error"]` — so formatting is fixed deterministically at the gate (and again by lint-staged at commit). Hand-emulating Prettier's wrapping while authoring is wasted reasoning and often wrong; the genuinely manual tier is non-auto-fixable lint.

The merge-workflow fix was prompted by this PR: the old doc led with "spawn the audit agent" as step 1, so a doc-only PR triggered a redundant local audit when CI had already stamped the marker. Making the doc marker-first prevents that.

## Scope

Documentation only — three markdown files, no source. Quality Gate skips (no `.ts/.tsx/...` or gate-affecting config staged). CI stamps `GAIA-Audit` automatically since the delta is entirely out of audit scope. wiki-style and template-path audits run clean on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)