### PR TITLE
wiki: sync through 1ef7eec; scrub website path from Release-Notes, mark maintainer-only

### DIFF
--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -34,6 +34,7 @@ wiki/entities
 wiki/meta
 wiki/.obsidian/workspace.json
 wiki/concepts/Release Workflow.md
+wiki/concepts/Release-Notes.md
 wiki/decisions/Bundle-time Scrub.md
 wiki/decisions/CLI-Binary-Split.md
 wiki/decisions/Forensics Triage Workflow.md

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "1182692b75c3e360020dd146d089ecca169b4eee",
-  "last_evaluated_at": "2026-06-03T16:38:58Z",
+  "last_evaluated_sha": "1ef7eec85fb73221984447c576074ec248954913",
+  "last_evaluated_at": "2026-06-03T17:46:45Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/concepts/Release-Notes.md
+++ b/wiki/concepts/Release-Notes.md
@@ -14,13 +14,13 @@ The CHANGELOG is written for GAIA's own contributors: terse, imperative, full of
 
 ## Outputs
 
-1. **Release data file** — a `.ts` file under `../website/src/pages/changelog/releases/<version>.ts` following the `Release` type schema. The changelog page auto-discovers these files and sorts by version.
+1. **Release data file**: a per-version `.ts` file in the website's changelog releases directory, following the `Release` type schema. The changelog page auto-discovers these files and sorts by version.
 
-2. **Editorial-decisions report** — printed to terminal, auditing which CHANGELOG lines were dropped, consolidated, or flagged as ambiguous. Never silent cuts.
+2. **Editorial-decisions report**: printed to terminal, auditing which CHANGELOG lines were dropped, consolidated, or flagged as ambiguous. Never silent cuts.
 
 ## Key rules
 
-- **Restate at adopter impact altitude.** Name the component adopters touch — CI, Code Review Audit, `/update-gaia`. "What changed and what it means for me," not "which function moved."
+- **Restate at adopter impact altitude.** Name the component adopters touch: CI, Code Review Audit, `/update-gaia`. "What changed and what it means for me," not "which function moved."
 - **Drop changes with no adopter relevance.** Test: would an adopter building their own product notice or benefit? Drop ADR reframes, internal wiki work, maintainer-only tooling, and docs-only edits.
 - **Flag ambiguous actors, don't guess.** When a CHANGELOG line could mean "GAIA now does X" (keep) or "I did X to the repo" (drop), surface it under "Needs a human ruling."
 - **Consolidate scattered lines about one subject** into one bullet per adopter-facing change.
@@ -34,14 +34,14 @@ The CHANGELOG is written for GAIA's own contributors: terse, imperative, full of
 ## Workflow
 
 1. Resolve version → block → date. For a live cut, run `date +%F`.
-2. Read `../website/src/pages/changelog/types.ts` for current fields and the newest `releases/*.ts` for current file form. Read the version's block from `CHANGELOG.md`.
+2. Read the website changelog's type definitions for current fields and the newest existing release file for current file form. Read the version's block from `CHANGELOG.md`.
 3. Classify every line: keep, drop (rule category), consolidate-with-siblings, or ambiguous.
 4. Translate kept lines through the contract. Group by bucket (Added / Improved / Fixed). Omit empty optional keys.
 5. Write the `.ts` in exact form of the reference file (today: bare default export, keys alphabetical).
-6. Print the editorial-decisions report — no silent cuts.
+6. Print the editorial-decisions report: no silent cuts.
 
 ## Relation to other skills
 
-- **Not `/gaia-release`** — that cuts the release itself (version bump, manifest, tag). This translates CHANGELOG for the website.
-- **Not for adopters' own release notes** — only for GAIA public notes on gaiareact.com.
-- **Excludes from distribution tarball** — maintainers only, like `/gaia-release`.
+- **Not `/gaia-release`**: that cuts the release itself (version bump, manifest, tag). This translates CHANGELOG for the website.
+- **Not for adopters' own release notes**: only for GAIA public notes on gaiareact.com.
+- **Excludes from distribution tarball**: maintainers only, like `/gaia-release`.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 1ef7eec SKIP — tooling fix; maintainer-only skill documentation
+- 2026-06-03 0845873 SKIP — wiki state file maintenance only
+- 2026-06-03 e022c9d WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md
 - 2026-06-03 1182692 WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md
 - 2026-06-03 3ab9e1b SKIP — wiki: self-referential
 - 2026-06-03 71eee79 SKIP — Serena policy: sync/log maintenance

--- a/wiki/meta/lint-report-2026-06-04.md
+++ b/wiki/meta/lint-report-2026-06-04.md
@@ -1,0 +1,24 @@
+---
+type: meta
+title: 'Lint Report 2026-06-04'
+created: 2026-06-04
+updated: 2026-06-04
+tags: [meta, lint]
+status: developing
+---
+
+# Lint Report: 2026-06-04
+
+## #11: Wiki drift check
+
+ℹ 1 commit behind HEAD. Run /gaia-wiki sync at next opportunity. Recent unsynced commits:
+
+- ad74dc7 wiki: sync through 1ef7eec
+
+## #12: Dead repo-relative paths
+
+✓ No dead repo-relative paths detected in wiki body prose.
+
+## #13: UAT/SPEC narrative-ref drift
+
+✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.


### PR DESCRIPTION
## Summary

Wiki maintenance from the `/gaia-wiki` chain plus a maintainer-only-leak fix surfaced by lint.

- **Sync state advance** (`ad74dc7`): evaluates `1182692..1ef7eec` (3 commits, 1 worthy was a no-op re-edit of an existing page). Advances `wiki/.state.json` + appends the SKIP/WORTHY classifications to `wiki/log.md`.
- **Mark `Release-Notes.md` maintainer-only**: the `release-notes` skill is maintainer-only and excluded from the distribution tarball, but its wiki page was **not** in `.gaia/release-exclude`, so it would ship to adopters. Added to category 2 (maintainer-only wiki content), alongside its peer `Release Workflow.md`.
- **Drop cross-repo `../website/...` paths** from the page: they tripped the lint `#12` dead-path check (the sibling `website/` repo isn't present in the open-source `gaia/` checkout) and carry no value in the open-source wiki. The page still describes that it writes release data into the website's changelog; it just no longer hardcodes the path.
- **Scrub em-dashes** to match the page's own stated house style (line 28: "no em-dashes").
- **Refresh lint report `#12`** to clean now that the dead path is gone.

## Lint verification (claude-obsidian 1.9.2)

- `#11` drift reads `low` (1 behind) and matches `gaia wiki state` — the stale-`#11` fix from #286 holds under the upgraded plugin.
- `#12` now clean. `#13` clean.

## Note (not fixed here)

Upstream `claude-obsidian:wiki-lint` `#1`–`#10` sections remain absent under 1.9.2 by design: those checks target Obsidian constructs (`[[wikilinks]]`, Dataview, canvas, `address:` frontmatter) that GAIA's plain-markdown wiki doesn't use. Decoupling the no-op wrapper from `lint.md` Step 1 is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)