### PR TITLE
fix(skills): alias-proof bare `gaia` CLI calls to repo-relative `.gaia/cli/gaia`

### DIFF
--- a/.claude/skills/gaia/references/fitness.md
+++ b/.claude/skills/gaia/references/fitness.md
@@ -4,7 +4,7 @@
 
 The check taxonomy, F-to-A+ grading rubric, and triage/heal orchestration protocol all live in `wiki/decisions/Claude Integration Fitness.md`. This file is the Orchestrator: it reads that page, runs its three phases, and owns the branch / repo-state harness layer described below. That harness layer — auto-branching, the unsafe-state guard — is `/gaia-fitness`-specific and is not part of the protocol in that page.
 
-**Scope note:** the harness this file wraps around the protocol is minimal — no Orchestrator-above-Triager layer, no preserved per-cycle artifact directories, no escalation handoff. On loop exhaustion it reports the unresolved findings with the grade, period. v1 introduces no `gaia` CLI subcommand — the agent runs the checks the wiki page defines (greps / `jq` / `gaia wiki …` calls) inline.
+**Scope note:** the harness this file wraps around the protocol is minimal — no Orchestrator-above-Triager layer, no preserved per-cycle artifact directories, no escalation handoff. On loop exhaustion it reports the unresolved findings with the grade, period. v1 introduces no `gaia` CLI subcommand — the agent runs the checks the wiki page defines (greps / `jq` / `.gaia/cli/gaia wiki …` calls) inline.
 
 ---
 

--- a/.claude/skills/gaia/references/wiki/consolidate.md
+++ b/.claude/skills/gaia/references/wiki/consolidate.md
@@ -12,7 +12,7 @@ Wiki pages emitted by `wiki-promote` carry `promoted_from: SPEC-NNN` and `promot
 
 ## Step 1 — Build the page index
 
-Run `gaia wiki page-index --json` and use the returned shape. The CLI walks the canonical domains (`wiki/decisions/`, `wiki/concepts/`, `wiki/modules/`, `wiki/flows/`, `wiki/components/`, `wiki/dependencies/`), skipping `wiki/_archived/`, `wiki/meta/`, `wiki/entities/`, `wiki/log.md`, `wiki/index.md`, `wiki/hot.md`, `wiki/overview.md`, `wiki/README.md`, and per-domain `_index.md` files.
+Run `.gaia/cli/gaia wiki page-index --json` and use the returned shape. The CLI walks the canonical domains (`wiki/decisions/`, `wiki/concepts/`, `wiki/modules/`, `wiki/flows/`, `wiki/components/`, `wiki/dependencies/`), skipping `wiki/_archived/`, `wiki/meta/`, `wiki/entities/`, `wiki/log.md`, `wiki/index.md`, `wiki/hot.md`, `wiki/overview.md`, `wiki/README.md`, and per-domain `_index.md` files.
 
 Each entry in `pages[]` provides `path`, `domain`, `title`, `type`, `status`, `tags`, `inbound_links`, and `outbound_links`. Augment with the consolidation-only fields the CLI does not surface — read each page's frontmatter for:
 
@@ -48,13 +48,13 @@ If a match references the older page's title (substring, case-insensitive), flag
 
 ### 2c. Near-collision slugs
 
-Run `gaia wiki near-collisions --max-distance 2` and surface its output. The CLI emits per-domain pairs that are within Levenshtein distance 2 (or where one slug is a prefix of the other) as tabular text. Flag each as a **near-collision** candidate. The newer page (by `promoted_at`, ties broken by file mtime) is the canonical.
+Run `.gaia/cli/gaia wiki near-collisions --max-distance 2` and surface its output. The CLI emits per-domain pairs that are within Levenshtein distance 2 (or where one slug is a prefix of the other) as tabular text. Flag each as a **near-collision** candidate. The newer page (by `promoted_at`, ties broken by file mtime) is the canonical.
 
 Distance 2 is the right floor: distance 3 produces excessive false positives in dense domains with short slugs (e.g. `Ky` matches every dependency, `State` collides with `Styles`).
 
 ### 2d. Subject-orphaned pages
 
-Run `gaia wiki orphans` to enumerate pages with zero inbound wikilinks. For each candidate, refine: keep only pages where the body title also has zero case-insensitive substring matches in `wiki/concepts/` and `wiki/modules/`, AND the page has not been touched in 90+ days (`git log -1 --format=%aI -- <path>`). Flag the survivors as **subject-orphaned**.
+Run `.gaia/cli/gaia wiki orphans` to enumerate pages with zero inbound wikilinks. For each candidate, refine: keep only pages where the body title also has zero case-insensitive substring matches in `wiki/concepts/` and `wiki/modules/`, AND the page has not been touched in 90+ days (`git log -1 --format=%aI -- <path>`). Flag the survivors as **subject-orphaned**.
 
 ### 2e. Suppress acknowledged findings
 
@@ -174,8 +174,8 @@ No-op. Finding remains active and will re-surface on the next consolidate run.
 Update `wiki/.state.json` via the CLI primitive (preserves sibling fields and key order automatically):
 
 1. Confirm the file exists. It should — `/gaia-wiki sync` creates it on first run. If missing, skip this step entirely and emit a warning in the Step 6 summary.
-2. Run `gaia wiki state-bump last_consolidated_sha "$(git rev-parse HEAD)"` (full 40-char SHA at consolidate-completion time, before any of this run's edits get committed).
-3. Run `gaia wiki state-bump last_consolidated_at "$(date -u +%FT%TZ)"`.
+2. Run `.gaia/cli/gaia wiki state-bump last_consolidated_sha "$(git rev-parse HEAD)"` (full 40-char SHA at consolidate-completion time, before any of this run's edits get committed).
+3. Run `.gaia/cli/gaia wiki state-bump last_consolidated_at "$(date -u +%FT%TZ)"`.
 
 `state-bump` performs an atomic write (`writeFileSync` to `.tmp` + `renameSync`) and preserves `last_evaluated_sha`, `last_evaluated_at`, and any future sibling fields verbatim.
 

--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -4,7 +4,7 @@ Dispatched by the `/gaia-wiki` router (`references/wiki.md` → "Lint"). Runs in
 
 ## Playbook
 
-Standalone GAIA-native wiki lint. Builds its own report shell, then writes GAIA-specific checks: **#11: Wiki drift check**, **#12: Dead repo-relative paths**, **#13: UAT/SPEC narrative-ref drift**, **#14: Orphan pages**, **#15: Frontmatter gaps**, and **#16: Empty sections**. Every check re-derives from a live `gaia wiki` CLI primitive on each run; the report is plain markdown that GAIA owns end to end.
+Standalone GAIA-native wiki lint. Builds its own report shell, then writes GAIA-specific checks: **#11: Wiki drift check**, **#12: Dead repo-relative paths**, **#13: UAT/SPEC narrative-ref drift**, **#14: Orphan pages**, **#15: Frontmatter gaps**, and **#16: Empty sections**. Every check re-derives from a live `.gaia/cli/gaia wiki` CLI primitive on each run; the report is plain markdown that GAIA owns end to end.
 
 ## Step 1: Create the report shell
 
@@ -41,12 +41,12 @@ Use `wiki/meta/lint-report-$DATE.md` as the canonical report path for every subs
 
 ## Step 2: GAIA check #11: Wiki drift
 
-Always run `gaia wiki state --json` fresh and write the `## #11: Wiki drift check` section from its output, replacing any existing `## #11` section in the report. Never carry over a `#11` section from a reused report: drift state is the most time-sensitive check, and a stale `#11` is exactly how a wiki that was just synced or recovered gets mis-reported as drifting.
+Always run `.gaia/cli/gaia wiki state --json` fresh and write the `## #11: Wiki drift check` section from its output, replacing any existing `## #11` section in the report. Never carry over a `#11` section from a reused report: drift state is the most time-sensitive check, and a stale `#11` is exactly how a wiki that was just synced or recovered gets mis-reported as drifting.
 
 ### 2a. Run the primitive
 
 ```bash
-gaia wiki state --json
+.gaia/cli/gaia wiki state --json
 ```
 
 The CLI returns a JSON object with `drift_severity` (`none` | `low` | `medium` | `high`), `head_short`, `state_sha`, `commits_ahead`, `reachable`, `recent_commits`, and `suggested_base`. If the command exits non-zero with `state_missing` (or equivalent reason), append:
@@ -115,7 +115,7 @@ Run the dead-paths primitive and append a `## #12: Dead repo-relative paths` sec
 ### 3a. Run the primitive
 
 ```bash
-gaia wiki dead-paths --json
+.gaia/cli/gaia wiki dead-paths --json
 ```
 
 Returns `{ "dead": [{ "filePath": "...", "line": N, "path": "..." }, ...] }`. Empty array means clean.
@@ -203,7 +203,7 @@ Run the orphans primitive and append a `## #14: Orphan pages` section, replacing
 ### 5a. Run the primitive
 
 ```bash
-gaia wiki orphans --json
+.gaia/cli/gaia wiki orphans --json
 ```
 
 Returns `{ "orphans": [{ "path": "...", "title": "...", "domain": "..." }, ...] }`. Empty array means clean.
@@ -240,7 +240,7 @@ Run the frontmatter primitive and append a `## #15: Frontmatter gaps` section, r
 ### 6a. Run the primitive
 
 ```bash
-gaia wiki frontmatter --json
+.gaia/cli/gaia wiki frontmatter --json
 ```
 
 Returns `{ "gaps": [{ "path": "...", "missing": ["type", "status"] }, ...] }`. Empty array means clean.
@@ -275,7 +275,7 @@ Run the empty-sections primitive and append a `## #16: Empty sections` section, 
 ### 7a. Run the primitive
 
 ```bash
-gaia wiki empty-sections --json
+.gaia/cli/gaia wiki empty-sections --json
 ```
 
 Returns `{ "empty": [{ "path": "...", "line": N, "heading": "..." }, ...] }`. Empty array means clean.

--- a/.claude/skills/gaia/references/wiki/sync.md
+++ b/.claude/skills/gaia/references/wiki/sync.md
@@ -10,15 +10,15 @@ Evaluate every commit between `wiki/.state.json` `last_evaluated_sha` and HEAD. 
 
 ## Step 1: Read state and compute drift
 
-Run `gaia wiki state --json` and parse the result. Use `head_short`, `state_sha`, `commits_ahead`, `reachable`, and `suggested_base` directly.
+Run `.gaia/cli/gaia wiki state --json` and parse the result. Use `head_short`, `state_sha`, `commits_ahead`, `reachable`, and `suggested_base` directly.
 
 Throughout this playbook, **the evaluation baseline** is the ref Steps 2, 3, and 8 evaluate from. On the normal path it is `last_evaluated_sha`; on the recovery path (below) it is `suggested_base`. Each branch states which.
 
-- If the command exits non-zero with a `state_missing` (or equivalent) reason, this is a fresh project (no prior sync). Treat the first commit as the baseline. Run `gaia wiki state-init "$(git rev-list --max-parents=0 HEAD | tail -1)"` to create `wiki/.state.json` with `{version, last_evaluated_sha, last_evaluated_at}`, then commit as `wiki: initialize state at {short_sha}`. Stop — no commits to evaluate yet.
+- If the command exits non-zero with a `state_missing` (or equivalent) reason, this is a fresh project (no prior sync). Treat the first commit as the baseline. Run `.gaia/cli/gaia wiki state-init "$(git rev-list --max-parents=0 HEAD | tail -1)"` to create `wiki/.state.json` with `{version, last_evaluated_sha, last_evaluated_at}`, then commit as `wiki: initialize state at {short_sha}`. Stop — no commits to evaluate yet.
 - If `commits_ahead === 0`: skip the evaluation pass (no commits to evaluate) but DO NOT exit yet — fall through to Step 9 (consolidate gate). The gate may still trigger consolidate based on accumulated page-adds since last consolidate run, even when this sync is a no-op. The Step 8 report still prints; just substitute `Wiki already in sync at {short_sha}.` for the regular summary block, then run Step 9.
 - If `reachable === false`: the recorded `last_evaluated_sha` is not in HEAD's history. GAIA's squash-merge flow orphans it on **every** merge — the evaluated branch SHA is replaced by a new squash commit on `main` — so this is the common case, not just a manual rebase. Recover the un-evaluated window instead of discarding it:
   - **Recovery path — when `suggested_base` is non-empty.** The CLI resolved `suggested_base` to the newest commit reachable from HEAD at or older than `last_evaluated_at` — a reachable baseline equivalent to where the orphaned SHA left off. Adopt `suggested_base` as the evaluation baseline and run the normal pass (Steps 2–9) from it. Do NOT jump to HEAD and do NOT log a `RE_ANCHOR` line — the window is evaluated, not abandoned. Step 6 advances `last_evaluated_sha` to HEAD as usual.
-  - **Fallback path — when `suggested_base` is empty.** Only when the CLI cannot resolve a baseline (no `last_evaluated_at`, or it predates all history) revert to the lossy-but-safe re-anchor: run `gaia wiki state-bump last_evaluated_sha "$(git rev-parse HEAD)"`, then `gaia wiki log-prepend --sha "$(git rev-parse --short HEAD)" --decision RE_ANCHOR --reason "re-anchored after history rewrite (no recoverable baseline)"`, commit, exit. Skip Step 9 — there is no recovered range to consolidate against.
+  - **Fallback path — when `suggested_base` is empty.** Only when the CLI cannot resolve a baseline (no `last_evaluated_at`, or it predates all history) revert to the lossy-but-safe re-anchor: run `.gaia/cli/gaia wiki state-bump last_evaluated_sha "$(git rev-parse HEAD)"`, then `.gaia/cli/gaia wiki log-prepend --sha "$(git rev-parse --short HEAD)" --decision RE_ANCHOR --reason "re-anchored after history rewrite (no recoverable baseline)"`, commit, exit. Skip Step 9 — there is no recovered range to consolidate against.
 - Otherwise proceed with the evaluation pass on the normal baseline (`last_evaluated_sha`).
 
 ## Step 2: Drift cap check
@@ -41,8 +41,8 @@ Run, using the evaluation baseline from Step 1 (normal path: `last_evaluated_sha
 
 ```bash
 # Normal path: BASE=$(jq -r .last_evaluated_sha wiki/.state.json)
-# Recovery path: BASE=<suggested_base from `gaia wiki state --json`>
-gaia wiki commit-classify --since "$BASE" --json
+# Recovery path: BASE=<suggested_base from `.gaia/cli/gaia wiki state --json`>
+.gaia/cli/gaia wiki commit-classify --since "$BASE" --json
 ```
 
 On the recovery path, classify from `suggested_base` — NOT the orphaned `last_evaluated_sha`. The orphaned SHA's `..HEAD` range is topologically unreliable after a squash; `suggested_base` is reachable and time-anchored.
@@ -93,16 +93,16 @@ For each commit (worthy or skipped), first dedup against the existing ledger, th
 # Skip commits a prior sync already catalogued — avoids double-logging.
 # Grep the working-tree log so lines this sync already prepended count too.
 grep -qF "<short_sha>" wiki/log.md && continue
-gaia wiki log-prepend --sha <short_sha> --decision <WORTHY|SKIP> --reason "<one-line reason>"
+.gaia/cli/gaia wiki log-prepend --sha <short_sha> --decision <WORTHY|SKIP> --reason "<one-line reason>"
 ```
 
 The dedup guard matters most on the recovery path (Step 1): the resolved `suggested_base` is time-anchored, so it can sit one or two commits behind a boundary a prior sync already logged. Skip any commit whose short SHA is already in `wiki/log.md` rather than appending a duplicate line.
 
 The CLI inserts a single canonical line `- <YYYY-MM-DD> <sha> <decision> — <reason>` at the top of `wiki/log.md` (after frontmatter), atomically, newest entries on top. Examples:
 
-- WORTHY: `gaia wiki log-prepend --sha abc1234 --decision WORTHY --reason "added /services/Gemini integration → wiki/services/Gemini.md"`
-- SKIP: `gaia wiki log-prepend --sha def5678 --decision SKIP --reason "typo-only commit"`
-- Serena-policy SKIP: `gaia wiki log-prepend --sha 9a0b1c2 --decision SKIP --reason "Serena handles inventory — added Button variant in app/components/Button"`
+- WORTHY: `.gaia/cli/gaia wiki log-prepend --sha abc1234 --decision WORTHY --reason "added /services/Gemini integration → wiki/services/Gemini.md"`
+- SKIP: `.gaia/cli/gaia wiki log-prepend --sha def5678 --decision SKIP --reason "typo-only commit"`
+- Serena-policy SKIP: `.gaia/cli/gaia wiki log-prepend --sha 9a0b1c2 --decision SKIP --reason "Serena handles inventory — added Button variant in app/components/Button"`
 
 ## Step 6: Advance state file
 
@@ -111,17 +111,17 @@ Run:
 ```bash
 NEW_HEAD=$(git rev-parse HEAD)
 NEW_HEAD_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-gaia wiki state-bump last_evaluated_sha "$NEW_HEAD"
-gaia wiki state-bump last_evaluated_at "$NEW_HEAD_AT"
+.gaia/cli/gaia wiki state-bump last_evaluated_sha "$NEW_HEAD"
+.gaia/cli/gaia wiki state-bump last_evaluated_at "$NEW_HEAD_AT"
 ```
 
 `state-bump` writes atomically — preserving sibling fields (`last_consolidated_sha` owned by `/gaia-wiki consolidate`) and key order.
 
-If `last_consolidated_sha` is absent on the existing state (first sync ever): bootstrap it with `gaia wiki state-bump last_consolidated_sha "$NEW_HEAD"`. This gives the consolidate gate a baseline so subsequent runs accumulate from a known point.
+If `last_consolidated_sha` is absent on the existing state (first sync ever): bootstrap it with `.gaia/cli/gaia wiki state-bump last_consolidated_sha "$NEW_HEAD"`. This gives the consolidate gate a baseline so subsequent runs accumulate from a known point.
 
 ## Step 7 — Land
 
-Run: `gaia wiki sync land --branch-aware`
+Run: `.gaia/cli/gaia wiki sync land --branch-aware`
 
 Exit codes:
 

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -11,7 +11,7 @@ Trigger: user asks to create a component, scaffold a card, etc.
 ## Workflow
 
 1. Confirm with user via AskUserQuestion: name (PascalCase), parent dir (default `app/components`), props (or "none"), story (default yes).
-2. Run: `gaia scaffold component <Name> [flags]`
+2. Run: `.gaia/cli/gaia scaffold component <Name> [flags]`
 3. Verify: `pnpm typecheck` clean. Open the new files, sanity-check the props.
 4. If user wants more (variants, conditional rendering, complex children): edit the generated files. The skill does not regenerate.
 

--- a/.claude/skills/new-hook/SKILL.md
+++ b/.claude/skills/new-hook/SKILL.md
@@ -11,5 +11,5 @@ Trigger: user asks to create a custom React hook.
 ## Workflow
 
 1. Confirm: name (use\*), params, return type.
-2. Run: `gaia scaffold hook <useFoo> [--params "a:string,b:number"] [--returns "ReturnType"]`.
+2. Run: `.gaia/cli/gaia scaffold hook <useFoo> [--params "a:string,b:number"] [--returns "ReturnType"]`.
 3. Verify: `pnpm typecheck` clean. Open and sanity-check.

--- a/.claude/skills/new-route/SKILL.md
+++ b/.claude/skills/new-route/SKILL.md
@@ -11,7 +11,7 @@ Trigger: user asks to add a new page/route.
 ## Workflow
 
 1. Confirm with the user: name (kebab-case), group (`_public+` or `_session+`), and which of `--loader`, `--action`, `--i18n` they want.
-2. Run: `gaia scaffold route <name> --group <group> [flags]`
+2. Run: `.gaia/cli/gaia scaffold route <name> --group <group> [flags]`
 3. Verify: `pnpm typecheck` clean; `pnpm dev` reaches the new route.
 
 ## Flags

--- a/.claude/skills/new-service/SKILL.md
+++ b/.claude/skills/new-service/SKILL.md
@@ -11,7 +11,7 @@ Trigger: user asks to scaffold an API service.
 ## Workflow
 
 1. Confirm: name (kebab), endpoints, schema (`name:type` pairs), with mocks?
-2. Run: `gaia scaffold service <name> --endpoints "..." --schema "..." [--mocks]`
+2. Run: `.gaia/cli/gaia scaffold service <name> --endpoints "..." --schema "..." [--mocks]`
 3. Verify: `pnpm typecheck` clean; if `--mocks`, run a single MSW round-trip in a vitest test.
 4. Wire the service into the consuming page/hook (CLI does not do this — manual).
 

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -21,7 +21,7 @@ if [ -n "$common_dir" ]; then
   main_root="$(cd "$(dirname "$absolute_common_dir")" 2>/dev/null && pwd)"
   current_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   if [ -n "$main_root" ] && [ -n "$current_root" ] && [ "$main_root" != "$current_root" ]; then
-    cached_line="Cached state unavailable on main; symlinks may be broken — run \`gaia setup link-worktree\` to repair."
+    cached_line="Cached state unavailable on main; symlinks may be broken — run \`.gaia/cli/gaia setup link-worktree\` to repair."
     cache_file="$main_root/.gaia/cache/update-check.json"
     if [ -f "$cache_file" ] && command -v jq >/dev/null 2>&1; then
       outdated_count="$(jq -r '.outdatedCount // 0' "$cache_file" 2>/dev/null)"

--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -28,7 +28,7 @@ if [ -n "$common_dir" ]; then
   main_root="$(cd "$(dirname "$absolute_common_dir")" 2>/dev/null && pwd)"
   current_root="$(git rev-parse --show-toplevel 2>/dev/null)"
   if [ -n "$main_root" ] && [ -n "$current_root" ] && [ "$main_root" != "$current_root" ]; then
-    cached_line="Cached state unavailable on main; symlinks may be broken — run \`gaia setup link-worktree\` to repair."
+    cached_line="Cached state unavailable on main; symlinks may be broken — run \`.gaia/cli/gaia setup link-worktree\` to repair."
     cache_file="$main_root/.gaia/cache/update-check.json"
     if [ -f "$cache_file" ] && command -v jq >/dev/null 2>&1; then
       gaia_current="$(jq -r '.gaiaCurrent // ""' "$cache_file" 2>/dev/null)"


### PR DESCRIPTION
Follow-up to the wiki-lint decouple (#289). Adopters do not get a bare `gaia` on PATH (the CLI `package.json` has no `bin` field, and nothing symlinks/exports it), so any skill instruction that runs `gaia <subcmd>` fails on a clean clone. This swaps every bare invocation for the repo-relative `.gaia/cli/gaia`, which resolves from the project root on every machine per `.claude/rules/instruction-files.md`.

## Changes

- **wiki playbooks** (`gaia/references/wiki/{sync,consolidate,lint}.md`): `gaia wiki ...` → `.gaia/cli/gaia wiki ...` across all code blocks and inline commands, plus the descriptive "`gaia wiki` CLI primitive" mentions.
- **`update-gaia` / `update-deps`**: `gaia setup link-worktree` → repo-relative.
- **`gaia/references/fitness.md`**: illustrative `gaia wiki …` → repo-relative.
- **scaffold skills** (`new-route`, `new-service`, `new-hook`, `new-component`): the `gaia scaffold <kind>` Run line carried the identical bug, so it is fixed here too. (These were beyond the original four-file scope but are required for the "no bare `gaia` in cmd position across `.claude/skills`" invariant to hold.)

## Verification

- `which gaia` misses on the dev machine (adopter condition); `.gaia/cli/gaia wiki state --json` works.
- Grep for bare `gaia <subcmd>` in command position across `.claude/skills` (excluding `.gaia/cli/gaia`, `gaia-` prefixes) returns nothing.
- No double-prefix (`.gaia/cli/.gaia/cli/gaia`) introduced.

## Scope

`.claude/`-only. Entire diff is out of audit scope, so the PR-merge gate clears via the out-of-scope bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)