### PR TITLE
wiki: sync through 4110bfe

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "1ef7eec85fb73221984447c576074ec248954913",
-  "last_evaluated_at": "2026-06-03T17:46:45Z",
+  "last_evaluated_sha": "4110bfe609ed69f40fa2ee482465fb49f9d59728",
+  "last_evaluated_at": "2026-06-03T19:37:04Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,11 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-03 4110bfe WORTHY — aliased bare gaia calls to repo-relative .gaia/cli/gaia across skill instructions
+- 2026-06-03 129a364 WORTHY — bumped claude-obsidian baseline v1.6.0→v1.9.2, reframed plugin skills as auxiliary
+- 2026-06-03 8015592 WORTHY — decoupled wiki-lint from upstream, added GAIA-native checks #11-#16
+- 2026-06-03 ced9876 WORTHY — scrubbed website paths from Release-Notes.md, marked maintainer-only
+- 2026-06-03 b8dfb81 SKIP — wiki: self-referential
 - 2026-06-03 1ef7eec SKIP — tooling fix; maintainer-only skill documentation
 - 2026-06-03 0845873 SKIP — wiki state file maintenance only
 - 2026-06-03 e022c9d WORTHY — added /release-notes skill → wiki/concepts/Release-Notes.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 4110bfe.