### PR TITLE
wiki: sync state through e7939cf

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "7b2efd0ffd1c1158b73664085b8cc6678c44daf7",
-  "last_evaluated_at": "2026-06-02T04:44:24Z",
+  "last_evaluated_sha": "e7939cf02d920dd926f9c4be6cd3dee741e95068",
+  "last_evaluated_at": "2026-06-02T05:00:41Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [v1.3.4] 2026-05-26 | Released
 
+- 2026-06-02 e7939cf SKIP — squash of already-synced prep PR #264 (health fixes + wiki sync through 7b2efd0); state advance only
 - 2026-06-02 7b2efd0f WORTHY — distribution-boundary leaks and wikilink scrub; edits Code Review Audit CI.md, PR Merge Workflow.md, pnpm.md
 - 2026-06-02 4e3d022f SKIP — README copy update; no wiki body
 - 2026-06-02 7d082f2c WORTHY — on-demand code-review-audit CI install + dual Claude token support → wiki/concepts/Code Review Audit CI.md, wiki/concepts/PR Merge Workflow.md


### PR DESCRIPTION
Pure state advance so the release preflight's benign-drift bypass recognizes it.

The prep PR (#264) squashed health fixes + wiki sync under a `chore:` subject, which preflight cannot treat as a wiki-sync artifact (it requires `wiki:`-prefixed drift subjects). `e7939cf` carries no un-synced product changes — only `wiki/.state.json` advance + a ledger entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)