### PR TITLE
fix(hooks): guard CI-defer source so missing lib doesn't kill wiki hooks

### DIFF
--- a/.claude/hooks/wiki-commit-nudge.sh
+++ b/.claude/hooks/wiki-commit-nudge.sh
@@ -25,7 +25,10 @@ grep -qE -- '--amend([[:space:]]|=|$)' <<<"$cmd" && exit 0
 
 # GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
 # down so they don't collide with the cron-managed wiki run.
-. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+if [ -f .claude/hooks/lib/gaia-ci-defer.sh ]; then
+  . .claude/hooks/lib/gaia-ci-defer.sh
+  gaia_ci_defer_if_managed wiki || true
+fi
 
 head_sha=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
 subject=$(git log -1 --format='%s' 2>/dev/null) || exit 0

--- a/.claude/hooks/wiki-drift-check.sh
+++ b/.claude/hooks/wiki-drift-check.sh
@@ -27,7 +27,10 @@ fi
 # GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
 # down so they don't collide with the cron-managed wiki run. The marker is
 # NOT advanced here so a future config change still gets the drift check.
-. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+if [ -f .claude/hooks/lib/gaia-ci-defer.sh ]; then
+  . .claude/hooks/lib/gaia-ci-defer.sh
+  gaia_ci_defer_if_managed wiki || true
+fi
 
 state_sha=$(jq -r '.last_evaluated_sha // empty' wiki/.state.json 2>/dev/null || echo "")
 [ -n "$state_sha" ] || exit 0

--- a/.claude/hooks/wiki-session-stop.sh
+++ b/.claude/hooks/wiki-session-stop.sh
@@ -24,7 +24,10 @@ session_marker="$GIT_DIR/claude-session-start"
 
 # GAIA CI deferral. When wiki.mode == "ci", local automatic triggers stand
 # down so they don't collide with the cron-managed wiki run.
-. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
+if [ -f .claude/hooks/lib/gaia-ci-defer.sh ]; then
+  . .claude/hooks/lib/gaia-ci-defer.sh
+  gaia_ci_defer_if_managed wiki || true
+fi
 
 start_sha=$(cat "$session_marker" 2>/dev/null) || exit 0
 [ -n "$start_sha" ] || exit 0


### PR DESCRIPTION
## Root cause

Commit c2a8751 (SPEC-001 smart-cron) added an identical CI-defer source line to all three wiki hooks:

```bash
. .claude/hooks/lib/gaia-ci-defer.sh 2>/dev/null && gaia_ci_defer_if_managed wiki || true
```

Under `set -euo pipefail`, **sourcing a missing file is fatal** — the shell exits with status 1 *before* the `|| true` or the `trap 'exit 0' ERR` can intercept it. The lib ships with GAIA, so production is unaffected, but any repo lacking it (notably the bats hook tmp-repos) makes each hook die at the source line: no output, no marker written.

This broke **14 tests** across three suites:
- `.gaia/tests/hooks/commit-nudge.bats` (4)
- `.gaia/tests/hooks/drift-check.bats` (5)
- `.gaia/tests/hooks/session-stop.bats` (5)

The `2>/dev/null ... || true` guard was *intended* to degrade gracefully when the optional lib is absent, but that idiom does not protect the missing-file case under `errexit`. This is a hook robustness regression; the suites were never re-run when c2a8751 landed, so it went unnoticed.

## Fix

Guard the source with a file-existence test in all three hooks:

```bash
if [ -f .claude/hooks/lib/gaia-ci-defer.sh ]; then
  . .claude/hooks/lib/gaia-ci-defer.sh
  gaia_ci_defer_if_managed wiki || true
fi
```

Behavior when the lib is present (every real GAIA repo) is unchanged. Surgical: 3 files, +12/-3.

## Verification

- The 3 previously-failing suites: **21/21 pass**.
- Full `bats .gaia/tests/hooks/`: **133 passing, 0 failing**.
- SPEC-003 suites (`red-ledger-lib`, `capture-red-observations`, `red-verify-commit-check`, `red-verify-e2e`): **52/52 pass**, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)