### PR TITLE
feat: mechanical TDD RED-verification (SPEC-003)

### DIFF
--- a/.claude/hooks/capture-red-observations.sh
+++ b/.claude/hooks/capture-red-observations.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# PostToolUse Bash hook: OBSERVE-AND-RECORD half of the RED-verification gate.
+#
+# When the agent runs a one-shot vitest run (`pnpm test --run [scope]`), this
+# hook re-invokes vitest with the json reporter on the same scope, reads the
+# per-test results, and appends every GENUINELY-FAILING test to the
+# RED-observation ledger (.gaia/local/red-ledger/observations.jsonl). The
+# companion check hook (red-verify-commit-check.sh) later reads that ledger to
+# decide whether a `git commit` introducing a now-passing new test may land.
+#
+# This hook ONLY observes. It never blocks, never emits a deny, and ALWAYS
+# exits 0 — a missing capture only means the check may later deny, which is the
+# safe direction. It mirrors the merge-audit gate's split of "observe and
+# record" from "deny the consequential action."
+#
+# Valid RED = a per-test `assertionResults[].status == "failed"`. A file-level
+# collection/compile error (file status "failed", empty assertionResults,
+# non-empty message — no test body ran) is NOT a valid RED and is skipped.
+#
+# Test seam: set RED_CAPTURE_JSON_OVERRIDE to an existing json file to feed
+# canned vitest output and skip the real vitest re-run (used by the bats suite
+# so it stays fast and offline). Production never sets it.
+#
+# -e is intentionally omitted: every fallible command is individually guarded so
+# the hook can never abort before its unconditional exit 0.
+set -uo pipefail
+
+# --- guards: jq present, this is a Bash tool call -----------------------------
+input=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+[ "$tool_name" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# --- scope match: a `(pnpm|npm) [run] test … --run …` invocation --------------
+# Reuse block-bare-test.sh's token grammar for the `(pnpm|npm) test` detection,
+# but require the POSITIVE `--run` case (a bare run is blocked upstream by
+# block-bare-test.sh and never reaches a passing PostToolUse). `test:ci` /
+# `test:lint-staged` carry a `test:` token, not a bare `test` token, so the
+# `test([[:space:]]|$)` boundary skips them unless they also pass `--run` as an
+# explicit arg — keeping behavior aligned with the bare-test hook.
+printf '%s' "$cmd" \
+  | grep -Eq '(^|[^[:alnum:]_-])(pnpm|npm)[[:space:]]+(run[[:space:]]+)?test([[:space:]]|$)' \
+  || exit 0
+printf '%s' "$cmd" | grep -Eq -- '--run([[:space:]]|$)' || exit 0
+
+# --- source the shared lib (ledger path, repo-rel, signal helper) -------------
+[ -f .claude/hooks/lib/red-ledger.sh ] && . .claude/hooks/lib/red-ledger.sh
+type red_ledger_path >/dev/null 2>&1 || exit 0
+
+ledger=$(red_ledger_path)
+ledger_dir=$(dirname "$ledger")
+tmp_dir="${ledger_dir}/.tmp"
+
+# --- obtain structured json: canned override, or a scoped vitest re-run -------
+json_file=""
+cleanup_json=0
+
+if [ -n "${RED_CAPTURE_JSON_OVERRIDE:-}" ] && [ -f "${RED_CAPTURE_JSON_OVERRIDE}" ]; then
+  json_file="${RED_CAPTURE_JSON_OVERRIDE}"
+else
+  # Parse the agent command for a scope arg (a path/dir/pattern) so the json
+  # re-run is bounded to the same files the agent targeted. Take the tokens
+  # AFTER the `test` token, dropping recognizable flags/options. If none
+  # remain, re-run the whole suite (capture cost is accepted at this stage; the
+  # SPEC forbids re-running only at the COMMIT gate).
+  scope=$(printf '%s\n' "$cmd" | awk '
+    {
+      seen = 0
+      for (i = 1; i <= NF; i++) {
+        if (!seen) { if ($i == "test") seen = 1; continue }
+        tok = $i
+        if (tok ~ /^-/) continue                 # flags: --run, --reporter, -t, …
+        if (tok == "run" || tok == "exec") continue
+        if (tok ~ /=/) continue                  # --opt=value already caught by ^-, but be safe
+        print tok
+      }
+    }')
+
+  mkdir -p "$tmp_dir" 2>/dev/null || true
+  json_file=$(mktemp "${tmp_dir}/vitest-XXXXXX.json" 2>/dev/null || echo "")
+  [ -n "$json_file" ] || exit 0
+  cleanup_json=1
+
+  # Re-invoke vitest directly (not `pnpm test`) with the json reporter. Using
+  # `pnpm exec vitest` avoids the project `test` script, passes json cleanly,
+  # and dodges block-bare-test.sh (different command word) — and this is a hook
+  # subprocess, not a Bash-tool call, so no PreToolUse hook intercepts it.
+  # shellcheck disable=SC2086 # $scope is an intentional word-split arg list.
+  pnpm exec vitest --run --reporter=json --outputFile="$json_file" $scope \
+    >/dev/null 2>&1 || true
+
+  # If vitest produced no parseable json (binary missing, etc.), bail silently.
+  if [ ! -s "$json_file" ] || ! jq -e . "$json_file" >/dev/null 2>&1; then
+    [ "$cleanup_json" -eq 1 ] && rm -f "$json_file" 2>/dev/null || true
+    exit 0
+  fi
+fi
+
+# --- parse per-test failures, attach signals, append to the ledger ------------
+mkdir -p "$ledger_dir" 2>/dev/null || true
+observed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+# Walk each file (testResults[]). Emit a TSV line "file<TAB>fullName<TAB>kind"
+# per genuinely-failing per-test result. Collection-error files (status failed,
+# zero assertionResults, non-empty message — no test body ran) yield nothing.
+# failureKind is informational: a missing-implementation runtime error
+# (TypeError/ReferenceError/is not a function/is not defined) → "runtime",
+# otherwise "assertion".
+failures=$(jq -r '
+  .testResults[]?
+  | . as $f
+  | select((.assertionResults | length) > 0)
+  | .name as $name
+  | .assertionResults[]
+  | select(.status == "failed")
+  | ([ ($name // ""),
+       (.fullName // ""),
+       ( (.failureMessages // [] | join(" "))
+         | if test("TypeError|ReferenceError|is not a function|is not defined")
+           then "runtime" else "assertion" end )
+     ] | @tsv)
+' "$json_file" 2>/dev/null || echo "")
+
+if [ -n "$failures" ]; then
+  # Cache signal lookups per file so each file is parsed once.
+  cached_file=""
+  cached_signals=""
+  while IFS=$'\t' read -r raw_file full_name kind; do
+    [ -n "$raw_file" ] || continue
+    [ -n "$full_name" ] || continue
+
+    rel_file=$(red_ledger_repo_rel "$raw_file")
+    [ -n "$rel_file" ] || continue
+
+    # Recompute the file's {fullName → signal} map once and reuse it.
+    if [ "$rel_file" != "$cached_file" ]; then
+      cached_file="$rel_file"
+      cached_signals=$(red_ledger_signals "$rel_file" 2>/dev/null || echo "")
+    fi
+    [ -n "$cached_signals" ] || continue
+
+    # Match the failing fullName to the helper's signal output. Exact-match the
+    # fullName field; skip (fail-open) when no signal is found — never invent one.
+    signal=$(printf '%s\n' "$cached_signals" | jq -r --arg fn "$full_name" \
+      'select(.fullName == $fn) | .signal' 2>/dev/null | head -n1)
+    [ -n "$signal" ] || continue
+
+    # Build the ledger line safely with jq -n --arg (never string-concat json).
+    jq -c -n \
+      --argjson schema 1 \
+      --arg file "$rel_file" \
+      --arg fullName "$full_name" \
+      --arg signal "$signal" \
+      --arg failureKind "$kind" \
+      --arg observedAt "$observed_at" \
+      '{schema: $schema, file: $file, fullName: $fullName, signal: $signal, failureKind: $failureKind, observedAt: $observedAt}' \
+      >> "$ledger" 2>/dev/null || true
+  done <<< "$failures"
+fi
+
+# --- cleanup; never block --------------------------------------------------
+[ "$cleanup_json" -eq 1 ] && rm -f "$json_file" 2>/dev/null || true
+
+exit 0

--- a/.claude/hooks/lib/red-ledger.sh
+++ b/.claude/hooks/lib/red-ledger.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared helpers for the RED-observation ledger, sourced by both the capture
+# hook (.claude/hooks/capture-red-observations.sh) and the commit check
+# (.claude/hooks/red-verify-commit-check.sh). Keeping the path, the
+# repo-relative normalization, and the signal invocation in one place keeps
+# the two hooks in sync by construction.
+#
+# Usage (from a hook script, pwd = repo root):
+#   [ -f .claude/hooks/lib/red-ledger.sh ] && . .claude/hooks/lib/red-ledger.sh
+#   ledger=$(red_ledger_path)
+#   rel=$(red_ledger_repo_rel "$some_path")
+#   red_ledger_signals "$rel"          # NDJSON on stdout; helper's exit code
+#
+# No persistent `cd`; all paths are repo-relative or resolved via `git -C`.
+# Guarded so double-sourcing is a no-op.
+
+[ -n "${RED_LEDGER_LIB_SOURCED:-}" ] && return 0
+RED_LEDGER_LIB_SOURCED=1
+
+# Repo-relative path to the append-only JSON Lines ledger.
+red_ledger_path() {
+  printf '%s\n' '.gaia/local/red-ledger/observations.jsonl'
+}
+
+# Repo-relative path to the Node signal helper.
+red_ledger_signal_script() {
+  printf '%s\n' '.gaia/scripts/red-ledger/extract-test-signals.mjs'
+}
+
+# Normalize an absolute-or-relative path to a repo-relative POSIX path.
+# Strips a leading repo-root prefix and any leading `./`. Idempotent: an
+# already-repo-relative path returns unchanged. pwd is the repo root, so a
+# bare relative path is already repo-relative.
+red_ledger_repo_rel() {
+  local path="$1"
+  local root
+
+  # Resolve the repo root; fall back to pwd when not inside a work tree.
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root="$PWD"
+  [ -n "$root" ] || root="$PWD"
+
+  # Strip a leading repo-root prefix (with or without trailing slash).
+  case "$path" in
+    "$root"/*) path="${path#"$root"/}" ;;
+    "$root") path="" ;;
+  esac
+
+  # Strip any leading `./` segments.
+  while [ "${path#./}" != "$path" ]; do
+    path="${path#./}"
+  done
+
+  printf '%s\n' "$path"
+}
+
+# Run the Node signal helper for a repo-relative test path and echo its NDJSON
+# output. Propagates the helper's exit code so the caller can apply its own
+# fail-open / fail-closed policy. Exits 0 with no output (and a stderr note) if
+# Node is unavailable, treating that as "cannot recompute signal".
+red_ledger_signals() {
+  local rel="$1"
+  local script
+  script=$(red_ledger_signal_script)
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo "red-ledger: node not found; cannot compute signals" >&2
+    return 0
+  fi
+  [ -f "$script" ] || {
+    echo "red-ledger: signal helper missing at $script" >&2
+    return 0
+  }
+
+  node "$script" "$rel"
+}

--- a/.claude/hooks/red-verify-commit-check.sh
+++ b/.claude/hooks/red-verify-commit-check.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# PreToolUse Bash hook: DENY `git commit` when a new-at-HEAD test that now
+# passes has no observed failing run (RED) on record matching its current
+# content. This is the "deny the consequential action" half of mechanical TDD
+# RED-verification: the sibling capture hook (capture-red-observations.sh)
+# records REDs at test-run time; this hook enforces them at commit. It mirrors
+# pr-merge-audit-check.sh: a PreToolUse Bash deny gating the least-reversible
+# action on a recorded marker keyed to content.
+#
+# The check is a LEDGER LOOKUP + a SIGNAL RECOMPUTE. It never re-runs tests;
+# husky's `test:lint-staged` remains the GREEN confirmation. For each staged
+# test file that is new/modified at HEAD, it computes the set of CURRENT tests
+# (working-tree content) and the set that existed at HEAD, then demands a
+# matching valid RED only for tests whose fullName is NEW at HEAD. Edits,
+# renames, and refactors of tests already present at HEAD are out of scope and
+# never demand a fresh RED.
+#
+# Scope is driven entirely by the signal helper's emitted current-test set.
+# Tests with dynamic titles (template-literal/computed names, test.each rows
+# templated with substitutions) emit NO signal from the helper, so they never
+# appear in the current-test set and are therefore EXEMPT by construction: an
+# uncomputable identity yields no RED demand, matching the SPEC's fail-open
+# posture for uncomputable identity and its "edits/refactors never demand a
+# RED" spirit. A new dynamic-title test passing on first run is not blocked.
+#
+# Fail-open vs fail-closed (threat model: a cooperative-but-fallible agent):
+#   - git / jq / node unavailable  -> exit 0 (allow). Sibling-hook posture.
+#   - a staged test file the helper cannot parse (mid-edit syntax error)
+#     -> that file is skipped, never denied (husky's GREEN gate and the
+#        agent's own run surface the syntax error). Fail-open.
+#   - the deny path is fail-closed ONLY for the clean case: a parseable
+#     new-at-HEAD passing test with no matching valid RED in the ledger.
+#
+# -e is intentionally omitted: we must not abort before writing the deny JSON.
+# All error-prone commands are individually guarded (|| true, 2>/dev/null) so a
+# transient failure can never crash the hook into a default-allow that skips
+# the gate for the clean case, nor a default-deny that blocks honest work.
+set -uo pipefail
+
+input=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null)
+[ "$tool_name" = "Bash" ] || exit 0
+
+# Avoid the name `command`: it would shadow bash's `command` builtin and break
+# later `command -v ...` guards.
+cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Command-position match for `git commit`. Reuse the anchored-segment technique
+# from block-no-verify.sh / pr-merge-audit-check.sh: split on pipeline
+# separators so every segment begins at a command word, strip leading env-var
+# assignments to expose it, and act only when that word is `git` AND the
+# segment carries a `commit` subcommand token. This avoids false positives on
+# `git commit` inside a quoted message, heredoc, or grep pattern.
+# ---------------------------------------------------------------------------
+
+# Fast path: short-circuit when `git` is not an invoked command word anywhere.
+[[ "$cmd" =~ (^|[[:space:]&;|()])git([[:space:]]|$) ]] || exit 0
+
+saw_commit=0
+while IFS= read -r seg; do
+  # Command word = first token after leading whitespace + env-var assignments.
+  seg_cmd=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*//')
+  [[ "$seg_cmd" =~ ^git([[:space:]]|$) ]] || continue
+  [[ "$seg" =~ (^|[[:space:]])commit([[:space:]]|$) ]] && saw_commit=1
+done < <(printf '%s\n' "$cmd" | tr '|&;()' '\n')
+
+[ "$saw_commit" -eq 1 ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Repo-scope guard: a `git -C ../other commit` targets a different repo whose
+# RED ledger is not ours, so allow it. Fail-closed (enforce) on any ambiguity.
+# ---------------------------------------------------------------------------
+[ -f .claude/hooks/lib/repo-scope.sh ] && . .claude/hooks/lib/repo-scope.sh
+if type cmd_targets_foreign_repo >/dev/null 2>&1 \
+   && cmd_targets_foreign_repo "$cmd"; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Shared RED-ledger lib: ledger path, repo-relative normalization, and the
+# signal-helper wrapper. Without it we cannot compute identity, so fail-open.
+# ---------------------------------------------------------------------------
+[ -f .claude/hooks/lib/red-ledger.sh ] && . .claude/hooks/lib/red-ledger.sh
+type red_ledger_path >/dev/null 2>&1 || exit 0
+type red_ledger_signals >/dev/null 2>&1 || exit 0
+type red_ledger_signal_script >/dev/null 2>&1 || exit 0
+
+command -v git >/dev/null 2>&1 || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+
+# This hook only enforces where git answers (a real work tree at pwd).
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# ---------------------------------------------------------------------------
+# Staged test files new/modified at HEAD, filtered to the vitest include glob
+# (app/**/*.test.ts|tsx, confirmed against vitest.config.ts: './app/**/*.test.{ts,tsx}').
+# A pure deletion/rename-away cannot add a new passing test, so --diff-filter=ACM.
+# ---------------------------------------------------------------------------
+staged=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
+[ -n "$staged" ] || exit 0
+
+ledger=$(red_ledger_path)
+signal_script=$(red_ledger_signal_script)
+
+# Collect offenders as "file\tfullName" lines.
+offenders=""
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  # vitest include glob is './app/**/*.test.{ts,tsx}' (vitest.config.ts). In a
+  # case statement `*` already spans slashes, so `app/*.test.ts` matches any
+  # depth under app/. Match the app/ prefix AND a .test.ts/.tsx suffix.
+  case "$path" in
+    app/*.test.ts | app/*.test.tsx) ;;
+    *) continue ;;
+  esac
+
+  rel=$(red_ledger_repo_rel "$path")
+
+  # Current tests: helper over the working-tree (staged) file content on disk.
+  # Parse failure (mid-edit syntax error) -> skip this file (fail-open).
+  current_ndjson=""
+  current_ndjson=$(red_ledger_signals "$rel" 2>/dev/null) || { continue; }
+  # No emitted tests (empty file, only dynamic-title tests, or no-tests file):
+  # nothing in scope for this file.
+  [ -n "$current_ndjson" ] || continue
+
+  # HEAD tests: feed the HEAD blob (`git show HEAD:<path>`) through the helper
+  # via --stdin. The shared red_ledger_signals reads from disk only, so call the
+  # helper script directly here with --stdin to parse HEAD content rather than
+  # the staged working-tree file. A new-at-HEAD file yields empty HEAD content
+  # -> every current test is new. If HEAD content is unparseable we cannot prove
+  # a test pre-existed; treat the HEAD set as empty (conservative: more tests
+  # look new), but a genuinely new file is the common case on this path.
+  head_src=$(git show "HEAD:$rel" 2>/dev/null || true)
+  head_fullnames=""
+  if [ -n "$head_src" ]; then
+    head_ndjson=$(printf '%s' "$head_src" \
+      | node "$signal_script" "$rel" --stdin 2>/dev/null || true)
+    if [ -n "$head_ndjson" ]; then
+      head_fullnames=$(printf '%s\n' "$head_ndjson" \
+        | jq -r '.fullName // empty' 2>/dev/null || true)
+    fi
+  fi
+
+  # For each CURRENT test, decide new-at-HEAD, then require a matching RED.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    full=$(printf '%s' "$line" | jq -r '.fullName // empty' 2>/dev/null || true)
+    sig=$(printf '%s' "$line" | jq -r '.signal // empty' 2>/dev/null || true)
+    [ -n "$full" ] && [ -n "$sig" ] || continue
+
+    # New-at-HEAD test? Present-at-HEAD fullNames are out of scope (edits,
+    # renames, refactors of an existing test never demand a fresh RED), even
+    # when their signal changed.
+    if [ -n "$head_fullnames" ] \
+       && printf '%s\n' "$head_fullnames" | grep -qxF -- "$full"; then
+      continue
+    fi
+
+    # In scope: require >=1 ledger line with schema 1, this file, this
+    # fullName, and this CURRENT signal. A matching RED at a stale signal
+    # (test edited after its RED) does not count -> the edit-to-pass hole is
+    # closed. A missing ledger file means zero matches -> deny.
+    matched=0
+    if [ -f "$ledger" ]; then
+      matched=$(jq -r --arg f "$rel" --arg n "$full" --arg s "$sig" '
+        select((.schema // 0) == 1
+          and (.file // "") == $f
+          and (.fullName // "") == $n
+          and (.signal // "") == $s)
+        | "x"' "$ledger" 2>/dev/null \
+        | head -1 | grep -c x 2>/dev/null || true)
+    fi
+    [ -z "$matched" ] && matched=0
+
+    if [ "$matched" -eq 0 ]; then
+      offenders="${offenders}${rel}	${full}
+"
+    fi
+  done <<EOF
+$current_ndjson
+EOF
+done <<EOF
+$staged
+EOF
+
+# ---------------------------------------------------------------------------
+# Decision: allow when no offenders; otherwise deny, naming each offender.
+# ---------------------------------------------------------------------------
+if [ -z "$offenders" ]; then
+  exit 0
+fi
+
+# Build a human-readable list of "  • file › fullName" lines.
+offender_list=$(printf '%s' "$offenders" \
+  | while IFS=$'\t' read -r f n; do
+      [ -n "$f" ] || continue
+      printf '  \xe2\x80\xa2 %s \xe2\x80\xba %s\n' "$f" "$n"
+    done)
+
+reason="TDD RED-verification: a new test has no observed failing run (RED) on record at its current content.
+
+$offender_list
+
+These tests are new at HEAD and pass now, but no matching RED was recorded for the current test body. A passing test that was never seen failing first does not prove the test can fail; that is the gap this gate closes.
+
+To unblock:
+  1. Run \`pnpm test --run\` and confirm the test FAILS (RED) before the change that makes it pass.
+  2. Then make the change that turns it green and commit.
+
+A RED is bound to the test's content: editing a test after its RED invalidates that RED, so a fresh failing run must be observed for the current body. Edits, renames, and refactors of tests already present at HEAD are out of scope and never demand a RED."
+
+# --arg safely escapes $reason; never interpolate dynamic values into the JSON.
+jq -n --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,11 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/red-verify-commit-check.sh",
+            "statusMessage": "Checking RED-before-GREEN gate…"
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/block-rm-rf.sh",
             "statusMessage": "Checking rm -rf safety…"
           },
@@ -133,6 +138,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/wiki-commit-nudge.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/capture-red-observations.sh"
           }
         ]
       },

--- a/.gaia/scripts/red-ledger/README.md
+++ b/.gaia/scripts/red-ledger/README.md
@@ -1,0 +1,64 @@
+# RED-observation ledger
+
+Mechanical TDD RED-verification records each test the agent observed failing,
+so the commit gate can confirm a new passing test was seen failing first. Two
+hooks share this directory's contract: a PostToolUse capture hook appends
+observations, and a PreToolUse check denies a commit whose new passing test has
+no matching RED on record.
+
+## Ledger
+
+- **Directory:** `.gaia/local/red-ledger/` (under the gitignored `.gaia/local/`,
+  so the ledger never gets committed). The capture hook `mkdir -p`s it on first
+  write.
+- **File:** `.gaia/local/red-ledger/observations.jsonl` — append-only JSON
+  Lines, one observation per line. Capture never rewrites or dedups; duplicate
+  observations for the same `(file, fullName, signal)` are harmless and the
+  check treats "at least one matching valid RED exists" as satisfied.
+
+## Record schema
+
+```json
+{"schema":1,"file":"app/x/index.test.ts","fullName":"X does Y","signal":"sha256:…","failureKind":"assertion","observedAt":"2026-06-04T20:55:00Z"}
+```
+
+- `schema` (number) — version, currently `1`. Readers ignore lines whose
+  schema they do not understand (forward-compat).
+- `file` (string) — repo-relative POSIX path to the test file. No leading
+  `./`, never absolute.
+- `fullName` (string) — vitest's `assertionResults[].fullName`: the enclosing
+  describe titles plus the test title, space-joined.
+- `signal` (string) — `sha256:` followed by the lowercase-hex sha256 of the
+  test's normalized source span (see below).
+- `failureKind` (string) — `"assertion"` or `"runtime"`. Both are valid REDs.
+  A `"collection"` kind is never written: a suite-level collection or compile
+  error where no test body ran is not a valid RED.
+- `observedAt` (string) — ISO-8601 UTC timestamp.
+
+## Content signal
+
+vitest's `--reporter=json` emits `location: null` for every assertion, so the
+signal is derived from the test file source, not the reporter. The signal binds
+a RED to a specific test body: editing the body changes the signal and
+invalidates the RED, so a fresh failing run must be observed.
+
+## Helper: `extract-test-signals.mjs`
+
+Node ESM, Node stdlib only (resolves `typescript` from `node_modules` for a
+robust AST walk).
+
+```
+node .gaia/scripts/red-ledger/extract-test-signals.mjs <repo-relative-test-path>
+node .gaia/scripts/red-ledger/extract-test-signals.mjs <path> --stdin
+```
+
+Reads the file from disk (or stdin with `--stdin`) and prints one JSON object
+per discovered `test(...)`/`it(...)` call, newline-delimited:
+`{"fullName":"…","signal":"sha256:…"}`. Exit `0` on success (no output when no
+tests are found); non-zero with a one-line stderr message on a parse failure.
+
+`fullName` is the enclosing describe titles (outermost first) plus the test
+title, single-space-joined. `signal` is `sha256:` plus the lowercase-hex
+sha256 of the test call expression's normalized source — trimmed, with internal
+whitespace runs collapsed to single spaces, so it stays stable across pure
+reformatting and changes when the title, assertion, or body changes.

--- a/.gaia/scripts/red-ledger/extract-test-signals.mjs
+++ b/.gaia/scripts/red-ledger/extract-test-signals.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// Extract per-test (fullName, content signal) pairs from a vitest/jest test
+// file, for the RED-observation ledger.
+//
+// A RED observation binds to a test by (file, fullName, signal). The signal
+// lets the commit gate invalidate a RED once the test body changes: a fresh
+// failing run must then be observed. vitest's --reporter=json emits
+// location: null for every assertion, so the signal cannot come from the
+// reporter. It is derived here, from the test file source.
+//
+// Invocation:
+//   node .gaia/scripts/red-ledger/extract-test-signals.mjs <repo-relative-test-path>
+//   ... --stdin   (read source bytes from stdin instead of disk)
+//
+// Output (stdout): one JSON object per discovered test(...)/it(...) call,
+// newline-delimited:
+//   {"fullName":"...","signal":"sha256:..."}
+// Exit 0 on success (even when zero tests are found — emits nothing).
+// Exit non-zero with a one-line stderr message on a parse failure.
+//
+// fullName: the titles of all enclosing describe(...) blocks (outermost
+// first) plus the test's own title, single-space-joined. Matches vitest's
+// fullName: top-level test('foo') -> "foo"; describe('a', describe('b',
+// test('c'))) -> "a b c".
+//
+// signal: "sha256:" + lowercase-hex sha256 of the NORMALIZED source text of
+// the whole test call expression (from the test/it identifier through the
+// matching close paren). Normalization: trim leading/trailing whitespace,
+// then collapse every internal run of whitespace to a single space. Stable
+// under pure reformatting; changes when the title, assertion, or body
+// changes.
+
+import {createHash} from 'node:crypto';
+import {createRequire} from 'node:module';
+import {readFileSync} from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+const args = process.argv.slice(2);
+const useStdin = args.includes('--stdin');
+const filePath = args.find((a) => !a.startsWith('--'));
+
+if (!filePath) {
+  process.stderr.write(
+    'extract-test-signals: missing <repo-relative-test-path> argument\n',
+  );
+  process.exit(2);
+}
+
+let ts;
+try {
+  ts = require('typescript');
+} catch {
+  process.stderr.write(
+    'extract-test-signals: cannot resolve "typescript" from node_modules\n',
+  );
+  process.exit(3);
+}
+
+let source;
+try {
+  if (useStdin) {
+    source = readFileSync(0, 'utf8');
+  } else {
+    source = readFileSync(filePath, 'utf8');
+  }
+} catch (err) {
+  process.stderr.write(
+    `extract-test-signals: cannot read ${filePath}: ${err.message}\n`,
+  );
+  process.exit(4);
+}
+
+const scriptKind = /\.tsx$/i.test(filePath)
+  ? ts.ScriptKind.TSX
+  : ts.ScriptKind.TS;
+
+let sourceFile;
+try {
+  sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    scriptKind,
+  );
+} catch (err) {
+  process.stderr.write(
+    `extract-test-signals: parse failed for ${filePath}: ${err.message}\n`,
+  );
+  process.exit(5);
+}
+
+// createSourceFile is lenient and records syntactic diagnostics rather than
+// throwing. A genuinely broken file must fail the helper so the caller can
+// fall back to fail-open (capture) / fail-closed-but-named (check).
+const diagnostics = sourceFile.parseDiagnostics ?? [];
+if (diagnostics.length > 0) {
+  const first = diagnostics[0];
+  const message = ts.flattenDiagnosticMessageText(first.messageText, '\n');
+  process.stderr.write(
+    `extract-test-signals: syntax error in ${filePath}: ${message}\n`,
+  );
+  process.exit(6);
+}
+
+// Resolve a call-expression callee to its bare identifier name, ignoring
+// chained modifiers (test.each(...)(...), it.concurrent(...), describe.skip).
+// Returns the base name: 'test', 'it', 'describe', or null.
+function baseCalleeName(node) {
+  let expr = node.expression;
+  // Unwrap a call-of-a-call (test.each(table)('name', fn)).
+  while (ts.isCallExpression(expr)) {
+    expr = expr.expression;
+  }
+  // Walk down a property-access chain to its leftmost identifier.
+  while (ts.isPropertyAccessExpression(expr)) {
+    expr = expr.expression;
+  }
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+  return null;
+}
+
+// The first string-literal/template title argument of a test/describe call.
+// Returns the literal text, or null when the title is dynamic (template with
+// substitutions, an identifier, etc.) — a dynamic title cannot be matched to
+// a recorded fullName, so we skip it.
+function titleOf(node) {
+  const arg = node.arguments[0];
+  if (!arg) {
+    return null;
+  }
+  if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
+    return arg.text;
+  }
+  return null;
+}
+
+const TEST_NAMES = new Set(['test', 'it']);
+const DESCRIBE_NAMES = new Set(['describe', 'suite']);
+
+function normalize(text) {
+  return text.trim().replace(/\s+/g, ' ');
+}
+
+function signalFor(node) {
+  const text = node.getText(sourceFile);
+  const normalized = normalize(text);
+  const hex = createHash('sha256').update(normalized, 'utf8').digest('hex');
+  return `sha256:${hex}`;
+}
+
+const lines = [];
+
+function visit(node, ancestors) {
+  if (ts.isCallExpression(node)) {
+    const name = baseCalleeName(node);
+    if (name && TEST_NAMES.has(name)) {
+      const title = titleOf(node);
+      if (title !== null) {
+        const fullName = [...ancestors, title].join(' ');
+        lines.push(
+          JSON.stringify({fullName, signal: signalFor(node)}),
+        );
+      }
+      // A test call never nests further test/describe blocks worth tracking;
+      // still descend in case of unusual nesting, but without pushing a title.
+      ts.forEachChild(node, (child) => visit(child, ancestors));
+      return;
+    }
+    if (name && DESCRIBE_NAMES.has(name)) {
+      const title = titleOf(node);
+      const nextAncestors =
+        title !== null ? [...ancestors, title] : ancestors;
+      ts.forEachChild(node, (child) => visit(child, nextAncestors));
+      return;
+    }
+  }
+  ts.forEachChild(node, (child) => visit(child, ancestors));
+}
+
+visit(sourceFile, []);
+
+if (lines.length > 0) {
+  process.stdout.write(lines.join('\n') + '\n');
+}
+process.exit(0);

--- a/.gaia/tests/hooks/capture-red-observations.bats
+++ b/.gaia/tests/hooks/capture-red-observations.bats
@@ -1,0 +1,204 @@
+#!/usr/bin/env bats
+
+# Tests for the RED-capture hook (.claude/hooks/capture-red-observations.sh).
+#
+# The hook is the OBSERVE-AND-RECORD half of the RED-verification gate. On a
+# `(pnpm|npm) test --run [scope]` PostToolUse, it re-invokes vitest with the
+# json reporter, reads the per-test results, and appends every genuinely-failing
+# test to the ledger (.gaia/local/red-ledger/observations.jsonl). It only
+# observes — it never blocks and always exits 0.
+#
+# vitest's config `include` glob is `./app/**/*.test.{ts,tsx}`, so the fixture
+# test files under .gaia/tests/hooks/fixtures/red-ledger/ cannot be run by a
+# real vitest invocation (they fall outside the include set). The deterministic
+# assertions therefore feed CANNED vitest json via the hook's documented test
+# seam RED_CAPTURE_JSON_OVERRIDE, while the source-file fixtures supply the real
+# bodies the signal helper hashes — so the signals are genuine, not stubbed. The
+# negative/robustness cases exercise the real (no-override) code path: they bail
+# before vitest ever runs, so they stay fast and offline.
+#
+# The hook hard-codes the ledger at .gaia/local/red-ledger/observations.jsonl
+# relative to pwd, so the suite runs from the repo root (like
+# red-ledger-lib.bats) and asserts on that gitignored path. setup/teardown
+# stash and restore any pre-existing local ledger so a developer's scratch
+# ledger is never clobbered.
+
+setup() {
+  REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  HOOK="$REPO_ROOT/.claude/hooks/capture-red-observations.sh"
+  FIX_REL=".gaia/tests/hooks/fixtures/red-ledger"
+  JSON_REL="$FIX_REL/json"
+  LEDGER_REL=".gaia/local/red-ledger/observations.jsonl"
+  LEDGER_ABS="$REPO_ROOT/$LEDGER_REL"
+
+  # Stash any pre-existing local ledger; restore in teardown.
+  STASH=""
+  if [ -f "$LEDGER_ABS" ]; then
+    STASH=$(mktemp -t red-ledger-stash-XXXXXX)
+    cp "$LEDGER_ABS" "$STASH"
+  fi
+  rm -f "$LEDGER_ABS"
+}
+
+teardown() {
+  rm -f "$LEDGER_ABS"
+  if [ -n "${STASH:-}" ] && [ -f "$STASH" ]; then
+    mkdir -p "$(dirname "$LEDGER_ABS")"
+    cp "$STASH" "$LEDGER_ABS"
+    rm -f "$STASH"
+  fi
+  return 0
+}
+
+# Build a PostToolUse Bash payload and pipe it to the hook from the repo root.
+# Args: <tool_name> <command> [json_override_relpath]
+run_capture() {
+  local tool="$1" cmd="$2" override_rel="${3:-}"
+  local payload
+  payload=$(jq -n --arg t "$tool" --arg c "$cmd" \
+    '{tool_name: $t, tool_input: {command: $c}, tool_response: {stdout: "", stderr: "", interrupted: false}}')
+
+  # Export the override so it reaches the hook on the RIGHT side of the pipe
+  # (a `VAR=x cmd | hook` prefix would set it on the left command, not the hook).
+  local env_prefix=""
+  if [ -n "$override_rel" ]; then
+    env_prefix="export RED_CAPTURE_JSON_OVERRIDE='$REPO_ROOT/$override_rel'; "
+  fi
+  run bash -c "cd '$REPO_ROOT' && ${env_prefix}printf '%s' '$payload' | bash '$HOOK'"
+}
+
+# Count ledger lines (0 when the file is absent).
+ledger_lines() {
+  [ -f "$LEDGER_ABS" ] && wc -l < "$LEDGER_ABS" | tr -d ' ' || echo 0
+}
+
+# --- failing run records one RED per genuinely-failing test -------------------
+
+@test "assertion-fail run appends exactly one RED for the failing test" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/mixed-pass-fail.test.ts" \
+    "$JSON_REL/assertion-fail.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 1 ]
+
+  line=$(cat "$LEDGER_ABS")
+  [ "$(printf '%s' "$line" | jq -r '.schema')" = "1" ]
+  [ "$(printf '%s' "$line" | jq -r '.file')" = "$FIX_REL/mixed-pass-fail.test.ts" ]
+  [ "$(printf '%s' "$line" | jq -r '.fullName')" = "fails on assertion" ]
+  [ "$(printf '%s' "$line" | jq -r '.failureKind')" = "assertion" ]
+  [[ "$(printf '%s' "$line" | jq -r '.signal')" == sha256:* ]]
+  [[ "$(printf '%s' "$line" | jq -r '.observedAt')" == *T*Z ]]
+}
+
+@test "recorded signal matches the helper's signal for that test" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/mixed-pass-fail.test.ts" \
+    "$JSON_REL/assertion-fail.json"
+  [ "$status" -eq 0 ]
+
+  recorded=$(printf '%s' "$(cat "$LEDGER_ABS")" | jq -r '.signal')
+  expected=$(cd "$REPO_ROOT" && node .gaia/scripts/red-ledger/extract-test-signals.mjs \
+    "$FIX_REL/mixed-pass-fail.test.ts" \
+    | jq -r 'select(.fullName == "fails on assertion") | .signal')
+  [ -n "$expected" ]
+  [ "$recorded" = "$expected" ]
+}
+
+@test "the passing test in the same file is NOT recorded" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/mixed-pass-fail.test.ts" \
+    "$JSON_REL/assertion-fail.json"
+  [ "$status" -eq 0 ]
+  # Only one line, and it is the failing one — the passing test never appears.
+  [ "$(ledger_lines)" -eq 1 ]
+  run grep -c '"fullName":"passes fine"' "$LEDGER_ABS"
+  [ "$output" = "0" ]
+}
+
+# --- failureKind classification -----------------------------------------------
+
+@test "failureKind is runtime for a missing-implementation error" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/runtime-fail.test.ts" \
+    "$JSON_REL/runtime-fail.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 1 ]
+  [ "$(cat "$LEDGER_ABS" | jq -r '.failureKind')" = "runtime" ]
+  [ "$(cat "$LEDGER_ABS" | jq -r '.fullName')" = "calls a not-yet-implemented function" ]
+}
+
+# --- no RED for passing-only and collection-error runs ------------------------
+
+@test "passing-only run writes no ledger lines" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/two-tests.test.ts" \
+    "$JSON_REL/passing-only.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+@test "collection-error run writes no ledger lines (coarse false-RED guard)" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/broken.test.ts" \
+    "$JSON_REL/collection-error.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+# --- scope match: only `(pnpm|npm) test … --run …` acts -----------------------
+
+@test "bare pnpm test (no --run) exits 0 and writes nothing" {
+  # No override: must bail at the scope check before vitest is ever invoked.
+  run_capture "Bash" "pnpm test"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+@test "unrelated command (git status) exits 0 and writes nothing" {
+  run_capture "Bash" "git status"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+@test "pnpm typecheck exits 0 and writes nothing" {
+  run_capture "Bash" "pnpm typecheck"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+@test "a non-Bash tool call exits 0 and writes nothing" {
+  run_capture "Edit" "pnpm test --run $FIX_REL/mixed-pass-fail.test.ts" \
+    "$JSON_REL/assertion-fail.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+# --- robustness: malformed input, empty command -------------------------------
+
+@test "malformed stdin (not json) exits 0 and writes nothing" {
+  run bash -c "cd '$REPO_ROOT' && printf 'not json at all' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+@test "empty command exits 0 and writes nothing" {
+  run_capture "Bash" ""
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 0 ]
+}
+
+# --- append-only: a second failing run appends, never truncates ---------------
+
+@test "a second failing run appends rather than overwriting" {
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/mixed-pass-fail.test.ts" \
+    "$JSON_REL/assertion-fail.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 1 ]
+
+  run_capture "Bash" \
+    "pnpm test --run $FIX_REL/runtime-fail.test.ts" \
+    "$JSON_REL/runtime-fail.json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 2 ]
+}

--- a/.gaia/tests/hooks/fixtures/red-ledger/broken.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/broken.test.ts
@@ -1,0 +1,5 @@
+import {expect, test} from 'vitest';
+
+test('never closes', () => {
+  expect(1).toBe(1)
+// missing closing brace and paren

--- a/.gaia/tests/hooks/fixtures/red-ledger/changed.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/changed.test.ts
@@ -1,0 +1,5 @@
+import {expect, test} from 'vitest';
+
+test('computes a sum', () => {
+  expect(2 + 3).toBe(6);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/json/assertion-fail.json
+++ b/.gaia/tests/hooks/fixtures/red-ledger/json/assertion-fail.json
@@ -1,0 +1,30 @@
+{
+  "numTotalTestSuites": 1,
+  "numFailedTests": 1,
+  "numPassedTests": 1,
+  "numTotalTests": 2,
+  "success": false,
+  "testResults": [
+    {
+      "name": ".gaia/tests/hooks/fixtures/red-ledger/mixed-pass-fail.test.ts",
+      "status": "failed",
+      "message": "",
+      "assertionResults": [
+        {
+          "title": "passes fine",
+          "fullName": "passes fine",
+          "status": "passed",
+          "failureMessages": []
+        },
+        {
+          "title": "fails on assertion",
+          "fullName": "fails on assertion",
+          "status": "failed",
+          "failureMessages": [
+            "AssertionError: expected 1 to be 2 // Object.is equality\n    at <anonymous>"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.gaia/tests/hooks/fixtures/red-ledger/json/collection-error.json
+++ b/.gaia/tests/hooks/fixtures/red-ledger/json/collection-error.json
@@ -1,0 +1,16 @@
+{
+  "numTotalTestSuites": 1,
+  "numFailedTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTests": 0,
+  "numTotalTests": 0,
+  "success": false,
+  "testResults": [
+    {
+      "name": ".gaia/tests/hooks/fixtures/red-ledger/broken.test.ts",
+      "status": "failed",
+      "message": "Transform failed with 1 error:\n\n[PARSE_ERROR] Expected `}` but found `EOF`\n   app/broken.test.ts:5:19",
+      "assertionResults": []
+    }
+  ]
+}

--- a/.gaia/tests/hooks/fixtures/red-ledger/json/passing-only.json
+++ b/.gaia/tests/hooks/fixtures/red-ledger/json/passing-only.json
@@ -1,0 +1,28 @@
+{
+  "numTotalTestSuites": 1,
+  "numFailedTests": 0,
+  "numPassedTests": 2,
+  "numTotalTests": 2,
+  "success": true,
+  "testResults": [
+    {
+      "name": ".gaia/tests/hooks/fixtures/red-ledger/two-tests.test.ts",
+      "status": "passed",
+      "message": "",
+      "assertionResults": [
+        {
+          "title": "first test",
+          "fullName": "first test",
+          "status": "passed",
+          "failureMessages": []
+        },
+        {
+          "title": "second test",
+          "fullName": "second test",
+          "status": "passed",
+          "failureMessages": []
+        }
+      ]
+    }
+  ]
+}

--- a/.gaia/tests/hooks/fixtures/red-ledger/json/runtime-fail.json
+++ b/.gaia/tests/hooks/fixtures/red-ledger/json/runtime-fail.json
@@ -1,0 +1,24 @@
+{
+  "numTotalTestSuites": 1,
+  "numFailedTests": 1,
+  "numPassedTests": 0,
+  "numTotalTests": 1,
+  "success": false,
+  "testResults": [
+    {
+      "name": ".gaia/tests/hooks/fixtures/red-ledger/runtime-fail.test.ts",
+      "status": "failed",
+      "message": "",
+      "assertionResults": [
+        {
+          "title": "calls a not-yet-implemented function",
+          "fullName": "calls a not-yet-implemented function",
+          "status": "failed",
+          "failureMessages": [
+            "TypeError: __vite_ssr_import_1__.notImplemented is not a function\n    at <anonymous>"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.gaia/tests/hooks/fixtures/red-ledger/mixed-pass-fail.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/mixed-pass-fail.test.ts
@@ -1,0 +1,9 @@
+import {expect, test} from 'vitest';
+
+test('passes fine', () => {
+  expect(1).toBe(1);
+});
+
+test('fails on assertion', () => {
+  expect(1).toBe(2);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/nested-describe.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/nested-describe.test.ts
@@ -1,0 +1,9 @@
+import {describe, expect, test} from 'vitest';
+
+describe('outer', () => {
+  describe('inner', () => {
+    test('does a thing', () => {
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/no-tests.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/no-tests.test.ts
@@ -1,0 +1,2 @@
+// A syntactically valid module with no test/it calls.
+export const helper = (value: number): number => value * 2;

--- a/.gaia/tests/hooks/fixtures/red-ledger/runtime-fail.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/runtime-fail.test.ts
@@ -1,0 +1,7 @@
+import {expect, test} from 'vitest';
+import * as impl from './impl';
+
+test('calls a not-yet-implemented function', () => {
+  // @ts-expect-error intentionally missing implementation
+  expect(impl.notImplemented()).toBe(1);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/stable-a.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/stable-a.test.ts
@@ -1,0 +1,5 @@
+import {expect, test} from 'vitest';
+
+test('computes a sum', () => {
+  expect(2 + 3).toBe(5);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/stable-b.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/stable-b.test.ts
@@ -1,0 +1,5 @@
+import {expect, test} from 'vitest';
+
+test('computes a sum', () => {
+        expect(2 + 3).toBe(5);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/top-level.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/top-level.test.ts
@@ -1,0 +1,5 @@
+import {expect, test} from 'vitest';
+
+test('adds two numbers', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/two-tests.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/two-tests.test.ts
@@ -1,0 +1,9 @@
+import {expect, test} from 'vitest';
+
+test('first test', () => {
+  expect(1).toBe(1);
+});
+
+test('second test', () => {
+  expect(2).toBe(2);
+});

--- a/.gaia/tests/hooks/helpers/mock-hook-input.sh
+++ b/.gaia/tests/hooks/helpers/mock-hook-input.sh
@@ -2,6 +2,7 @@
 # Emit synthetic Claude Code hook-input JSON for testing.
 # Usage:
 #   mock-hook-input.sh user-prompt-submit <session_id> [prompt]
+#   mock-hook-input.sh pre-tool-use <session_id> <tool_name> <command>
 #   mock-hook-input.sh post-tool-use <session_id> <tool_name> <command>
 #   mock-hook-input.sh stop <session_id>
 set -euo pipefail
@@ -14,6 +15,12 @@ case "$event" in
     prompt="${3:-test prompt}"
     jq -n --arg sid "$session_id" --arg p "$prompt" \
       '{session_id: $sid, transcript_path: "/tmp/transcript.jsonl", cwd: ".", hook_event_name: "UserPromptSubmit", prompt: $p}'
+    ;;
+  pre-tool-use)
+    tool="${3:?tool_name required}"
+    cmd="${4:?command required}"
+    jq -n --arg sid "$session_id" --arg t "$tool" --arg c "$cmd" \
+      '{session_id: $sid, transcript_path: "/tmp/transcript.jsonl", cwd: ".", hook_event_name: "PreToolUse", tool_name: $t, tool_input: {command: $c}}'
     ;;
   post-tool-use)
     tool="${3:?tool_name required}"

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+# Tests for the RED-ledger foundation: the Node signal helper
+# (.gaia/scripts/red-ledger/extract-test-signals.mjs) and the shared shell lib
+# (.claude/hooks/lib/red-ledger.sh) that both RED hooks source.
+#
+# The signal helper parses a TS/TSX test file and emits one
+# {"fullName","signal"} line per test/it call. The shell lib provides the
+# ledger path, repo-relative path normalization, and a thin wrapper that runs
+# the helper. These tests exercise both against the fixture test files under
+# fixtures/red-ledger/.
+
+setup() {
+  REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  HELPER="$REPO_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
+  LIB="$REPO_ROOT/.claude/hooks/lib/red-ledger.sh"
+  FIX="$BATS_TEST_DIRNAME/fixtures/red-ledger"
+
+  # Repo-relative fixture paths (helper + lib expect repo-relative input run
+  # from the repo root).
+  FIX_REL=".gaia/tests/hooks/fixtures/red-ledger"
+}
+
+# Run the Node helper from the repo root with a repo-relative fixture path.
+run_helper() {
+  run bash -c "cd '$REPO_ROOT' && node '$HELPER' '$1'"
+}
+
+# Source the lib in a clean shell and run a function, from the repo root.
+run_lib() {
+  run bash -c "cd '$REPO_ROOT' && set -uo pipefail && . '$LIB' && $1"
+}
+
+# --- signal helper: fullName ---
+
+@test "helper emits the bare title for a top-level test" {
+  run_helper "$FIX_REL/top-level.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"fullName":"adds two numbers"'* ]]
+}
+
+@test "helper joins nested describe titles with the test title" {
+  run_helper "$FIX_REL/nested-describe.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"fullName":"outer inner does a thing"'* ]]
+}
+
+# --- signal helper: distinct tests, distinct signals ---
+
+@test "two tests in one file yield two lines with distinct signals" {
+  run_helper "$FIX_REL/two-tests.test.ts"
+  [ "$status" -eq 0 ]
+  # Two output lines.
+  [ "$(printf '%s\n' "$output" | grep -c '"fullName"')" -eq 2 ]
+  local sig1 sig2
+  sig1=$(printf '%s\n' "$output" | sed -n '1p' | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+  sig2=$(printf '%s\n' "$output" | sed -n '2p' | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+  [ -n "$sig1" ]
+  [ -n "$sig2" ]
+  [ "$sig1" != "$sig2" ]
+}
+
+@test "every signal carries the sha256: prefix" {
+  run_helper "$FIX_REL/two-tests.test.ts"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"signal":"sha256:'* ]]
+}
+
+# --- signal helper: stability under reformatting, change on edit ---
+
+@test "reformatting-only edit yields the same signal" {
+  run_helper "$FIX_REL/stable-a.test.ts"
+  [ "$status" -eq 0 ]
+  local sig_a
+  sig_a=$(printf '%s\n' "$output" | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+
+  run_helper "$FIX_REL/stable-b.test.ts"
+  [ "$status" -eq 0 ]
+  local sig_b
+  sig_b=$(printf '%s\n' "$output" | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+
+  [ -n "$sig_a" ]
+  [ "$sig_a" = "$sig_b" ]
+}
+
+@test "changing an assertion literal yields a different signal" {
+  run_helper "$FIX_REL/stable-a.test.ts"
+  [ "$status" -eq 0 ]
+  local sig_a
+  sig_a=$(printf '%s\n' "$output" | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+
+  run_helper "$FIX_REL/changed.test.ts"
+  [ "$status" -eq 0 ]
+  local sig_changed
+  sig_changed=$(printf '%s\n' "$output" | sed -E 's/.*"signal":"([^"]+)".*/\1/')
+
+  [ -n "$sig_a" ]
+  [ "$sig_a" != "$sig_changed" ]
+}
+
+# --- signal helper: exit codes ---
+
+@test "helper exits 0 with no output on a valid file with no tests" {
+  run_helper "$FIX_REL/no-tests.test.ts"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "helper exits non-zero with a stderr message on a broken file" {
+  run_helper "$FIX_REL/broken.test.ts"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"extract-test-signals"* ]]
+}
+
+@test "helper exits non-zero when the argument is missing" {
+  run bash -c "cd '$REPO_ROOT' && node '$HELPER'"
+  [ "$status" -ne 0 ]
+}
+
+@test "helper resolves typescript from node_modules" {
+  run bash -c "cd '$REPO_ROOT' && node -e 'require(\"typescript\")'"
+  [ "$status" -eq 0 ]
+}
+
+# --- shell lib: red_ledger_path ---
+
+@test "red_ledger_path echoes the gitignored ledger location" {
+  run_lib 'red_ledger_path'
+  [ "$status" -eq 0 ]
+  [ "$output" = ".gaia/local/red-ledger/observations.jsonl" ]
+}
+
+# --- shell lib: red_ledger_repo_rel ---
+
+@test "red_ledger_repo_rel strips the repo-root prefix from an absolute path" {
+  run_lib "red_ledger_repo_rel '$REPO_ROOT/$FIX_REL/top-level.test.ts'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX_REL/top-level.test.ts" ]
+}
+
+@test "red_ledger_repo_rel strips a leading ./" {
+  run_lib "red_ledger_repo_rel './$FIX_REL/top-level.test.ts'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX_REL/top-level.test.ts" ]
+}
+
+@test "red_ledger_repo_rel is idempotent on an already-relative path" {
+  run_lib "red_ledger_repo_rel '$FIX_REL/top-level.test.ts'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX_REL/top-level.test.ts" ]
+}
+
+# --- shell lib: red_ledger_signals ---
+
+@test "red_ledger_signals returns the helper NDJSON for a valid fixture" {
+  run_lib "red_ledger_signals '$FIX_REL/top-level.test.ts'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"fullName":"adds two numbers"'* ]]
+  [[ "$output" == *'"signal":"sha256:'* ]]
+}
+
+@test "red_ledger_signals propagates the helper non-zero exit on a broken file" {
+  run_lib "red_ledger_signals '$FIX_REL/broken.test.ts'"
+  [ "$status" -ne 0 ]
+}
+
+# --- double-sourcing is safe ---
+
+@test "sourcing the lib twice is a no-op" {
+  run bash -c "cd '$REPO_ROOT' && set -uo pipefail && . '$LIB' && . '$LIB' && red_ledger_path"
+  [ "$status" -eq 0 ]
+  [ "$output" = ".gaia/local/red-ledger/observations.jsonl" ]
+}

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -1,0 +1,339 @@
+#!/usr/bin/env bats
+
+# Tests for .claude/hooks/red-verify-commit-check.sh, the commit-gate half of
+# mechanical TDD RED-verification.
+#
+# The hook denies `git commit` when a new-at-HEAD test that now passes has no
+# matching valid RED on record in .gaia/local/red-ledger/observations.jsonl.
+# Edits/renames/refactors of tests already present at HEAD are out of scope and
+# never demand a RED. The hook never re-runs tests; it is a ledger lookup plus
+# a signal recompute via the shared helper.
+#
+# Each test builds a tmp git repo with a HEAD commit plus a staged change,
+# seeds the ledger by writing JSONL directly (computing the real signal with
+# the same helper the hook uses, so the match is exact), and runs the hook with
+# synthetic PreToolUse JSON on stdin. The hook always exits 0; allow vs deny is
+# carried in stdout: a deny emits `"permissionDecision": "deny"`, an allow
+# emits nothing.
+#
+# The hook runs with pwd = the tmp repo so bare `git` and the helper's relative
+# disk reads resolve against the staged change. In production the hook runs
+# with pwd = the project root, where .claude/hooks/lib (the shared shell lib)
+# and .gaia/scripts/red-ledger (the signal helper) live and resolve from pwd.
+# To reproduce that pwd=root invariant, the setup symlinks those two trees from
+# the home repo into the tmp repo at their repo-relative paths. The symlinked
+# helper still resolves `typescript` from the home repo's node_modules via
+# createRequire(import.meta.url), so the signal recompute works.
+
+setup() {
+  HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  HOOK_ABS="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
+  HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
+
+  REPO=$(mktemp -d -t red-verify-test-XXXXXX)
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+  git -C "$REPO" config commit.gpgsign false
+
+  # Mirror the repo-relative layout the hook resolves from pwd.
+  mkdir -p "$REPO/.claude/hooks/lib" "$REPO/.gaia/scripts"
+  ln -s "$HOME_ROOT/.claude/hooks/lib/red-ledger.sh" "$REPO/.claude/hooks/lib/red-ledger.sh"
+  ln -s "$HOME_ROOT/.claude/hooks/lib/repo-scope.sh" "$REPO/.claude/hooks/lib/repo-scope.sh"
+  ln -s "$HOME_ROOT/.gaia/scripts/red-ledger" "$REPO/.gaia/scripts/red-ledger"
+
+  # Seed a HEAD commit with a non-test file so HEAD exists. The symlinks are
+  # untracked working-tree entries; they never enter the staged diff.
+  echo "# readme" > "$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit --quiet -m "init"
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" || true
+  return 0
+}
+
+# Write file content (creating parent dirs) and stage it in the tmp repo.
+stage_file() {
+  local path="$1" content="$2"
+  mkdir -p "$REPO/$(dirname "$path")"
+  printf '%s' "$content" > "$REPO/$path"
+  git -C "$REPO" add "$path"
+}
+
+# Commit a file at HEAD (so a later staged edit is an EXISTING-test edit, not
+# a new-at-HEAD test). Leaves a clean tree.
+commit_file_at_head() {
+  local path="$1" content="$2"
+  mkdir -p "$REPO/$(dirname "$path")"
+  printf '%s' "$content" > "$REPO/$path"
+  git -C "$REPO" add "$path"
+  git -C "$REPO" commit --quiet -m "add $path"
+}
+
+# Compute the (fullName,signal) NDJSON for a repo-relative path's CURRENT
+# on-disk content, using the same helper the hook uses, run from the tmp repo.
+signals_for() {
+  local rel="$1"
+  ( cd "$REPO" && node "$HELPER" "$rel" )
+}
+
+# Append a ledger line. Args: file fullName signal [failureKind].
+seed_ledger() {
+  local file="$1" full="$2" sig="$3" kind="${4:-assertion}"
+  mkdir -p "$REPO/.gaia/local/red-ledger"
+  jq -nc --arg f "$file" --arg n "$full" --arg s "$sig" --arg k "$kind" \
+    '{schema:1, file:$f, fullName:$n, signal:$s, failureKind:$k, observedAt:"2026-06-04T00:00:00Z"}' \
+    >> "$REPO/.gaia/local/red-ledger/observations.jsonl"
+}
+
+# Seed a matching valid RED for one test of a staged file (computes the real
+# current signal so the match is exact).
+seed_matching_red() {
+  local rel="$1" want_full="$2"
+  local ndjson sig
+  ndjson=$(signals_for "$rel")
+  sig=$(printf '%s\n' "$ndjson" \
+    | jq -r --arg n "$want_full" 'select(.fullName == $n) | .signal' | head -1)
+  [ -n "$sig" ] || { echo "no signal for '$want_full' in $rel" >&2; return 1; }
+  seed_ledger "$rel" "$want_full" "$sig"
+}
+
+# Run the hook with a `git commit` command, from inside the tmp repo.
+run_commit_hook() {
+  local cmd="${1:-git commit -m change}"
+  local json
+  json=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+}
+
+denied() { [[ "$output" == *'"permissionDecision": "deny"'* ]]; }
+
+PASSING_TEST='import {expect, test} from "vitest";
+test("adds two numbers", () => {
+  expect(1 + 1).toBe(2);
+});
+'
+
+# --- UAT-001 / UAT-002: new test, no matching RED -> deny ---
+
+@test "denies a new test with no ledger entry (never run)" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"adds two numbers"* ]]
+}
+
+@test "denies a new first-run-pass test (ledger has no matching RED)" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  # An unrelated RED in the ledger must not satisfy this test.
+  seed_ledger "app/other/index.test.ts" "something else" "sha256:deadbeef"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+}
+
+# --- UAT-003: observed-fail then pass -> allow ---
+
+@test "allows a new test that has a matching valid RED" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  seed_matching_red "app/x/index.test.ts" "adds two numbers"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+# --- UAT-004: prose-only claim does not satisfy the gate ---
+
+@test "denies even when the commit message prose claims a failing test first" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  run_commit_hook 'git commit -m "wrote a failing test first, RED observed"'
+  [ "$status" -eq 0 ]
+  denied
+}
+
+# --- Edit-to-pass hole closed: RED at a stale signal does not count ---
+
+@test "denies when the test body changed after its RED (signal mismatch)" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  # Seed a RED for the SAME fullName but a different (stale) body signal.
+  seed_ledger "app/x/index.test.ts" "adds two numbers" "sha256:staleoldsignal"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"adds two numbers"* ]]
+}
+
+# --- Edits to EXISTING tests never fire ---
+
+@test "allows editing a test already present at HEAD even with no RED" {
+  # The test exists at HEAD with the same fullName.
+  commit_file_at_head "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("adds two numbers", () => {
+  expect(1 + 1).toBe(2);
+});
+'
+  # Stage an edit to that same test (same fullName, changed body) with no RED.
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("adds two numbers", () => {
+  expect(2 + 1).toBe(3);
+});
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+@test "denies a brand-new test added to a file that already exists at HEAD" {
+  commit_file_at_head "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("existing test", () => {
+  expect(1).toBe(1);
+});
+'
+  # Stage: keep the existing test, add a NEW one with no RED.
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("existing test", () => {
+  expect(1).toBe(1);
+});
+test("brand new test", () => {
+  expect(2).toBe(2);
+});
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"brand new test"* ]]
+  [[ "$output" != *"existing test"* ]]
+}
+
+# --- Non-test / no-new-test commits never fire ---
+
+@test "allows a commit staging only non-test source" {
+  stage_file "app/x/index.ts" 'export const x = 1;'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+@test "allows when 'git commit' appears only inside a quoted message string" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  # No real git commit invocation: the words are inside an echo string.
+  run_commit_hook 'echo "remember to git commit later"'
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+@test "ignores commands that are not git commit" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  run_commit_hook "git status"
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+# --- Foreign-repo commit -> out of scope ---
+
+@test "allows a foreign-repo git -C commit" {
+  OTHER=$(mktemp -d -t red-verify-other-XXXXXX)
+  git -C "$OTHER" init --quiet --initial-branch=main
+  git -C "$OTHER" config user.email "t@e.com"
+  git -C "$OTHER" config user.name "T"
+  git -C "$OTHER" config commit.gpgsign false
+  echo x > "$OTHER/f"; git -C "$OTHER" add f; git -C "$OTHER" commit --quiet -m i
+
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  run_commit_hook "git -C '$OTHER' commit -m change"
+  [ "$status" -eq 0 ]
+  ! denied
+  rm -rf "$OTHER"
+}
+
+# --- Unparseable staged test -> fail-open (not denied on that file) ---
+
+@test "does not deny an unparseable staged test file" {
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("never closes", () => {
+  expect(1).toBe(1)
+// missing closing brace and paren
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+# --- Dynamic-title test -> exempt (no computable signal, never in scope) ---
+
+@test "does not deny a new dynamic-title test (template-literal name)" {
+  # The signal helper emits NOTHING for a substitution-template title, so the
+  # test never enters the current-test set and is exempt by construction,
+  # matching the SPEC's fail-open posture for uncomputable identity. A new
+  # dynamic-title test passing first must not trigger a deny.
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+const n = 7;
+test(`dynamic ${n}`, () => {
+  expect(n).toBe(7);
+});
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+# --- Forward-compat: a ledger line with an unknown schema is ignored ---
+
+@test "ignores a ledger line with an unrecognized schema version" {
+  stage_file "app/x/index.test.ts" "$PASSING_TEST"
+  # Compute the real current signal but record it under schema 2 (unknown).
+  local ndjson sig
+  ndjson=$(signals_for "app/x/index.test.ts")
+  sig=$(printf '%s\n' "$ndjson" | jq -r 'select(.fullName=="adds two numbers") | .signal' | head -1)
+  mkdir -p "$REPO/.gaia/local/red-ledger"
+  jq -nc --arg s "$sig" \
+    '{schema:2, file:"app/x/index.test.ts", fullName:"adds two numbers", signal:$s, failureKind:"assertion", observedAt:"2026-06-04T00:00:00Z"}' \
+    >> "$REPO/.gaia/local/red-ledger/observations.jsonl"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+}
+
+# --- Multiple offenders are all named ---
+
+@test "names every offending new test in the deny reason" {
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("first new", () => { expect(1).toBe(1); });
+test("second new", () => { expect(2).toBe(2); });
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"first new"* ]]
+  [[ "$output" == *"second new"* ]]
+}
+
+# --- Mixed: one test with a RED, one without -> deny names only the offender ---
+
+@test "allows the RED-backed test but denies its un-RED'd sibling" {
+  stage_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("has red", () => { expect(1).toBe(1); });
+test("no red", () => { expect(2).toBe(2); });
+'
+  seed_matching_red "app/x/index.test.ts" "has red"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"no red"* ]]
+  [[ "$output" != *'"has red"'* ]]
+}
+
+# --- A .tsx test file is also in scope ---
+
+@test "denies a new .tsx test with no RED" {
+  stage_file "app/x/index.test.tsx" 'import {expect, test} from "vitest";
+test("renders something", () => { expect(true).toBe(true); });
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"renders something"* ]]
+}

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -116,7 +116,7 @@ test("adds two numbers", () => {
 });
 '
 
-# --- UAT-001 / UAT-002: new test, no matching RED -> deny ---
+# --- new test with no matching RED -> deny ---
 
 @test "denies a new test with no ledger entry (never run)" {
   stage_file "app/x/index.test.ts" "$PASSING_TEST"
@@ -135,7 +135,7 @@ test("adds two numbers", () => {
   denied
 }
 
-# --- UAT-003: observed-fail then pass -> allow ---
+# --- observed-fail then pass -> allow ---
 
 @test "allows a new test that has a matching valid RED" {
   stage_file "app/x/index.test.ts" "$PASSING_TEST"
@@ -145,7 +145,7 @@ test("adds two numbers", () => {
   ! denied
 }
 
-# --- UAT-004: prose-only claim does not satisfy the gate ---
+# --- prose-only claim does not satisfy the gate ---
 
 @test "denies even when the commit message prose claims a failing test first" {
   stage_file "app/x/index.test.ts" "$PASSING_TEST"

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+
+# End-to-end wiring test for mechanical TDD RED-verification.
+#
+# Phase 1 shipped the ledger schema + signal helper; phase 2 shipped the two
+# hooks (capture + check); this suite proves they agree on identity end to end
+# once both are registered in .claude/settings.json. The unit suites
+# (capture-red-observations.bats, red-verify-commit-check.bats) each exercise
+# one hook in isolation against canned inputs; this suite drives the REAL
+# capture code path to WRITE the ledger and then the REAL check code path to
+# READ it, in one tmp repo, so the signal one hook records is the exact signal
+# the other recomputes — the central guarantee the gate rests on.
+#
+# Both hooks run with pwd = the tmp repo, mirroring production's pwd = repo
+# root. The shared shell lib (.claude/hooks/lib) and the signal helper
+# (.gaia/scripts/red-ledger) are symlinked from the home repo into the tmp repo
+# at their repo-relative paths so they resolve from pwd; the symlinked helper
+# still resolves `typescript` from the home repo's node_modules via
+# createRequire(import.meta.url).
+#
+# Running real vitest in bats is impractical (the fixtures fall outside vitest's
+# include glob, and a real run is slow/online), so the capture step feeds canned
+# vitest json through the capture hook's documented RED_CAPTURE_JSON_OVERRIDE
+# seam. The signal is NOT canned: the capture hook recomputes it from the staged
+# test file's real on-disk body via the helper, and the check hook recomputes it
+# the same way — so RED→GREEN proves a genuine signal handshake, and
+# edited-after-RED proves the handshake breaks when the body changes.
+
+setup() {
+  HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  CAPTURE_HOOK="$HOME_ROOT/.claude/hooks/capture-red-observations.sh"
+  CHECK_HOOK="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
+  BARE_TEST_HOOK="$HOME_ROOT/.claude/hooks/block-bare-test.sh"
+  HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
+  LEDGER_REL=".gaia/local/red-ledger/observations.jsonl"
+
+  REPO=$(mktemp -d -t red-e2e-XXXXXX)
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test"
+  git -C "$REPO" config commit.gpgsign false
+
+  # Mirror the repo-relative layout both hooks resolve from pwd.
+  mkdir -p "$REPO/.claude/hooks/lib" "$REPO/.gaia/scripts"
+  ln -s "$HOME_ROOT/.claude/hooks/lib/red-ledger.sh" "$REPO/.claude/hooks/lib/red-ledger.sh"
+  ln -s "$HOME_ROOT/.claude/hooks/lib/repo-scope.sh" "$REPO/.claude/hooks/lib/repo-scope.sh"
+  ln -s "$HOME_ROOT/.gaia/scripts/red-ledger" "$REPO/.gaia/scripts/red-ledger"
+
+  # Seed a HEAD commit so HEAD exists; the test files added later are new at HEAD.
+  echo "# readme" > "$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit --quiet -m "init"
+}
+
+teardown() {
+  [ -n "${REPO:-}" ] && rm -rf "$REPO" || true
+  return 0
+}
+
+# Write file content (creating parent dirs) without staging.
+write_file() {
+  local path="$1" content="$2"
+  mkdir -p "$REPO/$(dirname "$path")"
+  printf '%s' "$content" > "$REPO/$path"
+}
+
+# Stage a path already written into the tmp repo.
+stage() { git -C "$REPO" add "$1"; }
+
+# Drive the CAPTURE hook for a `pnpm test --run <file>` PostToolUse, feeding
+# canned vitest json via the documented override seam. The hook recomputes the
+# signal from the file's CURRENT on-disk content, so the ledger line it writes
+# carries the genuine current signal. Args: <test-file-rel> <canned-json-abs>.
+run_capture() {
+  local file_rel="$1" json_abs="$2"
+  local payload
+  payload=$(jq -nc --arg c "pnpm test --run $file_rel" \
+    '{tool_name:"Bash", tool_input:{command:$c}, tool_response:{stdout:"", stderr:"", interrupted:false}}')
+  run bash -c "cd '$REPO' && export RED_CAPTURE_JSON_OVERRIDE='$json_abs'; printf '%s' '$payload' | bash '$CAPTURE_HOOK'"
+}
+
+# Drive the CHECK hook for a `git commit` PreToolUse, from inside the tmp repo.
+run_check() {
+  local cmd="${1:-git commit -m change}"
+  local payload
+  payload=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  run bash -c "cd '$REPO' && printf '%s' '$payload' | bash '$CHECK_HOOK'"
+}
+
+# Write a canned vitest json reporting ONE failing per-test result. Args:
+# <out-abs> <test-file-rel> <fullName>. The `name` field must equal the staged
+# file's repo-relative path so the capture hook keys the ledger to that file.
+canned_fail_json() {
+  local out="$1" file_rel="$2" full="$3"
+  jq -nc --arg name "$file_rel" --arg full "$full" '{
+    numTotalTestSuites: 1, numFailedTests: 1, numPassedTests: 0,
+    numTotalTests: 1, success: false,
+    testResults: [{
+      name: $name, status: "failed", message: "",
+      assertionResults: [
+        {title: $full, fullName: $full, status: "failed",
+         failureMessages: ["AssertionError: expected 1 to be 2"]}
+      ]
+    }]
+  }' > "$out"
+}
+
+ledger_lines() {
+  [ -f "$REPO/$LEDGER_REL" ] && wc -l < "$REPO/$LEDGER_REL" | tr -d ' ' || echo 0
+}
+
+denied() { [[ "$output" == *'"permissionDecision": "deny"'* ]]; }
+
+# A test whose body the capture hook can hash and the check hook recomputes.
+RED_TEST='import {expect, test} from "vitest";
+test("adds two numbers", () => {
+  expect(1 + 1).toBe(2);
+});
+'
+
+# ---------------------------------------------------------------------------
+# RED -> GREEN allowed: capture writes a RED for the test at its current body,
+# then the (unchanged-body) staged test commits without a deny. Proves the two
+# hooks compute the same signal for the same source.
+# ---------------------------------------------------------------------------
+@test "RED captured then GREEN: commit is allowed" {
+  write_file "app/x/index.test.ts" "$RED_TEST"
+
+  json="$REPO/canned.json"
+  canned_fail_json "$json" "app/x/index.test.ts" "adds two numbers"
+  run_capture "app/x/index.test.ts" "$json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 1 ]
+
+  # Stage the (unchanged) test — its current signal equals the captured one.
+  stage "app/x/index.test.ts"
+  run_check
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+# ---------------------------------------------------------------------------
+# Never-failed denied: a new passing test with no capture step has no RED.
+# ---------------------------------------------------------------------------
+@test "never captured: commit is denied" {
+  write_file "app/x/index.test.ts" "$RED_TEST"
+  stage "app/x/index.test.ts"
+  [ "$(ledger_lines)" -eq 0 ]
+  run_check
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"adds two numbers"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edited-after-RED denied: capture a RED, then change the staged test body so
+# its current signal no longer matches the recorded one -> deny. Proves the
+# content binding invalidates a stale RED.
+# ---------------------------------------------------------------------------
+@test "edited after RED: commit is denied on signal mismatch" {
+  write_file "app/x/index.test.ts" "$RED_TEST"
+
+  json="$REPO/canned.json"
+  canned_fail_json "$json" "app/x/index.test.ts" "adds two numbers"
+  run_capture "app/x/index.test.ts" "$json"
+  [ "$status" -eq 0 ]
+  [ "$(ledger_lines)" -eq 1 ]
+
+  # Edit the test body (same fullName, different assertion) AFTER its RED.
+  write_file "app/x/index.test.ts" 'import {expect, test} from "vitest";
+test("adds two numbers", () => {
+  expect(2 + 2).toBe(4);
+});
+'
+  stage "app/x/index.test.ts"
+  run_check
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"adds two numbers"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# UAT-005 regression guard: the untouched block-bare-test.sh still blocks a bare
+# `pnpm test` (no --run) with exit 2. This feature added no regression; the
+# assertion targets the existing hook directly and needs neither new hook.
+# ---------------------------------------------------------------------------
+@test "bare pnpm test is still blocked by block-bare-test.sh (exit 2)" {
+  payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"pnpm test"}}')
+  run bash -c "printf '%s' '$payload' | bash '$BARE_TEST_HOOK'"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"BLOCKED"* ]]
+}
+
+@test "pnpm test --run is NOT blocked by block-bare-test.sh" {
+  payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"pnpm test --run app/x/index.test.ts"}}')
+  run bash -c "printf '%s' '$payload' | bash '$BARE_TEST_HOOK'"
+  [ "$status" -eq 0 ]
+}

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -180,9 +180,9 @@ test("adds two numbers", () => {
 }
 
 # ---------------------------------------------------------------------------
-# UAT-005 regression guard: the untouched block-bare-test.sh still blocks a bare
-# `pnpm test` (no --run) with exit 2. This feature added no regression; the
-# assertion targets the existing hook directly and needs neither new hook.
+# Regression guard: the untouched block-bare-test.sh still blocks a bare
+# `pnpm test` (no --run) with exit 2. The RED-verification feature introduced no
+# regression; the assertion targets the existing hook directly and needs neither new hook.
 # ---------------------------------------------------------------------------
 @test "bare pnpm test is still blocked by block-bare-test.sh (exit 2)" {
   payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"pnpm test"}}')


### PR DESCRIPTION
## What

Makes TDD's RED step **verifiable instead of asserted**. GAIA already tells the agent to write a failing test first, but that "failing first" claim is self-certified. This adds a checked signal: a test must be observed failing before the change that makes it pass is allowed to commit.

Mirrors the merge-audit gate's split — observe-and-record vs deny-the-consequential-action — one floor down.

## Design (two hooks bound by one gitignored ledger)

1. **Capture** (PostToolUse, Bash) — `capture-red-observations.sh`. When the agent runs a one-shot vitest run, re-invokes vitest with `--reporter=json`, records each genuinely-failing test's identity to `.gaia/local/red-ledger/observations.jsonl`. Identity = `(file, fullName, content signal)`. Collection/compile errors are **not** valid REDs. Observe-only; never blocks.
2. **Enforce** (PreToolUse, Bash deny on `git commit`) — `red-verify-commit-check.sh`. For each **new-at-HEAD** test now passing, requires a prior RED whose content signal still matches the current test body. No match → deny, naming the test. A ledger lookup + signal recompute, never a test run.
3. **GREEN (unchanged)** — husky `test:lint-staged` still confirms affected tests pass at commit.

A shared Node helper (`extract-test-signals.mjs`) computes each test's content signal so a RED binds to a specific test body and is invalidated when that body is edited (closes the edit-to-pass hole). `block-bare-test.sh` and `.husky/pre-commit` are untouched (UAT-005).

## Phases

- **Phase 1 (this commit):** ledger schema + content-signal helper + shared shell lib + unit tests (17 bats).
- **Phase 2:** the two hooks + their bats suites.
- **Phase 3:** register both hooks in `.claude/settings.json` + end-to-end scenario.

SPEC: `.gaia/local/specs/SPEC-003/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
