### PR TITLE
fix(release): stop runtime-deps flagging prose path tokens as leaks

### DIFF
--- a/.claude/hooks/pr-merge-audit-check.sh
+++ b/.claude/hooks/pr-merge-audit-check.sh
@@ -263,7 +263,7 @@ None of the accepted signals is present:
   - GitHub CI status: absent or version/tree mismatch
   - chore(deps) PR:  PR title does not match \`chore(deps):\` or \`chore(deps-dev):\`
   - Out-of-scope:    PR changes at least one in-scope path (app/, test/, configs,
-                     CI workflows), not a wiki/docs/.gaia-only diff
+                     .github/workflows/), not a wiki/docs/.gaia-only diff
 
 To unblock:
   1. Spawn the code-review-audit agent locally, OR push to the PR branch

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20737,6 +20737,7 @@ var RUNTIME_MARKERS = /* @__PURE__ */ new Set([
   ".claude/wiki-safety-checked"
 ]);
 var PATH_PREFIXES = [".gaia/", ".claude/", ".specify/", ".github/"];
+var PROSE_PATH_ALLOWLIST = /* @__PURE__ */ new Set([".github/workflows"]);
 var PATH_BODY_CHAR = /[a-zA-Z0-9._/-]/;
 var stripCommentSuffix = (line) => {
   if (/^\s*#/.test(line)) return "";
@@ -20781,7 +20782,7 @@ var extractPathRefs = (filePath, source) => {
         const candidate = expandPath(stripped, found);
         if (candidate.length > prefix.length) {
           const trimmed = candidate.replace(/[./]+$/, "");
-          if (trimmed.length > prefix.length) {
+          if (trimmed.length > prefix.length && !PROSE_PATH_ALLOWLIST.has(trimmed)) {
             refs.push({ filePath, line: index + 1, path: trimmed });
           }
         }

--- a/.gaia/cli/src/release/runtime-deps.test.ts
+++ b/.gaia/cli/src/release/runtime-deps.test.ts
@@ -135,6 +135,29 @@ describe('extractPathRefs', () => {
       '.claude/hooks/x.sh',
     ]);
   });
+
+  test('skips prose-allowlisted directory tokens in user-facing strings', () => {
+    // pr-merge-audit-check.sh names `.github/workflows/` as an example
+    // in-scope path inside a multi-line `reason="..."` error string. It is
+    // descriptive prose shown to the operator, not a runtime invocation, so
+    // the scan must not treat it as a runtime-dependency leak.
+    const refs = extractPathRefs(
+      '.claude/hooks/pr-merge-audit-check.sh',
+      '                     .github/workflows/), not a wiki/docs/.gaia-only diff\n'
+    );
+    expect(refs.map((r) => r.path)).not.toContain('.github/workflows');
+  });
+
+  test('still flags a genuine file leak under an allowlisted directory', () => {
+    // The allowlist is exact-token. A real invocation of a file under
+    // .github/workflows/ is a distinct, longer token and must still flag,
+    // guarding against the allowlist over-suppressing genuine leaks.
+    const refs = extractPathRefs(
+      '.gaia/statusline/foo.sh',
+      'bash .github/workflows/deploy.yml\n'
+    );
+    expect(refs.map((r) => r.path)).toContain('.github/workflows/deploy.yml');
+  });
 });
 
 describe('release runtime-deps CLI', () => {

--- a/.gaia/cli/src/release/runtime-deps.ts
+++ b/.gaia/cli/src/release/runtime-deps.ts
@@ -101,6 +101,28 @@ const RUNTIME_MARKERS: ReadonlySet<string> = new Set([
 
 const PATH_PREFIXES = ['.gaia/', '.claude/', '.specify/', '.github/'] as const;
 
+/**
+ * Bare-directory tokens that surface only as prose inside shipped scripts,
+ * user-facing error text and help strings that name an in-scope directory as
+ * an example path. They are descriptive, never sourced or invoked, so they
+ * are not runtime dependencies and must not be reported as leaks.
+ *
+ * Entries are exact, fully-qualified tokens (the trimmed output of
+ * `extractPathRefs`). Exact-match is deliberate: allowlisting
+ * `.github/workflows` does NOT suppress a genuine leak to a file under it,
+ * `.github/workflows/foo.yml` is a distinct, longer token that still flags.
+ * This is the documented channel for prose false-positives, add the exact
+ * token plus a justification rather than reword the operator-facing prose.
+ *
+ *   - `.github/workflows`: named in `.claude/hooks/pr-merge-audit-check.sh`'s
+ *     merge-gate error message as an example in-scope path, alongside `app/`,
+ *     `test/`, `configs`. The directory is release-excluded; the reference is
+ *     descriptive, not an invocation. An inline-ignore comment cannot annotate
+ *     the occurrence because it lives inside a multi-line quoted `reason="..."`
+ *     string that renders to the operator, hence this central allowlist.
+ */
+const PROSE_PATH_ALLOWLIST: ReadonlySet<string> = new Set(['.github/workflows']);
+
 const PATH_BODY_CHAR = /[a-zA-Z0-9._/-]/;
 
 /**
@@ -204,7 +226,10 @@ export const extractPathRefs = (
           // intended path token.
           const trimmed = candidate.replace(/[./]+$/, '');
 
-          if (trimmed.length > prefix.length) {
+          if (
+            trimmed.length > prefix.length &&
+            !PROSE_PATH_ALLOWLIST.has(trimmed)
+          ) {
             refs.push({filePath, line: index + 1, path: trimmed});
           }
         }


### PR DESCRIPTION
## Problem

`./.gaia/cli/gaia-maintainer release runtime-deps` flagged `.github/workflows` in `.claude/hooks/pr-merge-audit-check.sh` as a runtime-dependency leak. The token is descriptive prose inside a multi-line quoted `reason="..."` merge-gate error string (listing example in-scope paths alongside `app/`, `test/`, `configs`), **not** a sourced or invoked path. The check is wired into `.github/workflows/release.yml`, so this false-positive could block a real release.

Surfaced by a `/health-audit` on main, deferred from #293. #301 had genericized the prose to "CI workflows" as a stopgap; this fixes the root cause and restores the precise wording.

## Root cause

In `.gaia/cli/src/release/runtime-deps.ts`, `extractPathRefs` extracts the token `.github/workflows` from the prose (it isn't a leading-`#` comment, so it isn't stripped), and `isShippedPath` returns false (not in the manifest, not a sentinel/marker/runtime-prefix) → reported as a leak.

## Fix (design decision: documented allowlist)

Add a documented `PROSE_PATH_ALLOWLIST` constant and skip allowlisted tokens in `extractPathRefs`. Entries are **exact, fully-qualified tokens**, so allowlisting `.github/workflows` does not suppress a genuine leak to a file under it — `.github/workflows/foo.yml` is a distinct, longer token that still flags. This is the documented channel for future prose false-positives.

**Rejected alternatives:**
- *Inline-ignore marker* — cannot annotate the line; it lives inside a multi-line quoted string that renders to the operator, so a comment would corrupt the error text.
- *Skip quoted strings* — real invocations routinely quote paths (`marker=".claude/i18n-strings-checked"`, `STATE_FILE="$PROJECT_ROOT/.gaia/local/..."`); would blind the scan to genuine quoted leaks.
- *Skip bare directories* — cannot distinguish a directory from an extensionless binary like `.gaia/cli/gaia` / `gaia-maintainer`, which are genuine runtime deps; would over-suppress.

The primitive reads only `.gaia/manifest.json`; this change does **not** touch `.gaia/release-scrub.yml` (a different mechanism) and does **not** remove `.github/` from `PATH_PREFIXES` (real `.github/` leaks still caught).

Also restores `.github/workflows/` in the hook prose (reverting the #301 stopgap) and rebundles `gaia-maintainer`.

## Tests (TDD)

Two `extractPathRefs` cases in `runtime-deps.test.ts`:
- (a) the prose line no longer yields `.github/workflows` (was failing → now passes)
- (b) a genuine `.github/workflows/deploy.yml` leak **still** flags (over-suppression guard)

## Verification

- `pnpm -C .gaia/cli typecheck` — clean
- `pnpm -C .gaia/cli test --run` — 1263 passed, 1 skipped (pre-existing)
- Rebundled (`pnpm -C .gaia/cli bundle`)
- E2E: `./.gaia/cli/gaia-maintainer release runtime-deps` → `leaks: none`, exit 0, with line 266 restored to `.github/workflows/`
- Binary-level over-suppression guard: a planted `.github/workflows/leak.yml` invocation still flags (exit 1)

## Scope

Maintainer-only change. **Zero adopter behavior change** beyond removing the release-gating false-positive — `release runtime-deps` is absent from the adopter `gaia` bundle, so only `gaia-maintainer` is rebundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)