### PR TITLE
wiki: sync through d739bf2

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "4110bfe609ed69f40fa2ee482465fb49f9d59728",
-  "last_evaluated_at": "2026-06-03T19:37:04Z",
+  "last_evaluated_sha": "d739bf252533e8091b9723b29f571a5492586e7f",
+  "last_evaluated_at": "2026-06-04T18:01:03Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,19 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-04 d739bf2 SKIP - maintainer-only prose allowlist
+- 2026-06-04 aae3722 SKIP - test harness fix, de-gate wiki-sync to advisory
+- 2026-06-04 b5277d4 SKIP - test fixture fixes
+- 2026-06-04 51848b9 SKIP - manifest regeneration, path leak fixes
+- 2026-06-04 6efa1f3 WORTHY - em-dash sweep, house style alignment
+- 2026-06-04 ddf057b WORTHY - dependency-CVE deterministic oracle → wiki/decisions/Quality Gate.md
+- 2026-06-04 8de1c81 SKIP - hook lib source guard, no wiki impact
+- 2026-06-04 cb4ddc4 WORTHY - mechanical TDD RED-verification (SPEC-003) → wiki/decisions/TDD RED-verification.md
+- 2026-06-04 c533575 WORTHY - anchored git guards to command position → wiki/concepts/Git Workflow.md
+- 2026-06-04 9caa1ed SKIP - spec metadata only
+- 2026-06-04 148fab7 WORTHY - hardened commit/review gates with proof gate and adversarial verification → wiki/decisions/Quality Gate.md
+- 2026-06-04 618ed55 WORTHY - added non-blocking residuals to health-audit gate → wiki/concepts/Health Audit.md
+- 2026-06-04 5366919 SKIP - wiki: self-referential
 - 2026-06-03 4110bfe WORTHY: aliased bare gaia calls to repo-relative .gaia/cli/gaia across skill instructions
 - 2026-06-03 129a364 WORTHY: bumped claude-obsidian baseline v1.6.0→v1.9.2, reframed plugin skills as auxiliary
 - 2026-06-03 8015592 WORTHY: decoupled wiki-lint from upstream, added GAIA-native checks #11-#16


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to d739bf2.