### PR TITLE
fix(update-gaia): scope three-way merge to the real release delta

### DIFF
--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -175,7 +175,7 @@ BACKUP_DIR=".gaia-backup/$(date +%Y%m%d-%H%M%S)"
 mkdir -p .gaia-merge "$BACKUP_DIR"
 ```
 
-Track six lists internally (`UpdateMergeReport`):
+Track seven lists internally (`UpdateMergeReport`):
 
 ```ts
 {
@@ -183,6 +183,7 @@ Track six lists internally (`UpdateMergeReport`):
   skip: string[];        // no change needed; left alone
   merge: string[];       // clean shared/wiki-owned merges written into the working tree
   add: string[];         // new files copied from latest
+  removed: string[];     // adopter deleted a baseline file; deletion respected, left absent
   delete: string[];      // files removed upstream; surfaced but NOT auto-deleted
   conflicts: Array<{
     path: string;
@@ -196,25 +197,24 @@ Track six lists internally (`UpdateMergeReport`):
 
 Let `A` = working-tree `<path>`, `B` = `$BASELINE_DIR/<path>`, `L` = `$LATEST_DIR/<path>`. Use `cmp -s` for equality; `mkdir -p` before writing.
 
-**Match in declared order — first matching row wins.** The first row applies to every class and runs before any class-specific check; it closes the silent-skip gap where the manifest declares a file but the adopter's tree never had it (in particular, the `shared` / `wiki-owned` `B` ≅ `L` row below would otherwise short-circuit and leave the file missing on disk).
+**Match in declared order — first matching row wins.** Baseline presence (`B`) is the discriminator for a missing working-tree file: `A` missing with `B` also missing means the file is genuinely new in the latest release and gets added; `A` missing with `B` present means the adopter deliberately deleted a file that shipped in their baseline, so the deletion is respected and the file is left absent. The `B` ≅ `L` row (no upstream change) short-circuits every class before any conflict is declared — an adopter-drifted file the release never touched has nothing to merge, so it stays as-is and emits no patch.
 
 | Class | Condition | Action | List |
 |---|---|---|---|
-| any | `A` missing and `L` exists | Copy `L` → `<path>` | `add[]` |
-| `owned` | `B` missing (new file) | Copy `L` → `<path>` | `add[]` |
-| `owned` | `A` ≅ `B` (no adopter drift) | Back up `A` to `$BACKUP_DIR/<path>`; copy `L` → `<path>` | `overwrite[]` |
-| `owned` | `A` ≅ `L` (adopter already current) | No-op | `skip[]` |
+| any | `A` missing and `B` missing (genuinely new in latest) | Copy `L` → `<path>` | `add[]` |
+| any | `A` missing and `B` exists (adopter deleted it) | No-op — respect the deletion, leave absent | `removed[]` |
+| `owned` | `B` missing (`A` exists; release newly owns this path) | Back up `A` to `$BACKUP_DIR/<path>`; copy `L` → `<path>` | `overwrite[]` |
+| any | `B` ≅ `L` (no upstream change) | No-op | `skip[]` |
+| any | `A` ≅ `B` (no adopter drift) | Back up `A` to `$BACKUP_DIR/<path>`; copy `L` → `<path>` | `owned` → `overwrite[]`; `shared` / `wiki-owned` → `merge[]` |
+| any | `A` ≅ `L` (adopter already at latest) | No-op | `skip[]` |
 | `owned` | `A` ≠ `B` and `A` ≠ `L` | `diff -u "$A" "$L" > .gaia-merge/<path>.patch` | `conflicts[]` |
-| `shared` / `wiki-owned` | `B` ≅ `L` (no upstream change) | No-op | `skip[]` |
-| `shared` / `wiki-owned` | `A` ≅ `B` (no adopter drift) | Back up `A` to `$BACKUP_DIR/<path>`; copy `L` → `<path>` | `merge[]` |
-| `shared` / `wiki-owned` | `A` ≅ `L` (adopter already at latest) | No-op | `skip[]` |
-| `shared` / `wiki-owned` | `A` ≠ `B` and `B` ≠ `L` | `diff -u "$A" "$L" > .gaia-merge/<path>.patch` | `conflicts[]` |
+| `shared` / `wiki-owned` | `A` ≠ `B` and `A` ≠ `L` | `diff -u "$A" "$L" > .gaia-merge/<path>.patch` | `conflicts[]` |
 
 **After iterating the manifest,** collect deletions: files present under `$BASELINE_DIR` that have no corresponding key in `$LATEST_MANIFEST`'s `.files`. Add each to `delete[]`. Do **not** remove them from the working tree.
 
 **Handling results:**
 
-- `overwrite[]`, `skip[]`, `merge[]`, `add[]`: **report counts only — no per-file narrative.** Do not read file bytes.
+- `overwrite[]`, `skip[]`, `merge[]`, `add[]`, `removed[]`: **report counts only — no per-file narrative.** Do not read file bytes.
 - `delete[]`: **ask the user before removing** each path.
 - `conflicts[]`: read the patch at `.gaia-merge/<path>.patch` and walk the user through the decision per file.
 
@@ -277,9 +277,10 @@ GAIA update: v$BASELINE → $LATEST_TAG
 
   Overwritten:  <n>
   Added:        <n>
+  Removed:      <n>  (files you deleted; left absent, deletion respected)
   Skipped:      <n>
   Conflicts:    <n>  (see .gaia-merge/)
-  Deleted:      <n>
+  Deleted:      <n>  (removed upstream; surfaced, not auto-deleted)
   Backed up:    <n>  (see .gaia-backup/<timestamp>/)
   Specs migrated: <n>  (flat .gaia/local/specs files folded into per-SPEC folders)
   Trailer invalidations: <n>  (open PRs stamped v$BASELINE will re-audit on next push)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Fixed
+
+- /update-gaia: scope the three-way merge to the real release delta — respect adopter-deleted files instead of re-injecting them, and skip owned files the release left unchanged instead of emitting spurious conflict patches (#267)
+
 ## [1.3.5] — 2026-06-02
 
 ### Added

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Update Workflow
 status: active
 created: 2026-04-22
-updated: 2026-05-01
+updated: 2026-06-02
 tags: [release, claude, adopter, drift]
 ---
 
@@ -43,7 +43,7 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 5. Download baseline + latest tarballs to `.gaia/cache/`.
 6. Walk the latest manifest. For each file, apply the decision table below.
 7. Only after the full walk succeeds, bump `.gaia/VERSION` and replace `.gaia/manifest.json` with the latest version's copy.
-8. Report summary: overwritten / added / skipped / conflicts / deleted / backed up.
+8. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.
 9. Remind the adopter to review `.gaia-merge/`, run the [[Quality Gate]], and commit manually.
 
 ## Decision table


### PR DESCRIPTION
Closes #267.

## Problem

`/update-gaia` ran the three-way merge eagerly. On a heavily-diverged adopter (react-japan, v1.3.4 → v1.3.5) it reported **178 adds + 44 conflicts** for what was genuinely a **+8-file, ~3-change** release, then had to detect the divergence and undo it — risky (pollutes the tree, can break the build via orphaned imports) and token-expensive.

Root cause was **runbook-vs-spec drift, not a design hole**: `wiki/concepts/Update Workflow.md` already documented the correct algorithm; the executable `SKILL.md` Step 7 table had regressed away from it.

## Fix

Re-aligned the Step 7 decision table with the wiki spec:

- **Re-injected deletions (165 of 178 adds).** The `A missing → copy L` row ignored baseline presence. Split on `B`: `A missing + B missing → add` (genuinely new) vs `A missing + B exists → removed[]` (adopter deleted it; left absent, intent respected).
- **Spurious owned conflicts (34 of 44).** The `shared`/`wiki-owned` rows had a `B ≅ L` short-circuit; the `owned` rows didn't, so any drifted owned file emitted a no-op patch even when the release never touched it. Promoted `B ≅ L → skip` to an `any`-class row above the conflict rows.

Added a `removed[]` reporting bucket + summary row, deduped the now-redundant shared/wiki-owned rows, synced the wiki concept summary list.

## Verification

Traced all four cases through the new first-match-wins table:

| Case | State | Outcome |
|---|---|---|
| Deleted template | `A` missing, `B` present | `removed[]` — no re-inject |
| Drift, upstream unchanged | `A≠B`, `B≅L` | `skip[]` — no patch |
| Genuinely new | `A` missing, `B` missing | `add[]` |
| Real drift + upstream change | `A≠B`, `A≠L`, `B≠L` | `conflicts[]` |

Result matches the report's acceptance criterion: ~8 adds + ~3 conflicts instead of 178 + 44.

## Scope notes

- **Divergence manifest (suggested in the issue) intentionally not built** — the table fix makes skips count-only (no I/O, no patch, no revert), removing the token-burn root cause without new persisted state.
- **`minimumReleaseAge` quarantine symptom** (the issue's secondary note) deliberately out of scope — it's a release-process matter and self-resolves once the bumped deps age past the 7-day window.
- Docs-only change (`.md` runbook + wiki + CHANGELOG); no gate-affecting source, nothing to lint/typecheck. No code test harness exists for this LLM-executed runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)