### PR TITLE
feat(skills): add maintainer-only release-notes skill + trigger-eval harness

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: release-notes
+description: Maintainer-only. Translate a version's GAIA CHANGELOG entries into plain-language public release notes for the marketing site (gaiareact.com). Writes a release-data `.ts` file under `../website/src/pages/changelog/releases/` plus an editorial-decisions report for human review. Use whenever the maintainer wants the adopter-facing notes for a version, e.g. "write release notes", "generate the changelog page entry", "translate the CHANGELOG for the website", "what's new on the site for v1.5.0", "public notes for 1.4.0", or right after cutting a release, and for one-time backfill of historical `## [x.y.z]` blocks. This is the website-notes step only. It does NOT edit `CHANGELOG.md`, it is not how you cut a release (version bump, manifest, and tag are `/gaia-release`), and it is not for an adopter's own app's release notes.
+---
+
+# release-notes
+
+Translate one version's CHANGELOG entries into adopter-facing release notes. The CHANGELOG is written for GAIA's own contributors: terse, imperative, full of internal mechanics and PR numbers. Adopters read the website. They don't care that an ADR was reframed or a memory was promoted; they care what GAIA now does for *their* project. This skill is the translation layer between the two audiences.
+
+**Maintainer-only.** Adopters never release GAIA, so this skill ships nowhere — it's excluded from the distribution tarball by `.gaia/release-exclude` (category 1), the same as `/gaia-release`. It pairs with `/gaia-release` but runs independently: you can point it at the `[Unreleased]` block while cutting a release, or at any historical `## [x.y.z]` block to backfill the website.
+
+**It never edits `CHANGELOG.md`.** The changelog stays technical and precise — that's its job. This skill only *reads* it.
+
+## Inputs
+
+Invocation carries a target version, e.g. `release-notes 1.4.0` (no leading `v`). Resolve which CHANGELOG block to translate, and where the date comes from, by that version:
+
+- **Graduated / historical** — `CHANGELOG.md` contains `## [<version>] — <YYYY-MM-DD>`. Translate that block. Take `version` and `date` **verbatim from the header**. The release already happened on that date; the shell clock is irrelevant.
+- **Live cut** — the version isn't graduated yet; its entries live under `## [Unreleased]`. Translate that block. `version` is the argument (the maintainer is cutting it now). `date` is **today from the shell clock** (`date +%F`).
+
+If no version was supplied and an `[Unreleased]` block exists, ask the maintainer which version is being cut — the version label has to come from a human, not a guess.
+
+### The date is never yours to invent
+
+Whether historical or live, the date comes from the CHANGELOG header or the shell — **never** from your own notion of "today." Models routinely misdate by months; a wrong `date` silently ships a wrong timeline to every visitor. For a live cut, run `date +%F` and use exactly that. This is the same discipline GAIA enforces for wiki playbook dates.
+
+## Output (a): the release data file
+
+Write to `../website/src/pages/changelog/releases/<version>.ts` (version with no leading `v`; `mkdir -p` the directory if it's missing). The changelog page auto-discovers every file via `import.meta.glob('../releases/*.ts')` and sorts by version, so **dropping the file in is all that's needed** — there's no index or import list to update.
+
+**The schema lives in `../website/src/pages/changelog/types.ts` (the `Release` type) — read it as the source of truth before writing.** As of this writing it is:
+
+```ts
+export type Release = {
+  added?: string[]; // "New"
+  date: string; // ISO yyyy-mm-dd
+  fixed?: string[]; // "Fixed"
+  headline?: string;
+  improved?: string[]; // "Improved"
+  summary?: string; // freeform fallback for legacy/coarse entries
+  version: string; // semver, no leading 'v'
+};
+```
+
+**Match the file form of the existing release files — don't trust this skill's literal shape.** The website's convention drifts (export style and key order have both changed). Before writing, open the newest `releases/*.ts` and mirror it exactly: `types.ts` gives you the *fields*, a live sibling file gives you the *serialization*. Today that form is a bare default export with keys in **alphabetical order** (the formatter sorts them). Omit any optional key with no content:
+
+```ts
+export default {
+  added: ['...'],
+  date: '2026-06-02',
+  fixed: ['...'],
+  headline: 'A short title or one plain sentence.',
+  improved: ['...'],
+  version: '1.4.0',
+};
+```
+
+- `added` → "New" (capabilities that didn't exist before). `improved` → "Improved" (changed/enhanced behavior). `fixed` → "Fixed".
+- `headline` — optional. A short title or one plain sentence, leading with the release's reason to exist. Skip it only if the release is a grab-bag with no single story. For a newly-shipped capability, carry the rule 1 `now` into the headline too — "GAIA apps now ship with a CSP", not "ship with".
+- `summary` vs buckets — **mutually exclusive.** The renderer shows `summary` as a single paragraph *instead of* the `added`/`improved`/`fixed` lists. The choice is driven by **how many distinct adopter-facing items survive the cut — not by the release's age or whether it's a backfill.** Use **buckets** whenever one or more itemizable adopter-facing changes remain; each lands as its own bullet under New/Improved/Fixed. Reserve `summary` for: (1) an **internal-only** release where every change was dropped as maintainer plumbing — a one-line "no adopter-facing changes" note (e.g. "Internal release-tooling fixes. No change to how GAIA apps behave."); (2) a genuine **one-sentence** story; or (3) a broad **inaugural / overview** release where a narrative reads better than a long list (the `1.0.0` entry). **Never mash two or more distinct items into one summary paragraph — if it can be two bullets, use buckets.** Never set both.
+- Bullet strings are markdown-lite: inline code in backticks, links as `[text](url)` (rendered as a new-tab link). PR links (`https://github.com/gaia-react/gaia/pull/NNN`) are *optional* — include one only when a reader would genuinely follow it for detail, never as decoration. The exemplars below omit them.
+
+## Output (b): the editorial-decisions report
+
+After writing the file, print a report to the terminal (don't write a file — this is a human gate the maintainer reads before accepting the notes). It makes your editorial judgment auditable. Use this structure:
+
+```
+## Release notes — v<version> (<date>)
+
+Wrote ../website/src/pages/changelog/releases/<version>.ts
+
+**Dropped** (with reason)
+- <changelog line> — <why: pure-internal / housekeeping / docs-only>
+
+**Consolidated**
+- <N changelog lines about X> → one <bucket> item
+
+**Needs a human ruling** (ambiguous actor — see rule 6)
+- <line> — feature or housekeeping? <why it's ambiguous>
+```
+
+Omit a section if it's empty. Never drop something silently: if it didn't make the notes, it appears under Dropped or Needs a human ruling.
+
+## The translation contract
+
+This is the substance of the skill — the rules that turn a contributor's changelog into an adopter's release notes.
+
+1. **Restate at capability/impact altitude, with a concrete subject.** Name the component the adopter touches — CI, Code Review Audit, `/update-gaia`, the quality gate. "what changed and what it means for me," not "which function moved." Avoid vague subjects — "the app", "the system", "the tooling", "things" read as placeholders. The scaffolded React app is **GAIA apps** (apps built from the template); effects on the developer's own code or files are **your …** (your utility classes, your `package.json`). So "the app ships with a CSP" becomes "GAIA apps now ship with a CSP."
+2. **Be more specific, not less.** Plain language is not vague language. One dense technical line often *splits* into two clear ones. Resist the urge to compress meaning out.
+3. **Ban filler.** No "improved performance," "various fixes," "enhanced reliability," "general improvements." If you write "optimized," say optimized *what* and the *observable result*. A bullet a reader can't act on or verify is noise. Don't restate the semver tier either: a "Patch release" / "Minor release" / "Major release" lead is redundant with the version number, which already conveys it. Descriptive framing ("Maintenance release", "Security release") is fine.
+4. **Drop changes with no adopter relevance — judge by relevance, not residence.** The test is whether an adopter *building their own product* would notice or benefit, not whether the changed file physically ships to their machine. A hook, guard, or workflow can ship to every adopter and still be maintainer-only in effect. Drop: ADR reframes, leak-check tweaks, internal status stamping, test-harness changes, docs-only edits, and fixes to GAIA's *own* development and release plumbing — sibling-repo push handling, release lockstep, contributor-only guard edge cases. The adopter's product behaves identically with or without them. Trap: "strip surrounding quotes from literal `git -C` captures so a quoted sibling-repo push is recognized as foreign" ships inside an adopter hook, yet only fires when *you* push across GAIA's own sibling repos during a release — drop it. (Contrast: GAIA CI / Code Review Audit that an adopter opts into via `/setup-gaia-ci` *is* adopter-facing — residence aside, an adopter who runs it sees the benefit, so keep it.)
+5. **Drop maintainer housekeeping on GAIA's own repo/wiki.** Promoting memories, reorganizing the wiki, dated audit artifacts, version-stamp bumps. These change GAIA's *own* state, not what GAIA *does* for an adopter.
+6. **Flag ambiguous actors — don't guess.** Imperative/passive changelog voice often hides the subject. "promote machine-local feedback memories into shared wiki" *reads* like a feature ("GAIA now promotes memories") but was the maintainer running `/gaia-audit` on GAIA's own wiki — housekeeping, drop it. When a line could mean "GAIA now does X" (keep) or "I did X to the repo" (drop) and the voice won't tell you which, put it under **Needs a human ruling** rather than picking. Guessing wrong either invents a feature or buries a real one.
+7. **Consolidate scattered lines about one subject.** Four CI / Code-Review-Audit lines describing one coherent change become one item. The adopter wants the story, not the commit-by-commit trail.
+8. **Keep breaking changes and migrations — plainly framed, with a pointer.** Plain does not mean painless. State the breakage in adopter terms, then point to the exact steps: "See the full changelog for exact steps" (or link the entry). Dropping the scary part to sound friendly is the one unforgivable edit.
+9. **House style: no em-dashes, present tense.** Use colons, commas, periods. The raw CHANGELOG violates both freely (em-dashes everywhere, "was changed from"), so never pipe a line through verbatim — always rewrite.
+10. **Bucket mapping.** `### Added` → `added` ("New"). `### Changed` → `improved` ("Improved"). `### Fixed` → `fixed` ("Fixed"). A `**BREAKING:**` or **Migration** sub-bullet stays in whatever bucket its parent lives in (usually `improved`).
+
+## Worked exemplars
+
+These are the calibration. Study how dense, internal-sounding changelog blocks collapse into a few adopter-meaningful bullets — and what gets cut. They show the *editorial result* and house style; take the literal export form and key order from a live `releases/*.ts` (see Output (a)), since the convention drifts.
+
+### `1.3.5` — seven Added, five Changed, four Fixed → two / three / one
+
+```ts
+export default {
+  added: [
+    'Dependency supply-chain hardening: new package versions are quarantined for 7 days before GAIA installs them, and downgrades are blocked, defending against a compromised fresh release.',
+    'GAIA apps now ship with a Content-Security-Policy that restricts which scripts can run, hardening them against script injection.',
+  ],
+  date: '2026-06-02',
+  fixed: [
+    "`Form/Chain` merges class names with `twMerge`, so your utility classes override the component's defaults instead of conflicting with them.",
+  ],
+  headline: 'Faster, cheaper CI and a hardened dependency supply chain.',
+  improved: [
+    'Code Review Audit on CI is now opt-in and installs on demand. When it runs, it only audits changes since the last green run instead of the whole codebase, so CI is faster and cheaper.',
+    'React Router v8 future flags are enabled so your app is ready for the v8 upgrade early. One flag (`v8_passThroughRequests`) changes how loaders and actions receive the request: if you have customized `app/root.tsx`, a small migration is needed. See the full changelog for exact steps.',
+    'Kickoff prompts print to the terminal instead of silently copying to your clipboard.',
+  ],
+  version: '1.3.5',
+};
+```
+
+Report for `1.3.5`:
+
+```
+**Dropped** (with reason)
+- stamp GAIA-Audit status on out-of-scope skips — internal status stamping, no adopter effect
+- clarify the gate owns formatting; make PR merge marker-first — internal workflow mechanics
+- document useDebounce return semantics — docs-only
+- detect orphaned wiki drift in preflight via suggested_base — internal release tooling
+- recover the un-evaluated window on sync re-anchor — internal wiki-sync mechanics
+- gaia-release updates softwareVersion — maintainer-only release tooling
+
+**Consolidated**
+- four Code Review Audit / CI lines (install on demand, honor both tokens, gate on since-last-green delta, incremental scope, opt-in) → one "Improved" item
+- two pnpm supply-chain lines (minimumReleaseAge quarantine, no-downgrade trustPolicy) → one "New" item
+```
+
+### `1.4.0` — note the `#270` housekeeping drop (rules 5/6)
+
+```ts
+export default {
+  date: '2026-06-02',
+  fixed: [
+    '`/update-gaia` no longer re-adds files you intentionally deleted.',
+    '`/update-gaia` only raises conflicts for files that actually changed in the release, instead of flooding you with spurious patches.',
+    'Wiki entries take their dates from your system clock instead of the model, so timestamps are always correct.',
+  ],
+  headline: '`/update-gaia` stops fighting you over your own files.',
+  version: '1.4.0',
+};
+```
+
+Report for `1.4.0`:
+
+```
+**Dropped** (with reason)
+- promote machine-local feedback memories into shared wiki (#270) — reads like a feature but was the maintainer running /gaia-audit, a content action on GAIA's own wiki, not adopter-visible behavior (rule 5/6)
+```
+
+The `#270` trap is the whole point of rule 6: under `### Changed`, in imperative voice, it looks exactly like a shipped capability. It isn't. When the voice hides the subject and you can't resolve it from context, surface it under "Needs a human ruling" instead of dropping or keeping on instinct.
+
+### When `summary` fits — internal-only or one-line releases
+
+A release with no distinct adopter-facing items left after the cut — an internal-only patch where everything was dropped as maintainer plumbing, or a genuinely one-sentence story — collapses to a single `summary` paragraph. This is about item count, not age: a backfilled old release with two real adopter changes still earns buckets. The shape, for an internal-only patch like `1.1.1`:
+
+```ts
+export default {
+  date: '2026-05-11',
+  headline: 'GAIA release fixes',
+  summary:
+    'Fix to the gaia-release maintainer reference, plus follow-ups from live init runs.',
+  version: '1.1.1',
+};
+```
+
+Use this only for an internal-only release or a genuinely one-line story. Anything with two or more distinct adopter-facing changes earns buckets — backfill or not.
+
+## Workflow
+
+1. Resolve the version → block → date (Inputs above). For a live cut, run `date +%F` now.
+2. Read `../website/src/pages/changelog/types.ts` for the current `Release` fields and the newest `releases/*.ts` for the current file form (export style + key order). Then read the version's block from `CHANGELOG.md`. Classify every line: keep, drop (rule 4/5), consolidate-with-siblings (rule 7), or ambiguous (rule 6).
+3. Translate the kept lines through the contract. Group by bucket (rule 10). Merge consolidations.
+4. Draft a `headline` if the release has a single story; otherwise omit it. For a coarse backfill with no bucket-worthy detail, write a `summary` paragraph instead of buckets.
+5. Assemble the `.ts` in the exact form of the file you read in step 2 (today: bare default export, keys alphabetical). Omit empty optional keys. Sweep for em-dashes and banned filler before writing (rule 3/9).
+6. `mkdir -p ../website/src/pages/changelog/releases` and write `<version>.ts`. No index to update — the page globs the directory.
+7. Print the editorial-decisions report. Every changelog line that didn't survive appears under Dropped or Needs a human ruling — no silent cuts.
+
+## See
+
+- `.claude/commands/gaia-release.md` — the release process this feeds; Step 14 already locksteps other website version sites.
+- `CHANGELOG.md` — the source. Read-only. Never edited here.
+- `eval/probe.py` — trigger-boundary validation harness (maintainer-only, excluded from the tarball). After editing the frontmatter `description`, re-run `python3 .claude/skills/release-notes/eval/probe.py --runs 3` to confirm the boundary still holds (target: 100% recall, 0% false-positive). Options in its docstring.

--- a/.claude/skills/release-notes/eval/.gitignore
+++ b/.claude/skills/release-notes/eval/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.claude/skills/release-notes/eval/probe.py
+++ b/.claude/skills/release-notes/eval/probe.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Local trigger probe for the installed `release-notes` skill.
+
+Maintainer-only validation harness. Verifies the skill's frontmatter
+`description` makes Claude trigger the skill for queries that should match, and
+NOT trigger for near-miss queries that should not. Run it after any edit to the
+`description` to confirm the trigger boundary still holds (target: 100% recall on
+the should-trigger set, 0% false-positive on the should-not set).
+
+It does NOT use the skill-creator's temp-command approach (which scores recall=0%
+because the real installed skill steals the trigger from the temp hash name).
+Instead it probes the real installed skill directly and detects, from streaming
+tool-use events, whether the model's first action is Skill(skill="release-notes")
+or a Read of the skill's SKILL.md. Detection is early and the process is killed
+the instant we detect, so permission prompts never fire.
+
+Requires the `claude` CLI on PATH (uses your Claude Code subscription auth, no
+ANTHROPIC_API_KEY needed). The repo root is resolved dynamically, so it runs from
+anywhere:
+
+  python3 .claude/skills/release-notes/eval/probe.py                 # full sweep
+  python3 .../eval/probe.py --runs 3                                 # 3 runs/query
+  python3 .../eval/probe.py --only "make the release-data"           # one query
+  python3 .../eval/probe.py --out /tmp/result.json                   # custom output
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+SKILL_NAME = "release-notes"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _repo_root() -> Path:
+    """Repo root, resolved dynamically so the probe is path-portable."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=SCRIPT_DIR, capture_output=True, text=True, check=True,
+        )
+        return Path(out.stdout.strip())
+    except Exception:
+        # eval/ -> release-notes/ -> skills/ -> .claude/ -> repo root
+        return SCRIPT_DIR.parents[3]
+
+
+REPO_ROOT = _repo_root()
+DEFAULT_EVAL = SCRIPT_DIR / "trigger-eval.json"
+
+
+def detect_trigger(accumulated_json: str, tool: str) -> bool:
+    """True if the first tool action targets the release-notes skill."""
+    if tool == "Skill":
+        # Skill input is {"skill":"release-notes",...}; sibling skills like
+        # "gaia-release" do not contain the substring "release-notes".
+        return "release-notes" in accumulated_json
+    if tool == "Read":
+        return f"skills/{SKILL_NAME}" in accumulated_json
+    return False
+
+
+def run_single(query: str, timeout: int, model: str) -> dict:
+    """Run one query; return {'triggered', 'first_tool', 'first_arg',
+    'elapsed', 'note'}. cwd is the repo root so the installed skill is found."""
+    cmd = [
+        "claude",
+        "-p", query,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--model", model,
+    ]
+    # Drop CLAUDECODE so a nested `claude -p` is allowed; the guard is for
+    # interactive terminal conflicts, not programmatic subprocess use.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+    triggered = False
+    first_tool = ""
+    accumulated_json = ""
+    pending_tool = None
+    start = time.time()
+    buffer = ""
+
+    def result(trig, tool, arg, n):
+        return {
+            "triggered": trig,
+            "first_tool": tool,
+            "first_arg": arg[:160],
+            "elapsed": round(time.time() - start, 1),
+            "note": n,
+        }
+
+    try:
+        while time.time() - start < timeout:
+            if process.poll() is not None:
+                rest = process.stdout.read()
+                if rest:
+                    buffer += rest.decode("utf-8", errors="replace")
+            else:
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    if process.poll() is not None:
+                        break
+                    continue
+                buffer += chunk.decode("utf-8", errors="replace")
+
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                etype = event.get("type")
+
+                if etype == "stream_event":
+                    se = event.get("event", {})
+                    st = se.get("type", "")
+
+                    if st == "content_block_start":
+                        cb = se.get("content_block", {})
+                        if cb.get("type") == "tool_use":
+                            name = cb.get("name", "")
+                            if name in ("Skill", "Read"):
+                                pending_tool = name
+                                first_tool = name
+                                accumulated_json = ""
+                            else:
+                                # First tool is something else -> non-trigger.
+                                return result(False, name, "", "first tool not Skill/Read")
+
+                    elif st == "content_block_delta" and pending_tool:
+                        delta = se.get("delta", {})
+                        if delta.get("type") == "input_json_delta":
+                            accumulated_json += delta.get("partial_json", "")
+                            if detect_trigger(accumulated_json, pending_tool):
+                                return result(True, pending_tool, accumulated_json, "early-detect")
+
+                    elif st in ("content_block_stop", "message_stop"):
+                        if pending_tool:
+                            trig = detect_trigger(accumulated_json, pending_tool)
+                            return result(trig, pending_tool, accumulated_json,
+                                          "block-stop" if trig else "tool but wrong target")
+                        if st == "message_stop":
+                            return result(False, first_tool or "(text)", "", "turn ended, no skill")
+
+                elif etype == "assistant":
+                    # Fallback: full assistant message (post-execution).
+                    msg = event.get("message", {})
+                    for ci in msg.get("content", []):
+                        if ci.get("type") != "tool_use":
+                            continue
+                        name = ci.get("name", "")
+                        inp = json.dumps(ci.get("input", {}))
+                        if name == "Skill" and SKILL_NAME in ci.get("input", {}).get("skill", ""):
+                            return result(True, "Skill", inp, "fallback-assistant")
+                        if name == "Read" and f"skills/{SKILL_NAME}" in ci.get("input", {}).get("file_path", ""):
+                            return result(True, "Read", inp, "fallback-assistant")
+                        return result(False, name, inp, "fallback wrong tool")
+
+                elif etype == "result":
+                    return result(triggered, first_tool or "(text)", "", "result event")
+
+            if process.poll() is not None:
+                break
+
+        return result(triggered, first_tool or "(timeout)", accumulated_json, "timeout/eof")
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--eval-set", default=str(DEFAULT_EVAL))
+    ap.add_argument("--runs", type=int, default=1)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--model", default="claude-opus-4-8")
+    ap.add_argument("--only", default=None,
+                    help="substring filter: only run queries containing this")
+    ap.add_argument("--out",
+                    default=str(Path(tempfile.gettempdir()) / "release-notes-probe-result.json"),
+                    help="where to write the JSON result (default: system temp dir)")
+    args = ap.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    if args.only:
+        eval_set = [q for q in eval_set if args.only.lower() in q["query"].lower()]
+
+    jobs = []  # (idx, query, should_trigger, run_idx)
+    for i, item in enumerate(eval_set):
+        for r in range(args.runs):
+            jobs.append((i, item["query"], item["should_trigger"], r))
+
+    out = {}  # idx -> {query, should_trigger, runs:[result...]}
+    for i, item in enumerate(eval_set):
+        out[i] = {"query": item["query"], "should_trigger": item["should_trigger"], "runs": []}
+
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        fut = {ex.submit(run_single, q, args.timeout, args.model): (idx, st)
+               for (idx, q, st, _) in jobs}
+        done = 0
+        for f in as_completed(fut):
+            idx, st = fut[f]
+            try:
+                res = f.result()
+            except Exception as e:
+                res = {"triggered": False, "first_tool": "ERROR", "first_arg": str(e)[:160],
+                       "elapsed": 0, "note": "exception"}
+            out[idx]["runs"].append(res)
+            done += 1
+            mark = "TRIG" if res["triggered"] else "----"
+            exp = "+" if st else "-"
+            print(f"[{done}/{len(jobs)}] {mark} exp={exp} {res['elapsed']:>5}s "
+                  f"{res['first_tool']:<8} :: {out[idx]['query'][:60]}", file=sys.stderr)
+
+    should_rows, shouldnot_rows = [], []
+    for idx in sorted(out):
+        row = out[idx]
+        rate = sum(1 for r in row["runs"] if r["triggered"]) / max(1, len(row["runs"]))
+        row["trigger_rate"] = rate
+        (should_rows if row["should_trigger"] else shouldnot_rows).append(row)
+
+    def fmt(rows, want):
+        lines = []
+        for row in rows:
+            rate = row["trigger_rate"]
+            ok = (rate >= 0.5) == want
+            status = "PASS" if ok else "FAIL"
+            firsts = ",".join(sorted({r["first_tool"] for r in row["runs"]}))
+            lines.append(f"  [{status}] rate={rate:.2f} first={firsts:<14} {row['query'][:64]}")
+        return "\n".join(lines)
+
+    recall = sum(1 for r in should_rows if r["trigger_rate"] >= 0.5) / max(1, len(should_rows))
+    fp_rate = sum(1 for r in shouldnot_rows if r["trigger_rate"] >= 0.5) / max(1, len(shouldnot_rows))
+
+    print("\n=== SHOULD TRIGGER (recall) ===")
+    print(fmt(should_rows, True))
+    print("\n=== SHOULD NOT TRIGGER (false positives) ===")
+    print(fmt(shouldnot_rows, False))
+    print(f"\nrecall = {recall * 100:.0f}%  "
+          f"({sum(1 for r in should_rows if r['trigger_rate'] >= 0.5)}/{len(should_rows)})")
+    print(f"false-positive rate = {fp_rate * 100:.0f}%  "
+          f"({sum(1 for r in shouldnot_rows if r['trigger_rate'] >= 0.5)}/{len(shouldnot_rows)})")
+
+    Path(args.out).write_text(json.dumps(out, indent=2))
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/release-notes/eval/trigger-eval.json
+++ b/.claude/skills/release-notes/eval/trigger-eval.json
@@ -1,0 +1,23 @@
+[
+  {"query": "we just merged the 1.5.0 release PR — generate the website changelog entry for it from the CHANGELOG", "should_trigger": true},
+  {"query": "translate the [Unreleased] block into adopter-facing release notes for gaiareact.com", "should_trigger": true},
+  {"query": "I need the public release notes for v1.4.0, the plain-language ones for the marketing site, not the raw changelog", "should_trigger": true},
+  {"query": "backfill the changelog page on the site for 1.2.0 through 1.3.4, we skipped a bunch of versions", "should_trigger": true},
+  {"query": "make the release-data .ts for 1.3.5 under website/src/pages/changelog/releases", "should_trigger": true},
+  {"query": "cutting 1.6.0 now, write up what's new for the website in plain english", "should_trigger": true},
+  {"query": "the CHANGELOG is way too technical for the public changelog page, turn the latest version into something adopters can actually read", "should_trigger": true},
+  {"query": "generate the release notes for the new version and tell me what you dropped and why", "should_trigger": true},
+  {"query": "do the gaiareact.com changelog entry for 1.5.0 and flag anything that's maintainer-only so I can review it", "should_trigger": true},
+  {"query": "write the public-facing summary of 1.4.0's changes for the site and leave out the internal plumbing", "should_trigger": true},
+
+  {"query": "add an entry to CHANGELOG.md for the package.json field-aware merge fix we just landed", "should_trigger": false},
+  {"query": "cut a new GAIA release: bump the version, graduate the changelog, regenerate the manifest, tag it", "should_trigger": false},
+  {"query": "write release notes for my own app's 2.0 launch, we shipped a new dashboard and SSO", "should_trigger": false},
+  {"query": "summarize the git commits since the last tag into a changelog", "should_trigger": false},
+  {"query": "update the copy on the features section of the marketing site, the CSP wording reads awkwardly", "should_trigger": false},
+  {"query": "what actually changed between 1.3.5 and 1.4.0?", "should_trigger": false},
+  {"query": "draft a tweet announcing the 1.5.0 release", "should_trigger": false},
+  {"query": "add a new step to gaia-release.md for locksteping the website version", "should_trigger": false},
+  {"query": "regenerate the manifest and bump the version for the release", "should_trigger": false},
+  {"query": "translate the README into Japanese for the docs site", "should_trigger": false}
+]

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -12,15 +12,19 @@
 
 # --- 1. Maintainer-only Claude surface ---
 # /gaia-release cuts releases of the GAIA template itself; adopters never
-# release GAIA. /health-audit is the maintainer-only autonomous audit +
-# auto-heal loop (runbook lives under .gaia/cli/health/, already excluded
-# wholesale via category 10). Other /gaia-* commands (plan, handoff,
-# pickup, audit) are adopter-useful and must NOT be added here.
-# preferred-base.sh is the maintainer's personal statusline left-side
-# renderer; adopters get the right-side-only gaia-statusline.sh wrapper
-# which delegates left-side rendering to the user's own global statusline.
+# release GAIA. The release-notes skill translates GAIA's CHANGELOG into
+# public release notes for the marketing site — a release-time maintainer
+# task, so it ships nowhere just like /gaia-release. /health-audit is the
+# maintainer-only autonomous audit + auto-heal loop (runbook lives under
+# .gaia/cli/health/, already excluded wholesale via category 10). Other
+# /gaia-* commands (plan, handoff, pickup, audit) are adopter-useful and
+# must NOT be added here. preferred-base.sh is the maintainer's personal
+# statusline left-side renderer; adopters get the right-side-only
+# gaia-statusline.sh wrapper which delegates left-side rendering to the
+# user's own global statusline.
 .claude/commands/gaia-release.md
 .claude/commands/health-audit.md
+.claude/skills/release-notes
 .gaia/statusline/preferred-base.sh
 
 # --- 2. Maintainer-only wiki content ---


### PR DESCRIPTION
## What

Adds a **maintainer-only** `release-notes` skill that translates a version's GAIA `CHANGELOG.md` block into adopter-facing public release notes for the marketing site (gaiareact.com), plus the trigger-eval harness used to validate it.

- **Output (a):** a release-data `.ts` at `../website/src/pages/changelog/releases/<version>.ts` (the changelog page auto-discovers via `import.meta.glob`, so no index to update). The skill reads a live sibling `releases/*.ts` to mirror the current file form — the website convention drifts (export style, key order).
- **Output (b):** an editorial-decisions report printed to the terminal — a human gate listing what was dropped, consolidated, or flagged as an ambiguous actor. No silent cuts.

It reads `CHANGELOG.md` only and **never edits it**. It is not the release-cutting flow (`/gaia-release` owns version bump, manifest, tag) and is not for an adopter's own app's release notes.

## Editorial contract (the substance)

The skill is mostly editorial judgment, encoded as numbered rules in `SKILL.md`:

- **Restate at capability/impact altitude** with a concrete subject — "GAIA apps **now** ship with a CSP", not "which function moved".
- **Drop by relevance, not residence** — a hook/guard/workflow can ship to every adopter and still be maintainer-only in effect (release plumbing, audit markers, repo-scope guards). Drop it.
- **Flag ambiguous actors** rather than guess — imperative changelog voice often hides whether "GAIA now does X" (keep) or "I did X to the repo" (drop).
- **Consolidate** scattered lines into one story; **keep breaking changes** plainly framed with a pointer.
- **House style:** no em-dashes, present tense, no filler — and no semver-tier lead ("Patch release" / "Minor" / "Major"), which the version number already conveys.
- **`summary` vs buckets is item-count-driven, not age/backfill-driven:** use New/Improved/Fixed buckets whenever one or more itemizable adopter-facing changes survive the cut; reserve a one-line `summary` for internal-only releases, a genuine one-sentence story, or an inaugural overview.

## Distribution

Excluded from the distribution tarball via `.gaia/release-exclude` (category 1), alongside `/gaia-release` — adopters never release GAIA, so the skill (and its `eval/` harness) ship nowhere.

## Trigger-eval harness (`eval/`)

- `eval/probe.py` + `eval/trigger-eval.json` (20 queries: 10 should-trigger, 10 near-miss should-not).
- Probes the **real installed skill** via `claude -p` streaming tool-use detection, killing on first detection so permission prompts never fire. Uses Claude Code subscription auth (**no `ANTHROPIC_API_KEY`**). Repo root is resolved dynamically, so it is path-portable (no hardcoded paths; passes the `.claude/` absolute-path audit).
- Re-validate after any `description` edit:
  ```
  python3 .claude/skills/release-notes/eval/probe.py --runs 3
  ```
  Target: 100% recall, 0% false-positive.

## Validation

- **Content quality:** with-skill 1.00 vs baseline 0.53 across three evals (backfill 1.3.5, backfill 1.4.0, live-cut 1.5.0). The 1.3.5 and 1.4.0 outputs byte-match the committed golden files.
- **Trigger boundary:** the probe over 20 queries scored **recall 100% (30/30 runs) and false-positive 0% (30/30 runs)** at 3 runs each. Release-adjacent traps (`cut a new GAIA release`, `regenerate the manifest`, editing `CHANGELOG.md`, an adopter's own app) all routed away from the skill every time.

## First use (provenance)

First applied downstream of this PR (in the website repo and GitHub Releases) to:
- backfill/rewrite the **19-version** changelog on gaiareact.com (`releases/*.ts`), and
- replace all **19 GitHub release bodies** (v1.0.0–v1.4.0) with the adopter-facing notes, matching the website 1-1.

The item-count `summary`-vs-buckets rule and the no-"Patch release" / headline-"now" refinements above came out of that first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
