### PR TITLE
fix(hooks): anchor git guards to command position

### DIFF
--- a/.claude/hooks/block-main-destructive-git.sh
+++ b/.claude/hooks/block-main-destructive-git.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 # PreToolUse Bash hook: block commits to main/master and force-push to main/master.
+#
+# Command-position anchoring: the rules fire only when `git` is the command word
+# of a pipeline segment (start of command, after a `| & ; ( )` separator, or
+# after an env-var prefix) — a real `git commit` / `git push` INVOCATION.
+# Command TEXT that merely contains the words (a grep pattern, an echo string,
+# a path, an argument to another program such as `grep -n -e git commit file`)
+# is not an invocation and never fires.
+#
 # Policy: wiki/concepts/Git Workflow.md
 set -euo pipefail
 
 payload=$(cat)
 cmd=$(echo "$payload" | jq -r '.tool_input.command // empty')
 
-# Only act on git commands — short-circuit everything else
-[[ "$cmd" =~ (^|[[:space:]&;|])git([[:space:]]|$) ]] || exit 0
+# Only act on git commands — short-circuit everything else. (Fast path only;
+# correctness comes from the command-position scan below.)
+[[ "$cmd" =~ (^|[[:space:]&;|()])git([[:space:]]|$) ]] || exit 0
 
 # Repo-scope: this repo's main-branch policy governs this repo only. A git
 # command aimed at a different repo (e.g. `git -C ../other push origin main`
@@ -30,58 +39,71 @@ deny() {
   exit 0
 }
 
-# Normalize: strip EVERY -C <path> for regex matching; capture the path git
-# would actually use for git queries. git applies multiple -C cumulatively
-# with the last absolute one winning, so capture the LAST occurrence (greedy
-# .* consumes through it) — a first-only capture lets `git -C <a> -C <b>
-# commit` slip past the commit/push regexes. Handles `git -C /abs/path`
-# (required by shell-cwd rule). Uses sed — bash 3.2 (macOS default) doesn't
-# populate BASH_REMATCH reliably.
-git_cwd=$(echo "$cmd" | sed -nE 's/.*[[:space:]]-C[[:space:]]+([^[:space:]]+).*/\1/p')
-norm=$(echo "$cmd" | sed -E 's/[[:space:]]-C[[:space:]]+[^[:space:]]+//g')
-
 current_branch() {
-  if [[ -n "$git_cwd" ]]; then
-    git -C "$git_cwd" symbolic-ref --short HEAD 2>/dev/null || echo ""
+  local cwd="$1"
+  if [[ -n "$cwd" ]]; then
+    git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || echo ""
   else
     git symbolic-ref --short HEAD 2>/dev/null || echo ""
   fi
 }
 
-# 1. Block commits while HEAD is on main or master.
-if [[ "$norm" =~ git[[:space:]]+commit([[:space:]]|$) ]]; then
-  branch=$(current_branch)
-  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
-    deny "Commits to '$branch' are forbidden (wiki/concepts/Git Workflow.md). Create a feature branch first."
-  fi
-fi
+# Walk each command-position segment. Separators (`| & ; ( )`, newlines) become
+# line breaks so every line begins at a command word; leading env-var
+# assignments are stripped to expose it. The commit/push rules act only on
+# segments whose command word is `git`, so `git commit` / `git push` appearing
+# as TEXT in another program's arguments never trips the gate.
+while IFS= read -r seg; do
+  # Command word = the first token after any leading whitespace + env-var
+  # assignments (`WORD=value `). bash 3.2 does not populate BASH_REMATCH
+  # reliably, so strip with sed rather than a capture loop.
+  seg_cmd=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
+  [[ "$seg_cmd" =~ ^git([[:space:]]|$) ]] || continue
 
-# 2. Block force-push when target mentions main or master.
-if [[ "$norm" =~ git[[:space:]]+push ]] \
-   && [[ "$norm" =~ (--force|--force-with-lease|[[:space:]]-f([[:space:]]|$)) ]] \
-   && [[ "$norm" =~ (main|master)([[:space:]]|$|:) ]]; then
-  deny "Force-push to main/master is forbidden (wiki/concepts/Git Workflow.md)."
-fi
+  # Normalize this segment: strip EVERY -C <path> for regex matching; capture
+  # the path git would actually use for branch queries. git applies multiple -C
+  # cumulatively with the last absolute one winning, so capture the LAST
+  # occurrence (greedy .* consumes through it) — a first-only capture lets
+  # `git -C <a> -C <b> commit` slip past the commit/push regexes. Handles
+  # `git -C /abs/path` (required by shell-cwd rule).
+  git_cwd=$(printf '%s' "$seg" | sed -nE 's/.*[[:space:]]-C[[:space:]]+([^[:space:]]+).*/\1/p')
+  norm=$(printf '%s' "$seg" | sed -E 's/[[:space:]]-C[[:space:]]+[^[:space:]]+//g')
 
-# 3. Block any `git push` originating from main/master (PR-only flow).
-#    Triggers when HEAD is on main/master OR when the push refspec explicitly
-#    names main/master/HEAD as the source. Closes the "forgot to switch
-#    branches" footgun.
-if [[ "$norm" =~ git[[:space:]]+push ]]; then
-  branch=$(current_branch)
-  on_main=0
-  [[ "$branch" == "main" || "$branch" == "master" ]] && on_main=1
-
-  # Refspec-targeted push from main/master/HEAD: e.g. `git push origin main`,
-  # `git push origin HEAD:main`, `git push origin main:main`.
-  refspec_main=0
-  if [[ "$norm" =~ git[[:space:]]+push[[:space:]]+[^[:space:]]+[[:space:]]+(HEAD|main|master)([[:space:]]|:|$) ]]; then
-    refspec_main=1
+  # 1. Block commits while HEAD is on main or master.
+  if [[ "$norm" =~ git[[:space:]]+commit([[:space:]]|$) ]]; then
+    branch=$(current_branch "$git_cwd")
+    if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+      deny "Commits to '$branch' are forbidden (wiki/concepts/Git Workflow.md). Create a feature branch first."
+    fi
   fi
 
-  if [[ "$on_main" -eq 1 || "$refspec_main" -eq 1 ]]; then
-    deny "Plain 'git push' from main/master is forbidden (wiki/concepts/Git Workflow.md). Create a feature branch and open a PR."
+  # 2. Block force-push when target mentions main or master.
+  if [[ "$norm" =~ git[[:space:]]+push ]] \
+     && [[ "$norm" =~ (--force|--force-with-lease|[[:space:]]-f([[:space:]]|$)) ]] \
+     && [[ "$norm" =~ (main|master)([[:space:]]|$|:) ]]; then
+    deny "Force-push to main/master is forbidden (wiki/concepts/Git Workflow.md)."
   fi
-fi
+
+  # 3. Block any `git push` originating from main/master (PR-only flow).
+  #    Triggers when HEAD is on main/master OR when the push refspec explicitly
+  #    names main/master/HEAD as the source. Closes the "forgot to switch
+  #    branches" footgun.
+  if [[ "$norm" =~ git[[:space:]]+push ]]; then
+    branch=$(current_branch "$git_cwd")
+    on_main=0
+    [[ "$branch" == "main" || "$branch" == "master" ]] && on_main=1
+
+    # Refspec-targeted push from main/master/HEAD: e.g. `git push origin main`,
+    # `git push origin HEAD:main`, `git push origin main:main`.
+    refspec_main=0
+    if [[ "$norm" =~ git[[:space:]]+push[[:space:]]+[^[:space:]]+[[:space:]]+(HEAD|main|master)([[:space:]]|:|$) ]]; then
+      refspec_main=1
+    fi
+
+    if [[ "$on_main" -eq 1 || "$refspec_main" -eq 1 ]]; then
+      deny "Plain 'git push' from main/master is forbidden (wiki/concepts/Git Workflow.md). Create a feature branch and open a PR."
+    fi
+  fi
+done < <(printf '%s\n' "$cmd" | tr '|&;()' '\n')
 
 exit 0

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -14,21 +14,35 @@
 #   HUSKY=0 (or falsy HUSKY= prefix) disables Husky for the invocation
 #   -c core.hooksPath=<path>        redirects hooks to a path with no floor
 #
+# Command-position anchoring: a token is only a bypass when it belongs to a
+# real `git commit` / `git push` INVOCATION — i.e. `git` is the command word of
+# a pipeline segment (start of command, after a `| & ; ( )` separator, or after
+# an env-var prefix like `HUSKY=0`). Command TEXT that merely mentions the words
+# (a grep pattern, an echo string, a path, an argument to another program such
+# as `grep -n -e git commit file`) is not an invocation and never fires. Without
+# this anchor the matcher fired on free-floating substrings: any command whose
+# text contained `commit` plus a `-n` flag tripped, even when `git` was not the
+# program being run.
+#
 # No carve-out is needed for GAIA's own legitimate --no-verify automation
 # (audit-stamp trailer, wiki autocommit squash): those run as hook scripts
 # (Stop / PreToolUse), not as Bash-tool calls, so a PreToolUse Bash hook never
 # intercepts them. Do not "fix" the missing carve-out — there is no bug.
 #
-# Fail-closed: a commit message that literally contains a bypass token (e.g.
-# `git commit -m "use --no-verify"`) over-blocks. That is the safe direction;
-# rephrase the message. Policy: wiki/decisions/Quality Gate.md
+# Residual fail-closed edge: a bypass token written literally INSIDE a commit
+# message (e.g. `git commit -m "use --no-verify"`) still over-blocks. That is
+# the safe direction; rephrase the message. The unambiguous tokens
+# (--no-verify, falsy HUSKY=, core.hooksPath=) also get a whole-command
+# fail-closed safety net so segment-splitting on a shell metacharacter inside a
+# message can never let a real bypass slip. Policy: wiki/decisions/Quality Gate.md
 set -euo pipefail
 
 payload=$(cat)
 cmd=$(echo "$payload" | jq -r '.tool_input.command // empty')
 
-# Only act on git commands — short-circuit everything else.
-[[ "$cmd" =~ (^|[[:space:]&;|])git([[:space:]]|$) ]] || exit 0
+# Only act on git commands — short-circuit everything else. (Fast path only;
+# correctness comes from the command-position scan below.)
+[[ "$cmd" =~ (^|[[:space:]&;|()])git([[:space:]]|$) ]] || exit 0
 
 # Repo-scope: this repo's commit-floor policy governs this repo only. A git
 # command aimed at a different repo (e.g. `git -C ../other commit --no-verify`)
@@ -39,16 +53,6 @@ if type cmd_targets_foreign_repo >/dev/null 2>&1 \
    && cmd_targets_foreign_repo "$cmd"; then
   exit 0
 fi
-
-# Only commit and push carry the floor — ignore every other git subcommand.
-# Detect the subcommand by token presence so global options between `git` and
-# the subcommand (e.g. `git -c core.hooksPath=… commit`) don't hide it. The
-# `[[:space:]]` word boundaries keep `commit` from matching `commit-graph`.
-is_commit=0
-is_push=0
-[[ "$cmd" =~ (^|[[:space:]])commit([[:space:]]|$) ]] && is_commit=1
-[[ "$cmd" =~ (^|[[:space:]])push([[:space:]]|$) ]] && is_push=1
-[[ "$is_commit" -eq 1 || "$is_push" -eq 1 ]] || exit 0
 
 deny() {
   jq -n --arg r "$1" '{
@@ -61,35 +65,84 @@ deny() {
   exit 0
 }
 
-sub="commit"
-[[ "$is_commit" -eq 1 ]] || sub="push"
-
 floor_msg() {
   echo "Hook bypass on 'git $sub' is forbidden ($1). The Quality Gate floor (typecheck/lint/test) runs via the Husky pre-commit hook — fix the failures, don't skip the gate. See wiki/decisions/Quality Gate.md."
 }
 
-# --no-verify — both commit and push.
-if [[ "$cmd" =~ (^|[[:space:]])--no-verify([[:space:]]|=|$) ]]; then
-  deny "$(floor_msg '--no-verify')"
-fi
+# Walk each command-position segment. Separators (`| & ; ( )`, newlines) become
+# line breaks so every line begins at a command word; leading env-var
+# assignments are stripped to expose it. A segment acts only when its command
+# word is `git` and it carries a `commit` / `push` subcommand token — so a
+# `-n` that belongs to a different program on the same command line (the
+# `git commit && grep -n …` case) never trips the commit branch.
+saw_commit=0
+saw_push=0
+while IFS= read -r seg; do
+  # Command word = the first token after any leading whitespace + env-var
+  # assignments (`WORD=value `). bash 3.2 does not populate BASH_REMATCH
+  # reliably, so strip with sed rather than a capture loop.
+  seg_cmd=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
+  [[ "$seg_cmd" =~ ^git([[:space:]]|$) ]] || continue
 
-# Falsy HUSKY= env prefix (HUSKY=0, HUSKY=false, HUSKY=no, or empty) — both.
-if [[ "$cmd" =~ (^|[[:space:]])HUSKY=(0|false|no)?([[:space:]]|$) ]]; then
-  deny "$(floor_msg 'HUSKY disabled')"
-fi
+  is_commit=0
+  is_push=0
+  [[ "$seg" =~ (^|[[:space:]])commit([[:space:]]|$) ]] && is_commit=1
+  [[ "$seg" =~ (^|[[:space:]])push([[:space:]]|$) ]] && is_push=1
+  [[ "$is_commit" -eq 1 || "$is_push" -eq 1 ]] || continue
 
-# -c core.hooksPath=<path> override — both. Git config keys are
-# case-insensitive, so match the key case-insensitively.
-if grep -iqE -- '-c[[:space:]]+core\.hookspath=' <<<"$cmd"; then
-  deny "$(floor_msg '-c core.hooksPath override')"
-fi
+  [[ "$is_commit" -eq 1 ]] && saw_commit=1
+  [[ "$is_push" -eq 1 ]] && saw_push=1
 
-# -n short flag = --no-verify, COMMIT ONLY. `git push -n` is --dry-run and must
-# pass. Matches a single-dash short-flag bundle containing n (-n, -nm, -anm),
-# never the long --no-verify (handled above) or --dry-run.
-if [[ "$is_commit" -eq 1 ]] \
-   && [[ "$cmd" =~ (^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$) ]]; then
-  deny "$(floor_msg '-n (= --no-verify)')"
+  sub="commit"
+  [[ "$is_commit" -eq 1 ]] || sub="push"
+
+  # All bypass checks are scoped to THIS git segment.
+
+  # --no-verify — both commit and push.
+  if [[ "$seg" =~ (^|[[:space:]])--no-verify([[:space:]]|=|$) ]]; then
+    deny "$(floor_msg '--no-verify')"
+  fi
+
+  # Falsy HUSKY= prefix (HUSKY=0, HUSKY=false, HUSKY=no, or empty) — both.
+  if [[ "$seg" =~ (^|[[:space:]])HUSKY=(0|false|no)?([[:space:]]|$) ]]; then
+    deny "$(floor_msg 'HUSKY disabled')"
+  fi
+
+  # -c core.hooksPath=<path> override — both. Git config keys are
+  # case-insensitive, so match the key case-insensitively.
+  if grep -iqE -- '-c[[:space:]]+core\.hookspath=' <<<"$seg"; then
+    deny "$(floor_msg '-c core.hooksPath override')"
+  fi
+
+  # -n short flag = --no-verify, COMMIT ONLY. `git push -n` is --dry-run and
+  # must pass. Matches a single-dash short-flag bundle containing n (-n, -nm,
+  # -anm), never the long --no-verify (handled above) or --dry-run. Scoped to
+  # the git segment so a `-n` on another program (grep/head/sort/tail) is inert.
+  if [[ "$is_commit" -eq 1 ]] \
+     && [[ "$seg" =~ (^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$) ]]; then
+    deny "$(floor_msg '-n (= --no-verify)')"
+  fi
+done < <(printf '%s\n' "$cmd" | tr '|&;()' '\n')
+
+# Fail-closed safety net for the UNAMBIGUOUS tokens. Segment-splitting on a
+# `| & ; ( )` that is actually inside a quoted commit message could orphan a
+# trailing bypass flag from its `git` segment (e.g. `git commit -m "a|b"
+# --no-verify`). These three tokens are specific enough that a whole-command
+# match, given a confirmed command-position commit/push above, is a real bypass
+# — re-assert it. (`-n` is deliberately excluded: it is too common in other
+# programs to test whole-command without re-introducing false positives.)
+if [[ "$saw_commit" -eq 1 || "$saw_push" -eq 1 ]]; then
+  sub="commit"
+  [[ "$saw_commit" -eq 1 ]] || sub="push"
+  if [[ "$cmd" =~ (^|[[:space:]])--no-verify([[:space:]]|=|$) ]]; then
+    deny "$(floor_msg '--no-verify')"
+  fi
+  if [[ "$cmd" =~ (^|[[:space:]])HUSKY=(0|false|no)?([[:space:]]|$) ]]; then
+    deny "$(floor_msg 'HUSKY disabled')"
+  fi
+  if grep -iqE -- '-c[[:space:]]+core\.hookspath=' <<<"$cmd"; then
+    deny "$(floor_msg '-c core.hooksPath override')"
+  fi
 fi
 
 exit 0

--- a/.gaia/specs.json
+++ b/.gaia/specs.json
@@ -12,7 +12,7 @@
       "id": "SPEC-002",
       "allocated_at": "2026-05-12T07:49:29Z",
       "source": "allocated",
-      "status": "in-progress",
+      "status": "shipped",
       "intent": "/gaia-fitness — adopter-facing Claude-integration health check + auto-heal; /health-audit refactored to compose it."
     },
     {

--- a/.gaia/tests/hooks/block-main-destructive-git.bats
+++ b/.gaia/tests/hooks/block-main-destructive-git.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+# Tests for .claude/hooks/block-main-destructive-git.sh.
+#
+# The hook blocks commits to main/master, force-push to main/master, and any
+# plain `git push` originating from main/master (PR-only flow). It fires only on
+# a real `git` INVOCATION in command position — command text that merely
+# mentions `git commit` / `git push` (a grep pattern, an echo string, an
+# argument to another program) does not trip it. Foreign-repo commands pass via
+# the shared repo-scope helper.
+#
+# Each test drives the hook as the harness does: a PreToolUse JSON payload on
+# stdin, run with the repo as the working directory (the hook resolves the
+# current branch from cwd and loads .claude/hooks/lib/repo-scope.sh relative to
+# cwd). The hook always exits 0; allow vs deny is carried in stdout.
+
+setup() {
+  HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
+  HOOK_ABS="$HOOKS_SRC/block-main-destructive-git.sh"
+
+  REPO=$(mktemp -d -t block-main-test-XXXXXX)
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+  git -C "$REPO" config commit.gpgsign false
+  echo "# readme" > "$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit --quiet -m "init"
+
+  # The hook sources the repo-scope helper relative to cwd — give the tmp repo
+  # a real copy so the foreign-repo bypass resolves.
+  mkdir -p "$REPO/.claude/hooks/lib"
+  cp "$HOOKS_SRC/lib/repo-scope.sh" "$REPO/.claude/hooks/lib/repo-scope.sh"
+
+  # A second, distinct repo for the foreign-repo case.
+  FOREIGN=$(mktemp -d -t block-main-foreign-XXXXXX)
+  git -C "$FOREIGN" init --quiet --initial-branch=main
+  git -C "$FOREIGN" config user.email "test@example.com"
+  git -C "$FOREIGN" config user.name "Test"
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" || true
+  [ -n "${FOREIGN:-}" ] && rm -rf "$FOREIGN" || true
+  return 0
+}
+
+on_main() { git -C "$REPO" checkout --quiet main; }
+on_feature() { git -C "$REPO" checkout --quiet -B feature; }
+
+# Run the hook with a given command, from inside the home repo.
+run_hook() {
+  local cmd="$1"
+  local json
+  json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
+  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+}
+
+assert_denied() {
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+assert_allowed() {
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'"permissionDecision": "deny"'* ]]
+}
+
+# --- denied ---
+
+@test "git commit on main is denied" {
+  on_main
+  run_hook 'git commit -m "x"'
+  assert_denied
+}
+
+@test "plain git push from main is denied" {
+  on_main
+  run_hook 'git push'
+  assert_denied
+}
+
+@test "git push origin main (refspec) is denied from a feature branch" {
+  on_feature
+  run_hook 'git push origin main'
+  assert_denied
+}
+
+@test "force-push to main is denied from a feature branch" {
+  on_feature
+  run_hook 'git push --force origin main'
+  assert_denied
+}
+
+@test "home-repo git -C commit on main is denied" {
+  on_main
+  run_hook "git -C $REPO commit -m \"x\""
+  assert_denied
+}
+
+# --- allowed ---
+
+@test "git commit on a feature branch is allowed" {
+  on_feature
+  run_hook 'git commit -m "x"'
+  assert_allowed
+}
+
+@test "git push origin feature from a feature branch is allowed" {
+  on_feature
+  run_hook 'git push origin feature'
+  assert_allowed
+}
+
+@test "plain git push from a feature branch is allowed" {
+  on_feature
+  run_hook 'git push'
+  assert_allowed
+}
+
+@test "foreign-repo commit is allowed even though it targets main" {
+  on_main
+  run_hook "git -C $FOREIGN commit -m \"x\""
+  assert_allowed
+}
+
+@test "a non-git command is ignored" {
+  on_main
+  run_hook 'pnpm run build'
+  assert_allowed
+}
+
+# --- command-position anchoring: the words appear, but git is not the program ---
+
+@test "grep for the text 'git commit' is allowed on main" {
+  on_main
+  run_hook 'grep -n -e git commit app/foo.ts'
+  assert_allowed
+}
+
+@test "echo of 'git push origin main' is allowed on main" {
+  on_main
+  run_hook 'echo "git push origin main"'
+  assert_allowed
+}
+
+@test "echo 'git commit' piped to grep is allowed on main" {
+  on_main
+  run_hook 'echo git commit && grep -n foo bar'
+  assert_allowed
+}
+
+# --- command-position anchoring still catches real invocations ---
+
+@test "git commit after an unrelated piped command is denied on main" {
+  on_main
+  run_hook 'echo hi | git commit -m "x"'
+  assert_denied
+}
+
+@test "git push origin main after && is denied" {
+  on_feature
+  run_hook 'true && git push origin main'
+  assert_denied
+}

--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -153,3 +153,42 @@ assert_allowed() {
   run_hook 'pnpm run build'
   assert_allowed
 }
+
+# --- command-position anchoring: the words appear, but git is not the program ---
+
+@test "grep with -n searching for the text 'git commit' is allowed" {
+  # The reported false positive: -n belongs to grep, 'git commit' is the search
+  # pattern. git is not in command position, so nothing fires.
+  run_hook 'grep -n -e git commit app/foo.ts'
+  assert_allowed
+}
+
+@test "echo of 'git commit' piped to grep -n is allowed" {
+  run_hook 'echo git commit && grep -n foo bar'
+  assert_allowed
+}
+
+@test "real git commit followed by grep -n is allowed (-n is grep's)" {
+  # -n is scoped to the git segment; the grep on the other side of && is inert.
+  run_hook 'git commit -m "x" && grep -n foo bar'
+  assert_allowed
+}
+
+@test "tail -n over a file path containing 'commit' is allowed" {
+  run_hook 'tail -n 5 git-commit-notes.txt'
+  assert_allowed
+}
+
+# --- command-position anchoring still catches real bypasses ---
+
+@test "git commit -n after an unrelated piped command is denied" {
+  run_hook 'echo hi | git commit -n -m "x"'
+  assert_denied
+}
+
+@test "bypass orphaned by a pipe inside the commit message is still denied" {
+  # Segment-splitting on the quoted '|' would orphan --no-verify from its git
+  # segment; the whole-command safety net re-asserts it.
+  run_hook 'git commit -m "a|b" --no-verify'
+  assert_denied
+}


### PR DESCRIPTION
## Problem

The two PreToolUse git guards matched `git`, the subcommand, and the bypass/branch tokens as **independent free-floating substrings** anywhere in the command text — they never verified `git` was the program being run. Any command whose *text* merely contained the words tripped the gate:

- `block-no-verify.sh` — `grep -n -e git commit file` denied as a `-n` (= `--no-verify`) bypass, because `-n` is grep's and `git commit` is the search pattern.
- `block-main-destructive-git.sh` — any Bash command containing `git commit` adjacency blocked while on `main`, even when `git` wasn't the program (e.g. a `grep`/`echo` mentioning it).

## Fix

Both hooks now walk **command-position segments**: separators (`| & ; ( )`, newlines) become line breaks so each segment begins at a command word, leading env-var assignments are stripped to expose it, and the rules act only on segments whose command word is `git`.

- **block-no-verify** — bypass checks scoped to the git segment, so a `-n` on another program (`grep`/`head`/`sort`/`tail`) is inert. A whole-command fail-closed safety net re-asserts the unambiguous tokens (`--no-verify`, falsy `HUSKY=`, `core.hooksPath=`) so segment-splitting on a shell metacharacter inside a quoted commit message can't let a real bypass slip. `-n` is excluded from the net (too common elsewhere).
- **block-main-destructive-git** — the commit/push branch rules act only on real `git` invocations; per-segment `-C` handling preserves correct branch resolution.

The residual fail-closed over-block (a bypass token written literally inside a commit message — itself a real `git commit` invocation) is unchanged and documented.

## Behavior change

| Command | Before | After |
|---|---|---|
| `grep -n -e git commit file` | denied | allowed |
| `echo git commit && grep -n foo` | denied | allowed |
| `git commit && grep -n foo` | denied | allowed |
| `git commit --no-verify` | denied | denied |
| `git commit -m "a\|b" --no-verify` | denied | denied (safety net) |
| `git commit` on main | denied | denied |
| `echo "git push origin main"` on main | denied | allowed |

## Tests

- New `block-main-destructive-git.bats` (15 cases — none existed): deny matrix, foreign-repo scope, command-position false positives.
- Extended `block-no-verify.bats` (+6 cases) for the false-positive class.
- Both suites green (22 + 15). shellcheck clean (only the pre-existing SC1091 source-not-followed info note).

## Also included

`chore(specs)`: flip `SPEC-002` allocator status `in-progress` → `shipped` (`/gaia-fitness` shipped). Carried as a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)