### PR TITLE
fix(gaia): derive wiki playbook dates from the shell clock, not the model

### DIFF
--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -174,6 +174,8 @@ For each over-budget file, propose one of: inline facts → wiki, consolidate du
 
 Write `$PROJECT_ROOT/.gaia/local/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md`. Create `$PROJECT_ROOT/.gaia/local/audit/` if missing. Also snapshot `git status --short` into the report's frontmatter so Stage 2 can detect drift.
 
+Derive the timestamp from the shell — never guess the current date/time: `date '+%Y-%m-%d-%H%M'` for the `{YYYY-MM-DD-HHMM}` filename, `date '+%Y-%m-%d %H:%M'` for the `generated:` field.
+
 ### Report template (strict schema — Stage 2 parses this)
 
 ````markdown

--- a/.claude/skills/gaia/references/forensics.md
+++ b/.claude/skills/gaia/references/forensics.md
@@ -79,6 +79,8 @@ Do not pass frontmatter through redaction. Frontmatter is written after the body
 
 Emit the strict-schema body. The frontmatter heads the body, and the same body is posted to the GH issue verbatim — at creation time (before `gh_issue_url` is back-filled into the local file in step 8) the local file and the GH issue are byte-identical, so downstream triage parses either with the same parser.
 
+Set `created` from `date +%F` (shell) — never guess the current date.
+
 Body layout (frontmatter + sections):
 
 ```markdown

--- a/.claude/skills/gaia/references/handoff.md
+++ b/.claude/skills/gaia/references/handoff.md
@@ -24,6 +24,8 @@ Run in parallel:
 
 Path: `.gaia/local/handoff/HANDOFF-{YYYY-MM-DD}-{slug}.md`
 
+Derive `{YYYY-MM-DD}` from `date +%F` and the **Date** line's timestamps from `date '+%Y-%m-%d %H:%M'` (shell) — never guess the current date/time.
+
 Use the template below. **Omit any section with no real content** — don't leave empty headings. Keep entries factual and concrete (file paths, commit hashes, command invocations). Cross-reference files with `@path/to/file:line` so the next session can jump straight in.
 
 ```markdown

--- a/.claude/skills/gaia/references/wiki/consolidate.md
+++ b/.claude/skills/gaia/references/wiki/consolidate.md
@@ -64,7 +64,7 @@ For every candidate, check the canonical page's `consolidation_ack` frontmatter 
 
 This is the last step the detection subagent runs. After writing the report file and emitting the findings JSON per the router's contract, the subagent STOPS — it does NOT proceed to Steps 4–6.
 
-Write to `wiki/meta/consolidate-report-<YYYY-MM-DD>.md`. Overwrite if a same-day report exists.
+Write to `wiki/meta/consolidate-report-<YYYY-MM-DD>.md`, where `<YYYY-MM-DD>` is `date +%F` (shell) — derive it deterministically, never guess the current date. The same value fills the frontmatter `created`/`updated` and the H1. Overwrite if a same-day report exists.
 
 Frontmatter:
 

--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -20,6 +20,22 @@ Capture the report path it produced — every appended GAIA check writes into th
 
 Do **not** restructure the upstream report format. Append GAIA sections at the bottom only.
 
+### Normalize the report date
+
+The upstream skill names the report from the model's notion of "today", which is unreliable (no LLM has a clock). Reconcile it against the shell clock before appending anything:
+
+```bash
+DATE=$(date +%F)
+```
+
+If the captured report path's date differs from `$DATE`, rename it and fix the in-file references:
+
+```bash
+git mv wiki/meta/lint-report-<upstream-date>.md wiki/meta/lint-report-$DATE.md
+```
+
+Then set the report's frontmatter (`title`, `created`, `updated`) and H1 heading to `$DATE`. Use the renamed path as the canonical report path for every subsequent step and the Step 5 summary.
+
 ## Step 2: GAIA check #11 — Wiki drift
 
 After the upstream lint finishes, run `gaia wiki state --json` and append a `## #11: Wiki drift check` section to the report file based on its output.

--- a/.claude/skills/gaia/references/wiki/sync.md
+++ b/.claude/skills/gaia/references/wiki/sync.md
@@ -77,6 +77,8 @@ Read the diff. Decide what wiki page(s) need updating:
   ---
   ```
 
+  Derive `<today>` from `date +%F` (shell) — never guess the current date. Take the `date`/`created` commit-date values from the commit itself: `git show -s --format=%cs <sha>`.
+
 Match the existing wiki voice: declarative, no preamble, concrete examples where useful. Don't paraphrase the commit message — extract the load-bearing facts and integrate them into the page's narrative.
 
 **Follow `.claude/rules/wiki-style.md` when writing or editing prose.** Present tense only. Never reference UAT-NNN, SPEC-NNN, PR numbers, commit SHAs, or "changed from X to Y on date" inside body prose. The historical record lives in `wiki/log.md` (which Step 5 maintains) and in git — not in pages.

--- a/wiki/meta/lint-report-2026-06-02.md
+++ b/wiki/meta/lint-report-2026-06-02.md
@@ -1,17 +1,17 @@
 ---
 type: meta
-title: 'Lint Report 2026-05-26'
-created: 2026-05-26
-updated: 2026-05-26
+title: 'Lint Report 2026-06-02'
+created: 2026-06-02
+updated: 2026-06-02
 tags: [meta, lint]
 status: developing
 ---
 
-# Lint Report: 2026-05-26
+# Lint Report: 2026-06-02
 
 ## #11: Wiki drift check
 
-ℹ 1 commit behind HEAD. Run `/gaia wiki sync` at next opportunity.
+⚠ `wiki/.state.json` `last_evaluated_sha` (`3bca3f6`) is not reachable from HEAD (squashed/rewritten history). Run `/gaia wiki sync` — it resolves a recovery baseline (`6eae9e2`) and evaluates the un-evaluated window.
 
 ## #12: Dead repo-relative paths
 


### PR DESCRIPTION
## What

Make every `/gaia` wiki/maintenance playbook derive dated artifact names and frontmatter from the shell clock instead of the model's guess.

## Why

No LLM has a clock. Six playbooks trusted the model to know "today", so a dispatched subagent stamped a lint report `lint-report-2026-05-26.md` when the actual date was `2026-06-02`. The model tier (Haiku vs Sonnet) is irrelevant — Sonnet would guess just as wrongly. The fix is **determinism**, not a bigger model.

## Fix

Each dated write now shells out to `date` — the pattern `fitness.md` already uses (`TIMESTAMP=$(date +%Y-%m-%d-%H%M)`):

| Playbook | Change |
|---|---|
| `wiki/sync.md` | `updated` frontmatter ← `date +%F`; commit dates ← `git show -s --format=%cs` |
| `wiki/consolidate.md` | report filename + frontmatter + H1 ← `date +%F` |
| `wiki/lint.md` | new **Normalize the report date** step — renames upstream's report to match `date +%F` (the upstream marketplace skill owns the filename and can't be told to shell out) |
| `audit.md` | `KNOWLEDGE-{…}.md` + `generated:` ← `date '+%Y-%m-%d-%H%M'` / `date '+%Y-%m-%d %H:%M'` |
| `forensics.md` | `created:` ← `date +%F` |
| `handoff.md` | `HANDOFF-{date}-{slug}.md` + Date line ← `date +%F` |

Also corrects the stale `lint-report-2026-05-26.md` → `lint-report-2026-06-02.md` artifact the bug produced.

## Test plan

- [ ] Re-run `/gaia wiki lint` on any day — report lands under today's real date, no manual rename needed
- [x] No absolute paths introduced in template-distributed `.claude/` files (audited with `grep -rn "/Users/\|/home/"`)
- [x] Quality Gate is a no-op — only `.md` changed, nothing in the `.ts/tsx/js/css`/config set

🤖 Generated with [Claude Code](https://claude.com/claude-code)