### PR TITLE
wiki: sync through 1ef7eec

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "1182692b75c3e360020dd146d089ecca169b4eee",
-  "last_evaluated_at": "2026-06-03T16:38:58Z",
+  "last_evaluated_sha": "1ef7eec85fb73221984447c576074ec248954913",
+  "last_evaluated_at": "2026-06-03T17:46:45Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 1ef7eec SKIP — tooling fix; maintainer-only skill documentation
+- 2026-06-03 0845873 SKIP — wiki state file maintenance only
+- 2026-06-03 e022c9d WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md
 - 2026-06-03 1182692 WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md
 - 2026-06-03 3ab9e1b SKIP — wiki: self-referential
 - 2026-06-03 71eee79 SKIP — Serena policy: sync/log maintenance


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 1ef7eec.