### PR TITLE
docs(wiki): promote machine-local feedback memories into shared wiki

### DIFF
--- a/wiki/concepts/Claude Integration Conventions.md
+++ b/wiki/concepts/Claude Integration Conventions.md
@@ -176,6 +176,18 @@ npx -y react-doctor@latest . --verbose --diff
 
 `--diff` scopes the scan to changed files, keeping pre-merge passes cheap.
 
+## 13. Proceed vs. AskUserQuestion
+
+When a recommendation already contains the concrete decisions (file paths, specific subsections to add, exact replacements), proceed directly instead of issuing `AskUserQuestion` to confirm sub-details.
+
+**Why:** The user reads the recommendation, decides at the recommendation level, and treats internal sub-decisions as Claude's responsibility. Confirming sub-decisions that were already in the recommendation slows work without changing the outcome.
+
+**How to apply:**
+
+- After laying out a clear, specific plan, default to executing it. Do not issue `AskUserQuestion` to confirm "should we do X" when X was already in the plan.
+- Reserve `AskUserQuestion` for genuinely branching decisions where the user's preference cannot be inferred (e.g., scope bundling vs. splitting, two valid approaches with different trade-offs).
+- A brief verification pass (path audit, wiki-style check) before commit is not a question — it is verifying the work.
+
 ---
 
 ## Cross-links

--- a/wiki/concepts/Claude Skills.md
+++ b/wiki/concepts/Claude Skills.md
@@ -98,3 +98,13 @@ GAIA's wiki workflow is powered by the `claude-obsidian` plugin, installed globa
 - `claude-obsidian:obsidian-markdown` — write correct Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, math, canvas syntax).
 
 The skill source lives in the upstream plugin cache (`~/.claude/plugins/cache/claude-obsidian-marketplace/claude-obsidian/<version>/skills/`), informational reference only — adopters should not edit these files. See [[Claude Integration Conventions]] § Wiki vendor relationship and [[DragonScale Opt-Out]] for the v1.6.0 baseline policy and why DragonScale's `wiki-fold` skill is dormant in our environment.
+
+## Playwright CLI vs. MCP
+
+GAIA uses the `playwright-cli` skill (Bash-invoked CLI) rather than the Playwright MCP server. The MCP server was evaluated and rejected.
+
+**Why:** MCP servers load tools into the system prompt every conversation, paying a token tax even when unused. For Playwright specifically, the per-test workflow is independent enough that CLI invocation works fine — there is no warm-state benefit that justifies the tax.
+
+**How to apply:** Do not recommend the Playwright MCP server for GAIA. When browser automation is needed, point at the existing `playwright-cli` skill.
+
+**Scope:** This is a Playwright-specific decision, not a blanket "CLI over MCP" policy. Other MCPs (Serena, claude-obsidian, context7) are evaluated on their own merits. Each MCP candidate is assessed individually.

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -182,6 +182,14 @@ Separate repo, separate npm package (`create-gaia`). Zero runtime deps. When an 
 
 The CLI is deliberately thin — heavy lifting (i18n, branding strip, plugin install) happens inside Claude Code via `/gaia-init`. See the `create-gaia` repo for the implementation.
 
+## Distribution boundary vs. source tree presence
+
+A file's presence in the GAIA source tree (`gaia/.claude/commands/`, etc.) does **not** mean it ships to end users. The release pipeline filters via `.gaia/release-exclude` (and related classifiers). Maintainer-only tools live in the source tree intentionally and are excluded at release time.
+
+**How to apply:** Before recommending or executing the removal of any file from `gaia/`, check `.gaia/release-exclude` and the release pipeline first. If the file is already excluded from distribution, leave it alone — the boundary is working. Only act when the file is actually leaking through to end users.
+
+**Note:** `gaia/.claude/commands/health-audit.md` was previously deleted based on source tree presence when it was already correctly excluded at line 20 of `.gaia/release-exclude`. The deletion stripped a working maintainer tool — the file was restored. Check the exclusion list before removing any file.
+
 ## See also
 
 - [[Update Workflow]] — how adopters pull later releases into an initialized project without clobbering drift.

--- a/wiki/decisions/CLI-Binary-Split.md
+++ b/wiki/decisions/CLI-Binary-Split.md
@@ -41,6 +41,19 @@ Tree-shaking via esbuild at build time requires two entry points:
 
 The `/gaia-release` command invokes `gaia-maintainer release <subcommand>` (never `gaia release`). When bundling at release time, both binaries are rebuilt in Step 7b to ensure the new version's `--version` output stays current.
 
+## GAIA-internal code placement rule
+
+GAIA-internal functionality that does not need to live in a specific folder for an external integration should live under `.gaia/`. The folders `.claude/`, `.specify/`, `app/`, and `bin/` exist at the root because Claude Code, spec-kit, the React Router app build, and the npm `bin` field require those exact locations. Everything else GAIA-owned (scripts, manifest, templates, statusline, cache, and the CLI source) belongs under `.gaia/`.
+
+**Why:** The adopter's repo root is precious surface — every top-level folder competes with the adopter's own code for attention. Keeping GAIA-internal tooling under `.gaia/` makes the boundary between "GAIA template scaffolding" and "your app" obvious, simplifies `/update-gaia` semantics (one tree to manage), and matches the principle already applied to `.gaia/scripts/`, `.gaia/statusline/`, and `.gaia/templates/`.
+
+**How to apply:**
+
+- New GAIA-internal code: default to `.gaia/<subfolder>/`.
+- Reviewing an existing root-level GAIA folder: ask "what external system requires this exact path?" If the answer is nothing, it is a candidate to move under `.gaia/`.
+- `bin/gaia` stays at root because the npm `bin` field points there — that is an external integration constraint.
+- `gaia-cli/` at root is a known exception pending migration.
+
 ## See also
 
 - [[Bundle-time Scrub]] — enforcement of the distribution boundary after binaries ship.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -9,6 +9,11 @@ tags: [meta, log]
 
 # Log
 
+- 2026-06-02 | audit promote | feedback_distro_boundary_vs_source_tree.md → wiki/concepts/Release Workflow.md § Distribution boundary vs. source tree presence
+- 2026-06-02 | audit promote | feedback_gaia_internals_in_dot_gaia.md → wiki/decisions/CLI-Binary-Split.md § GAIA-internal code placement rule
+- 2026-06-02 | audit promote | feedback_recommendation_over_questions.md → wiki/concepts/Claude Integration Conventions.md § 13
+- 2026-06-02 | audit promote | feedback_mcp_vs_cli.md → wiki/concepts/Claude Skills.md § Playwright CLI vs. MCP
+
 ## [v1.3.5] 2026-06-02 | Released
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
## Summary

`/gaia audit` surfaced four durable conventions trapped in machine-local memory (uncommitted, invisible to other developers). This promotes each into the git-tracked wiki, on the page that already owns its subject, and deletes the machine-local copies.

| Convention | Destination |
|---|---|
| Playwright CLI vs. MCP (with scope guard: not a blanket anti-MCP rule) | `wiki/concepts/Claude Skills.md` |
| Proceed vs. AskUserQuestion | `wiki/concepts/Claude Integration Conventions.md` § 13 |
| GAIA-internal code placement rule | `wiki/decisions/CLI-Binary-Split.md` |
| Distribution boundary ≠ source tree presence | `wiki/concepts/Release Workflow.md` |

Each move is recorded in `wiki/log.md`. Memory-file deletions are machine-local (not in this diff).

## Test plan

- Wiki-only `.md` changes — Quality Gate has nothing to check (no source/config).
- wiki-style audit greps (UAT/SPEC refs, historical phrasing) clean on all changed pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)