### PR TITLE
fix(tests): repair two pre-existing release-gate failures

### DIFF
--- a/.gaia/tests/forensics/fixtures/golden-init-redacted.md
+++ b/.gaia/tests/forensics/fixtures/golden-init-redacted.md
@@ -1,14 +1,11 @@
 ## Symptom
-
 The /gaia-init skill failed while running the rename step. I was trying to scaffold a new project called "my-app" and the process stopped partway through. The rename did not complete and the project directory still has the old GAIA branding in README.md and in the package.json name field. Running it again shows the same failure.
 
 ## Classification
-
 class: init
 evidence: "init" + .gaia/manifest.json
 
 ## Capture
-
 gaia_version: 1.2.0
 node: v20.11.0
 pnpm: 8.15.4
@@ -16,11 +13,9 @@ claude_code: 1.0.0
 branch: main
 dirty: false
 class_state_files:
-
-- .gaia/manifest.json: present, version 1.2.0
-- .gaia/local/setup-state.json: present, lastStep "rename"
-- package.json: present, name "gaia" (rename incomplete)
+  - .gaia/manifest.json: present, version 1.2.0
+  - .gaia/local/setup-state.json: present, lastStep "rename"
+  - package.json: present, name "gaia" (rename incomplete)
 
 ## Reproduction context
-
 The user ran /gaia-init on a fresh clone of the GAIA React template. They provided the project name "my-app". The rename step started but did not complete — the process appeared to hang and then exit without an error message. After the failure, the project still references "gaia" in package.json and README.md.

--- a/.gaia/tests/forensics/fixtures/golden-secrets-redacted.md
+++ b/.gaia/tests/forensics/fixtures/golden-secrets-redacted.md
@@ -1,14 +1,11 @@
 ## Symptom
-
 The hook at .claude/hooks/wiki-session-stop.sh failed with a permission error. The environment showed a GITHUB_TOKEN and also had an ANTHROPIC_API_KEY in the environment. The file other-tool.json was also present.
 
 ## Classification
-
 class: hook
 evidence: "hook" + .claude/hooks/wiki-session-stop.sh
 
 ## Capture
-
 gaia_version: 1.2.0
 node: v20.11.0
 pnpm: 8.15.4
@@ -16,12 +13,10 @@ claude_code: 1.0.0
 branch: main
 dirty: false
 class_state_files:
-
-- .claude/settings.json: present, hooks keys: PreToolUse, PostToolUse, Stop
-- wiki-session-stop.sh: filename only
-  GITHUB_TOKEN=<redacted>
-  ANTHROPIC_API_KEY=<redacted>
+  - .claude/settings.json: present, hooks keys: PreToolUse, PostToolUse, Stop
+  - wiki-session-stop.sh: filename only
+GITHUB_TOKEN=<redacted>
+ANTHROPIC_API_KEY=<redacted>
 
 ## Reproduction context
-
 The user was running a wiki-sync when the PostToolUse hook misfired. The hook script at .claude/hooks/wiki-session-stop.sh exited with code 1. Environment variables GITHUB_TOKEN and ANTHROPIC_API_KEY were present in the shell environment at time of failure.

--- a/.gaia/tests/forensics/fixtures/golden-update-redacted.md
+++ b/.gaia/tests/forensics/fixtures/golden-update-redacted.md
@@ -1,14 +1,11 @@
 ## Symptom
-
 update conflict in .claude/hooks/wiki-session-stop.sh — the three-way merge failed after running /update-gaia. The conflicting file has both GAIA upstream changes and local customizations that overlap.
 
 ## Classification
-
 class: update
 evidence: "update conflict" + .claude/hooks/wiki-session-stop.sh
 
 ## Capture
-
 gaia_version: 1.2.0
 node: v20.11.0
 pnpm: 8.15.4
@@ -16,10 +13,8 @@ claude_code: 1.0.0
 branch: main
 dirty: true
 class_state_files:
-
-- .gaia/manifest.json: present, version 1.2.0
-- .claude/hooks/wiki-session-stop.sh: conflict marker present
+  - .gaia/manifest.json: present, version 1.2.0
+  - .claude/hooks/wiki-session-stop.sh: conflict marker present
 
 ## Reproduction context
-
 The user ran /update-gaia to pull in the latest GAIA template changes. A merge conflict appeared in .claude/hooks/wiki-session-stop.sh because the upstream changed the hook structure while the user had added a custom notification block. The three-way merge could not resolve the overlap automatically.

--- a/.gaia/tests/smoke/wiki-promote/run.sh
+++ b/.gaia/tests/smoke/wiki-promote/run.sh
@@ -114,8 +114,12 @@ else
 fi
 
 # 4. revised-contracts contains the wiki_promote_targets sub-section.
+# .gaia/local/ is machine-local (gitignored), so this SPEC artifact is absent
+# in fresh clones and CI. Skip-with-PASS when absent, matching the
+# framework-neutral graceful-skip used for the specify CLI below; the content
+# check runs only where the local artifact exists.
 if [ ! -f "$REVISED_CONTRACTS" ]; then
-    fail "revised-contracts missing at $REVISED_CONTRACTS"
+    pass "revised-contracts check skipped; $REVISED_CONTRACTS absent (machine-local .gaia/local/)"
 else
     pass "revised-contracts present"
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,8 @@ package-lock.json
 /public/build
 .env.example
 .env
+
+# Forensics test fixtures are byte-sensitive: golden files are redaction-only
+# output compared byte-for-byte, and the parser fixtures are deliberately
+# malformed. Prettier reformatting any of them breaks the bats suite.
+.gaia/tests/forensics/fixtures/


### PR DESCRIPTION
Fixes two deterministic failures in the release-gate test harness that fail on clean `main`, plus a durability hardening so they cannot silently recur.

## Issue A: forensics golden byte-mismatch (`01-redaction-roundtrip.bats` tests 14, 15)

The goldens `golden-{secrets,init,update}-redacted.md` carried **markdown-formatter** output (blank line after every `##` heading, list bullets de-indented from `  - ` to `- `, env `KEY=val` lines re-indented as list children). But `redact_body` (and the canonical spec `forensics/redaction.md`) do **redaction only** (path/token/env), no reformatting, so byte-equality could never hold.

**Triage:** `gaia-forensics.md` step 5 (Redact) runs the redaction algorithm only; step 6 (Render) emits the strict-schema body. There is **no markdown formatter** anywhere in the pipeline. A generator diff confirmed the only deltas between each golden and `redact_body(input)` are formatter artifacts, zero redaction/content differences.

**Fix:** regenerate the three input-paired goldens from `redact_body "$FAKE_ROOT" "$(cat <input>)"` output, redaction-only, preserving input formatting and the input em dashes byte-for-byte. `golden-other-class.md` has no `.txt` input pairing and no byte test, left untouched.

## Issue B: wiki-promote missing local fixture (`smoke/wiki-promote/run.sh`)

Block 4 hard-`fail`ed when `.gaia/local/specs/SPEC-001-revised-contracts.md` was absent, but `.gaia/local/` is gitignored/machine-local, so it is absent in fresh clones and CI.

**Fix:** skip-with-PASS when the local artifact is missing, matching the framework-neutral graceful-skip already used for the `specify` CLI in block 5 of the same file. The content-grep still runs where the artifact exists (verified by temp-provisioning it).

## Durability: `.prettierignore` for the fixtures dir

`pnpm format` runs `prettier --write "**/*.{...,md,...}"` and `.prettierignore` did not exclude `.gaia/`, which is exactly how the goldens went stale. Ignore `.gaia/tests/forensics/fixtures/` so a future `pnpm format` leaves the goldens (and the deliberately-malformed parser fixtures) byte-stable. Verified: with `--ignore-path /dev/null` prettier re-introduces the exact mangling; with the rule active the goldens are ignored.

## Verification

- `01-redaction-roundtrip.bats`: 15/15 pass (was 13/15).
- Shared-golden suites `03-strict-schema` (9/9) and `09-other-class-offers-gh` (9/9): no regression.
- `wiki-promote/run.sh`: 9/9 PASS, in full `run-all` too; present-path branch re-verified.
- Quality Gate: no gate-relevant files staged (the closed config set does not include `.prettierignore`), correctly skipped.

## Merge note

Adding root `.prettierignore` puts the diff outside the audit out-of-scope allowlist, so the out-of-scope bypass no longer auto-clears the merge; a `code-review-audit` marker (CI or local agent) will be needed before `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)