### PR TITLE
wiki: sync through 7e6cfd5

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "3bca3f6221f0bf9e0a5e3f1e709a8f46d5a38865",
-  "last_evaluated_at": "2026-06-02T07:32:40.708Z",
+  "last_evaluated_sha": "7e6cfd5cee25eebebfb1dae2b2f04fa930d6cc5a",
+  "last_evaluated_at": "2026-06-02T09:37:47Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -16,4 +16,8 @@ tags: [meta, log]
 
 ## [v1.3.5] 2026-06-02 | Released
 
+- 2026-06-02 7e6cfd5 WORTHY — promote four durable conventions from memory to wiki
+- 2026-06-02 da69d69 WORTHY — sync playbooks to use shell clock, not model time — updates skill docs
+- 2026-06-02 9791414 WORTHY — updated wiki/concepts/Update Workflow.md decision table
+- 2026-06-02 f11d796 SKIP — CHANGELOG-only fix
 See CHANGELOG.md for details.


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 7e6cfd5.