### PR TITLE
feat(wiki-lint): decouple from upstream claude-obsidian; native orphan/frontmatter/empty-section checks

### DIFF
--- a/.claude/skills/gaia/references/wiki.md
+++ b/.claude/skills/gaia/references/wiki.md
@@ -145,9 +145,9 @@ Spawn:
 - `description`: `"Wiki lint"`
 - `prompt`: the string below (literal):
 
-  > `You are running the GAIA wiki-lint workflow in a fresh context. Read .claude/skills/gaia/references/wiki/lint.md from the project root and execute the "Playbook" section (Steps 1–5) verbatim. Your working directory is the project root. Return only the report path and the one-line summary required by Step 5 — no recap of the report contents.`
+  > `You are running the GAIA wiki-lint workflow in a fresh context. Read .claude/skills/gaia/references/wiki/lint.md from the project root and execute the "Playbook" section (Steps 1–8) verbatim. Your working directory is the project root. Return only the report path and the one-line summary required by Step 8: no recap of the report contents.`
 
-When the subagent returns, relay its summary verbatim. If the drift severity is **`high`**, prefix the surfaced line with `WIKI DRIFT:` per Step 5. If the subagent returns a `WIKI DEAD-PATHS:` line, surface it too. If the subagent returns a `UAT-SPEC DRIFT:` line, surface it too.
+When the subagent returns, relay its summary verbatim. If the drift severity is **`high`**, prefix the surfaced line with `WIKI DRIFT:` per Step 8. If the subagent returns a `WIKI DEAD-PATHS:`, `UAT-SPEC DRIFT:`, `WIKI ORPHANS:`, `WIKI FRONTMATTER:`, or `WIKI EMPTY-SECTIONS:` line, surface it too.
 
 ## Full chain (no sub-arg)
 

--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -4,49 +4,44 @@ Dispatched by the `/gaia-wiki` router (`references/wiki.md` → "Lint"). Runs in
 
 ## Playbook
 
-GAIA-local wrapper around the upstream `claude-obsidian:wiki-lint` skill. Runs the upstream lint flow first, then appends GAIA-specific checks **#11: Wiki drift check**, **#12: Dead repo-relative paths**, and **#13: UAT/SPEC narrative-ref drift** to the report.
+Standalone GAIA-native wiki lint. Builds its own report shell, then writes GAIA-specific checks: **#11: Wiki drift check**, **#12: Dead repo-relative paths**, **#13: UAT/SPEC narrative-ref drift**, **#14: Orphan pages**, **#15: Frontmatter gaps**, and **#16: Empty sections**. Every check re-derives from a live `gaia wiki` CLI primitive on each run; the report is plain markdown that GAIA owns end to end.
 
-Do **not** modify the upstream `claude-obsidian:wiki-lint` skill — it ships from a marketplace plugin and is read-only territory. Extensions live here.
+## Step 1: Create the report shell
 
-## Step 1: Run upstream wiki-lint
-
-Compute today's date from the shell clock first — no LLM has a clock, so the model's notion of "today" is unreliable:
+Compute today's date from the shell clock first: no LLM has a clock, so the model's notion of "today" is unreliable.
 
 ```bash
 DATE=$(date +%F)
 ```
 
-**Regenerate the report from scratch every run.** A lint report is a point-in-time snapshot; a stale report from an earlier run must never be reused or renamed into today's slot. Remove any same-day report before invoking upstream so it cannot be picked up and patched in place:
+**Regenerate the report from scratch every run.** A lint report is a point-in-time snapshot; a stale report from an earlier run must never be reused or renamed into today's slot. Remove any same-day report before writing the shell so a stale one cannot be picked up and patched in place:
 
 ```bash
 rm -f wiki/meta/lint-report-$DATE.md
 ```
 
-Then invoke the `claude-obsidian:wiki-lint` skill following its documented pattern. The runtime resolves the plugin and dispatches the upstream playbook; do not attempt to read the plugin's SKILL.md from a hardcoded path. The upstream skill writes the report to:
-
-```
-wiki/meta/lint-report-YYYY-MM-DD.md
-```
-
-Capture the report path it produced.
-
-Do **not** restructure the upstream report format. The GAIA checks below write into this same file: each **replaces** its own `## #NN` section if one already exists, otherwise appends it at the bottom. Never trust or carry over a pre-existing GAIA section — every check re-derives from its live CLI primitive on each run.
-
-### Normalize the report date
-
-Reconcile the captured report path against `$DATE`. If the upstream skill wrote a **fresh** report this run under a different (model-guessed) date, rename it and fix the in-file references:
+Then create the report file with the standard frontmatter and H1 heading:
 
 ```bash
-git mv wiki/meta/lint-report-<upstream-date>.md wiki/meta/lint-report-$DATE.md
+cat > wiki/meta/lint-report-$DATE.md <<EOF
+---
+type: meta
+title: 'Lint Report $DATE'
+created: $DATE
+updated: $DATE
+tags: [meta, lint]
+status: developing
+---
+
+# Lint Report: $DATE
+EOF
 ```
 
-But if the captured path points at a report from an earlier date that the upstream skill **reused** rather than regenerated, do not rename it — that carries stale content forward. Start a fresh `wiki/meta/lint-report-$DATE.md` instead and write every section below from the live primitives.
+Use `wiki/meta/lint-report-$DATE.md` as the canonical report path for every subsequent step and the Step 8 summary. The GAIA checks below write into this same file: each **replaces** its own `## #NN` section if one already exists, otherwise appends it at the bottom. Never trust or carry over a pre-existing GAIA section: every check re-derives from its live CLI primitive on each run.
 
-Then set the report's frontmatter (`title`, `created`, `updated`) and H1 heading to `$DATE`. Use this path as the canonical report path for every subsequent step and the Step 5 summary.
+## Step 2: GAIA check #11: Wiki drift
 
-## Step 2: GAIA check #11 — Wiki drift
-
-After the upstream lint finishes, always run `gaia wiki state --json` fresh and write the `## #11: Wiki drift check` section from its output — replacing any existing `## #11` section in the report. Never carry over a `#11` section from a reused report: drift state is the most time-sensitive check, and a stale `#11` is exactly how a wiki that was just synced or recovered gets mis-reported as drifting.
+Always run `gaia wiki state --json` fresh and write the `## #11: Wiki drift check` section from its output, replacing any existing `## #11` section in the report. Never carry over a `#11` section from a reused report: drift state is the most time-sensitive check, and a stale `#11` is exactly how a wiki that was just synced or recovered gets mis-reported as drifting.
 
 ### 2a. Run the primitive
 
@@ -59,17 +54,17 @@ The CLI returns a JSON object with `drift_severity` (`none` | `low` | `medium` |
 ```markdown
 ## #11: Wiki drift check
 
-⚠ `wiki/.state.json` missing — system has never run sync. Run `/gaia-wiki sync` to initialize.
+⚠ `wiki/.state.json` missing: system has never run sync. Run `/gaia-wiki sync` to initialize.
 ```
 
 Then stop the drift check.
 
-If `reachable === false`, the recorded SHA was orphaned (the squash-merge flow replaces the evaluated branch SHA on every merge). Append — and surface `suggested_base` when the CLI resolved a recovery baseline so the reader knows the window is recoverable, not lost:
+If `reachable === false`, the recorded SHA was orphaned (the squash-merge flow replaces the evaluated branch SHA on every merge). Append, and surface `suggested_base` when the CLI resolved a recovery baseline so the reader knows the window is recoverable, not lost:
 
 ```markdown
 ## #11: Wiki drift check
 
-⚠ `wiki/.state.json` `last_evaluated_sha` (`<state_sha>`) is not reachable from HEAD (squashed/rewritten history). Run `/gaia-wiki sync` — it resolves a recovery baseline (`<suggested_base>`) and evaluates the un-evaluated window.
+⚠ `wiki/.state.json` `last_evaluated_sha` (`<state_sha>`) is not reachable from HEAD (squashed/rewritten history). Run `/gaia-wiki sync`: it resolves a recovery baseline (`<suggested_base>`) and evaluates the un-evaluated window.
 ```
 
 When `suggested_base` is empty (no recoverable baseline), drop the parenthetical and say `it re-anchors to HEAD.` instead. Then stop.
@@ -113,7 +108,7 @@ Example ERROR (`high`) section:
 - p3q4r5s refactor: ...
 ```
 
-## Step 3: GAIA check #12 — Dead repo-relative paths
+## Step 3: GAIA check #12: Dead repo-relative paths
 
 Run the dead-paths primitive and append a `## #12: Dead repo-relative paths` section. Detects backticked paths in wiki body prose that reference files no longer present on disk (e.g. a hook removed in a refactor still cited in a concept page).
 
@@ -140,15 +135,15 @@ Otherwise:
 ```markdown
 ## #12: Dead repo-relative paths
 
-⚠ {dead.length} dead path reference(s) in wiki/ — files no longer exist on disk:
+⚠ {dead.length} dead path reference(s) in wiki/, files no longer exist on disk:
 
 - `wiki/concepts/Foo.md:23` → `.claude/hooks/old-hook.sh`
 - `wiki/concepts/Bar.md:45` → `.claude/hooks/missing-helper.sh`
 ```
 
-List every dead reference (one per line). Do not truncate — the count is small enough to be actionable.
+List every dead reference (one per line). Do not truncate: the count is small enough to be actionable.
 
-## Step 4: GAIA check #13 — UAT/SPEC narrative-ref drift
+## Step 4: GAIA check #13: UAT/SPEC narrative-ref drift
 
 Detects narrative `UAT-NNN` and concrete maintainer `SPEC-NNN` references that crept into instruction files (`.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.claude/rules/`, `.claude/hooks/`) and shipped extension surfaces (`.specify/extensions/gaia/{README.md, commands, lib, rules, templates}`) plus the maintainer-only `.gaia/tests/` smoke harnesses. The rule rationale + structural-vs-narrative triage table lives in `.claude/rules/wiki-style.md` (Exceptions section).
 
@@ -177,8 +172,8 @@ grep -rEn "\bSPEC-00[1-9]\b" \
 
 Both scans return raw match lines. Apply the structural-vs-narrative filter from `wiki-style.md`:
 
-- **Skip (structural — not findings):** template format examples (`> - UAT-NNN — Given …`), CLI argument values (`--uat-id UAT-007`), JS/Python/YAML literals (`uat_id: 'UAT-099'`), regex targets that match SPEC YAML structure, filename literals (`uat-001.spec.ts`), illustrative `(e.g. SPEC-002)` examples in usage docs, generic placeholders (`SPEC-NNN`, `SPEC-NNN.md`), variable-name fragments (`uat_id`, `uats_block`).
-- **Flag (narrative — findings):** section-header parentheticals (`#### 5b. Discuss-this escape (UAT-004)`), inline narrative parentheticals (`(UAT-022, UAT-027)`), comments naming specific working-doc IDs, pass/fail label prefixes (`pass "UAT-001 …"`), prose using a maintainer SPEC ID as a system-wide constant (`operate under SPEC-001's scope_boundaries`).
+- **Skip (structural, not findings):** template format examples (`> - UAT-NNN → Given …`), CLI argument values (`--uat-id UAT-007`), JS/Python/YAML literals (`uat_id: 'UAT-099'`), regex targets that match SPEC YAML structure, filename literals (`uat-001.spec.ts`), illustrative `(e.g. SPEC-002)` examples in usage docs, generic placeholders (`SPEC-NNN`, `SPEC-NNN.md`), variable-name fragments (`uat_id`, `uats_block`).
+- **Flag (narrative, findings):** section-header parentheticals (`#### 5b. Discuss-this escape (UAT-004)`), inline narrative parentheticals (`(UAT-022, UAT-027)`), comments naming specific working-doc IDs, pass/fail label prefixes (`pass "UAT-001 …"`), prose using a maintainer SPEC ID as a system-wide constant (`operate under SPEC-001's scope_boundaries`).
 
 If both scans produce zero narrative findings (all matches are structural):
 
@@ -195,22 +190,132 @@ Otherwise:
 
 ⚠ {N} narrative ref(s) found in instruction files / shipped extension surfaces:
 
-- `.claude/skills/foo/SKILL.md:42` — `(UAT-012)` parenthetical in section header
-- `.specify/extensions/gaia/commands/bar.md:88` — `operate under SPEC-001's scope_boundaries` prose
+- `.claude/skills/foo/SKILL.md:42` → `(UAT-012)` parenthetical in section header
+- `.specify/extensions/gaia/commands/bar.md:88` → `operate under SPEC-001's scope_boundaries` prose
 ```
 
-List every narrative finding (one per line). Structural matches are not listed — they are the regex's false positives by design.
+List every narrative finding (one per line). Structural matches are not listed: they are the regex's false positives by design.
 
-## Step 5: Surface to the user
+## Step 5: GAIA check #14: Orphan pages
+
+Run the orphans primitive and append a `## #14: Orphan pages` section, replacing any existing `## #14` section. Detects wiki pages that no other page links to with a wikilink.
+
+### 5a. Run the primitive
+
+```bash
+gaia wiki orphans --json
+```
+
+Returns `{ "orphans": [{ "path": "...", "title": "...", "domain": "..." }, ...] }`. Empty array means clean.
+
+Intentionally-unlinked maintainer-only pages are kept reachable via marker-wrapped links in `wiki/index.md`, so a page that shows up here is a genuine orphan: it signals a missing cross-reference, not a maintainer page.
+
+### 5b. Append the section
+
+If `orphans.length === 0`:
+
+```markdown
+## #14: Orphan pages
+
+✓ No orphan pages (every page has at least one inbound wikilink).
+```
+
+Otherwise:
+
+```markdown
+## #14: Orphan pages
+
+⚠ {orphans.length} orphan page(s), no inbound wikilinks:
+
+- `wiki/concepts/Foo.md` (Foo Concept)
+- `wiki/modules/Bar.md` (Bar Module)
+```
+
+List every orphan (one per line) as `` - `wiki/path.md` (title) ``.
+
+## Step 6: GAIA check #15: Frontmatter gaps
+
+Run the frontmatter primitive and append a `## #15: Frontmatter gaps` section, replacing any existing `## #15` section. The required floor is `type` and `status`.
+
+### 6a. Run the primitive
+
+```bash
+gaia wiki frontmatter --json
+```
+
+Returns `{ "gaps": [{ "path": "...", "missing": ["type", "status"] }, ...] }`. Empty array means clean.
+
+### 6b. Append the section
+
+If `gaps.length === 0`:
+
+```markdown
+## #15: Frontmatter gaps
+
+✓ All wiki pages carry the required frontmatter (type, status).
+```
+
+Otherwise:
+
+```markdown
+## #15: Frontmatter gaps
+
+⚠ {gaps.length} page(s) missing required frontmatter:
+
+- `wiki/concepts/Foo.md`: missing status
+- `wiki/modules/Bar.md`: missing status, tags
+```
+
+List every gap (one per line) as `` - `wiki/path.md`: missing {comma-joined fields} ``.
+
+## Step 7: GAIA check #16: Empty sections
+
+Run the empty-sections primitive and append a `## #16: Empty sections` section, replacing any existing `## #16` section. Detects headings with no body content beneath them.
+
+### 7a. Run the primitive
+
+```bash
+gaia wiki empty-sections --json
+```
+
+Returns `{ "empty": [{ "path": "...", "line": N, "heading": "..." }, ...] }`. Empty array means clean.
+
+### 7b. Append the section
+
+If `empty.length === 0`:
+
+```markdown
+## #16: Empty sections
+
+✓ No empty sections detected.
+```
+
+Otherwise:
+
+```markdown
+## #16: Empty sections
+
+⚠ {empty.length} empty section(s):
+
+- `wiki/concepts/Foo.md:42` → `## Heading`
+- `wiki/modules/Bar.md:88` → `### Subheading`
+```
+
+List every empty section (one per line) as `` - `wiki/path.md:42` → `## Heading` ``.
+
+## Step 8: Surface to the user
 
 Print to the user:
 
 1. The report path (e.g. `wiki/meta/lint-report-2026-05-03.md`).
-2. A one-line summary that includes the drift severity and count, plus dead-path count if non-zero, plus narrative-ref count if non-zero.
+2. A one-line summary that includes the drift severity and count, plus dead-path count, orphan count, frontmatter-gap count, and empty-section count when any of those is non-zero, plus narrative-ref count if non-zero.
 
 If `drift_severity` is **`high`**, surface it prominently (separate line, prefixed with `WIKI DRIFT:`).
 If `dead.length > 0`, surface as a separate line prefixed with `WIKI DEAD-PATHS:` followed by the count.
 If narrative-ref findings > 0, surface as a separate line prefixed with `UAT-SPEC DRIFT:` followed by the count.
+If `orphans.length > 0`, surface as a separate line prefixed with `WIKI ORPHANS:` followed by the count.
+If `gaps.length > 0`, surface as a separate line prefixed with `WIKI FRONTMATTER:` followed by the count.
+If `empty.length > 0`, surface as a separate line prefixed with `WIKI EMPTY-SECTIONS:` followed by the count.
 
 ## Notes
 

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -842,10 +842,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path49) {
-  if (!path49)
+function getElementAtPath(obj, path51) {
+  if (!path51)
     return obj;
-  return path49.reduce((acc, key) => acc?.[key], obj);
+  return path51.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -1254,11 +1254,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path49, issues) {
+function prefixIssues(path51, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path49);
+    iss.path.unshift(path51);
     return iss;
   });
 }
@@ -1405,16 +1405,16 @@ function flattenError(error51, mapper = (issue2) => issue2.message) {
 }
 function formatError(error51, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error52, path49 = []) => {
+  const processError = (error52, path51 = []) => {
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path49, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path51, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path49, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path49, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
       } else {
-        const fullpath = [...path49, ...issue2.path];
+        const fullpath = [...path51, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -1441,17 +1441,17 @@ function formatError(error51, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error51, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error52, path49 = []) => {
+  const processError = (error52, path51 = []) => {
     var _a3, _b;
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path49, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path51, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path49, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path49, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
       } else {
-        const fullpath = [...path49, ...issue2.path];
+        const fullpath = [...path51, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -1483,8 +1483,8 @@ function treeifyError(error51, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path49 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path49) {
+  const path51 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path51) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -14176,13 +14176,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path49 = ref.slice(1).split("/").filter(Boolean);
-  if (path49.length === 0) {
+  const path51 = ref.slice(1).split("/").filter(Boolean);
+  if (path51.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path49[0] === defsKey) {
-    const key = path49[1];
+  if (path51[0] === defsKey) {
+    const key = path51[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -25324,21 +25324,21 @@ var loadManifest = (manifestPath) => {
     return { ok: false, message: "manifest.files is missing or not an object" };
   }
   const files = /* @__PURE__ */ new Map();
-  for (const [path49, value] of Object.entries(shape.files)) {
+  for (const [path51, value] of Object.entries(shape.files)) {
     if (typeof value !== "string") {
       return {
         ok: false,
-        message: `manifest.files["${path49}"] is not a string`
+        message: `manifest.files["${path51}"] is not a string`
       };
     }
     if (!VALID_RAW_CLASSES.has(value)) {
       return {
         ok: false,
-        message: `manifest.files["${path49}"] has unknown class: "${value}"`
+        message: `manifest.files["${path51}"] has unknown class: "${value}"`
       };
     }
     const rawClass = value;
-    files.set(path49, {
+    files.set(path51, {
       normalizedClass: normalizeClass(rawClass),
       rawClass
     });
@@ -27145,16 +27145,317 @@ var run67 = (argv, options = {}) => {
   }
 };
 
-// src/wiki/log-prepend.ts
-import { existsSync as existsSync36, readFileSync as readFileSync33, renameSync as renameSync11, writeFileSync as writeFileSync17 } from "node:fs";
+// src/wiki/empty-sections.ts
+import { readdirSync as readdirSync7, readFileSync as readFileSync33, statSync as statSync6 } from "node:fs";
 import path43 from "node:path";
-var HELP_TEXT55 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+
+// src/wiki/util/frontmatter.ts
+var FRONTMATTER_FENCE = "---";
+var SCALAR_PATTERN = /^([\w-]+)\s*:\s*(.*)$/u;
+var stripQuotes2 = (raw) => {
+  if (raw.length < 2) return raw;
+  const first = raw.charAt(0);
+  const last = raw.charAt(raw.length - 1);
+  if (first === '"' && last === '"' || first === "'" && last === "'") {
+    return raw.slice(1, -1);
+  }
+  return raw;
+};
+var parseScalar = (raw) => {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "null" || trimmed === "~") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (inner === "") return [];
+    return inner.split(",").flatMap((entry) => {
+      const stripped = stripQuotes2(entry.trim());
+      return stripped.length > 0 ? [stripped] : [];
+    });
+  }
+  if (/^-?\d+(\.\d+)?$/u.test(trimmed)) {
+    return Number(trimmed);
+  }
+  return stripQuotes2(trimmed);
+};
+var parseFrontmatter = (raw) => {
+  const lines = raw.split("\n");
+  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE) {
+    return { body: raw, frontmatter: {}, hasFrontmatter: false };
+  }
+  let closingIndex = -1;
+  for (let index = 1; index < lines.length; index += 1) {
+    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE) {
+      closingIndex = index;
+      break;
+    }
+  }
+  if (closingIndex === -1) {
+    return { body: raw, frontmatter: {}, hasFrontmatter: false };
+  }
+  const yamlLines = lines.slice(1, closingIndex);
+  const frontmatter = {};
+  for (const line of yamlLines) {
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const match = SCALAR_PATTERN.exec(line);
+    if (match === null) continue;
+    const key = match[1];
+    const value = match[2].trim();
+    frontmatter[key] = parseScalar(value);
+  }
+  const body = lines.slice(closingIndex + 1).join("\n");
+  return { body, frontmatter, hasFrontmatter: true };
+};
+
+// src/wiki/empty-sections.ts
+var HELP_TEXT55 = `Usage: gaia wiki empty-sections [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
+  LEAF headings with no body \u2014 no child heading and no non-blank, non-heading
+  content before the next sibling/shallower heading or EOF. Parent headings
+  are never flagged. Fenced code blocks and the frontmatter block are handled.
+  Without --json, prints one "path:line  heading" line per finding. With
+  --json, emits { "empty": [ { path, line, heading } ] }.
+`;
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SKIP_PATH_FRAGMENTS2 = ["wiki/meta/"];
+var SKIP_PATHS = /* @__PURE__ */ new Set(["wiki/hot.md", "wiki/log.md"]);
+var ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
+var FENCE_PATTERN = /^\s*(?:```|~~~)/u;
+var shouldSkipFile2 = (relPath) => SKIP_PATHS.has(relPath) || SKIP_PATH_FRAGMENTS2.some((fragment) => relPath.startsWith(fragment));
+var walkMarkdown2 = (root, dir) => {
+  const entries = readdirSync7(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const full = path43.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown2(root, full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(path43.relative(root, full));
+    }
+  }
+  return out;
+};
+var collectHeadings = (body, bodyLineOffset) => {
+  const headings = [];
+  const lines = body.split("\n");
+  let inFence = false;
+  for (const [index, line] of lines.entries()) {
+    if (FENCE_PATTERN.test(line)) {
+      inFence = !inFence;
+      if (headings.length > 0) headings.at(-1).hasContent = true;
+      continue;
+    }
+    if (inFence) {
+      if (headings.length > 0) headings.at(-1).hasContent = true;
+      continue;
+    }
+    const match = ATX_HEADING_PATTERN.exec(line);
+    if (match !== null) {
+      headings.push({
+        hasContent: false,
+        level: match[1].length,
+        line: bodyLineOffset + index + 1,
+        text: line.trim()
+      });
+      continue;
+    }
+    if (line.trim() !== "" && headings.length > 0) {
+      headings.at(-1).hasContent = true;
+    }
+  }
+  return headings;
+};
+var findInBody = (body, bodyLineOffset, relPath) => {
+  const headings = collectHeadings(body, bodyLineOffset);
+  const found = [];
+  for (const [index, heading] of headings.entries()) {
+    if (heading.hasContent) continue;
+    let hasChildHeading = false;
+    for (let next = index + 1; next < headings.length; next += 1) {
+      const candidate = headings[next];
+      if (candidate.level <= heading.level) break;
+      hasChildHeading = true;
+      break;
+    }
+    if (hasChildHeading) continue;
+    found.push({ heading: heading.text, line: heading.line, path: relPath });
+  }
+  return found;
+};
+var findEmptySections = (cwd) => {
+  const wikiDir = path43.join(cwd, "wiki");
+  try {
+    statSync6(wikiDir);
+  } catch {
+    return [];
+  }
+  const empty = [];
+  const files = walkMarkdown2(cwd, wikiDir).sort();
+  for (const filePath of files) {
+    if (shouldSkipFile2(filePath)) continue;
+    const content = readFileSync33(path43.join(cwd, filePath), "utf8");
+    const { body } = parseFrontmatter(content);
+    const offset = content.split("\n").length - body.split("\n").length;
+    empty.push(...findInBody(body, offset, filePath));
+  }
+  return empty;
+};
+var run68 = (argv, options = {}) => {
+  let json2 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS53.has(token)) {
+      process.stdout.write(HELP_TEXT55);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "wiki empty-sections"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const empty = findEmptySections(cwd);
+    if (json2) {
+      process.stdout.write(`${JSON.stringify({ empty }, null, 2)}
+`);
+      return EXIT_CODES.OK;
+    }
+    if (empty.length === 0) {
+      process.stdout.write("No empty sections found.\n");
+      return EXIT_CODES.OK;
+    }
+    const lines = empty.map(
+      (section) => `${section.path}:${section.line}  ${section.heading}`
+    );
+    process.stdout.write(`${lines.join("\n")}
+`);
+    return EXIT_CODES.OK;
+  } catch (error51) {
+    structuredError({
+      code: "empty_sections_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "wiki empty-sections"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};
+
+// src/wiki/frontmatter.ts
+import { readdirSync as readdirSync8, readFileSync as readFileSync34, statSync as statSync7 } from "node:fs";
+import path44 from "node:path";
+var HELP_TEXT56 = `Usage: gaia wiki frontmatter [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
+  frontmatter. Required floor is type and status. Without --json, prints one
+  "path: missing a, b" line per gap. With --json, emits
+  { "gaps": [ { path, missing } ] }.
+`;
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var REQUIRED_FIELDS = ["type", "status"];
+var SKIP_PATH_FRAGMENTS3 = ["wiki/meta/"];
+var shouldSkipFile3 = (relPath) => SKIP_PATH_FRAGMENTS3.some((fragment) => relPath.startsWith(fragment));
+var walkMarkdown3 = (root, dir) => {
+  const entries = readdirSync8(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const full = path44.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown3(root, full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(path44.relative(root, full));
+    }
+  }
+  return out;
+};
+var hasField = (frontmatter, field) => Object.prototype.hasOwnProperty.call(frontmatter, field) && frontmatter[field] !== null;
+var findFrontmatterGaps = (cwd) => {
+  const wikiDir = path44.join(cwd, "wiki");
+  try {
+    statSync7(wikiDir);
+  } catch {
+    return [];
+  }
+  const gaps = [];
+  const files = walkMarkdown3(cwd, wikiDir).sort();
+  for (const filePath of files) {
+    if (shouldSkipFile3(filePath)) continue;
+    const content = readFileSync34(path44.join(cwd, filePath), "utf8");
+    const { frontmatter } = parseFrontmatter(content);
+    const missing = REQUIRED_FIELDS.filter(
+      (field) => !hasField(frontmatter, field)
+    );
+    if (missing.length > 0) {
+      gaps.push({ missing, path: filePath });
+    }
+  }
+  return gaps;
+};
+var run69 = (argv, options = {}) => {
+  let json2 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS54.has(token)) {
+      process.stdout.write(HELP_TEXT56);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "wiki frontmatter"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const gaps = findFrontmatterGaps(cwd);
+    if (json2) {
+      process.stdout.write(`${JSON.stringify({ gaps }, null, 2)}
+`);
+      return EXIT_CODES.OK;
+    }
+    if (gaps.length === 0) {
+      process.stdout.write("No frontmatter gaps found.\n");
+      return EXIT_CODES.OK;
+    }
+    const lines = gaps.map((gap) => `${gap.path}: missing ${gap.missing.join(", ")}`);
+    process.stdout.write(`${lines.join("\n")}
+`);
+    return EXIT_CODES.OK;
+  } catch (error51) {
+    structuredError({
+      code: "frontmatter_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "wiki frontmatter"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};
+
+// src/wiki/log-prepend.ts
+import { existsSync as existsSync36, readFileSync as readFileSync35, renameSync as renameSync11, writeFileSync as writeFileSync17 } from "node:fs";
+import path45 from "node:path";
+var HELP_TEXT57 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
-var FRONTMATTER_FENCE = "---";
+var FRONTMATTER_FENCE2 = "---";
 var takeValue10 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) {
@@ -27211,11 +27512,11 @@ var todayUtc = () => {
   return `${year}-${month}-${day}`;
 };
 var scanFrontmatter = (lines) => {
-  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE) {
+  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE2) {
     return { kind: "missing" };
   }
   for (let index = 1; index < lines.length; index += 1) {
-    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE) {
+    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE2) {
       return { endLineIndex: index, kind: "present" };
     }
   }
@@ -27233,14 +27534,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run68 = (argv, options = {}) => {
+var run70 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT55);
+    process.stdout.write(HELP_TEXT57);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS53.has(first)) {
-    process.stdout.write(HELP_TEXT55);
+  if (HELP_TOKENS55.has(first)) {
+    process.stdout.write(HELP_TEXT57);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags14(argv);
@@ -27263,7 +27564,7 @@ var run68 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const logPath = path43.join(repoRoot2, "wiki", "log.md");
+  const logPath = path45.join(repoRoot2, "wiki", "log.md");
   if (!existsSync36(logPath)) {
     structuredError({
       code: "log_missing",
@@ -27272,7 +27573,7 @@ var run68 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync33(logPath, "utf8");
+  const raw = readFileSync35(logPath, "utf8");
   const lines = raw.split("\n");
   const scan = scanFrontmatter(lines);
   if (scan.kind === "missing" || scan.kind === "malformed") {
@@ -27298,14 +27599,14 @@ var run68 = (argv, options = {}) => {
 };
 
 // src/wiki/near-collisions.ts
-import { existsSync as existsSync37, readdirSync as readdirSync7, statSync as statSync6 } from "node:fs";
-import path44 from "node:path";
-var HELP_TEXT56 = `Usage: gaia wiki near-collisions [--max-distance 3]
+import { existsSync as existsSync37, readdirSync as readdirSync9, statSync as statSync8 } from "node:fs";
+import path46 from "node:path";
+var HELP_TEXT58 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS = [
   "components",
@@ -27343,9 +27644,9 @@ var levenshtein = (a, b) => {
 var collectDomainSlugs = (wikiRoot) => {
   const collected = [];
   for (const domain2 of DOMAIN_DIRS) {
-    const domainDir = path44.join(wikiRoot, domain2);
-    if (!existsSync37(domainDir) || !statSync6(domainDir).isDirectory()) continue;
-    const entries = readdirSync7(domainDir, { withFileTypes: true });
+    const domainDir = path46.join(wikiRoot, domain2);
+    if (!existsSync37(domainDir) || !statSync8(domainDir).isDirectory()) continue;
+    const entries = readdirSync9(domainDir, { withFileTypes: true });
     const slugs = [];
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -27414,9 +27715,9 @@ var parseFlags15 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run69 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS54.has(argv[0])) {
-    process.stdout.write(HELP_TEXT56);
+var run71 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS56.has(argv[0])) {
+    process.stdout.write(HELP_TEXT58);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags15(argv);
@@ -27439,7 +27740,7 @@ var run69 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path44.join(repoRoot2, "wiki");
+  const wikiRoot = path46.join(repoRoot2, "wiki");
   const domainGroups = collectDomainSlugs(wikiRoot);
   const collisions = findCollisions(domainGroups, parsed.flags.maxDistance);
   if (collisions.length === 0) return EXIT_CODES.OK;
@@ -27452,67 +27753,8 @@ var run69 = (argv, options = {}) => {
 };
 
 // src/wiki/page-index.ts
-import { existsSync as existsSync38, readdirSync as readdirSync8, readFileSync as readFileSync34, statSync as statSync7 } from "node:fs";
-import path45 from "node:path";
-
-// src/wiki/util/frontmatter.ts
-var FRONTMATTER_FENCE2 = "---";
-var SCALAR_PATTERN = /^([\w-]+)\s*:\s*(.*)$/u;
-var stripQuotes2 = (raw) => {
-  if (raw.length < 2) return raw;
-  const first = raw.charAt(0);
-  const last = raw.charAt(raw.length - 1);
-  if (first === '"' && last === '"' || first === "'" && last === "'") {
-    return raw.slice(1, -1);
-  }
-  return raw;
-};
-var parseScalar = (raw) => {
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "null" || trimmed === "~") return null;
-  if (trimmed === "true") return true;
-  if (trimmed === "false") return false;
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    const inner = trimmed.slice(1, -1).trim();
-    if (inner === "") return [];
-    return inner.split(",").flatMap((entry) => {
-      const stripped = stripQuotes2(entry.trim());
-      return stripped.length > 0 ? [stripped] : [];
-    });
-  }
-  if (/^-?\d+(\.\d+)?$/u.test(trimmed)) {
-    return Number(trimmed);
-  }
-  return stripQuotes2(trimmed);
-};
-var parseFrontmatter = (raw) => {
-  const lines = raw.split("\n");
-  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE2) {
-    return { body: raw, frontmatter: {}, hasFrontmatter: false };
-  }
-  let closingIndex = -1;
-  for (let index = 1; index < lines.length; index += 1) {
-    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE2) {
-      closingIndex = index;
-      break;
-    }
-  }
-  if (closingIndex === -1) {
-    return { body: raw, frontmatter: {}, hasFrontmatter: false };
-  }
-  const yamlLines = lines.slice(1, closingIndex);
-  const frontmatter = {};
-  for (const line of yamlLines) {
-    if (line.trim() === "" || line.trim().startsWith("#")) continue;
-    const match = SCALAR_PATTERN.exec(line);
-    if (match === null) continue;
-    const key = match[1];
-    const value = match[2].trim();
-    frontmatter[key] = parseScalar(value);
-  }
-  const body = lines.slice(closingIndex + 1).join("\n");
-  return { body, frontmatter, hasFrontmatter: true };
-};
+import { existsSync as existsSync38, readdirSync as readdirSync10, readFileSync as readFileSync36, statSync as statSync9 } from "node:fs";
+import path47 from "node:path";
 
 // src/wiki/util/wikilinks.ts
 var WIKILINK_PATTERN = /\[\[([^\][]+)\]\]/gu;
@@ -27532,12 +27774,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT57 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT59 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS2 = [
   "components",
   "concepts",
@@ -27550,7 +27792,7 @@ var DOMAIN_DIRS2 = [
 ];
 var SKIPPED_FILES2 = /* @__PURE__ */ new Set(["_index.md", "README.md"]);
 var ROOT_LINK_SOURCES = ["index.md", "overview.md", "hot.md"];
-var slugFromPath = (filePath) => path45.basename(filePath, ".md");
+var slugFromPath = (filePath) => path47.basename(filePath, ".md");
 var extractTitle = (body, fallback) => {
   const lines = body.split("\n");
   for (const line of lines) {
@@ -27576,16 +27818,16 @@ var arrayOfStrings = (value) => {
 var collectPages = (wikiRoot) => {
   const pages = [];
   for (const domain2 of DOMAIN_DIRS2) {
-    const domainDir = path45.join(wikiRoot, domain2);
-    if (!existsSync38(domainDir) || !statSync7(domainDir).isDirectory()) continue;
-    const entries = readdirSync8(domainDir, { withFileTypes: true });
+    const domainDir = path47.join(wikiRoot, domain2);
+    if (!existsSync38(domainDir) || !statSync9(domainDir).isDirectory()) continue;
+    const entries = readdirSync10(domainDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(".md")) continue;
       if (SKIPPED_FILES2.has(entry.name)) continue;
       if (entry.name.startsWith("_")) continue;
-      const absPath = path45.join(domainDir, entry.name);
-      const raw = readFileSync34(absPath, "utf8");
+      const absPath = path47.join(domainDir, entry.name);
+      const raw = readFileSync36(absPath, "utf8");
       const { body, frontmatter } = parseFrontmatter(raw);
       const slug = slugFromPath(entry.name);
       const title = extractTitle(body, slug);
@@ -27594,7 +27836,7 @@ var collectPages = (wikiRoot) => {
         body,
         domain: domain2,
         outboundTargets: targets,
-        relativePath: path45.posix.join("wiki", domain2, entry.name),
+        relativePath: path47.posix.join("wiki", domain2, entry.name),
         slug,
         status: stringValue(frontmatter.status),
         tags: arrayOfStrings(frontmatter.tags),
@@ -27608,9 +27850,9 @@ var collectPages = (wikiRoot) => {
 var collectRootLinkSources = (wikiRoot) => {
   const sources = [];
   for (const filename of ROOT_LINK_SOURCES) {
-    const absPath = path45.join(wikiRoot, filename);
+    const absPath = path47.join(wikiRoot, filename);
     if (!existsSync38(absPath)) continue;
-    const raw = readFileSync34(absPath, "utf8");
+    const raw = readFileSync36(absPath, "utf8");
     const { body } = parseFrontmatter(raw);
     sources.push(extractWikilinks(body));
   }
@@ -27662,16 +27904,16 @@ var printHuman11 = (index) => {
 };
 var computePageIndex = (cwd) => {
   const repoRoot2 = resolveRepoRoot2(cwd);
-  const wikiRoot = path45.join(repoRoot2, "wiki");
+  const wikiRoot = path47.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run70 = (argv, options = {}) => {
+var run72 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS55.has(token)) {
-      process.stdout.write(HELP_TEXT57);
+    if (HELP_TOKENS57.has(token)) {
+      process.stdout.write(HELP_TEXT59);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -27696,7 +27938,7 @@ var run70 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path45.join(repoRoot2, "wiki");
+  const wikiRoot = path47.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   const index = buildIndex(pages, rootSources);
@@ -27710,17 +27952,24 @@ var run70 = (argv, options = {}) => {
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT58 = `Usage: gaia wiki orphans
+var HELP_TEXT60 = `Usage: gaia wiki orphans [--json]
 
-  Newline-separated list of wiki pages with zero inbound wikilinks.
+  List wiki pages with zero inbound wikilinks. Without --json, prints one
+  repo-relative path per line. With --json, emits { "orphans": [ { path,
+  title, domain } ] }.
 `;
-var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var isMaintainerOnly = (path49) => path49.startsWith("wiki/meta/") || path49.startsWith("wiki/entities/");
-var run71 = (argv, options = {}) => {
+var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var isMaintainerOnly = (path51) => path51.startsWith("wiki/meta/") || path51.startsWith("wiki/entities/");
+var run73 = (argv, options = {}) => {
+  let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS56.has(token)) {
-      process.stdout.write(HELP_TEXT58);
+    if (HELP_TOKENS58.has(token)) {
+      process.stdout.write(HELP_TEXT60);
       return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json2 = true;
+      continue;
     }
     structuredError({
       code: "invalid_arguments",
@@ -27736,12 +27985,23 @@ var run71 = (argv, options = {}) => {
     const orphans = [];
     for (const page of index.pages) {
       if (page.inbound_links === 0 && !isMaintainerOnly(page.path)) {
-        orphans.push(page.path);
+        orphans.push({
+          domain: page.domain,
+          path: page.path,
+          title: page.title
+        });
       }
     }
-    if (orphans.length > 0) {
-      process.stdout.write(`${orphans.join("\n")}
+    if (json2) {
+      process.stdout.write(`${JSON.stringify({ orphans }, null, 2)}
 `);
+      return EXIT_CODES.OK;
+    }
+    if (orphans.length > 0) {
+      process.stdout.write(
+        `${orphans.map((orphan) => orphan.path).join("\n")}
+`
+      );
     }
     return EXIT_CODES.OK;
   } catch (error51) {
@@ -27755,11 +28015,11 @@ var run71 = (argv, options = {}) => {
 };
 
 // src/wiki/state.ts
-import { existsSync as existsSync39, readdirSync as readdirSync9, readFileSync as readFileSync35, statSync as statSync8 } from "node:fs";
-import path46 from "node:path";
-var HELP_TEXT59 = `Usage: gaia wiki state [--json]
+import { existsSync as existsSync39, readdirSync as readdirSync11, readFileSync as readFileSync37, statSync as statSync10 } from "node:fs";
+import path48 from "node:path";
+var HELP_TEXT61 = `Usage: gaia wiki state [--json]
 `;
-var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var classifySeverity = (commitCount) => {
   if (commitCount <= 0) return "none";
   if (commitCount <= 5) return "low";
@@ -27779,12 +28039,12 @@ var DOMAIN_DIRS3 = [
 var countDomainPages = (wikiRoot) => {
   const counts = {};
   for (const domain2 of DOMAIN_DIRS3) {
-    const domainDir = path46.join(wikiRoot, domain2);
-    if (!existsSync39(domainDir) || !statSync8(domainDir).isDirectory()) {
+    const domainDir = path48.join(wikiRoot, domain2);
+    if (!existsSync39(domainDir) || !statSync10(domainDir).isDirectory()) {
       counts[domain2] = 0;
       continue;
     }
-    const entries = readdirSync9(domainDir, { withFileTypes: true });
+    const entries = readdirSync11(domainDir, { withFileTypes: true });
     let count = 0;
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -27798,7 +28058,7 @@ var countDomainPages = (wikiRoot) => {
 };
 var readStateFile2 = (statePath) => {
   if (!existsSync39(statePath)) return null;
-  const raw = readFileSync35(statePath, "utf8");
+  const raw = readFileSync37(statePath, "utf8");
   try {
     return JSON.parse(raw);
   } catch {
@@ -27829,14 +28089,14 @@ var printHuman12 = (state, write) => {
   write(`${lines.join("\n")}
 `);
 };
-var run72 = (argv, options = {}) => {
+var run74 = (argv, options = {}) => {
   const write = options.write ?? ((chunk) => {
     process.stdout.write(chunk);
   });
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS57.has(token)) {
-      write(HELP_TEXT59);
+    if (HELP_TOKENS59.has(token)) {
+      write(HELP_TEXT61);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -27861,8 +28121,8 @@ var run72 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path46.join(repoRoot2, "wiki");
-  const statePath = path46.join(wikiRoot, ".state.json");
+  const wikiRoot = path48.join(repoRoot2, "wiki");
+  const statePath = path48.join(wikiRoot, ".state.json");
   const stateFile = readStateFile2(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? "";
   const stateAt = stateFile?.last_evaluated_at ?? "";
@@ -27896,15 +28156,15 @@ var run72 = (argv, options = {}) => {
 };
 
 // src/wiki/state-bump.ts
-import { existsSync as existsSync40, readFileSync as readFileSync36 } from "node:fs";
-import path47 from "node:path";
-var HELP_TEXT60 = `Usage: gaia wiki state-bump <field> <value>
+import { existsSync as existsSync40, readFileSync as readFileSync38 } from "node:fs";
+import path49 from "node:path";
+var HELP_TEXT62 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson2 = (raw) => {
   try {
     return JSON.parse(raw);
@@ -27926,13 +28186,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run73 = (argv, options = {}) => {
+var run75 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT60);
+    process.stdout.write(HELP_TEXT62);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS58.has(argv[0])) {
-    process.stdout.write(HELP_TEXT60);
+  if (HELP_TOKENS60.has(argv[0])) {
+    process.stdout.write(HELP_TEXT62);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -27967,7 +28227,7 @@ var run73 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const statePath = path47.join(repoRoot2, "wiki", ".state.json");
+  const statePath = path49.join(repoRoot2, "wiki", ".state.json");
   if (!existsSync40(statePath)) {
     structuredError({
       code: "state_missing",
@@ -27976,7 +28236,7 @@ var run73 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync36(statePath, "utf8");
+  const raw = readFileSync38(statePath, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -28007,8 +28267,8 @@ var run73 = (argv, options = {}) => {
 // src/wiki/state-init.ts
 import { execFileSync as execFileSync8 } from "node:child_process";
 import { existsSync as existsSync41, mkdirSync as mkdirSync21 } from "node:fs";
-import path48 from "node:path";
-var HELP_TEXT61 = `Usage: gaia wiki state-init <sha>
+import path50 from "node:path";
+var HELP_TEXT63 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -28016,7 +28276,7 @@ var HELP_TEXT61 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag) \u2014 it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha2 = (ref, cwd) => {
   try {
     const out = execFileSync8(
@@ -28033,13 +28293,13 @@ var resolveFullSha2 = (ref, cwd) => {
     return null;
   }
 };
-var run74 = (argv, options = {}) => {
+var run76 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT61);
+    process.stdout.write(HELP_TEXT63);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS59.has(argv[0])) {
-    process.stdout.write(HELP_TEXT61);
+  if (HELP_TOKENS61.has(argv[0])) {
+    process.stdout.write(HELP_TEXT63);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -28083,8 +28343,8 @@ var run74 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiDir = path48.join(repoRoot2, "wiki");
-  const statePath = path48.join(wikiDir, ".state.json");
+  const wikiDir = path50.join(repoRoot2, "wiki");
+  const statePath = path50.join(wikiDir, ".state.json");
   if (existsSync41(statePath)) {
     structuredError({
       code: "state_already_exists",
@@ -28164,7 +28424,7 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
 };
 
 // src/wiki/sync-land.ts
-var HELP_TEXT62 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT64 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -28175,7 +28435,7 @@ var HELP_TEXT62 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT10 = 2;
 var parseFlags16 = (argv) => {
   let branchAware = false;
@@ -28301,9 +28561,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run75 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS60.has(argv[0])) {
-    process.stdout.write(HELP_TEXT62);
+var run77 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS62.has(argv[0])) {
+    process.stdout.write(HELP_TEXT64);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags16(argv);
@@ -28388,7 +28648,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT63 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT65 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -28397,9 +28657,11 @@ var HELP_TEXT63 = `Usage: gaia wiki <subcommand> [args]
   log-prepend --sha <h> --decision <D> --reason "..."
                                               Prepend a decision line to wiki/log.md.
   page-index [--json]                         Frontmatter + wikilink walk.
-  orphans                                     Pages with zero inbound links.
+  orphans [--json]                            Pages with zero inbound links.
   near-collisions [--max-distance N]          Per-domain Levenshtein over slugs.
   dead-paths [--json]                         Backticked repo paths in wiki/ that don't exist.
+  frontmatter [--json]                        Pages missing required frontmatter (type, status).
+  empty-sections [--json]                     Headings with no content before the next heading.
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
@@ -28409,16 +28671,16 @@ var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS63 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS61.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS63.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run75(rest);
+    return run77(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -28431,20 +28693,22 @@ var SUBCOMMAND_HANDLERS7 = {
   "commit-classify": run65,
   "dead-paths": run66,
   "diff-size": run67,
-  "log-prepend": run68,
-  "near-collisions": run69,
-  orphans: run71,
-  "page-index": run70,
-  state: run72,
-  "state-bump": run73,
-  "state-init": run74,
+  "empty-sections": run68,
+  frontmatter: run69,
+  "log-prepend": run70,
+  "near-collisions": run71,
+  orphans: run73,
+  "page-index": run72,
+  state: run74,
+  "state-bump": run75,
+  "state-init": run76,
   sync: runSync
 };
-var run76 = async (argv) => {
+var run78 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS61.has(subcommand)) {
-    process.stdout.write(HELP_TEXT63);
+  if (subcommand === void 0 || HELP_TOKENS63.has(subcommand)) {
+    process.stdout.write(HELP_TEXT65);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS7[subcommand];
@@ -28461,7 +28725,7 @@ var run76 = async (argv) => {
 };
 
 // src/index.ts
-var HELP_TEXT64 = `Usage: gaia <subcommand> [args]
+var HELP_TEXT66 = `Usage: gaia <subcommand> [args]
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -28479,9 +28743,9 @@ var HELP_TEXT64 = `Usage: gaia <subcommand> [args]
   setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize|write-tool-mode
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT64);
+  process.stdout.write(HELP_TEXT66);
 };
-var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS64 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS8 = {
   automation: run12,
   "ci-revert": run14,
@@ -28494,12 +28758,12 @@ var SUBCOMMAND_HANDLERS8 = {
   telemetry: run60,
   update: run62,
   "update-deps": run64,
-  wiki: run76
+  wiki: run78
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS62.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS64.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -842,10 +842,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema2) {
   return mergeDefs(schema2._zod.def);
 }
-function getElementAtPath(obj, path50) {
-  if (!path50)
+function getElementAtPath(obj, path52) {
+  if (!path52)
     return obj;
-  return path50.reduce((acc, key) => acc?.[key], obj);
+  return path52.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -1254,11 +1254,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path50, issues) {
+function prefixIssues(path52, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path50);
+    iss.path.unshift(path52);
     return iss;
   });
 }
@@ -1405,16 +1405,16 @@ function flattenError(error51, mapper = (issue2) => issue2.message) {
 }
 function formatError(error51, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error52, path50 = []) => {
+  const processError = (error52, path52 = []) => {
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path50, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path52, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path50, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path52, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path50, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path52, ...issue2.path]);
       } else {
-        const fullpath = [...path50, ...issue2.path];
+        const fullpath = [...path52, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -1441,17 +1441,17 @@ function formatError(error51, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error51, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error52, path50 = []) => {
+  const processError = (error52, path52 = []) => {
     var _a3, _b;
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path50, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path52, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path50, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path52, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path50, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path52, ...issue2.path]);
       } else {
-        const fullpath = [...path50, ...issue2.path];
+        const fullpath = [...path52, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -1483,8 +1483,8 @@ function treeifyError(error51, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path50 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path50) {
+  const path52 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path52) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -14176,13 +14176,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path50 = ref.slice(1).split("/").filter(Boolean);
-  if (path50.length === 0) {
+  const path52 = ref.slice(1).split("/").filter(Boolean);
+  if (path52.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path50[0] === defsKey) {
-    const key = path50[1];
+  if (path52[0] === defsKey) {
+    const key = path52[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -27980,21 +27980,21 @@ var loadManifest2 = (manifestPath) => {
     return { ok: false, message: "manifest.files is missing or not an object" };
   }
   const files = /* @__PURE__ */ new Map();
-  for (const [path50, value] of Object.entries(shape.files)) {
+  for (const [path52, value] of Object.entries(shape.files)) {
     if (typeof value !== "string") {
       return {
         ok: false,
-        message: `manifest.files["${path50}"] is not a string`
+        message: `manifest.files["${path52}"] is not a string`
       };
     }
     if (!VALID_RAW_CLASSES.has(value)) {
       return {
         ok: false,
-        message: `manifest.files["${path50}"] has unknown class: "${value}"`
+        message: `manifest.files["${path52}"] has unknown class: "${value}"`
       };
     }
     const rawClass = value;
-    files.set(path50, {
+    files.set(path52, {
       normalizedClass: normalizeClass(rawClass),
       rawClass
     });
@@ -29801,16 +29801,317 @@ var run60 = (argv, options = {}) => {
   }
 };
 
-// src/wiki/log-prepend.ts
-import { existsSync as existsSync39, readFileSync as readFileSync37, renameSync as renameSync9, writeFileSync as writeFileSync15 } from "node:fs";
+// src/wiki/empty-sections.ts
+import { readdirSync as readdirSync10, readFileSync as readFileSync37, statSync as statSync8 } from "node:fs";
 import path45 from "node:path";
-var HELP_TEXT49 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+
+// src/wiki/util/frontmatter.ts
+var FRONTMATTER_FENCE = "---";
+var SCALAR_PATTERN = /^([\w-]+)\s*:\s*(.*)$/u;
+var stripQuotes2 = (raw) => {
+  if (raw.length < 2) return raw;
+  const first = raw.charAt(0);
+  const last = raw.charAt(raw.length - 1);
+  if (first === '"' && last === '"' || first === "'" && last === "'") {
+    return raw.slice(1, -1);
+  }
+  return raw;
+};
+var parseScalar = (raw) => {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "null" || trimmed === "~") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (inner === "") return [];
+    return inner.split(",").flatMap((entry) => {
+      const stripped = stripQuotes2(entry.trim());
+      return stripped.length > 0 ? [stripped] : [];
+    });
+  }
+  if (/^-?\d+(\.\d+)?$/u.test(trimmed)) {
+    return Number(trimmed);
+  }
+  return stripQuotes2(trimmed);
+};
+var parseFrontmatter = (raw) => {
+  const lines = raw.split("\n");
+  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE) {
+    return { body: raw, frontmatter: {}, hasFrontmatter: false };
+  }
+  let closingIndex = -1;
+  for (let index = 1; index < lines.length; index += 1) {
+    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE) {
+      closingIndex = index;
+      break;
+    }
+  }
+  if (closingIndex === -1) {
+    return { body: raw, frontmatter: {}, hasFrontmatter: false };
+  }
+  const yamlLines = lines.slice(1, closingIndex);
+  const frontmatter = {};
+  for (const line of yamlLines) {
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const match = SCALAR_PATTERN.exec(line);
+    if (match === null) continue;
+    const key = match[1];
+    const value = match[2].trim();
+    frontmatter[key] = parseScalar(value);
+  }
+  const body = lines.slice(closingIndex + 1).join("\n");
+  return { body, frontmatter, hasFrontmatter: true };
+};
+
+// src/wiki/empty-sections.ts
+var HELP_TEXT49 = `Usage: gaia wiki empty-sections [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
+  LEAF headings with no body \u2014 no child heading and no non-blank, non-heading
+  content before the next sibling/shallower heading or EOF. Parent headings
+  are never flagged. Fenced code blocks and the frontmatter block are handled.
+  Without --json, prints one "path:line  heading" line per finding. With
+  --json, emits { "empty": [ { path, line, heading } ] }.
+`;
+var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var SKIP_PATH_FRAGMENTS2 = ["wiki/meta/"];
+var SKIP_PATHS = /* @__PURE__ */ new Set(["wiki/hot.md", "wiki/log.md"]);
+var ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
+var FENCE_PATTERN = /^\s*(?:```|~~~)/u;
+var shouldSkipFile2 = (relPath) => SKIP_PATHS.has(relPath) || SKIP_PATH_FRAGMENTS2.some((fragment) => relPath.startsWith(fragment));
+var walkMarkdown2 = (root, dir) => {
+  const entries = readdirSync10(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const full = path45.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown2(root, full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(path45.relative(root, full));
+    }
+  }
+  return out;
+};
+var collectHeadings = (body, bodyLineOffset) => {
+  const headings = [];
+  const lines = body.split("\n");
+  let inFence = false;
+  for (const [index, line] of lines.entries()) {
+    if (FENCE_PATTERN.test(line)) {
+      inFence = !inFence;
+      if (headings.length > 0) headings.at(-1).hasContent = true;
+      continue;
+    }
+    if (inFence) {
+      if (headings.length > 0) headings.at(-1).hasContent = true;
+      continue;
+    }
+    const match = ATX_HEADING_PATTERN.exec(line);
+    if (match !== null) {
+      headings.push({
+        hasContent: false,
+        level: match[1].length,
+        line: bodyLineOffset + index + 1,
+        text: line.trim()
+      });
+      continue;
+    }
+    if (line.trim() !== "" && headings.length > 0) {
+      headings.at(-1).hasContent = true;
+    }
+  }
+  return headings;
+};
+var findInBody = (body, bodyLineOffset, relPath) => {
+  const headings = collectHeadings(body, bodyLineOffset);
+  const found = [];
+  for (const [index, heading] of headings.entries()) {
+    if (heading.hasContent) continue;
+    let hasChildHeading = false;
+    for (let next = index + 1; next < headings.length; next += 1) {
+      const candidate = headings[next];
+      if (candidate.level <= heading.level) break;
+      hasChildHeading = true;
+      break;
+    }
+    if (hasChildHeading) continue;
+    found.push({ heading: heading.text, line: heading.line, path: relPath });
+  }
+  return found;
+};
+var findEmptySections = (cwd) => {
+  const wikiDir = path45.join(cwd, "wiki");
+  try {
+    statSync8(wikiDir);
+  } catch {
+    return [];
+  }
+  const empty = [];
+  const files = walkMarkdown2(cwd, wikiDir).sort();
+  for (const filePath of files) {
+    if (shouldSkipFile2(filePath)) continue;
+    const content = readFileSync37(path45.join(cwd, filePath), "utf8");
+    const { body } = parseFrontmatter(content);
+    const offset = content.split("\n").length - body.split("\n").length;
+    empty.push(...findInBody(body, offset, filePath));
+  }
+  return empty;
+};
+var run61 = (argv, options = {}) => {
+  let json3 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS47.has(token)) {
+      process.stdout.write(HELP_TEXT49);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "wiki empty-sections"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const empty = findEmptySections(cwd);
+    if (json3) {
+      process.stdout.write(`${JSON.stringify({ empty }, null, 2)}
+`);
+      return EXIT_CODES.OK;
+    }
+    if (empty.length === 0) {
+      process.stdout.write("No empty sections found.\n");
+      return EXIT_CODES.OK;
+    }
+    const lines = empty.map(
+      (section) => `${section.path}:${section.line}  ${section.heading}`
+    );
+    process.stdout.write(`${lines.join("\n")}
+`);
+    return EXIT_CODES.OK;
+  } catch (error51) {
+    structuredError({
+      code: "empty_sections_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "wiki empty-sections"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};
+
+// src/wiki/frontmatter.ts
+import { readdirSync as readdirSync11, readFileSync as readFileSync38, statSync as statSync9 } from "node:fs";
+import path46 from "node:path";
+var HELP_TEXT50 = `Usage: gaia wiki frontmatter [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
+  frontmatter. Required floor is type and status. Without --json, prints one
+  "path: missing a, b" line per gap. With --json, emits
+  { "gaps": [ { path, missing } ] }.
+`;
+var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var REQUIRED_FIELDS = ["type", "status"];
+var SKIP_PATH_FRAGMENTS3 = ["wiki/meta/"];
+var shouldSkipFile3 = (relPath) => SKIP_PATH_FRAGMENTS3.some((fragment) => relPath.startsWith(fragment));
+var walkMarkdown3 = (root, dir) => {
+  const entries = readdirSync11(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const full = path46.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown3(root, full));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(path46.relative(root, full));
+    }
+  }
+  return out;
+};
+var hasField = (frontmatter, field) => Object.prototype.hasOwnProperty.call(frontmatter, field) && frontmatter[field] !== null;
+var findFrontmatterGaps = (cwd) => {
+  const wikiDir = path46.join(cwd, "wiki");
+  try {
+    statSync9(wikiDir);
+  } catch {
+    return [];
+  }
+  const gaps = [];
+  const files = walkMarkdown3(cwd, wikiDir).sort();
+  for (const filePath of files) {
+    if (shouldSkipFile3(filePath)) continue;
+    const content = readFileSync38(path46.join(cwd, filePath), "utf8");
+    const { frontmatter } = parseFrontmatter(content);
+    const missing = REQUIRED_FIELDS.filter(
+      (field) => !hasField(frontmatter, field)
+    );
+    if (missing.length > 0) {
+      gaps.push({ missing, path: filePath });
+    }
+  }
+  return gaps;
+};
+var run62 = (argv, options = {}) => {
+  let json3 = false;
+  for (const token of argv) {
+    if (HELP_TOKENS48.has(token)) {
+      process.stdout.write(HELP_TEXT50);
+      return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
+    }
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown flag: ${token}`,
+      subcommand: "wiki frontmatter"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const gaps = findFrontmatterGaps(cwd);
+    if (json3) {
+      process.stdout.write(`${JSON.stringify({ gaps }, null, 2)}
+`);
+      return EXIT_CODES.OK;
+    }
+    if (gaps.length === 0) {
+      process.stdout.write("No frontmatter gaps found.\n");
+      return EXIT_CODES.OK;
+    }
+    const lines = gaps.map((gap) => `${gap.path}: missing ${gap.missing.join(", ")}`);
+    process.stdout.write(`${lines.join("\n")}
+`);
+    return EXIT_CODES.OK;
+  } catch (error51) {
+    structuredError({
+      code: "frontmatter_failed",
+      message: error51 instanceof Error ? error51.message : String(error51),
+      subcommand: "wiki frontmatter"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};
+
+// src/wiki/log-prepend.ts
+import { existsSync as existsSync39, readFileSync as readFileSync39, renameSync as renameSync9, writeFileSync as writeFileSync15 } from "node:fs";
+import path47 from "node:path";
+var HELP_TEXT51 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
-var FRONTMATTER_FENCE = "---";
+var FRONTMATTER_FENCE2 = "---";
 var takeValue16 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0) {
@@ -29867,11 +30168,11 @@ var todayUtc3 = () => {
   return `${year}-${month}-${day}`;
 };
 var scanFrontmatter = (lines) => {
-  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE) {
+  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE2) {
     return { kind: "missing" };
   }
   for (let index = 1; index < lines.length; index += 1) {
-    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE) {
+    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE2) {
       return { endLineIndex: index, kind: "present" };
     }
   }
@@ -29889,14 +30190,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run61 = (argv, options = {}) => {
+var run63 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT49);
+    process.stdout.write(HELP_TEXT51);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS47.has(first)) {
-    process.stdout.write(HELP_TEXT49);
+  if (HELP_TOKENS49.has(first)) {
+    process.stdout.write(HELP_TEXT51);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags22(argv);
@@ -29919,7 +30220,7 @@ var run61 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const logPath = path45.join(repoRoot2, "wiki", "log.md");
+  const logPath = path47.join(repoRoot2, "wiki", "log.md");
   if (!existsSync39(logPath)) {
     structuredError({
       code: "log_missing",
@@ -29928,7 +30229,7 @@ var run61 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync37(logPath, "utf8");
+  const raw = readFileSync39(logPath, "utf8");
   const lines = raw.split("\n");
   const scan = scanFrontmatter(lines);
   if (scan.kind === "missing" || scan.kind === "malformed") {
@@ -29954,14 +30255,14 @@ var run61 = (argv, options = {}) => {
 };
 
 // src/wiki/near-collisions.ts
-import { existsSync as existsSync40, readdirSync as readdirSync10, statSync as statSync8 } from "node:fs";
-import path46 from "node:path";
-var HELP_TEXT50 = `Usage: gaia wiki near-collisions [--max-distance 3]
+import { existsSync as existsSync40, readdirSync as readdirSync12, statSync as statSync10 } from "node:fs";
+import path48 from "node:path";
+var HELP_TEXT52 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS2 = [
   "components",
@@ -29999,9 +30300,9 @@ var levenshtein = (a, b) => {
 var collectDomainSlugs = (wikiRoot) => {
   const collected = [];
   for (const domain2 of DOMAIN_DIRS2) {
-    const domainDir = path46.join(wikiRoot, domain2);
-    if (!existsSync40(domainDir) || !statSync8(domainDir).isDirectory()) continue;
-    const entries = readdirSync10(domainDir, { withFileTypes: true });
+    const domainDir = path48.join(wikiRoot, domain2);
+    if (!existsSync40(domainDir) || !statSync10(domainDir).isDirectory()) continue;
+    const entries = readdirSync12(domainDir, { withFileTypes: true });
     const slugs = [];
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -30070,9 +30371,9 @@ var parseFlags23 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run62 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS48.has(argv[0])) {
-    process.stdout.write(HELP_TEXT50);
+var run64 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS50.has(argv[0])) {
+    process.stdout.write(HELP_TEXT52);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags23(argv);
@@ -30095,7 +30396,7 @@ var run62 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path46.join(repoRoot2, "wiki");
+  const wikiRoot = path48.join(repoRoot2, "wiki");
   const domainGroups = collectDomainSlugs(wikiRoot);
   const collisions = findCollisions(domainGroups, parsed.flags.maxDistance);
   if (collisions.length === 0) return EXIT_CODES.OK;
@@ -30108,67 +30409,8 @@ var run62 = (argv, options = {}) => {
 };
 
 // src/wiki/page-index.ts
-import { existsSync as existsSync41, readdirSync as readdirSync11, readFileSync as readFileSync38, statSync as statSync9 } from "node:fs";
-import path47 from "node:path";
-
-// src/wiki/util/frontmatter.ts
-var FRONTMATTER_FENCE2 = "---";
-var SCALAR_PATTERN = /^([\w-]+)\s*:\s*(.*)$/u;
-var stripQuotes2 = (raw) => {
-  if (raw.length < 2) return raw;
-  const first = raw.charAt(0);
-  const last = raw.charAt(raw.length - 1);
-  if (first === '"' && last === '"' || first === "'" && last === "'") {
-    return raw.slice(1, -1);
-  }
-  return raw;
-};
-var parseScalar = (raw) => {
-  const trimmed = raw.trim();
-  if (trimmed === "" || trimmed === "null" || trimmed === "~") return null;
-  if (trimmed === "true") return true;
-  if (trimmed === "false") return false;
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    const inner = trimmed.slice(1, -1).trim();
-    if (inner === "") return [];
-    return inner.split(",").flatMap((entry) => {
-      const stripped = stripQuotes2(entry.trim());
-      return stripped.length > 0 ? [stripped] : [];
-    });
-  }
-  if (/^-?\d+(\.\d+)?$/u.test(trimmed)) {
-    return Number(trimmed);
-  }
-  return stripQuotes2(trimmed);
-};
-var parseFrontmatter = (raw) => {
-  const lines = raw.split("\n");
-  if ((lines[0] ?? "").trim() !== FRONTMATTER_FENCE2) {
-    return { body: raw, frontmatter: {}, hasFrontmatter: false };
-  }
-  let closingIndex = -1;
-  for (let index = 1; index < lines.length; index += 1) {
-    if ((lines[index] ?? "").trim() === FRONTMATTER_FENCE2) {
-      closingIndex = index;
-      break;
-    }
-  }
-  if (closingIndex === -1) {
-    return { body: raw, frontmatter: {}, hasFrontmatter: false };
-  }
-  const yamlLines = lines.slice(1, closingIndex);
-  const frontmatter = {};
-  for (const line of yamlLines) {
-    if (line.trim() === "" || line.trim().startsWith("#")) continue;
-    const match = SCALAR_PATTERN.exec(line);
-    if (match === null) continue;
-    const key = match[1];
-    const value = match[2].trim();
-    frontmatter[key] = parseScalar(value);
-  }
-  const body = lines.slice(closingIndex + 1).join("\n");
-  return { body, frontmatter, hasFrontmatter: true };
-};
+import { existsSync as existsSync41, readdirSync as readdirSync13, readFileSync as readFileSync40, statSync as statSync11 } from "node:fs";
+import path49 from "node:path";
 
 // src/wiki/util/wikilinks.ts
 var WIKILINK_PATTERN = /\[\[([^\][]+)\]\]/gu;
@@ -30188,12 +30430,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT51 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT53 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS3 = [
   "components",
   "concepts",
@@ -30206,7 +30448,7 @@ var DOMAIN_DIRS3 = [
 ];
 var SKIPPED_FILES2 = /* @__PURE__ */ new Set(["_index.md", "README.md"]);
 var ROOT_LINK_SOURCES = ["index.md", "overview.md", "hot.md"];
-var slugFromPath = (filePath) => path47.basename(filePath, ".md");
+var slugFromPath = (filePath) => path49.basename(filePath, ".md");
 var extractTitle = (body, fallback) => {
   const lines = body.split("\n");
   for (const line of lines) {
@@ -30232,16 +30474,16 @@ var arrayOfStrings = (value) => {
 var collectPages = (wikiRoot) => {
   const pages = [];
   for (const domain2 of DOMAIN_DIRS3) {
-    const domainDir = path47.join(wikiRoot, domain2);
-    if (!existsSync41(domainDir) || !statSync9(domainDir).isDirectory()) continue;
-    const entries = readdirSync11(domainDir, { withFileTypes: true });
+    const domainDir = path49.join(wikiRoot, domain2);
+    if (!existsSync41(domainDir) || !statSync11(domainDir).isDirectory()) continue;
+    const entries = readdirSync13(domainDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(".md")) continue;
       if (SKIPPED_FILES2.has(entry.name)) continue;
       if (entry.name.startsWith("_")) continue;
-      const absPath = path47.join(domainDir, entry.name);
-      const raw = readFileSync38(absPath, "utf8");
+      const absPath = path49.join(domainDir, entry.name);
+      const raw = readFileSync40(absPath, "utf8");
       const { body, frontmatter } = parseFrontmatter(raw);
       const slug = slugFromPath(entry.name);
       const title = extractTitle(body, slug);
@@ -30250,7 +30492,7 @@ var collectPages = (wikiRoot) => {
         body,
         domain: domain2,
         outboundTargets: targets,
-        relativePath: path47.posix.join("wiki", domain2, entry.name),
+        relativePath: path49.posix.join("wiki", domain2, entry.name),
         slug,
         status: stringValue(frontmatter.status),
         tags: arrayOfStrings(frontmatter.tags),
@@ -30264,9 +30506,9 @@ var collectPages = (wikiRoot) => {
 var collectRootLinkSources = (wikiRoot) => {
   const sources = [];
   for (const filename of ROOT_LINK_SOURCES) {
-    const absPath = path47.join(wikiRoot, filename);
+    const absPath = path49.join(wikiRoot, filename);
     if (!existsSync41(absPath)) continue;
-    const raw = readFileSync38(absPath, "utf8");
+    const raw = readFileSync40(absPath, "utf8");
     const { body } = parseFrontmatter(raw);
     sources.push(extractWikilinks(body));
   }
@@ -30318,16 +30560,16 @@ var printHuman6 = (index) => {
 };
 var computePageIndex = (cwd) => {
   const repoRoot2 = resolveRepoRoot2(cwd);
-  const wikiRoot = path47.join(repoRoot2, "wiki");
+  const wikiRoot = path49.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run63 = (argv, options = {}) => {
+var run65 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS49.has(token)) {
-      process.stdout.write(HELP_TEXT51);
+    if (HELP_TOKENS51.has(token)) {
+      process.stdout.write(HELP_TEXT53);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -30352,7 +30594,7 @@ var run63 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path47.join(repoRoot2, "wiki");
+  const wikiRoot = path49.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   const index = buildIndex(pages, rootSources);
@@ -30366,17 +30608,24 @@ var run63 = (argv, options = {}) => {
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT52 = `Usage: gaia wiki orphans
+var HELP_TEXT54 = `Usage: gaia wiki orphans [--json]
 
-  Newline-separated list of wiki pages with zero inbound wikilinks.
+  List wiki pages with zero inbound wikilinks. Without --json, prints one
+  repo-relative path per line. With --json, emits { "orphans": [ { path,
+  title, domain } ] }.
 `;
-var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var isMaintainerOnly = (path50) => path50.startsWith("wiki/meta/") || path50.startsWith("wiki/entities/");
-var run64 = (argv, options = {}) => {
+var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var isMaintainerOnly = (path52) => path52.startsWith("wiki/meta/") || path52.startsWith("wiki/entities/");
+var run66 = (argv, options = {}) => {
+  let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS50.has(token)) {
-      process.stdout.write(HELP_TEXT52);
+    if (HELP_TOKENS52.has(token)) {
+      process.stdout.write(HELP_TEXT54);
       return EXIT_CODES.OK;
+    }
+    if (token === "--json") {
+      json3 = true;
+      continue;
     }
     structuredError({
       code: "invalid_arguments",
@@ -30392,12 +30641,23 @@ var run64 = (argv, options = {}) => {
     const orphans = [];
     for (const page of index.pages) {
       if (page.inbound_links === 0 && !isMaintainerOnly(page.path)) {
-        orphans.push(page.path);
+        orphans.push({
+          domain: page.domain,
+          path: page.path,
+          title: page.title
+        });
       }
     }
-    if (orphans.length > 0) {
-      process.stdout.write(`${orphans.join("\n")}
+    if (json3) {
+      process.stdout.write(`${JSON.stringify({ orphans }, null, 2)}
 `);
+      return EXIT_CODES.OK;
+    }
+    if (orphans.length > 0) {
+      process.stdout.write(
+        `${orphans.map((orphan) => orphan.path).join("\n")}
+`
+      );
     }
     return EXIT_CODES.OK;
   } catch (error51) {
@@ -30411,15 +30671,15 @@ var run64 = (argv, options = {}) => {
 };
 
 // src/wiki/state-bump.ts
-import { existsSync as existsSync42, readFileSync as readFileSync39 } from "node:fs";
-import path48 from "node:path";
-var HELP_TEXT53 = `Usage: gaia wiki state-bump <field> <value>
+import { existsSync as existsSync42, readFileSync as readFileSync41 } from "node:fs";
+import path50 from "node:path";
+var HELP_TEXT55 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson2 = (raw) => {
   try {
     return JSON.parse(raw);
@@ -30441,13 +30701,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run65 = (argv, options = {}) => {
+var run67 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT53);
+    process.stdout.write(HELP_TEXT55);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS51.has(argv[0])) {
-    process.stdout.write(HELP_TEXT53);
+  if (HELP_TOKENS53.has(argv[0])) {
+    process.stdout.write(HELP_TEXT55);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30482,7 +30742,7 @@ var run65 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const statePath = path48.join(repoRoot2, "wiki", ".state.json");
+  const statePath = path50.join(repoRoot2, "wiki", ".state.json");
   if (!existsSync42(statePath)) {
     structuredError({
       code: "state_missing",
@@ -30491,7 +30751,7 @@ var run65 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync39(statePath, "utf8");
+  const raw = readFileSync41(statePath, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -30522,8 +30782,8 @@ var run65 = (argv, options = {}) => {
 // src/wiki/state-init.ts
 import { execFileSync as execFileSync8 } from "node:child_process";
 import { existsSync as existsSync43, mkdirSync as mkdirSync20 } from "node:fs";
-import path49 from "node:path";
-var HELP_TEXT54 = `Usage: gaia wiki state-init <sha>
+import path51 from "node:path";
+var HELP_TEXT56 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -30531,7 +30791,7 @@ var HELP_TEXT54 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag) \u2014 it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha2 = (ref, cwd) => {
   try {
     const out = execFileSync8(
@@ -30548,13 +30808,13 @@ var resolveFullSha2 = (ref, cwd) => {
     return null;
   }
 };
-var run66 = (argv, options = {}) => {
+var run68 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT54);
+    process.stdout.write(HELP_TEXT56);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS52.has(argv[0])) {
-    process.stdout.write(HELP_TEXT54);
+  if (HELP_TOKENS54.has(argv[0])) {
+    process.stdout.write(HELP_TEXT56);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30598,8 +30858,8 @@ var run66 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiDir = path49.join(repoRoot2, "wiki");
-  const statePath = path49.join(wikiDir, ".state.json");
+  const wikiDir = path51.join(repoRoot2, "wiki");
+  const statePath = path51.join(wikiDir, ".state.json");
   if (existsSync43(statePath)) {
     structuredError({
       code: "state_already_exists",
@@ -30679,7 +30939,7 @@ var inspectWorkingTree = (cwd, runner = defaultRunner5) => {
 };
 
 // src/wiki/sync-land.ts
-var HELP_TEXT55 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT57 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -30690,7 +30950,7 @@ var HELP_TEXT55 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT18 = 2;
 var parseFlags24 = (argv) => {
   let branchAware = false;
@@ -30816,9 +31076,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run67 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS53.has(argv[0])) {
-    process.stdout.write(HELP_TEXT55);
+var run69 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS55.has(argv[0])) {
+    process.stdout.write(HELP_TEXT57);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags24(argv);
@@ -30903,7 +31163,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT56 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT58 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -30912,9 +31172,11 @@ var HELP_TEXT56 = `Usage: gaia wiki <subcommand> [args]
   log-prepend --sha <h> --decision <D> --reason "..."
                                               Prepend a decision line to wiki/log.md.
   page-index [--json]                         Frontmatter + wikilink walk.
-  orphans                                     Pages with zero inbound links.
+  orphans [--json]                            Pages with zero inbound links.
   near-collisions [--max-distance N]          Per-domain Levenshtein over slugs.
   dead-paths [--json]                         Backticked repo paths in wiki/ that don't exist.
+  frontmatter [--json]                        Pages missing required frontmatter (type, status).
+  empty-sections [--json]                     Headings with no content before the next heading.
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
@@ -30924,16 +31186,16 @@ var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS56.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run67(rest);
+    return run69(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -30946,20 +31208,22 @@ var SUBCOMMAND_HANDLERS7 = {
   "commit-classify": run58,
   "dead-paths": run59,
   "diff-size": run60,
-  "log-prepend": run61,
-  "near-collisions": run62,
-  orphans: run64,
-  "page-index": run63,
+  "empty-sections": run61,
+  frontmatter: run62,
+  "log-prepend": run63,
+  "near-collisions": run64,
+  orphans: run66,
+  "page-index": run65,
   state: run37,
-  "state-bump": run65,
-  "state-init": run66,
+  "state-bump": run67,
+  "state-init": run68,
   sync: runSync
 };
-var run68 = async (argv) => {
+var run70 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
-    process.stdout.write(HELP_TEXT56);
+  if (subcommand === void 0 || HELP_TOKENS56.has(subcommand)) {
+    process.stdout.write(HELP_TEXT58);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS7[subcommand];
@@ -30976,7 +31240,7 @@ var run68 = async (argv) => {
 };
 
 // src/index.maintainer.ts
-var HELP_TEXT57 = `Usage: gaia-maintainer <subcommand> [args]
+var HELP_TEXT59 = `Usage: gaia-maintainer <subcommand> [args]
 
 Maintainer-only binary. Adopters use 'gaia' (no release namespace).
 
@@ -30994,9 +31258,9 @@ Maintainer-only binary. Adopters use 'gaia' (no release namespace).
   setup status|mark-step|finalize|link-worktree
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT57);
+  process.stdout.write(HELP_TEXT59);
 };
-var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS8 = {
   automation: run12,
   init: run21,
@@ -31007,12 +31271,12 @@ var SUBCOMMAND_HANDLERS8 = {
   telemetry: run53,
   update: run55,
   "update-deps": run57,
-  wiki: run68
+  wiki: run70
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS55.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS57.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }

--- a/.gaia/cli/src/wiki/empty-sections.test.ts
+++ b/.gaia/cli/src/wiki/empty-sections.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for `gaia wiki empty-sections`.
+ */
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {findEmptySections, run} from './empty-sections.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+  writeFile: (relativePath: string, contents: string) => void;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-wiki-empty-sections-'));
+  execFileSync('git', ['init', '-q'], {cwd: root});
+  mkdirSync(path.join(root, 'wiki'), {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+    writeFile: (relativePath, contents) => {
+      const absPath = path.join(root, relativePath);
+      mkdirSync(path.dirname(absPath), {recursive: true});
+      writeFileSync(absPath, contents, 'utf8');
+    },
+  };
+};
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('wiki empty-sections', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+    sandbox = setupSandbox();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('flags a leaf heading followed by a sibling-level heading with no body', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      [
+        '# Foo',
+        '',
+        'Intro.',
+        '',
+        '## Bar',
+        '',
+        '## Baz',
+        '',
+        'Content under baz.',
+        '',
+      ].join('\n')
+    );
+
+    const empty = findEmptySections(sandbox.root);
+    expect(empty).toEqual([
+      {heading: '## Bar', line: 5, path: 'wiki/concepts/Foo.md'},
+    ]);
+  });
+
+  test('does not flag a parent heading whose child headings have content', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Parent.md',
+      [
+        '# Accessibility',
+        '',
+        '## Static lint',
+        '',
+        'Lint catches issues.',
+        '',
+        '## Cross-references',
+        '',
+        'See the playbook.',
+        '',
+      ].join('\n')
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('does not flag a heading whose only span content is a deeper heading with content', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Nested.md',
+      [
+        '# Runbook',
+        '',
+        '## Operator runbook',
+        '',
+        '### Halt a runaway run',
+        '',
+        'Press the stop button.',
+        '',
+      ].join('\n')
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('flags a leaf child while leaving its parent unflagged', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Mixed.md',
+      [
+        '# Top',
+        '',
+        '## Parent',
+        '',
+        '### Filled',
+        '',
+        'Body here.',
+        '',
+        '### Empty',
+        '',
+        '## Sibling',
+        '',
+        'More body.',
+        '',
+      ].join('\n')
+    );
+
+    const empty = findEmptySections(sandbox.root);
+    expect(empty).toEqual([
+      {heading: '### Empty', line: 9, path: 'wiki/concepts/Mixed.md'},
+    ]);
+  });
+
+  test('flags an EOF-terminated empty section', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      ['# Foo', '', 'Intro.', '', '## Trailing', '', ''].join('\n')
+    );
+
+    const empty = findEmptySections(sandbox.root);
+    expect(empty).toEqual([
+      {heading: '## Trailing', line: 5, path: 'wiki/concepts/Foo.md'},
+    ]);
+  });
+
+  test('does not flag a heading that has body content', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      ['# Foo', '', 'Body for foo.', '', '## Bar', '', 'Body for bar.', ''].join(
+        '\n'
+      )
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('ignores fake headings inside fenced code blocks', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Code.md',
+      [
+        '# Code',
+        '',
+        'Intro.',
+        '',
+        '## Example',
+        '',
+        '```sh',
+        '# this is a shell comment, not a heading',
+        'echo hi',
+        '```',
+        '',
+      ].join('\n')
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('treats fenced code content as satisfying the prior heading', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Code.md',
+      [
+        '# Code',
+        '',
+        'Intro.',
+        '',
+        '## Snippet',
+        '',
+        '```ts',
+        'const x = 1;',
+        '```',
+        '',
+      ].join('\n')
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('reports the original line number despite frontmatter', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      [
+        '---',
+        'type: concept',
+        'status: stable',
+        '---',
+        '',
+        '# Foo',
+        '',
+        'Intro.',
+        '',
+        '## Empty',
+        '',
+        '## Next',
+        '',
+        'Content.',
+        '',
+      ].join('\n')
+    );
+
+    const empty = findEmptySections(sandbox.root);
+    expect(empty).toEqual([
+      {heading: '## Empty', line: 10, path: 'wiki/concepts/Foo.md'},
+    ]);
+  });
+
+  test('skips wiki/meta/** audit artifacts', () => {
+    sandbox.writeFile(
+      'wiki/meta/report.md',
+      ['# Report', '', '## Empty Heading', '', ''].join('\n')
+    );
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('skips the auto-managed sentinels wiki/hot.md and wiki/log.md', () => {
+    sandbox.writeFile('wiki/hot.md', ['# Recent Context', '', ''].join('\n'));
+    sandbox.writeFile('wiki/log.md', ['# Log', '', ''].join('\n'));
+
+    expect(findEmptySections(sandbox.root)).toEqual([]);
+  });
+
+  test('CLI prints "path:line  heading" lines', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      [
+        '# Foo',
+        '',
+        'Intro.',
+        '',
+        '## Bar',
+        '',
+        '## Baz',
+        '',
+        'Content.',
+        '',
+      ].join('\n')
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe(
+      'wiki/concepts/Foo.md:5  ## Bar'
+    );
+  });
+
+  test('CLI prints a clean message when there are no empty sections', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      ['# Foo', '', 'All good.', ''].join('\n')
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe('No empty sections found.');
+  });
+
+  test('--json emits a structured empty object', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      [
+        '# Foo',
+        '',
+        'Intro.',
+        '',
+        '## Bar',
+        '',
+        '## Baz',
+        '',
+        'Content.',
+        '',
+      ].join('\n')
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.outputs.join('')) as {
+      empty: ReadonlyArray<{heading: string; line: number; path: string}>;
+    };
+    expect(parsed.empty).toEqual([
+      {heading: '## Bar', line: 5, path: 'wiki/concepts/Foo.md'},
+    ]);
+  });
+
+  test('rejects unknown flags', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('unknown flag');
+  });
+
+  test('exits 0 when there is no wiki/ directory', () => {
+    rmSync(path.join(sandbox.root, 'wiki'), {force: true, recursive: true});
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe('No empty sections found.');
+  });
+});

--- a/.gaia/cli/src/wiki/empty-sections.ts
+++ b/.gaia/cli/src/wiki/empty-sections.ts
@@ -1,0 +1,250 @@
+/**
+ * `gaia wiki empty-sections [--json]` handler.
+ *
+ * Flags LEAF markdown headings (`#`..`######`) that have no body. A heading
+ * H at level L is empty only when, within its section span (the lines after
+ * H up to the next heading of level <= L, or end of file), there is BOTH:
+ *   1. no child heading (no heading of level > L), AND
+ *   2. no non-blank, non-heading content line.
+ *
+ * A parent heading (one that has child headings) is never flagged — its
+ * children are evaluated individually, and a genuinely-empty leaf child gets
+ * flagged on its own. Content inside fenced code blocks (```) counts as body
+ * and a `#` inside a fence is not a heading; the leading frontmatter block is
+ * stripped before evaluation.
+ *
+ * Scans `wiki/**\/*.md` except `wiki/meta/**` (dated audit artifacts) and the
+ * auto-managed sentinels `wiki/hot.md` and `wiki/log.md`.
+ *
+ * Output: one `path:line  heading` line per finding, or a clean message.
+ * With `--json`, emits { "empty": [ { path, line, heading } ] }. Exit 0
+ * always — empty sections are informational, not a failure.
+ */
+import {readdirSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {parseFrontmatter} from './util/frontmatter.js';
+
+const HELP_TEXT = `Usage: gaia wiki empty-sections [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
+  LEAF headings with no body — no child heading and no non-blank, non-heading
+  content before the next sibling/shallower heading or EOF. Parent headings
+  are never flagged. Fenced code blocks and the frontmatter block are handled.
+  Without --json, prints one "path:line  heading" line per finding. With
+  --json, emits { "empty": [ { path, line, heading } ] }.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const SKIP_PATH_FRAGMENTS = ['wiki/meta/'] as const;
+const SKIP_PATHS = new Set(['wiki/hot.md', 'wiki/log.md']);
+
+const ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
+const FENCE_PATTERN = /^\s*(?:```|~~~)/u;
+
+type EmptySection = {
+  heading: string;
+  line: number;
+  path: string;
+};
+
+type RunOptions = {
+  cwd?: string;
+};
+
+const shouldSkipFile = (relPath: string): boolean =>
+  SKIP_PATHS.has(relPath) ||
+  SKIP_PATH_FRAGMENTS.some((fragment) => relPath.startsWith(fragment));
+
+const walkMarkdown = (root: string, dir: string): string[] => {
+  const entries = readdirSync(dir, {withFileTypes: true});
+  const out: string[] = [];
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown(root, full));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(path.relative(root, full));
+    }
+  }
+
+  return out;
+};
+
+type Heading = {
+  hasContent: boolean;
+  level: number;
+  line: number;
+  text: string;
+};
+
+/**
+ * Build the ordered heading list for one page body, tracking whether each
+ * heading was followed (before the next heading) by any non-blank,
+ * non-heading content line. Fenced-code lines count as content; a `#` inside
+ * a fence is never a heading. `bodyLineOffset` is the number of frontmatter
+ * lines stripped ahead of `body`, so reported lines map back to the file.
+ */
+const collectHeadings = (body: string, bodyLineOffset: number): Heading[] => {
+  const headings: Heading[] = [];
+  const lines = body.split('\n');
+  let inFence = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (FENCE_PATTERN.test(line)) {
+      inFence = !inFence;
+      if (headings.length > 0) (headings.at(-1) as Heading).hasContent = true;
+      continue;
+    }
+
+    if (inFence) {
+      if (headings.length > 0) (headings.at(-1) as Heading).hasContent = true;
+      continue;
+    }
+
+    const match = ATX_HEADING_PATTERN.exec(line);
+
+    if (match !== null) {
+      headings.push({
+        hasContent: false,
+        level: (match[1] as string).length,
+        line: bodyLineOffset + index + 1,
+        text: line.trim(),
+      });
+      continue;
+    }
+
+    if (line.trim() !== '' && headings.length > 0) {
+      (headings.at(-1) as Heading).hasContent = true;
+    }
+  }
+
+  return headings;
+};
+
+/**
+ * A heading is empty only when it is a LEAF (no following heading is deeper,
+ * before a sibling/shallower heading closes its span) AND it carries no body
+ * content. Parent headings are skipped; their children are evaluated on their
+ * own.
+ */
+const findInBody = (
+  body: string,
+  bodyLineOffset: number,
+  relPath: string
+): EmptySection[] => {
+  const headings = collectHeadings(body, bodyLineOffset);
+  const found: EmptySection[] = [];
+
+  for (const [index, heading] of headings.entries()) {
+    if (heading.hasContent) continue;
+
+    // Walk forward to the end of this heading's span (next heading of level
+    // <= its level). A deeper heading inside the span makes it a parent.
+    let hasChildHeading = false;
+
+    for (let next = index + 1; next < headings.length; next += 1) {
+      const candidate = headings[next] as Heading;
+
+      if (candidate.level <= heading.level) break;
+      hasChildHeading = true;
+      break;
+    }
+
+    if (hasChildHeading) continue;
+
+    found.push({heading: heading.text, line: heading.line, path: relPath});
+  }
+
+  return found;
+};
+
+export const findEmptySections = (cwd: string): readonly EmptySection[] => {
+  const wikiDir = path.join(cwd, 'wiki');
+
+  try {
+    statSync(wikiDir);
+  } catch {
+    return [];
+  }
+
+  const empty: EmptySection[] = [];
+  const files = walkMarkdown(cwd, wikiDir).sort();
+
+  for (const filePath of files) {
+    if (shouldSkipFile(filePath)) continue;
+
+    const content = readFileSync(path.join(cwd, filePath), 'utf8');
+    const {body} = parseFrontmatter(content);
+    const offset = content.split('\n').length - body.split('\n').length;
+    empty.push(...findInBody(body, offset, filePath));
+  }
+
+  return empty;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'wiki empty-sections',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const empty = findEmptySections(cwd);
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify({empty}, null, 2)}\n`);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (empty.length === 0) {
+      process.stdout.write('No empty sections found.\n');
+
+      return EXIT_CODES.OK;
+    }
+
+    const lines = empty.map(
+      (section) => `${section.path}:${section.line}  ${section.heading}`
+    );
+    process.stdout.write(`${lines.join('\n')}\n`);
+
+    return EXIT_CODES.OK;
+  } catch (error) {
+    structuredError({
+      code: 'empty_sections_failed',
+      message: error instanceof Error ? error.message : String(error),
+      subcommand: 'wiki empty-sections',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};

--- a/.gaia/cli/src/wiki/frontmatter.test.ts
+++ b/.gaia/cli/src/wiki/frontmatter.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for `gaia wiki frontmatter`.
+ */
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {findFrontmatterGaps, run} from './frontmatter.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+  writeFile: (relativePath: string, contents: string) => void;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-wiki-frontmatter-'));
+  execFileSync('git', ['init', '-q'], {cwd: root});
+  mkdirSync(path.join(root, 'wiki'), {recursive: true});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+    writeFile: (relativePath, contents) => {
+      const absPath = path.join(root, relativePath);
+      mkdirSync(path.dirname(absPath), {recursive: true});
+      writeFileSync(absPath, contents, 'utf8');
+    },
+  };
+};
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+describe('wiki frontmatter', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+    sandbox = setupSandbox();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('flags a page missing status', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      '---\ntype: concept\n---\n\n# Foo\n\nBody.\n'
+    );
+
+    const gaps = findFrontmatterGaps(sandbox.root);
+    expect(gaps).toEqual([{missing: ['status'], path: 'wiki/concepts/Foo.md'}]);
+  });
+
+  test('flags a page missing both type and status', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Bare.md',
+      '---\ntitle: Bare\n---\n\n# Bare\n\nBody.\n'
+    );
+
+    const gaps = findFrontmatterGaps(sandbox.root);
+    expect(gaps).toEqual([
+      {missing: ['type', 'status'], path: 'wiki/concepts/Bare.md'},
+    ]);
+  });
+
+  test('flags a page with no frontmatter block at all', () => {
+    sandbox.writeFile('wiki/concepts/None.md', '# None\n\nNo frontmatter.\n');
+
+    const gaps = findFrontmatterGaps(sandbox.root);
+    expect(gaps).toEqual([
+      {missing: ['type', 'status'], path: 'wiki/concepts/None.md'},
+    ]);
+  });
+
+  test('treats a null required field as missing', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Null.md',
+      '---\ntype: concept\nstatus: ~\n---\n\n# Null\n'
+    );
+
+    const gaps = findFrontmatterGaps(sandbox.root);
+    expect(gaps).toEqual([{missing: ['status'], path: 'wiki/concepts/Null.md'}]);
+  });
+
+  test('does not flag a page carrying both required fields', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Good.md',
+      '---\ntype: concept\nstatus: stable\n---\n\n# Good\n'
+    );
+
+    expect(findFrontmatterGaps(sandbox.root)).toEqual([]);
+  });
+
+  test('skips wiki/meta/** audit artifacts', () => {
+    sandbox.writeFile(
+      'wiki/meta/lint-report-2026-05-07.md',
+      '# Lint Report\n\nNo frontmatter convention here.\n'
+    );
+
+    expect(findFrontmatterGaps(sandbox.root)).toEqual([]);
+  });
+
+  test('CLI prints "path: missing ..." lines', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      '---\ntype: concept\n---\n\n# Foo\n'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe(
+      'wiki/concepts/Foo.md: missing status'
+    );
+  });
+
+  test('CLI prints a clean message when there are no gaps', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Good.md',
+      '---\ntype: concept\nstatus: stable\n---\n\n# Good\n'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe('No frontmatter gaps found.');
+  });
+
+  test('--json emits a structured gaps object', () => {
+    sandbox.writeFile(
+      'wiki/concepts/Foo.md',
+      '---\ntype: concept\n---\n\n# Foo\n'
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.outputs.join('')) as {
+      gaps: ReadonlyArray<{missing: string[]; path: string}>;
+    };
+    expect(parsed.gaps).toEqual([
+      {missing: ['status'], path: 'wiki/concepts/Foo.md'},
+    ]);
+  });
+
+  test('rejects unknown flags', () => {
+    const exit = run(['--bogus'], {cwd: sandbox.root});
+    expect(exit).toBe(1);
+    expect(stdio.errors.join('')).toContain('unknown flag');
+  });
+
+  test('exits 0 when there is no wiki/ directory', () => {
+    rmSync(path.join(sandbox.root, 'wiki'), {force: true, recursive: true});
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('').trim()).toBe('No frontmatter gaps found.');
+  });
+});

--- a/.gaia/cli/src/wiki/frontmatter.ts
+++ b/.gaia/cli/src/wiki/frontmatter.ts
@@ -1,0 +1,159 @@
+/**
+ * `gaia wiki frontmatter [--json]` handler.
+ *
+ * Flags wiki pages missing required frontmatter. The required-field floor is
+ * `type` and `status` — the two fields essentially all GAIA pages carry. A
+ * page gaps if it is missing the frontmatter block entirely, or if either
+ * required field is absent or null.
+ *
+ * Scans `wiki/**\/*.md` except `wiki/meta/**` (dated audit artifacts that do
+ * not follow the page frontmatter convention).
+ *
+ * Output: one `path: missing a, b` line per gap, or a clean message. With
+ * `--json`, emits { "gaps": [ { path, missing } ] }. Exit 0 always — gaps
+ * are informational, not a failure.
+ */
+import {readdirSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {parseFrontmatter} from './util/frontmatter.js';
+
+const HELP_TEXT = `Usage: gaia wiki frontmatter [--json]
+
+  Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
+  frontmatter. Required floor is type and status. Without --json, prints one
+  "path: missing a, b" line per gap. With --json, emits
+  { "gaps": [ { path, missing } ] }.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const REQUIRED_FIELDS = ['type', 'status'] as const;
+
+const SKIP_PATH_FRAGMENTS = ['wiki/meta/'] as const;
+
+type Gap = {
+  missing: string[];
+  path: string;
+};
+
+type RunOptions = {
+  cwd?: string;
+};
+
+const shouldSkipFile = (relPath: string): boolean =>
+  SKIP_PATH_FRAGMENTS.some((fragment) => relPath.startsWith(fragment));
+
+const walkMarkdown = (root: string, dir: string): string[] => {
+  const entries = readdirSync(dir, {withFileTypes: true});
+  const out: string[] = [];
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown(root, full));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(path.relative(root, full));
+    }
+  }
+
+  return out;
+};
+
+const hasField = (
+  frontmatter: ReturnType<typeof parseFrontmatter>['frontmatter'],
+  field: string
+): boolean =>
+  Object.prototype.hasOwnProperty.call(frontmatter, field) &&
+  frontmatter[field] !== null;
+
+export const findFrontmatterGaps = (cwd: string): readonly Gap[] => {
+  const wikiDir = path.join(cwd, 'wiki');
+
+  try {
+    statSync(wikiDir);
+  } catch {
+    return [];
+  }
+
+  const gaps: Gap[] = [];
+  const files = walkMarkdown(cwd, wikiDir).sort();
+
+  for (const filePath of files) {
+    if (shouldSkipFile(filePath)) continue;
+
+    const content = readFileSync(path.join(cwd, filePath), 'utf8');
+    const {frontmatter} = parseFrontmatter(content);
+    const missing = REQUIRED_FIELDS.filter(
+      (field) => !hasField(frontmatter, field)
+    );
+
+    if (missing.length > 0) {
+      gaps.push({missing, path: filePath});
+    }
+  }
+
+  return gaps;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  let json = false;
+
+  for (const token of argv) {
+    if (HELP_TOKENS.has(token)) {
+      process.stdout.write(HELP_TEXT);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+      continue;
+    }
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown flag: ${token}`,
+      subcommand: 'wiki frontmatter',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  try {
+    const cwd = options.cwd ?? process.cwd();
+    const gaps = findFrontmatterGaps(cwd);
+
+    if (json) {
+      process.stdout.write(`${JSON.stringify({gaps}, null, 2)}\n`);
+
+      return EXIT_CODES.OK;
+    }
+
+    if (gaps.length === 0) {
+      process.stdout.write('No frontmatter gaps found.\n');
+
+      return EXIT_CODES.OK;
+    }
+
+    const lines = gaps.map((gap) => `${gap.path}: missing ${gap.missing.join(', ')}`);
+    process.stdout.write(`${lines.join('\n')}\n`);
+
+    return EXIT_CODES.OK;
+  } catch (error) {
+    structuredError({
+      code: 'frontmatter_failed',
+      message: error instanceof Error ? error.message : String(error),
+      subcommand: 'wiki frontmatter',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+};

--- a/.gaia/cli/src/wiki/index.ts
+++ b/.gaia/cli/src/wiki/index.ts
@@ -13,6 +13,8 @@ import {structuredError} from '../stderr.js';
 import {run as runCommitClassify} from './commit-classify.js';
 import {run as runDeadPaths} from './dead-paths.js';
 import {run as runDiffSize} from './diff-size.js';
+import {run as runEmptySections} from './empty-sections.js';
+import {run as runFrontmatter} from './frontmatter.js';
 import {run as runLogPrepend} from './log-prepend.js';
 import {run as runNearCollisions} from './near-collisions.js';
 import {run as runOrphans} from './orphans.js';
@@ -31,9 +33,11 @@ const HELP_TEXT = `Usage: gaia wiki <subcommand> [args]
   log-prepend --sha <h> --decision <D> --reason "..."
                                               Prepend a decision line to wiki/log.md.
   page-index [--json]                         Frontmatter + wikilink walk.
-  orphans                                     Pages with zero inbound links.
+  orphans [--json]                            Pages with zero inbound links.
   near-collisions [--max-distance N]          Per-domain Levenshtein over slugs.
   dead-paths [--json]                         Backticked repo paths in wiki/ that don't exist.
+  frontmatter [--json]                        Pages missing required frontmatter (type, status).
+  empty-sections [--json]                     Headings with no content before the next heading.
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
@@ -80,6 +84,8 @@ const SUBCOMMAND_HANDLERS: Readonly<
   'commit-classify': runCommitClassify,
   'dead-paths': runDeadPaths,
   'diff-size': runDiffSize,
+  'empty-sections': runEmptySections,
+  frontmatter: runFrontmatter,
   'log-prepend': runLogPrepend,
   'near-collisions': runNearCollisions,
   orphans: runOrphans,

--- a/.gaia/cli/src/wiki/orphans.test.ts
+++ b/.gaia/cli/src/wiki/orphans.test.ts
@@ -149,4 +149,50 @@ describe('wiki orphans', () => {
     expect(exit).toBe(0);
     expect(stdio.outputs.join('')).toBe('');
   });
+
+  test('--json enriches each orphan with title and domain', () => {
+    sandbox.writePage(
+      'wiki/concepts/Hub.md',
+      '---\ntype: concept\n---\n\n# Hub\n\nLinks to [[Spoke]].\n'
+    );
+    sandbox.writePage(
+      'wiki/concepts/Spoke.md',
+      '---\ntype: concept\n---\n\n# Spoke\n\nMentions [[Hub]].\n'
+    );
+    sandbox.writePage(
+      'wiki/concepts/Lonely.md',
+      '---\ntype: concept\n---\n\n# Release Notes\n\nNo references in or out.\n'
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.outputs.join('')) as {
+      orphans: ReadonlyArray<{domain: string; path: string; title: string}>;
+    };
+    expect(parsed.orphans).toEqual([
+      {
+        domain: 'concepts',
+        path: 'wiki/concepts/Lonely.md',
+        title: 'Release Notes',
+      },
+    ]);
+  });
+
+  test('--json emits an empty orphans array when there are none', () => {
+    sandbox.writePage(
+      'wiki/concepts/A.md',
+      '---\ntype: concept\n---\n\n# A\n\n[[B]]\n'
+    );
+    sandbox.writePage(
+      'wiki/concepts/B.md',
+      '---\ntype: concept\n---\n\n# B\n\n[[A]]\n'
+    );
+
+    const exit = run(['--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const parsed = JSON.parse(stdio.outputs.join('')) as {orphans: unknown[]};
+    expect(parsed.orphans).toEqual([]);
+  });
 });

--- a/.gaia/cli/src/wiki/orphans.ts
+++ b/.gaia/cli/src/wiki/orphans.ts
@@ -1,9 +1,10 @@
 /**
- * `gaia wiki orphans` handler.
+ * `gaia wiki orphans [--json]` handler.
  *
- * Newline-separated list of repo-relative paths of pages with
- * `inbound_links === 0` per the page-index walk. No `--json` flag — the
- * output is a list intended for piping to `wc -l` or similar.
+ * Default output: newline-separated list of repo-relative paths of pages
+ * with `inbound_links === 0` per the page-index walk, intended for piping
+ * to `wc -l` or similar. With `--json`, each orphan is enriched with its
+ * `title` and `domain` (both already derived by the page-index walk).
  *
  * Replaces the prose subject-orphan pass in `wiki/consolidate.md` Step 2d.
  */
@@ -11,9 +12,11 @@ import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {computePageIndex} from './page-index.js';
 
-const HELP_TEXT = `Usage: gaia wiki orphans
+const HELP_TEXT = `Usage: gaia wiki orphans [--json]
 
-  Newline-separated list of wiki pages with zero inbound wikilinks.
+  List wiki pages with zero inbound wikilinks. Without --json, prints one
+  repo-relative path per line. With --json, emits { "orphans": [ { path,
+  title, domain } ] }.
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
@@ -28,6 +31,12 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const isMaintainerOnly = (path: string): boolean =>
   path.startsWith('wiki/meta/') || path.startsWith('wiki/entities/');
 
+type Orphan = {
+  domain: string;
+  path: string;
+  title: string;
+};
+
 type RunOptions = {
   cwd?: string;
 };
@@ -36,11 +45,18 @@ export const run = (
   argv: readonly string[],
   options: RunOptions = {}
 ): number => {
+  let json = false;
+
   for (const token of argv) {
     if (HELP_TOKENS.has(token)) {
       process.stdout.write(HELP_TEXT);
 
       return EXIT_CODES.OK;
+    }
+
+    if (token === '--json') {
+      json = true;
+      continue;
     }
     structuredError({
       code: 'invalid_arguments',
@@ -56,16 +72,28 @@ export const run = (
   try {
     cwd = options.cwd ?? process.cwd();
     const index = computePageIndex(cwd);
-    const orphans: string[] = [];
+    const orphans: Orphan[] = [];
 
     for (const page of index.pages) {
       if (page.inbound_links === 0 && !isMaintainerOnly(page.path)) {
-        orphans.push(page.path);
+        orphans.push({
+          domain: page.domain,
+          path: page.path,
+          title: page.title,
+        });
       }
     }
 
+    if (json) {
+      process.stdout.write(`${JSON.stringify({orphans}, null, 2)}\n`);
+
+      return EXIT_CODES.OK;
+    }
+
     if (orphans.length > 0) {
-      process.stdout.write(`${orphans.join('\n')}\n`);
+      process.stdout.write(
+        `${orphans.map((orphan) => orphan.path).join('\n')}\n`
+      );
     }
 
     return EXIT_CODES.OK;

--- a/.gaia/release-scrub.yml
+++ b/.gaia/release-scrub.yml
@@ -265,7 +265,7 @@ transforms:
       # the meta-prefix alternative below covers them as a class.
       - id: wikilink-to-excluded
         description: "Wikilinks pointing at release-excluded wiki slugs"
-        pattern: "\\[\\[(Release Workflow|Bundle-time Scrub|GAIA|Steven Sacks|dashboard|Entities|Meta|CLI-Binary-Split|Forensics Triage Workflow|consolidate-report-[0-9-]+|lint-report-[0-9-]+)\\]\\]"
+        pattern: "\\[\\[(Release Workflow|Release-Notes|Bundle-time Scrub|GAIA|Steven Sacks|dashboard|Entities|Meta|CLI-Binary-Split|Forensics Triage Workflow|consolidate-report-[0-9-]+|lint-report-[0-9-]+)\\]\\]"
         scope:
           - "wiki/**/*.md"
         path-allowlist:

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -98,7 +98,9 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Dark Mode Modernization]]
 - [[Content Security Policy]] — per-request nonce CSP; Report-Only pending an upstream React Router fix; documents the `unsafe-inline` and no-`report-uri` trade-offs.
 - [[Dispatched-Check Rollup via Polling]] — in-loop pollers stamp dispatched-workflow jobs via the Checks API so they land in `statusCheckRollup`; documents why a `workflow_run` listener is not viable under `GITHUB_TOKEN`.
-- Forensics Triage Workflow — autonomous triage for `gaia-forensics`-labeled issues; default-deny path policy + draft-PR contract.
+<!-- gaia:maintainer-only:start -->
+- [[Forensics Triage Workflow]]
+<!-- gaia:maintainer-only:end -->
 - [[Quality Gate]]
 - [[pnpm]]
 - [[DragonScale Opt-Out]]
@@ -133,6 +135,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Update Workflow]] — `/update-gaia` three-way diff, manifest classes (`owned` / `shared` / `wiki-owned`), `.gaia-merge` sidecar patches.
 <!-- gaia:maintainer-only:start -->
 - [[Release Workflow]] — Maintainer flow: `/gaia-release`, `release.yml`, tarball scrubbing, `create-gaia` bootstrapper.
+- [[Release-Notes]]
 <!-- gaia:maintainer-only:end -->
 - [[GAIA Spec]] — `/gaia-spec`: Socratic discovery wrapper around spec-kit; produces an immutable SPEC artifact and chains into `/gaia-plan`.
 - [[GAIA Plan]] — `/gaia-plan`: feature plan + orchestrator scaffolding, clipboard handoff to a fresh session.

--- a/wiki/meta/lint-report-2026-06-04.md
+++ b/wiki/meta/lint-report-2026-06-04.md
@@ -11,9 +11,7 @@ status: developing
 
 ## #11: Wiki drift check
 
-ℹ 1 commit behind HEAD. Run /gaia-wiki sync at next opportunity. Recent unsynced commits:
-
-- ad74dc7 wiki: sync through 1ef7eec
+ℹ 2 commits behind HEAD. Run /gaia-wiki sync at next opportunity.
 
 ## #12: Dead repo-relative paths
 
@@ -22,3 +20,15 @@ status: developing
 ## #13: UAT/SPEC narrative-ref drift
 
 ✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.
+
+## #14: Orphan pages
+
+✓ No orphan pages (every page has at least one inbound wikilink).
+
+## #15: Frontmatter gaps
+
+✓ All wiki pages carry the required frontmatter (type, status).
+
+## #16: Empty sections
+
+✓ No empty sections detected.


### PR DESCRIPTION
## Summary

GAIA's wiki lint wrapped `claude-obsidian:wiki-lint` in Step 1, but that skill targets Obsidian constructs (wikilink graph via vault transport, Dataview, canvas, `address:` frontmatter) that GAIA's plain-markdown wiki does not use, so its sections `#1`-`#10` never appeared. This **decouples** the no-op wrapper and replaces the lost coverage with GAIA-native checks.

### Lint playbook (`lint.md`)
- Step 1 no longer invokes the upstream plugin; it builds its own report shell directly (preserving the regenerate-fresh / never-reuse-a-stale-report discipline).
- `#11` drift, `#12` dead-paths, `#13` UAT/SPEC narrative-ref: unchanged in substance.
- New ported checks, each re-derived from a `gaia wiki` CLI primitive every run: **`#14` orphan pages**, **`#15` frontmatter gaps** (type/status floor), **`#16` empty sections**.

### New CLI primitives (`.gaia/cli/src/wiki/`)
- `orphans` gains `--json` → `{ orphans: [{ path, title, domain }] }`
- `frontmatter [--json]` → flags pages missing the `type`/`status` floor
- `empty-sections [--json]` → flags **leaf** headings with no body; parent headings whose children carry content are never flagged (the naive "any heading before another heading" rule was a 100% false-positive trap on normal `# Title` → `## Section` structure)
- Plus tests; rebuilt `gaia` + `gaia-maintainer` binaries.

### De-orphan + leak-check
The two intentionally-unlinked maintainer-only pages (`Release-Notes`, `Forensics Triage Workflow`) are kept reachable via **marker-wrapped** `index.md` links, so `#14` stays clean locally and the links strip from the adopter bundle. `release-scrub.yml` gains the `Release-Notes` slug so an unwrapped link to it fails the bundle leak-check.

### Router (`wiki.md`)
Lint dispatch updated to Steps 1-8 and to surface the new `WIKI ORPHANS:` / `WIKI FRONTMATTER:` / `WIKI EMPTY-SECTIONS:` prominent lines.

## Verification
- CLI `typecheck` pass; `test` 1261 passed / 1 skipped (pre-existing).
- All 5 primitives smoke clean against the live wiki.
- End-to-end: a fresh Haiku lint subagent run through the updated router produced a clean `#11`-`#16` report.

## Follow-ups (not in this PR)
- `Claude Skills.md` is partially stale post-decouple (header "v1.6.0", "powered by claude-obsidian" framing).
- The `gaia` shell-alias collides with the playbooks' bare `gaia wiki ...` calls; worth alias-proofing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)