### PR TITLE
wiki: advance consolidate state (0 findings)

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -2,6 +2,6 @@
   "version": 1,
   "last_evaluated_sha": "1182692b75c3e360020dd146d089ecca169b4eee",
   "last_evaluated_at": "2026-06-03T16:38:58Z",
-  "last_consolidated_sha": "59de5426ec369a09917edc54052b985b8bf558df",
-  "last_consolidated_at": "2026-05-22T20:00:01Z"
+  "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
+  "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/meta/consolidate-report-2026-06-04.md
+++ b/wiki/meta/consolidate-report-2026-06-04.md
@@ -1,0 +1,21 @@
+---
+type: meta
+title: Consolidate Report — 2026-06-04
+status: active
+created: 2026-06-04
+updated: 2026-06-04
+tags: [meta, consolidate]
+---
+
+# Consolidate Report — 2026-06-04
+
+Run summary: 0 findings across 0 domains.
+
+No supersession candidates, reversed decisions, near-collision slugs, or subject-orphaned pages detected.
+
+**Detection notes:**
+
+- **Supersession (2a):** One title pair met the Jaccard ≥ 0.7 threshold (`Code Review Audit Agent` vs `Code Review Audit CI`, Jaccard = 0.75), but neither page carries `promoted_from` frontmatter, so the required provenance gap condition does not hold. Not flagged.
+- **Reversed decisions (2b):** No negation patterns (`replaces`, `supersedes`, `no longer use`, `deprecated in favor of`, `reversed`, `obsoletes`) referencing another decision page's title were found in any decision page body.
+- **Near-collision slugs (2c):** No slug pairs within Levenshtein distance 2 or prefix-relationship found across any domain.
+- **Subject-orphaned (2d):** 24 pages have zero inbound wikilinks, but none have been untouched for 90+ days (oldest is 44 days). The 90-day threshold was not met by any candidate.


### PR DESCRIPTION
## What

Advances `wiki/.state.json` `last_consolidated_sha` from the May 22 baseline (`59de5426`) to the current main tip (`e022c9d`), and adds the 0-findings consolidate report for today.

## Why

The `/gaia-wiki consolidate` run this session executed *after* the wiki-sync PR (#284) had already auto-merged, so its state bump had no sync commit to ride along with (consolidate doesn't commit on its own). Left unlanded, `last_consolidated_sha` stays stuck at May 22 and the consolidate gate re-fires on every future sync (it sees ≥2 pages added since then).

## Detection result

No findings: no supersession candidates, reversed decisions, near-collision slugs, or subject-orphaned pages. Full notes in the report.

## Scope

Wiki-only (`wiki/.state.json`, `wiki/meta/`). Out of audit scope; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)