### PR TITLE
fix(hooks): strip surrounding quotes from repo-scope path captures

### DIFF
--- a/.claude/hooks/lib/repo-scope.sh
+++ b/.claude/hooks/lib/repo-scope.sh
@@ -56,6 +56,15 @@ cmd_targets_foreign_repo() {
   # No redirection found: the command runs against the home repo.
   [ -n "$target_dir" ] || return 1
 
+  # Strip one layer of surrounding quotes the capture may have included
+  # (callers legitimately write `git -C "/abs/path"` or `cd '/abs/path' &&`).
+  # The space-delimited capture keeps the quotes, which would defeat the
+  # `git -C "$target_dir"` lookup below.
+  case "$target_dir" in
+    \"*\") target_dir="${target_dir#\"}"; target_dir="${target_dir%\"}" ;;
+    \'*\') target_dir="${target_dir#\'}"; target_dir="${target_dir%\'}" ;;
+  esac
+
   # Expand a leading ~ (our cross-repo flows use ~/path targets). The tilde
   # arrives as a literal character in the command text — bash never expanded
   # it because it was inside the tool_input string — so strip it by offset.

--- a/.github/audit/tests/repo-scope.bats
+++ b/.github/audit/tests/repo-scope.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Tests for .claude/hooks/lib/repo-scope.sh's cmd_targets_foreign_repo().
+#
+# The helper decides whether a `git`/`gh` command targets a SIBLING repo
+# (return 0 = foreign, allow) versus the HOME repo (return 1 = enforce the
+# main-push / audit guards). block-main-destructive-git.sh and
+# pr-merge-audit-check.sh both source it.
+#
+# This suite lives under .github/audit/tests/ because that is the only
+# directory the CI bats runner (audit-ci-tests.yml, check name
+# "bats (.github/audit)") executes — co-locating it keeps the helper under
+# regression coverage.
+#
+# Each test sources the helper, then calls it from inside a `git init`'d HOME
+# fixture so its cwd-based `git rev-parse --show-toplevel` resolves to that
+# fixture. A second `git init`'d SIBLING fixture stands in for the foreign
+# repo. Both toplevels are canonicalised with `pwd -P`, so the macOS
+# /var → /private/var symlink under BATS_TEST_TMPDIR does not matter.
+#
+# Coverage:
+#   1. quoted `git -C "<sibling>"` push           → foreign (regression)
+#   2. quoted `cd '<sibling>' &&` push            → foreign (regression)
+#   3. unquoted `git -C <sibling>` push           → foreign (guard)
+#   4. quoted `git -C "<home>"` push              → home (quote-strip safe)
+#   5. plain home `git push origin main`          → home (enforce)
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  LIB="$REPO_ROOT/.claude/hooks/lib/repo-scope.sh"
+  [ -f "$LIB" ] || skip "repo-scope.sh not found"
+  # shellcheck source=/dev/null
+  . "$LIB"
+
+  HOME_REPO="$BATS_TEST_TMPDIR/home"
+  SIBLING_REPO="$BATS_TEST_TMPDIR/sibling"
+  init_repo "$HOME_REPO"
+  init_repo "$SIBLING_REPO"
+}
+
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init --quiet --initial-branch=main
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config commit.gpgsign false
+  echo "# readme" > "$dir/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" commit --quiet -m "init"
+}
+
+# Evaluate a command string as if issued from inside the HOME repo, so the
+# helper's cwd-based home-repo lookup resolves to HOME_REPO.
+in_home() {
+  ( cd "$HOME_REPO" && cmd_targets_foreign_repo "$1" )
+}
+
+# -----------------------------------------------------------------------------
+# 1. Quoted `git -C "<sibling>"` resolves as foreign.
+# -----------------------------------------------------------------------------
+
+@test "quoted git -C sibling push: foreign (allow)" {
+  run in_home "git -C \"$SIBLING_REPO\" push origin main"
+  [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# 2. Quoted `cd '<sibling>' &&` resolves as foreign.
+# -----------------------------------------------------------------------------
+
+@test "quoted cd sibling && git push: foreign (allow)" {
+  run in_home "cd '$SIBLING_REPO' && git push origin main"
+  [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# 3. Unquoted `git -C <sibling>` still resolves as foreign (guard).
+# -----------------------------------------------------------------------------
+
+@test "unquoted git -C sibling push: foreign (allow)" {
+  run in_home "git -C $SIBLING_REPO push origin main"
+  [ "$status" -eq 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# 4. Quoted `git -C "<home>"` resolves as HOME — quote-strip stays safe.
+# -----------------------------------------------------------------------------
+
+@test "quoted git -C home push: home (enforce)" {
+  run in_home "git -C \"$HOME_REPO\" push origin main"
+  [ "$status" -ne 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# 5. Plain home `git push origin main` resolves as HOME (enforce).
+# -----------------------------------------------------------------------------
+
+@test "plain git push from home: home (enforce)" {
+  run in_home "git push origin main"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -37,6 +37,7 @@ jobs:
             code:
               - '.github/audit/**'
               - '.github/workflows/audit-ci-tests.yml'
+              - '.claude/hooks/lib/repo-scope.sh'
       - if: steps.filter.outputs.code == 'true'
         name: Install bats
         run: sudo apt-get update && sudo apt-get install -y bats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Fixed
+
+- repo-scope guard: strip surrounding quotes from literal `git -C "<path>"` and `cd '<path>'` captures so a quoted sibling-repo push is recognized as foreign and allowed, instead of being denied as a home-repo push to main
+
 ## [1.4.0] — 2026-06-02
 
 ### Changed


### PR DESCRIPTION
## Summary

Fixes a shipped defect in `.claude/hooks/lib/repo-scope.sh` (`owned` — distributed to adopters, overwritten on `/update-gaia`).

`cmd_targets_foreign_repo()` decides whether a `git`/`gh` command targets a **sibling** repo (allow) versus the **home** repo (enforce the main-push / audit guards). The step-2 (`-C <path>`) and step-3 (`cd <path> &&`) captures both use `([^[:space:]]+)`, which captures the path **with** any surrounding quotes:

```
git -C "/abs/path" <push> origin <main>   →  target_dir='"/abs/path"'
  →  git -C '"/abs/path"' rev-parse  → fails  → return 1 (fail-closed)
```

`block-main-destructive-git.sh` then falsely **denies a legitimate sibling-repo write to the main branch** with "Plain 'git push' from main/master is forbidden". This breaks the cross-repo isolation the hook header advertises and the `/gaia-release` create-gaia/website lockstep flows.

## Fix

Strip one layer of surrounding single/double quotes after both captures and before the `~`-expansion `case` block. Only **literal** paths (quoted or unquoted) are resolvable — `$VAR` forms still fall closed because the hook reads `tool_input.command` verbatim and never sees the shell expansion.

## Tests

New `.github/audit/tests/repo-scope.bats` (runs under the `bats (.github/audit)` CI check — the only CI-wired bats runner). Red-then-green: the two quoted cases failed before the fix, all five pass after.

- quoted `-C "<sibling>"` → foreign (allow) — regression
- quoted `cd '<sibling>' &&` → foreign (allow) — regression
- unquoted `-C <sibling>` → foreign (allow) — guard
- quoted `-C "<home>"` → home (enforce) — quote-strip stays safe
- plain home write to main → home (enforce)

Verified end-to-end by driving the real `block-main-destructive-git.sh` hook with JSON payloads: quoted sibling write allowed, quoted/plain home write to main still denied. `shellcheck` clean.

## Follow-up (intentionally out of scope)

The `/gaia-release` runbook (Steps 13–14) describes sibling pushes with `-C "$CG"` / `cd "$CG" &&` (`$VAR`) forms, which the guard cannot resolve. Switching those to literal absolute paths — plus a one-line note that `$VAR` forms won't be recognized — is a separate prose change; kept out to keep this PR surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
