### PR TITLE
wiki: sync through 9cf2039

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "37b19ed9390fce056807869cdd872ba671db7f44",
-  "last_evaluated_at": "2026-06-02T09:46:47.385Z",
+  "last_evaluated_sha": "9cf2039fd077c2705429f76b7650cb3b5cc2e3e4",
+  "last_evaluated_at": "2026-06-03T09:20:13Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,4 +11,9 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 9cf2039 WORTHY — refactored /gaia router into discrete /gaia-* commands; updated 16 wiki pages
+- 2026-06-03 93929fb SKIP — chore: generic chore
+- 2026-06-03 b621f3d WORTHY — documented literal-path requirement in gaia-release → wiki/decisions/Release Workflow.md
+- 2026-06-03 acb98ee WORTHY — fixed repo-scope.sh hook to handle quoted paths in sibling-repo targets
+- 2026-06-03 6dcc977 SKIP — chore(release): release plumbing
 See CHANGELOG.md for details.


### PR DESCRIPTION
Wiki sync through commit 9cf2039 (split /gaia router into discrete /gaia-* commands).

Updates `wiki/.state.json` and appends the sync entry to `wiki/log.md`. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)