### PR TITLE
Sync spec allocator (SPEC-001 shipped, SPEC-003 allocated)

### DIFF
--- a/.gaia/specs.json
+++ b/.gaia/specs.json
@@ -5,7 +5,7 @@
       "id": "SPEC-001",
       "allocated_at": "2026-05-05T23:25:51Z",
       "source": "backfilled",
-      "status": "in-progress",
+      "status": "shipped",
       "intent": "GAIA CI auto-maintenance system shipped to every adopter (smart cron, auto-merge, auto-revert)."
     },
     {
@@ -14,6 +14,13 @@
       "source": "allocated",
       "status": "in-progress",
       "intent": "/gaia-fitness — adopter-facing Claude-integration health check + auto-heal; /health-audit refactored to compose it."
+    },
+    {
+      "id": "SPEC-003",
+      "allocated_at": "2026-06-04T09:35:37Z",
+      "source": "allocated",
+      "status": "in-progress",
+      "intent": "GAIA's test-driven workflow already instructs the agent to write a failing"
     }
   ]
 }


### PR DESCRIPTION
Spec-tracking metadata sync from the spec-allocator agent.

- Mark `SPEC-001` (CI auto-maintenance) **shipped**.
- Record the `SPEC-003` allocation (in-progress).

`.gaia/`-only, no code or behavior change — clears the merge audit gate via the out-of-scope bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)