### PR TITLE
Harden commit and review gates

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -99,6 +99,60 @@ Beyond general best practices, verify adherence to these project-specific patter
 - Route files (`app/routes/`) are thin shells — loader, action, meta, and a one-line page import. UI belongs in `app/pages/`.
 - Localization: every user-facing string comes from `t()`. Hardcoded JSX strings are bugs.
 
+## Finding Proof Gate (holistic reviewer)
+
+Every finding you (the main agent) report must clear this gate before it reaches the report. The gate sits **on top of** the tool-specific false-positive patterns elsewhere in this agent (the react-doctor barrel-import / multiple-useState noise called out under "Merge findings", the knip bucket classification); it does not replace them. Those patterns reject *known* bad findings. This gate makes *every* finding prove itself. The deterministic advisories (react-doctor, knip) are oracles, not probabilistic judgments, so they pass through under their own false-positive handling and are not subject to this gate.
+
+Before reporting a finding, run all four checks:
+
+1. **Cites an exact `file:line`.** Point at the specific line where the defect lives, not a file, a function, or a region. No line, no finding.
+2. **Names a concrete failure mode: input + state + bad outcome.** Give the input that triggers it, the state it fires in, and the wrong result that follows (for example, "when the loader returns `null` and the user submits the form twice, the second action reads a stale `id` and writes to the wrong record"). A category label on its own ("possible race condition", "potential XSS", "might leak") is not a failure mode; it names a worry, not a path.
+3. **Confirms you read the callers and tests, not just the flagged line.** Trace the line in context: who calls it, what the test suite already covers, what guards sit upstream. A "missing null check" that every caller already guards, or that a test already asserts against, is not a defect.
+4. **Assigns a severity you can defend.** Critical, Important, or Suggestion must follow from the failure mode's actual blast radius, not from how alarming the category sounds. If you cannot say why it belongs at that tier, it is at the wrong tier.
+
+**Fail any check, drop or demote the finding.** A finding that cannot cite a line or name a concrete failure mode is dropped. A finding that is real but whose severity you cannot defend at the assigned tier is demoted to the tier you can defend (and dropped if that lands below Suggestion). Demote rather than delete when the defect is genuine but smaller than first judged.
+
+**Adversarially verify every Critical and Important survivor.** The four checks above are self-applied, so they share your blind spots. Before a holistic finding is reported at Critical or Important, hand it to a fresh-context refuter that did not produce it. Spawn one `Agent` refuter per surviving Critical/Important holistic finding, in parallel from a single tool-call message (the same dispatch discipline as the rule-based subagents). This pass applies only to your own (probabilistic) findings at those two tiers; Suggestions stay self-policed, and the react-doctor / knip oracles and the rule-based subagent findings are out of scope.
+
+A refuter overturns a finding only with **concrete counter-evidence**, the mirror of the gate's concrete-failure-mode bar:
+
+- the specific guard (`file:line`) that prevents the claimed input or state from reaching the defect,
+- a test that already asserts the correct behavior, or
+- a demonstration that the failure path is unreachable.
+
+Act on the verdict:
+
+- Counter-evidence shows the defect cannot occur → **drop** the finding.
+- Counter-evidence shows it occurs but with a smaller blast radius than claimed → **demote** to the tier the evidence supports.
+- No concrete counter-evidence → the finding **stands** at its tier. "Seems unlikely" or "probably fine" is not a refutation; absence of a refutation defaults to keeping the finding.
+
+Spawn each refuter with this prompt:
+
+```
+You are an adversarial reviewer. Your job is to REFUTE the finding below, not to confirm it. Assume the original reviewer was too eager.
+
+Finding:
+- Location: `path/to/file.tsx:42`
+- Failure mode: [input + state + bad outcome, verbatim from the finding]
+- Claimed severity: Critical | Important
+
+Changed files in scope: [list from git diff]
+
+Read the flagged line, its callers, and the tests that exercise it. You may overturn this finding ONLY by citing concrete counter-evidence:
+- a specific guard (`file:line`) that prevents the claimed input/state from reaching the defect, or
+- a test that already asserts the correct behavior, or
+- a demonstration that the failure path is unreachable.
+
+Report exactly one verdict:
+- REFUTED (cannot occur): [cite the counter-evidence]
+- DOWNGRADE (occurs but smaller): [cite evidence, name the tier it actually warrants]
+- STANDS (no concrete counter-evidence found)
+
+Do not refute on intuition. If you cannot cite counter-evidence, the verdict is STANDS.
+```
+
+**Zero findings is valid.** The gate is allowed to empty the report. If nothing survives the gate (the four checks or the adversarial pass), report no findings: that is a clean result, not a failure to look hard enough. Do not manufacture findings to fill the sections. A fabricated or unprovable finding is worse than none, because noise erodes trust in every real finding beside it.
+
 ## Output Format
 
 Structure your review as follows:
@@ -142,7 +196,8 @@ Include only when there are specific, concrete patterns worth reinforcing. Skip 
 6. **Be proportionate** — don't nitpick formatting when there are security holes; focus energy on what matters most
 7. **Respect existing patterns** — if the codebase has an established way of doing something, don't suggest alternatives unless there's a concrete benefit
 8. **Dispatch in parallel** — once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor` and `pnpm knip --reporter json` from a single tool-call message so they run concurrently with your own review
-9. **Resolve suggestions before writing the marker** — after the report is produced and before deciding on the marker, attempt to auto-fix every item in the Suggestions section. For each: if the fix is surgical (touches `app/` source only, ≤10 files, no convention surface), apply it in a self-heal commit and set `AUDIT_SELF_HEALED="true"`. If a suggestion requires a human tradeoff (architectural restructuring, breaking change, conflicting convention), mark it **Escalated** with explicit rationale — escalated suggestions unconditionally block the marker. Never proceed to the marker with any suggestion that is neither fixed in the working tree nor explicitly escalated.
+9. **Verify Critical/Important survivors adversarially**: after your own review produces candidate findings and before finalizing the report, run each surviving holistic Critical/Important finding through a fresh-context refuter per the Finding Proof Gate, then drop, demote, or keep it on the refuter's verdict. The report is not produced until this pass completes.
+10. **Resolve suggestions before writing the marker** — after the report is produced and before deciding on the marker, attempt to auto-fix every item in the Suggestions section. For each: if the fix is surgical (touches `app/` source only, ≤10 files, no convention surface), apply it in a self-heal commit and set `AUDIT_SELF_HEALED="true"`. If a suggestion requires a human tradeoff (architectural restructuring, breaking change, conflicting convention), mark it **Escalated** with explicit rationale — escalated suggestions unconditionally block the marker. Never proceed to the marker with any suggestion that is neither fixed in the working tree nor explicitly escalated.
 
 ## Rules-Based Audit (Specialist Subagents + react-doctor + knip)
 
@@ -327,7 +382,7 @@ Both variables travel forward to the marker-write step below.
 
 `.claude/hooks/pr-merge-audit-check.sh` blocks `gh pr merge` until a marker file at `.gaia/local/audit/<HEAD-sha>.ok` exists. The marker proves the audit ran against the exact commit being merged. **You** are responsible for writing the marker — only when the audit is genuinely clean.
 
-After producing the report, decide whether to write the marker:
+After producing the report (which includes the adversarial verification of Critical/Important survivors), decide whether to write the marker:
 
 - **Write the marker** when all of the following are true:
   1. The Critical Issues section is empty.

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# PreToolUse Bash hook: deny `git commit` / `git push` that carry a hook
+# bypass, so GAIA's commit-time deterministic floor (typecheck / lint / test,
+# run by the Husky pre-commit hook) cannot be silently skipped.
+#
+# "Enforced, not advisory" applies to GAIA's own gate: a floor the agent can
+# opt out of is advisory. This closes the commit/push layer. The apex merge
+# gate (pr-merge-audit-check.sh) already holds and is untouched.
+#
+# Bypass tokens denied (on commit OR push, unless noted):
+#   --no-verify                     skips client-side hooks
+#   -n                              COMMIT ONLY (= --no-verify). On `push`, -n
+#                                   means --dry-run and is harmless — never block it.
+#   HUSKY=0 (or falsy HUSKY= prefix) disables Husky for the invocation
+#   -c core.hooksPath=<path>        redirects hooks to a path with no floor
+#
+# No carve-out is needed for GAIA's own legitimate --no-verify automation
+# (audit-stamp trailer, wiki autocommit squash): those run as hook scripts
+# (Stop / PreToolUse), not as Bash-tool calls, so a PreToolUse Bash hook never
+# intercepts them. Do not "fix" the missing carve-out — there is no bug.
+#
+# Fail-closed: a commit message that literally contains a bypass token (e.g.
+# `git commit -m "use --no-verify"`) over-blocks. That is the safe direction;
+# rephrase the message. Policy: wiki/decisions/Quality Gate.md
+set -euo pipefail
+
+payload=$(cat)
+cmd=$(echo "$payload" | jq -r '.tool_input.command // empty')
+
+# Only act on git commands — short-circuit everything else.
+[[ "$cmd" =~ (^|[[:space:]&;|])git([[:space:]]|$) ]] || exit 0
+
+# Repo-scope: this repo's commit-floor policy governs this repo only. A git
+# command aimed at a different repo (e.g. `git -C ../other commit --no-verify`)
+# is out of scope — allow it. Fail-closed: any ambiguity falls through and the
+# policy still enforces. Mirrors block-main-destructive-git.sh.
+[ -f .claude/hooks/lib/repo-scope.sh ] && . .claude/hooks/lib/repo-scope.sh
+if type cmd_targets_foreign_repo >/dev/null 2>&1 \
+   && cmd_targets_foreign_repo "$cmd"; then
+  exit 0
+fi
+
+# Only commit and push carry the floor — ignore every other git subcommand.
+# Detect the subcommand by token presence so global options between `git` and
+# the subcommand (e.g. `git -c core.hooksPath=… commit`) don't hide it. The
+# `[[:space:]]` word boundaries keep `commit` from matching `commit-graph`.
+is_commit=0
+is_push=0
+[[ "$cmd" =~ (^|[[:space:]])commit([[:space:]]|$) ]] && is_commit=1
+[[ "$cmd" =~ (^|[[:space:]])push([[:space:]]|$) ]] && is_push=1
+[[ "$is_commit" -eq 1 || "$is_push" -eq 1 ]] || exit 0
+
+deny() {
+  jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+sub="commit"
+[[ "$is_commit" -eq 1 ]] || sub="push"
+
+floor_msg() {
+  echo "Hook bypass on 'git $sub' is forbidden ($1). The Quality Gate floor (typecheck/lint/test) runs via the Husky pre-commit hook — fix the failures, don't skip the gate. See wiki/decisions/Quality Gate.md."
+}
+
+# --no-verify — both commit and push.
+if [[ "$cmd" =~ (^|[[:space:]])--no-verify([[:space:]]|=|$) ]]; then
+  deny "$(floor_msg '--no-verify')"
+fi
+
+# Falsy HUSKY= env prefix (HUSKY=0, HUSKY=false, HUSKY=no, or empty) — both.
+if [[ "$cmd" =~ (^|[[:space:]])HUSKY=(0|false|no)?([[:space:]]|$) ]]; then
+  deny "$(floor_msg 'HUSKY disabled')"
+fi
+
+# -c core.hooksPath=<path> override — both. Git config keys are
+# case-insensitive, so match the key case-insensitively.
+if grep -iqE -- '-c[[:space:]]+core\.hookspath=' <<<"$cmd"; then
+  deny "$(floor_msg '-c core.hooksPath override')"
+fi
+
+# -n short flag = --no-verify, COMMIT ONLY. `git push -n` is --dry-run and must
+# pass. Matches a single-dash short-flag bundle containing n (-n, -nm, -anm),
+# never the long --no-verify (handled above) or --dry-run.
+if [[ "$is_commit" -eq 1 ]] \
+   && [[ "$cmd" =~ (^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$) ]]; then
+  deny "$(floor_msg '-n (= --no-verify)')"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -110,6 +110,11 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/block-no-verify.sh",
+            "statusMessage": "Checking commit-floor bypass…"
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/block-rm-rf.sh",
             "statusMessage": "Checking rm -rf safety…"
           },

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -20,6 +20,7 @@
     ".claude/hooks/block-eslint-config-edit.sh": "owned",
     ".claude/hooks/block-lockfile-edit.sh": "owned",
     ".claude/hooks/block-main-destructive-git.sh": "owned",
+    ".claude/hooks/block-no-verify.sh": "owned",
     ".claude/hooks/block-rm-rf.sh": "owned",
     ".claude/hooks/block-secrets-write.sh": "owned",
     ".claude/hooks/block-vitest-globals-tsconfig.sh": "owned",

--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+# Tests for .claude/hooks/block-no-verify.sh.
+#
+# The hook denies `git commit` / `git push` carrying a hook bypass so the
+# Quality Gate floor (typecheck / lint / test, run by the Husky pre-commit
+# hook) cannot be skipped. Bypass tokens: --no-verify, `-n` (commit only —
+# `push -n` is --dry-run), a falsy HUSKY= env prefix, and a `-c
+# core.hooksPath=` override. Foreign-repo commands pass via the shared
+# repo-scope helper.
+#
+# Each test drives the hook exactly as the harness does: a PreToolUse JSON
+# payload on stdin, run with the repo as the working directory (the hook loads
+# .claude/hooks/lib/repo-scope.sh relative to cwd, so the helper is copied into
+# the tmp repo). The hook always exits 0; allow vs deny is carried in stdout —
+# a deny emits `"permissionDecision": "deny"`, an allow emits nothing. The
+# deny cases double as a jq/setup canary: a missing jq would exit early with no
+# output and those assertions would fail rather than false-pass.
+
+setup() {
+  HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
+  HOOK_ABS="$HOOKS_SRC/block-no-verify.sh"
+
+  REPO=$(mktemp -d -t no-verify-test-XXXXXX)
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+  git -C "$REPO" config commit.gpgsign false
+  echo "# readme" > "$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit --quiet -m "init"
+  git -C "$REPO" checkout --quiet -b feature
+
+  # The hook sources the repo-scope helper relative to cwd — give the tmp repo
+  # a real copy so the foreign-repo bypass resolves.
+  mkdir -p "$REPO/.claude/hooks/lib"
+  cp "$HOOKS_SRC/lib/repo-scope.sh" "$REPO/.claude/hooks/lib/repo-scope.sh"
+
+  # A second, distinct repo for the foreign-repo case.
+  FOREIGN=$(mktemp -d -t no-verify-foreign-XXXXXX)
+  git -C "$FOREIGN" init --quiet --initial-branch=main
+  git -C "$FOREIGN" config user.email "test@example.com"
+  git -C "$FOREIGN" config user.name "Test"
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" || true
+  [ -n "${FOREIGN:-}" ] && rm -rf "$FOREIGN" || true
+  return 0
+}
+
+# Run the hook with a given command, from inside the home repo.
+run_hook() {
+  local cmd="$1"
+  local json
+  json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
+  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+}
+
+assert_denied() {
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+assert_allowed() {
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}
+
+# --- denied ---
+
+@test "git commit --no-verify is denied" {
+  run_hook 'git commit --no-verify -m "x"'
+  assert_denied
+}
+
+@test "git commit -n is denied" {
+  run_hook 'git commit -n -m "x"'
+  assert_denied
+}
+
+@test "git commit with bundled short flags -anm is denied" {
+  run_hook 'git commit -anm "x"'
+  assert_denied
+}
+
+@test "HUSKY=0 git commit is denied" {
+  run_hook 'HUSKY=0 git commit -m "x"'
+  assert_denied
+}
+
+@test "git -c core.hooksPath=/dev/null commit is denied" {
+  run_hook 'git -c core.hooksPath=/dev/null commit -m "x"'
+  assert_denied
+}
+
+@test "git push --no-verify is denied" {
+  run_hook 'git push --no-verify'
+  assert_denied
+}
+
+@test "HUSKY=0 git push is denied" {
+  run_hook 'HUSKY=0 git push origin feature'
+  assert_denied
+}
+
+# --- allowed ---
+
+@test "plain git commit on a feature branch is allowed" {
+  run_hook 'git commit -m "x"'
+  assert_allowed
+}
+
+@test "git push -n (dry-run) is allowed" {
+  run_hook 'git push -n origin feature'
+  assert_allowed
+}
+
+@test "git push --dry-run is allowed" {
+  run_hook 'git push --dry-run origin feature'
+  assert_allowed
+}
+
+@test "plain git push on a feature branch is allowed" {
+  run_hook 'git push origin feature'
+  assert_allowed
+}
+
+@test "HUSKY=1 git commit is allowed (enabling is not a bypass)" {
+  run_hook 'HUSKY=1 git commit -m "x"'
+  assert_allowed
+}
+
+@test "home-repo git -C commit (no bypass) is allowed" {
+  # Capital -C changes directory; it is not a bypass. The home repo's own
+  # `git -C <home> commit` must pass — only lowercase `-c core.hooksPath=`
+  # (the next test) carries a bypass.
+  run_hook "git -C $REPO commit -m \"x\""
+  assert_allowed
+}
+
+@test "foreign-repo commit with a bypass is allowed (out of scope)" {
+  run_hook "git -C $FOREIGN commit --no-verify -m \"x\""
+  assert_allowed
+}
+
+@test "a non-commit/push git command with a hooksPath override is ignored" {
+  run_hook 'git -c core.hooksPath=/dev/null status'
+  assert_allowed
+}
+
+@test "a non-git command is ignored" {
+  run_hook 'pnpm run build'
+  assert_allowed
+}


### PR DESCRIPTION
Gate-hardening changes for 1.5.0, split across a commit gate and a review gate so the diff reads cleanly.

## 1. Commit gate: block hook-bypass on `git commit`/`git push` (`90d14a1`)

New PreToolUse Bash guard `block-no-verify.sh` denies commit/push invocations that carry a hook bypass, so GAIA's commit-time deterministic floor (typecheck/lint/test, run by the Husky pre-commit hook) cannot be silently skipped. "Enforced, not advisory" now holds at the commit layer, not just the apex merge gate.

Tokens denied (on commit or push, unless noted):
- `--no-verify`
- a falsy `HUSKY=` env prefix (`HUSKY=0`, etc.)
- a `core.hooksPath` redirect
- the `-n` short flag **commit-only** (`git push -n` means `--dry-run` and stays allowed)

Foreign-repo commands pass via the shared repo-scope helper, mirroring `block-main-destructive-git.sh`. GAIA's own bypass automation (audit-stamp trailer, wiki autocommit squash) needs no carve-out: it runs as hook scripts, not Bash-tool calls, so a PreToolUse Bash hook never intercepts it. Wired into `settings.json` beside the existing git guards, registered in the manifest, and covered by a bats suite spanning the full acceptance matrix (16 cases, all passing).

## 2. Review gate: proof gate + adversarial verification for the holistic reviewer (`fe27977`)

Every holistic-reviewer finding must clear a four-check proof gate before it is reported: exact `file:line`, a concrete failure mode (input + state + bad outcome), confirmation the callers and tests were read, and a defensible severity. Fail any check and the finding is dropped or demoted.

The gate layers on top of the existing tool-specific false-positive patterns rather than replacing them, and preserves "zero findings is valid" (it may empty the report). Deterministic oracles (react-doctor, knip) are exempt; they are not probabilistic judgments.

On top of the gate, every Critical/Important survivor is then challenged independently. Each goes to a fresh-context refuter that did not produce it, and the refuter can overturn the finding only with concrete counter-evidence: a guard at `file:line`, a covering test, or an unreachable path. Absent that evidence the finding STANDS, so a single refuter can never kill a real bug on intuition. "Cannot occur" drops the finding; "smaller blast radius" demotes it. The pass runs before the report is finalized, so a dropped or demoted Critical flows into the marker and merge-gate decision correctly. The four self-applied checks share the reviewer's blind spots; the adversarial pass supplies the independent eyes a self-check cannot.

## Notes

- No app source touched (`.sh`/`.bats`/`.json`/`.md` only), so the Quality Gate had nothing to run.
- The new commit guard caught its own first commit attempt because the message body contained a literal bypass token, confirming the guard fires. Message rephrased per the guard's own remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
