### PR TITLE
wiki: bump claude-obsidian baseline to v1.9.2; reframe plugin skills as auxiliary

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -9,7 +9,7 @@ tags: [meta, schema]
 # GAIA React: LLM Wiki
 
 Mode: B (Codebase) + E (Research)
-Plugin baseline: claude-obsidian v1.6.0 (DragonScale features intentionally not adopted — see [[DragonScale Opt-Out]])
+Plugin baseline: claude-obsidian v1.9.2 (DragonScale features intentionally not adopted — see [[DragonScale Opt-Out]])
 Purpose: Persistent knowledge base for the GAIA React workflow — architecture, conventions, decisions, Claude integration.
 Owner: Steven Sacks
 Created: 2026-04-20

--- a/wiki/concepts/Claude Integration Conventions.md
+++ b/wiki/concepts/Claude Integration Conventions.md
@@ -29,7 +29,7 @@ See [[modules/Claude Integration|the modules page]] for the inventory of current
 
 ### Wiki vendor relationship
 
-GAIA does **not** vendor the `claude-obsidian` plugin into the repo. The plugin is installed **globally** via the Claude Code plugin marketplace (`~/.claude/plugins/marketplaces/claude-obsidian-marketplace/`) at the v1.6.0 baseline. Adopters get it the moment they have Claude Code installed; nothing under `wiki/` or `.claude/` in this repo carries plugin source code.
+GAIA does **not** vendor the `claude-obsidian` plugin into the repo. The plugin is installed **globally** via the Claude Code plugin marketplace (`~/.claude/plugins/marketplaces/claude-obsidian-marketplace/`) at the v1.9.2 baseline. Adopters get it the moment they have Claude Code installed; nothing under `wiki/` or `.claude/` in this repo carries plugin source code.
 
 What this means in practice:
 

--- a/wiki/concepts/Claude Skills.md
+++ b/wiki/concepts/Claude Skills.md
@@ -82,22 +82,18 @@ Stack-specific or deep-dive content lives in `references/{topic}.md` inside the 
 
 See [[Claude Integration Conventions]] for the broader convention covering extension points, monorepo retrofit, and service swaps.
 
-## Plugin skills (claude-obsidian v1.6.0)
+## Plugin skills (claude-obsidian v1.9.2)
 
-GAIA's wiki workflow is powered by the `claude-obsidian` plugin, installed globally via the Claude Code marketplace (not vendored into this repo). The plugin contributes ten `claude-obsidian:*` skills. They auto-load on context match alongside GAIA's project-local skills:
+Core wiki maintenance (sync, consolidate, lint) runs through GAIA's native CLI (`.gaia/cli/gaia wiki ...`), not the plugin. Wiki-lint in particular is a GAIA-native check with its own rules and report, independent of the plugin's `wiki-lint` skill. The `claude-obsidian` plugin is installed globally via the Claude Code marketplace (not vendored into this repo) and supplies **auxiliary** skills only. Its skills auto-load on context match alongside GAIA's project-local skills.
 
-- `claude-obsidian:wiki` — bootstrap or check the wiki vault; routes to specialized sub-skills.
-- `claude-obsidian:wiki-ingest` — read a source (file or URL), extract entities/concepts, file structured pages, update cross-references and the log.
-- `claude-obsidian:wiki-query` — answer questions using the vault (hot cache → index → drill in), with citations; quick / standard / deep modes.
-- `claude-obsidian:wiki-lint` — health check: orphans, dead wikilinks, stale claims, missing cross-refs, frontmatter gaps; updates Dataview dashboards.
-- `claude-obsidian:save` — file the current chat or a specific insight as a structured wiki note.
-- `claude-obsidian:autoresearch` — autonomous iterative research loop that searches, synthesizes, and files findings into the vault.
-- `claude-obsidian:canvas` — create and edit Obsidian canvas files (images, text, PDFs, wiki pages).
-- `claude-obsidian:defuddle` — strip ads/nav/boilerplate from web pages before ingesting (saves 40-60% tokens).
-- `claude-obsidian:obsidian-bases` — create and edit Obsidian Bases (the native database layer for dynamic tables, filters, formulas).
-- `claude-obsidian:obsidian-markdown` — write correct Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, math, canvas syntax).
+The auxiliary skills GAIA leans on:
 
-The skill source lives in the upstream plugin cache (`~/.claude/plugins/cache/claude-obsidian-marketplace/claude-obsidian/<version>/skills/`), informational reference only — adopters should not edit these files. See [[Claude Integration Conventions]] § Wiki vendor relationship and [[DragonScale Opt-Out]] for the v1.6.0 baseline policy and why DragonScale's `wiki-fold` skill is dormant in our environment.
+- `claude-obsidian:wiki-ingest`: read a source (file or URL), extract entities/concepts, file structured pages, update cross-references and the log.
+- `claude-obsidian:wiki-query`: answer questions using the vault (hot cache → index → drill in), with citations; quick / standard / deep modes.
+- `claude-obsidian:save`: file the current chat or a specific insight as a structured wiki note.
+- `claude-obsidian:obsidian-markdown`: write correct Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, math, canvas syntax).
+
+The plugin ships more `claude-obsidian:*` skills than these (canvas, autoresearch, defuddle, obsidian-bases, plus the wiki-cli / wiki-mode / wiki-retrieve / think additions among them); GAIA pulls any of them in only when a task matches. The skill source lives in the upstream plugin cache (`~/.claude/plugins/cache/claude-obsidian-marketplace/claude-obsidian/<version>/skills/`), informational reference only: adopters should not edit these files. See [[Claude Integration Conventions]] § Wiki vendor relationship and [[DragonScale Opt-Out]] for the v1.9.2 baseline policy and why DragonScale's `wiki-fold` skill is dormant in our environment.
 
 ## Playwright CLI vs. MCP
 

--- a/wiki/decisions/DragonScale Opt-Out.md
+++ b/wiki/decisions/DragonScale Opt-Out.md
@@ -25,7 +25,7 @@ GAIA is a **template repo**. Every adopter forks it, runs `gaia-init`, and opera
 
 ## Decision
 
-GAIA does not adopt DragonScale. We do not vendor `bin/setup-dragonscale.sh`, do not document it as part of the standard workflow, do not allow `address: c-NNNNNN` frontmatter, and do not require `ollama` or `python3` for any wiki operation. The plugin remains installed at v1.6.0 — DragonScale's files exist in the upstream cache but are never invoked.
+GAIA does not adopt DragonScale. We do not vendor `bin/setup-dragonscale.sh`, do not document it as part of the standard workflow, do not allow `address: c-NNNNNN` frontmatter, and do not require `ollama` or `python3` for any wiki operation. The plugin remains installed at v1.9.2 — DragonScale's files exist in the upstream cache but are never invoked.
 
 ## Rationale (per mechanism)
 
@@ -46,7 +46,7 @@ DragonScale is engineered for **large, evolving, long-horizon knowledge vaults**
 
 Any GAIA adopter who scales their wiki past ~200 pages, starts running `/autoresearch` heavily, or otherwise wants the DragonScale features can opt in **per fork** without GAIA's involvement:
 
-1. Confirm `claude-obsidian` plugin is installed (it is, post-v1.6.0 baseline).
+1. Confirm `claude-obsidian` plugin is installed (it is, post-v1.9.2 baseline).
 2. Run `bash ~/.claude/plugins/cache/claude-obsidian-marketplace/claude-obsidian/<version>/bin/setup-dragonscale.sh` from the project root.
 3. Install local prerequisites only for the mechanisms they want — `ollama` + `nomic-embed-text` for tiling, `python3` for boundary scoring.
 4. Update their fork's wiki schema doc (e.g. `wiki/index.md` or a top-level `CLAUDE.md`) to permit `address: c-NNNNNN`.


### PR DESCRIPTION
Follow-up to the wiki-lint decouple (#289). Refreshes the wiki to the installed claude-obsidian baseline (v1.9.2) and reframes the plugin's role now that core wiki maintenance is GAIA-native.

## Changes

- **`wiki/concepts/Claude Skills.md`** — header to v1.9.2; reframe so core wiki maintenance (sync, consolidate, lint) runs through GAIA's native CLI and the plugin supplies auxiliary skills only. Note wiki-lint is a native check independent of the plugin's `wiki-lint` skill. Drop the brittle exhaustive 10-skill enumeration in favor of the few GAIA leans on plus a note that the plugin ships more.
- **CURRENT-BASELINE bumps v1.6.0 → v1.9.2** in `wiki/README.md`, `Claude Integration Conventions.md`, and `DragonScale Opt-Out.md` (installed/operative baseline).
- **Preserved** the DragonScale-origin (introduced-in-1.6.0) references in `Claude Integration Conventions.md` and `DragonScale Opt-Out.md` — factually true, not a baseline statement.

## Scope

Wiki-only. Entire diff is out of audit scope (`wiki/`), so the PR-merge audit gate clears via the out-of-scope bypass. Wiki-style audit (UAT/SPEC refs, historical phrasing) run clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)