### PR TITLE
wiki: sync through 1182692

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "de08f3dabc776d3d548b87410cc46c302574faf8",
-  "last_evaluated_at": "2026-06-03T10:56:42Z",
+  "last_evaluated_sha": "1182692b75c3e360020dd146d089ecca169b4eee",
+  "last_evaluated_at": "2026-06-03T16:38:58Z",
   "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
   "last_consolidated_at": "2026-05-22T20:00:01Z"
 }

--- a/wiki/concepts/Release-Notes.md
+++ b/wiki/concepts/Release-Notes.md
@@ -1,0 +1,47 @@
+---
+type: skill
+status: active
+description: Maintainer-only. Translate a version's GAIA CHANGELOG entries into plain-language public release notes for the marketing site.
+---
+
+# Release Notes
+
+Maintainer-only skill that translates a version's CHANGELOG entries into adopter-facing public release notes for gaiareact.com.
+
+## Purpose
+
+The CHANGELOG is written for GAIA's own contributors: terse, imperative, full of internal mechanics and PR numbers. Adopters reading the website care what GAIA now does for their project, not internal implementation details.
+
+## Outputs
+
+1. **Release data file** — a `.ts` file under `../website/src/pages/changelog/releases/<version>.ts` following the `Release` type schema. The changelog page auto-discovers these files and sorts by version.
+
+2. **Editorial-decisions report** — printed to terminal, auditing which CHANGELOG lines were dropped, consolidated, or flagged as ambiguous. Never silent cuts.
+
+## Key rules
+
+- **Restate at adopter impact altitude.** Name the component adopters touch — CI, Code Review Audit, `/update-gaia`. "What changed and what it means for me," not "which function moved."
+- **Drop changes with no adopter relevance.** Test: would an adopter building their own product notice or benefit? Drop ADR reframes, internal wiki work, maintainer-only tooling, and docs-only edits.
+- **Flag ambiguous actors, don't guess.** When a CHANGELOG line could mean "GAIA now does X" (keep) or "I did X to the repo" (drop), surface it under "Needs a human ruling."
+- **Consolidate scattered lines about one subject** into one bullet per adopter-facing change.
+- **Keep breaking changes plainly framed** with a pointer to exact steps.
+- **House style:** no em-dashes, present tense, no filler words like "improved performance" without specifics.
+
+## Invocation
+
+`release-notes <version>` (e.g. `release-notes 1.4.0`, no leading `v`). Resolves which CHANGELOG block to translate (graduated `## [x.y.z]` or `[Unreleased]`) and derives the date from the block header or system clock.
+
+## Workflow
+
+1. Resolve version → block → date. For a live cut, run `date +%F`.
+2. Read `../website/src/pages/changelog/types.ts` for current fields and the newest `releases/*.ts` for current file form. Read the version's block from `CHANGELOG.md`.
+3. Classify every line: keep, drop (rule category), consolidate-with-siblings, or ambiguous.
+4. Translate kept lines through the contract. Group by bucket (Added / Improved / Fixed). Omit empty optional keys.
+5. Write the `.ts` in exact form of the reference file (today: bare default export, keys alphabetical).
+6. Print the editorial-decisions report — no silent cuts.
+
+## Relation to other skills
+
+- **Not `/gaia-release`** — that cuts the release itself (version bump, manifest, tag). This translates CHANGELOG for the website.
+- **Not for adopters' own release notes** — only for GAIA public notes on gaiareact.com.
+- **Excludes from distribution tarball** — maintainers only, like `/gaia-release`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,8 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 1182692 WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md
+- 2026-06-03 3ab9e1b SKIP — wiki: self-referential
 - 2026-06-03 71eee79 SKIP — Serena policy: sync/log maintenance
 - 2026-06-03 e6d4dd8 WORTHY — field-aware package.json merge → wiki/concepts/Update Workflow.md
 - 2026-06-03 918ba86 WORTHY — fixed PR Merge Workflow bypass logic → wiki/concepts/PR Merge Workflow.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 1182692.