### PR TITLE
wiki: sync through de08f3d

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "9cf2039fd077c2705429f76b7650cb3b5cc2e3e4",
-  "last_evaluated_at": "2026-06-03T09:20:13Z",
+  "last_evaluated_sha": "de08f3dabc776d3d548b87410cc46c302574faf8",
+  "last_evaluated_at": "2026-06-03T10:56:42Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,10 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 71eee79 SKIP — Serena policy: sync/log maintenance
+- 2026-06-03 e6d4dd8 WORTHY — field-aware package.json merge → wiki/concepts/Update Workflow.md
+- 2026-06-03 918ba86 WORTHY — fixed PR Merge Workflow bypass logic → wiki/concepts/PR Merge Workflow.md
+- 2026-06-03 de08f3d SKIP — docs/README.md only
 - 2026-06-03 9cf2039 WORTHY — refactored /gaia router into discrete /gaia-* commands; updated 16 wiki pages
 - 2026-06-03 93929fb SKIP — chore: generic chore
 - 2026-06-03 b621f3d WORTHY — documented literal-path requirement in gaia-release → wiki/decisions/Release Workflow.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to de08f3d.