### PR TITLE
fix(pr-merge): out-of-scope bypass for docs/metadata-only PRs (#276)

### DIFF
--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -22,9 +22,24 @@
 #      the same narrowing applied to code-review-audit.yml, tests.yml, and
 #      chromatic.yml — all four surfaces skip together on chore(deps) PRs.
 #
-# Any signal proves the audit ran against this content and the agent saw
-# no Critical Issues and no unresolved Important Issues. Without one, the
-# hook denies the gh pr merge call. To unblock:
+#   5. Out-of-scope bypass: every file the PR changes (vs its merge base with
+#      the default branch) lives on a surface outside audit scope — wiki,
+#      instruction files (.claude / .specify), .gaia metadata, prose docs, and
+#      root-level markdown. These mirror the surfaces code-review-audit.yml
+#      treats as out of scope via its `has_source` check, so the agent has no
+#      rules that apply and there is nothing to audit. Evaluated fail-closed:
+#      any in-scope path (app/, test/, configs, .github/workflows/) makes the
+#      marker mandatory again, so a PR that changes auditable source can never
+#      reach this branch — it cannot mask an audit that withheld its marker
+#      over unresolved findings. Pure local git; works even when the repo's
+#      installed code-review-audit.yml predates the out-of-scope status stamp
+#      (or CI is absent), which is the case on clones that enabled CI before
+#      the stamp step existed.
+#
+# Signals 1-4 prove the audit ran against this content and the agent saw no
+# Critical Issues and no unresolved Important Issues; signal 5 proves there is
+# nothing in audit scope to review. Without one, the hook denies the gh pr
+# merge call. To unblock:
 #   1. Spawn the code-review-audit agent on the current branch, OR push to the
 #      PR branch and wait for CI's audit to stamp the GitHub commit status (CI
 #      skips when the PR modifies the audit workflow file itself — in that case
@@ -188,6 +203,58 @@ if check_chore_deps_pr; then
   exit 0
 fi
 
+# Out-of-scope bypass: accept the merge when every file this PR changes lives
+# on a surface outside audit scope. The agent has no rules that apply to wiki,
+# instruction files, .gaia metadata, or prose, so there is nothing to audit and
+# no marker is required — the same determination code-review-audit.yml's
+# `has_source` check makes when it skips. Keep the out-of-scope set below in
+# sync with that check's complement (.github/workflows/code-review-audit.yml).
+#
+# Strict allowlist, evaluated fail-closed: the diff base must resolve, the diff
+# must be non-empty, and EVERY path must be out of scope. Any unresolved base,
+# diff error, or in-scope path (app/, test/, configs, .github/workflows/) falls
+# through to the normal deny. A PR that touches auditable source therefore can
+# never reach this bypass — it cannot mask an audit that withheld its marker
+# over unresolved findings, since that PR's diff carries in-scope paths by
+# definition. Pure local git: no gh, no network, no dependence on a CI stamp.
+check_out_of_scope_pr() {
+  # Resolve the PR base — the default branch this work forks from. Prefer the
+  # remote's advertised default; fall back to main. The merge base scopes the
+  # diff to THIS PR's changes, not unrelated drift already on the base branch.
+  default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's@^refs/remotes/origin/@@')
+  [ -n "$default_branch" ] || default_branch="main"
+
+  base=$(git merge-base HEAD "origin/${default_branch}" 2>/dev/null \
+    || git merge-base HEAD "${default_branch}" 2>/dev/null \
+    || true)
+  [ -n "$base" ] || return 1
+
+  changed=$(git diff --name-only "${base}...HEAD" 2>/dev/null) || return 1
+  [ -n "$changed" ] || return 1
+
+  # First in-scope (or unrecognized) path makes the marker mandatory. `case`
+  # globs match across slashes, so `wiki/*` covers `wiki/concepts/foo.md`. The
+  # `*/*` arm catches every other nested path (app/, test/, configs in
+  # subdirs); the final `*)` catches root-level files that are not markdown
+  # (package.json, tsconfig.json, *.config.ts, …).
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$path" in
+      wiki/*|.claude/*|.specify/*|.gaia/*|docs/*) continue ;;
+      */*) return 1 ;;
+      *.md) continue ;;
+      *) return 1 ;;
+    esac
+  done <<< "$changed"
+
+  return 0
+}
+
+if check_out_of_scope_pr; then
+  exit 0
+fi
+
 reason="PR merge gate: no code-review-audit signal for HEAD ${sha:0:12}.
 
 None of the accepted signals is present:
@@ -195,6 +262,8 @@ None of the accepted signals is present:
   - Commit trailer:  ${trailer_status}
   - GitHub CI status: absent or version/tree mismatch
   - chore(deps) PR:  PR title does not match \`chore(deps):\` or \`chore(deps-dev):\`
+  - Out-of-scope:    PR changes at least one in-scope path (app/, test/, configs,
+                     .github/workflows/) — not a wiki/docs/.gaia-only diff
 
 To unblock:
   1. Spawn the code-review-audit agent locally, OR push to the PR branch

--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -416,3 +416,19 @@ fi
 ```
 
 If `gh` is unavailable or errors, tell the user to open the PR manually: `$branch` → `main`.
+
+### Step 12: Flag a stale CI audit workflow
+
+`.github/workflows/code-review-audit.yml` is **not** synced by `/update-gaia` — it installs and updates only via `/setup-gaia-ci`. A project that enabled GAIA CI on an older release therefore keeps whatever audit workflow shipped then, frozen, even after this update pulls a newer template. A stale workflow still audits in-scope PRs correctly, but an older copy may not stamp the `GAIA-Audit` status on out-of-scope (docs/metadata-only) PRs — which includes the update PR just opened. The merge gate's out-of-scope bypass keeps that PR mergeable regardless, but the workflow is worth refreshing.
+
+Probe for drift and advise only when the installed workflow is behind:
+
+```bash
+audit_drift="$(.gaia/cli/gaia setup-ci check-audit-drift --json 2>/dev/null \
+  | jq -r '.state // "unknown"' 2>/dev/null || echo unknown)"
+if [ "$audit_drift" = "drifted" ]; then
+  echo "Heads up: .github/workflows/code-review-audit.yml is out of date vs the $LATEST_TAG template. Run /setup-gaia-ci to refresh it so the CI audit stamps the GAIA-Audit status correctly (including on out-of-scope PRs). The merge gate's out-of-scope bypass keeps this docs-only update PR mergeable in the meantime."
+fi
+```
+
+`in_sync` means nothing to do; `missing` means GAIA CI is not installed (the merge gate falls back to the local `code-review-audit` agent, or the out-of-scope bypass for docs/metadata-only PRs), so stay silent. Only `drifted` warrants the nudge.

--- a/.gaia/tests/hooks/pr-merge-audit-check.bats
+++ b/.gaia/tests/hooks/pr-merge-audit-check.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+# Tests for the out-of-scope bypass in .claude/hooks/pr-merge-audit-check.sh.
+#
+# The hook denies `gh pr merge` unless a code-review-audit signal exists for
+# HEAD. Signal 5 (check_out_of_scope_pr) is a fail-closed allowlist bypass: it
+# allows the merge when EVERY file the PR changes (vs its merge base with the
+# default branch) lives outside audit scope — wiki/, .claude/, .specify/,
+# .gaia/, docs/, and root-level markdown. Any in-scope path (app/, test/,
+# configs, .github/workflows/) keeps the marker mandatory.
+#
+# Each test drives the hook exactly as the harness does: a PreToolUse JSON
+# payload on stdin, run with the repo as the working directory (the hook uses
+# bare `git`, not `git -C`). The hook always exits 0; allow vs deny is carried
+# in stdout — a deny emits `"permissionDecision": "deny"`, an allow emits
+# nothing. The in-scope (deny) cases double as a jq/setup canary: if jq were
+# missing the hook would exit early with no output and those assertions would
+# fail rather than false-pass.
+#
+# Setup models a PR: a base commit on `main`, then a `feature` branch carrying
+# the change under test. merge-base(HEAD, main) resolves to the base commit, so
+# the bypass diffs only the feature's files. No remote is needed — the hook
+# falls back from `origin/main` to `main`.
+
+setup() {
+  HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/pr-merge-audit-check.sh
+  REPO=$(mktemp -d -t pr-merge-test-XXXXXX)
+
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+  git -C "$REPO" config commit.gpgsign false
+
+  mkdir -p "$REPO/.gaia"
+  printf '1.4.0\n' > "$REPO/.gaia/VERSION"
+  echo "# readme" > "$REPO/README.md"
+  git -C "$REPO" add .gaia/VERSION README.md
+  git -C "$REPO" commit --quiet -m "init"
+
+  git -C "$REPO" checkout --quiet -b feature
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" || true
+  return 0
+}
+
+# Commit one or more files (path=content pairs) on the feature branch.
+commit_files() {
+  while [ "$#" -gt 0 ]; do
+    local path="$1" content="$2"; shift 2
+    mkdir -p "$REPO/$(dirname "$path")"
+    printf '%s\n' "$content" > "$REPO/$path"
+    git -C "$REPO" add "$path"
+  done
+  git -C "$REPO" commit --quiet -m "change"
+}
+
+# Run the hook with a `gh pr merge` command, from inside the repo.
+run_merge_hook() {
+  local cmd="${1:-gh pr merge 30 --squash --delete-branch}"
+  local json
+  json=$(jq -n --arg c "$cmd" \
+    '{tool_name: "Bash", tool_input: {command: $c}}')
+  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+}
+
+@test "allows a docs/metadata-only PR (wiki + .claude + .gaia)" {
+  commit_files \
+    ".claude/skills/update-gaia/SKILL.md" "updated" \
+    "wiki/concepts/PR Merge Workflow.md" "updated" \
+    ".gaia/manifest.json" "{}"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}
+
+@test "allows a root-level markdown-only PR" {
+  commit_files "README.md" "# changed"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}
+
+@test "allows a docs-only PR under docs/" {
+  commit_files "docs/guide.md" "guide"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}
+
+@test "denies a PR that changes app/ source" {
+  commit_files "app/components/Foo/index.tsx" "export const Foo = () => null"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+@test "denies a PR that changes a root config (package.json)" {
+  commit_files "package.json" '{"name":"x"}'
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+@test "denies a PR that changes a root *.config.ts" {
+  commit_files "vitest.config.ts" "export default {}"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+@test "denies a PR mixing out-of-scope docs with in-scope source" {
+  commit_files \
+    "wiki/x.md" "doc" \
+    "app/y.ts" "export const y = 1"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+@test "denies a PR that changes a CI workflow" {
+  commit_files ".github/workflows/tests.yml" "name: t"
+  run_merge_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+@test "ignores commands that are not gh pr merge" {
+  commit_files "app/y.ts" "export const y = 1"
+  run_merge_hook "git status"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-06-02
+updated: 2026-06-03
 tags: [concept, ci, review]
 ---
 
@@ -45,7 +45,7 @@ gh api repos/{owner}/{repo}/actions/workflows \
 gh api repos/{owner}/{repo}/actions/permissions --jq .enabled                          # false → CI cannot run; go local
 ```
 
-Spawning the local agent when CI has already stamped the marker is redundant; skipping it when CI will never stamp leaves the merge permanently blocked.
+Spawning the local agent when CI has already stamped the marker is redundant; skipping it when CI will never stamp leaves the merge permanently blocked. The exception is a PR whose entire diff is out of audit scope: the hook's out-of-scope bypass (see step 3) clears those with no marker at all, so no local run is needed even when CI never stamps.
 
 ## Four-step protocol
 
@@ -70,7 +70,7 @@ Task(
 
 ### 3. Marker handshake
 
-The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove the audit ran clean against the content being merged, plus one bypass for pre-verified PR classes:
+The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove the audit ran clean against the content being merged, plus two bypasses for PRs that need no audit signal:
 
 | Signal                                                                    | Source                       | How it gets there                                                                                                 |
 | ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -78,6 +78,7 @@ The hook (`pr-merge-audit-check.sh`) accepts any one of three signals that prove
 | `GAIA-Audit:` commit-message trailer on HEAD                              | Local audit agent            | `audit-stamp-trailer.sh` writes an empty commit with the trailer                                                  |
 | `GAIA-Audit` GitHub commit status on HEAD, description `<version> <tree>` | CI (`code-review-audit.yml`) | CI stamps this after a full audit (on the audit SHA) and on HEAD when the un-audited delta is entirely out of audit scope. No empty marker commit is pushed — that would strand HEAD on a check-less commit. |
 | PR title matches `^chore\(deps(-dev)?\):` (bypass)                        | `/update-deps` wrapper       | Wrapper opens dep-bump PRs with the canonical prefix; the local quality gate stands in for the audit signal.      |
+| Every changed file is out of audit scope (bypass)                         | `pr-merge-audit-check.sh`    | The PR's full diff against its merge base with the default branch touches only out-of-scope surfaces — `wiki/`, `.claude/`, `.specify/`, `.gaia/`, `docs/`, root-level markdown. The agent has no rules that apply, so no marker is required. This mirrors `code-review-audit.yml`'s `has_source` skip locally, so the gate clears even when the installed workflow predates the out-of-scope status stamp or CI is absent. Evaluated fail-closed: any in-scope path (`app/`, `test/`, configs, `.github/workflows/`) keeps the marker mandatory, so a PR carrying auditable source can never reach this bypass. |
 
 Tree-sha equality is the load-bearing check for both the trailer and the status: identical trees mean identical content, so an audit on a different commit SHA but the same tree is auditing the same code.
 
@@ -128,6 +129,6 @@ If `state == "MERGED"`, do NOT retry the merge. Treat it as merged, run any post
 
 - Never merge without a marker for HEAD. The hook denies it. The audit must cover the merged content — CI produces the marker when it audits the PR; otherwise the local agent does.
 - Never hand-write a marker file to bypass the gate. The agent (local or CI) owns marker emission.
-- When CI is not auditing this PR (`.github/workflows/code-review-audit.yml` is absent, Actions disabled, the workflow inactive, or a `gate_label` excludes it), the local `code-review-audit` agent is the only way to produce the marker — run it.
+- When CI is not auditing an **in-scope** PR (`.github/workflows/code-review-audit.yml` is absent, Actions disabled, the workflow inactive, or a `gate_label` excludes it), the local `code-review-audit` agent is the only way to produce the marker — run it. A PR whose entire diff is out of audit scope needs no marker; the hook's out-of-scope bypass clears it.
 
 See [[Code Review Audit Agent]], [[Quality Gate]], [[Git Workflow]].


### PR DESCRIPTION
Fixes #276.

## Problem

The merge hook (`pr-merge-audit-check.sh`) blocks `gh pr merge` until a `GAIA-Audit` marker exists for HEAD. On a docs/metadata-only PR whose installed `code-review-audit.yml` **predates the out-of-scope status stamp** (#257), CI runs green but writes **no** status — so the gate is unsatisfiable without a ceremonial local audit.

This is **not** a fresh-1.4.0 problem: a project created on 1.4.0 that runs `/setup-gaia-ci` installs the corrected template (stamp step present), and out-of-scope PRs stamp cleanly. The exposed cohort is projects that enabled CI on **≤ v1.3.4** (pre-#257) and `/update-gaia`'d forward — `/update-gaia` never refreshes the installed workflow (it's `release-exclude`d and installs only via `/setup-gaia-ci`), so the stale workflow stays frozen. That's the forensics reporter's dogfood site.

## Why not the forensics-proposed fix

The autofix bot proposed keying a bypass on "CI run = `success` + no `GAIA-Audit` status." That's **unsafe**: the audit workflow concludes `success` even when it finds **Critical Issues** (only an *abort* goes red), and on those PRs the marker is *withheld*. The merge hook is the sole gate for them, so that bypass would let critical-issue PRs merge.

## Fix

**1. Fail-closed out-of-scope bypass** (`pr-merge-audit-check.sh`). Allow the merge only when the PR's full diff vs its merge base touches *exclusively* out-of-scope surfaces (`wiki/`, `.claude/`, `.specify/`, `.gaia/`, `docs/`, root `*.md`) — mirroring `code-review-audit.yml`'s `has_source` skip, locally. Any in-scope path (`app/`, `test/`, configs, `.github/workflows/`) keeps the marker mandatory, so a PR carrying auditable source can **never** reach the bypass. Pure local git — no `gh`, no dependence on a CI stamp. The hook *is* synced by `/update-gaia`, so it lands in the working tree before the stuck PR is merged, letting it self-clear.

**2. Upgrader nudge** (`update-gaia/SKILL.md`, Step 12). After opening the update PR, probe `gaia setup-ci check-audit-drift`; if `drifted`, tell the user to run `/setup-gaia-ci` to refresh the stale workflow.

**3. Docs** — `PR Merge Workflow.md` documents the bypass (signal table + "No exceptions" carve-out).

## Tests

New `.gaia/tests/hooks/pr-merge-audit-check.bats` — 9 cases (allow docs/metadata/root-md; deny app/config/`*.config.ts`/workflow/mixed; ignore non-merge commands). **9/9 pass.** `shellcheck -S warning` clean. Deny cases double as a jq canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)