### PR TITLE
wiki: sync through e68dbfd

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d739bf252533e8091b9723b29f571a5492586e7f",
-  "last_evaluated_at": "2026-06-04T18:01:03Z",
+  "last_evaluated_sha": "e68dbfd9e137a45dc7c57b3e99c61d0b62517f72",
+  "last_evaluated_at": "2026-06-04T18:14:49Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/concepts/Claude Hooks.md
+++ b/wiki/concepts/Claude Hooks.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-05-03
+updated: 2026-06-05
 tags: [concept, claude, hooks]
 ---
 
@@ -41,8 +41,11 @@ Hooks are grouped by the safeguard they enforce, not by event type.
 Each script reads `tool_input.command` from stdin and filters by content; there is no `if:` annotation on the hook entry.
 
 - **`block-bare-test.sh`**: denies bare `pnpm test` / `npm test` (and `run test` variants); they start vitest watch mode. Requires `--run` for a one-shot pass. See [[Test Runner]].
-- **`block-main-destructive-git.sh`**: denies (1) `git commit` while HEAD is `main`/`master`, (2) force-push to `main`/`master`, and (3) plain `git push` originating from `main`/`master` (PR-only flow, closes the "forgot to switch branches" footgun). Handles `git -C <path>` invocations correctly. Authoritative rule: [[Git Workflow]].
+- **`block-no-verify.sh`**: denies `git commit` or `git push` carrying a hook-bypass token: `--no-verify`, a falsy `HUSKY=` env prefix, or a `core.hooksPath` redirect. Also denies `git commit -n` (short form of `--no-verify`); `git push -n` (dry-run) stays allowed. Foreign-repo commands pass via the shared repo-scope helper. The hook walks command-position segments so a `-n` on another program (`grep`, `head`, `sort`, `tail`) is inert. Keeps an unambiguous whole-command fail-closed net for the tokens that cannot appear anywhere else (`--no-verify`, `HUSKY=`, `core.hooksPath=`).
+- **`block-main-destructive-git.sh`**: denies (1) `git commit` while HEAD is `main`/`master`, (2) force-push to `main`/`master`, and (3) plain `git push` originating from `main`/`master` (PR-only flow, closes the "forgot to switch branches" footgun). Walks command-position segments so `git commit` text in an argument or a different program's flag does not trigger a false deny. Authoritative rule: [[Git Workflow]].
 - **`block-rm-rf.sh`**: denies catastrophic `rm -rf` patterns: `--no-preserve-root`, absolute paths, `~` / `$HOME`, `.`, unscoped `*`, `.git`, `node_modules`. Allows scoped scratch paths (`.gaia/local/plans/*`, `.gaia/local/audit/*`, `.gaia/local/handoff/*`, `.gaia/cache/*`, `dist/*`, `build/*`).
+- **`capture-red-observations.sh`** (PostToolUse, Bash): on a one-shot vitest run, re-invokes vitest with `--reporter=json` scoped to the agent's target, records each genuinely-failing per-test result to the RED-observation ledger (`.gaia/local/red-ledger/`). Records file, full test name, content signal, and failure kind. Collection/compile errors are excluded. Observe-only; always exits 0. See [[TDD RED Verification]].
+- **`red-verify-commit-check.sh`** (PreToolUse, Bash deny): before each `git commit`, checks every new-at-HEAD test file against the RED-observation ledger. Requires a ledger RED whose content signal still matches the current test body; no matching entry denies the commit, naming the offending test. Fail-open on missing tooling or unparseable test files. See [[TDD RED Verification]].
 
 ### Advisory (Bash)
 
@@ -67,4 +70,4 @@ The wiki sync system is convergent: the user's already-paid-for Claude session d
 
 Ask Claude to add a hook; Claude will drop the script into `.claude/hooks/` and register it in `.claude/settings.json` via the `update-config` skill. Naming convention: `block-{noun}.sh` for blockers, `check-{noun}.sh` for advisory, `pre-{event}-{noun}.sh` for pre-event reminders. Blocker scripts begin with `#!/usr/bin/env bash` + `set -euo pipefail`, read stdin via `jq`, and either `exit 0`/`exit 2` or emit the structured `hookSpecificOutput.permissionDecision` JSON.
 
-See [[Quality Gate]], [[Pre-commit Hooks]], [[Git Workflow]], [[Claude Integration Conventions]].
+See [[Quality Gate]], [[Pre-commit Hooks]], [[Git Workflow]], [[Claude Integration Conventions]], [[TDD RED Verification]].

--- a/wiki/concepts/Code Review Audit Agent.md
+++ b/wiki/concepts/Code Review Audit Agent.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-20
-updated: 2026-06-02
+updated: 2026-06-05
 tags: [concept, claude, agent, review]
 ---
 
@@ -17,6 +17,14 @@ Reviews security, performance, code smells, architecture, robustness, and mainta
 Knip runs pre-merge here (post-task by design) and its findings are bucketed advisory: real dead code, intentional library export (update `entry` globs), or implicit dependency (update `ignoreDependencies`). See [[knip]].
 
 A deterministic `pnpm audit --json` run is the oracle for known-vulnerable dependencies; the Security dimension does not LLM-judge current CVEs. Its high/critical advisories surface in an advisory bucket (read-only; never blocking the marker), scoped by a severity threshold and a machine-local baseline allowlist at `.gaia/local/dep-audit-baseline.json`. It is distinct from the blocking GAIA CI `pnpm audit` cron, which opens review-required security PRs. See [[pnpm-audit]].
+
+## Finding proof gate and adversarial verification
+
+Every holistic-reviewer finding must clear a four-check proof gate before it is reported: the finding must cite an exact `file:line`, name a concrete failure mode (input + state + bad outcome), confirm that callers and tests were read, and assign a defensible severity. Any check that fails drops or demotes the finding.
+
+Critical and Important holistic findings that survive the proof gate go to a selective adversarial pass: a fresh-context refuter subagent that did not produce the finding reads the cited evidence and attempts to rebut. A refuter overturns a finding only with concrete counter-evidence (a guard at `file:line`, a covering test, or an unreachable path). Without that, the verdict defaults to STANDS. Outcome options: drop on "cannot occur," demote on "smaller blast radius," keep otherwise. The resulting disposition flows into the marker-decision interlock so a dropped Critical does not block the merge gate.
+
+Deterministic oracles (`react-doctor`, `knip`) are exempt from the proof gate and adversarial pass; they are not probabilistic judgments.
 
 ## Incremental scope
 

--- a/wiki/decisions/TDD RED Verification.md
+++ b/wiki/decisions/TDD RED Verification.md
@@ -1,0 +1,44 @@
+---
+type: decision
+status: active
+priority: 1
+date: 2026-06-04
+created: 2026-06-04
+updated: 2026-06-05
+tags: [decision, tdd, hooks, quality]
+---
+
+# TDD RED Verification
+
+Mechanical enforcement that TDD's RED phase actually ran before a commit introduces a new test. Two PreToolUse/PostToolUse hooks and a content-signal ledger close the gap between "a test exists" and "the test was observed failing."
+
+## Problem
+
+Writing a test that starts green (either mirroring existing behavior or trivially passing) satisfies neither the TDD discipline nor the intent of the [[Quality Gate]]. No tooling previously caught a test that was never red.
+
+## Decision
+
+A RED-observation ledger at `.gaia/local/red-ledger/` (machine-local, gitignored) stores per-test evidence from the last one-shot vitest run. Two hooks enforce the lifecycle:
+
+- **`capture-red-observations.sh`** (PostToolUse, Bash): after any one-shot vitest run, re-invokes vitest with `--reporter=json` scoped to the same target and records each genuinely-failing test. Each record stores `file`, `fullName`, a normalized content signal (deterministic hash of the test body), and `failureKind`. Collection and compile errors are excluded to avoid coarse false-REDs. Observe-only; always exits 0.
+
+- **`red-verify-commit-check.sh`** (PreToolUse, Bash deny): before `git commit`, walks every test file that is new at HEAD. For each new test, the hook computes the current content signal and looks it up in the ledger. A missing entry or a signal mismatch (test body changed since the RED was observed) denies the commit, naming the offending test. Fail-open on missing tooling or unparseable test files; fail-closed only for the clean case.
+
+The content signal is a normalized hash of the test body so that a cosmetic rename does not reuse a stale RED entry from a substantively different test.
+
+## Scope
+
+- Pre-commit check on `git commit` only. Does not gate `git push` or CI.
+- New tests only: tests that already exist at the merge base are not checked.
+- Fail-open: the hook does not block when the ledger tooling (Node, the signal extractor) is unavailable or when a test file cannot be parsed by the TS compiler API.
+
+## Infrastructure
+
+- `.gaia/scripts/red-ledger/extract-test-signals.mjs`: Node ESM helper using the TypeScript compiler API to emit `{fullName, signal}` NDJSON for each test in a file.
+- `.claude/hooks/lib/red-ledger.sh`: shared shell library sourced by both hooks. Owns ledger path resolution, repo-relative normalization, and signal invocation.
+
+## Consequences
+
+A new test always requires a one-shot vitest run that observes the test failing before the commit is allowed. This is a one-time step per new test; a green-only test that was never run red will be denied at commit time with a clear message naming the test.
+
+See [[Claude Hooks]] for hook registration. See the [[Quality Gate]] for the broader pre-commit enforcement surface.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -108,6 +108,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[spec-kit Extension Strategy]]
 - [[Wiki Management]]: wiki primitives, state file, deterministic classification
 - [[Claude Integration Fitness]]: check taxonomy + F-to-A+ grading + triage/heal protocol run by `/gaia-fitness`.
+- [[TDD RED Verification]]: mechanical enforcement that a new test was observed failing before commit; RED-observation ledger + two hooks.
 <!-- gaia:maintainer-only:start -->
 - [[Bundle-time Scrub]]: marker-strip + leak-check + runtime-deps; closes the audit-round loop with build-time enforcement.
 <!-- gaia:maintainer-only:end -->

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,19 +11,20 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
-- 2026-06-04 d739bf2 SKIP - maintainer-only prose allowlist
-- 2026-06-04 aae3722 SKIP - test harness fix, de-gate wiki-sync to advisory
-- 2026-06-04 b5277d4 SKIP - test fixture fixes
-- 2026-06-04 51848b9 SKIP - manifest regeneration, path leak fixes
-- 2026-06-04 6efa1f3 WORTHY - em-dash sweep, house style alignment
-- 2026-06-04 ddf057b WORTHY - dependency-CVE deterministic oracle → wiki/decisions/Quality Gate.md
-- 2026-06-04 8de1c81 SKIP - hook lib source guard, no wiki impact
-- 2026-06-04 cb4ddc4 WORTHY - mechanical TDD RED-verification (SPEC-003) → wiki/decisions/TDD RED-verification.md
-- 2026-06-04 c533575 WORTHY - anchored git guards to command position → wiki/concepts/Git Workflow.md
-- 2026-06-04 9caa1ed SKIP - spec metadata only
-- 2026-06-04 148fab7 WORTHY - hardened commit/review gates with proof gate and adversarial verification → wiki/decisions/Quality Gate.md
-- 2026-06-04 618ed55 WORTHY - added non-blocking residuals to health-audit gate → wiki/concepts/Health Audit.md
-- 2026-06-04 5366919 SKIP - wiki: self-referential
+- 2026-06-04 e68dbfd SKIP - wiki: self-referential (sync commit)
+- 2026-06-04 d739bf2 SKIP - prose path allowlist in runtime-deps; maintainer-only CLI, no adopter architecture change
+- 2026-06-04 aae3722 SKIP - wiki-sync smoke harness repair; test infrastructure only
+- 2026-06-04 b5277d4 SKIP - test fixture / golden file repair; no architecture change
+- 2026-06-04 51848b9 SKIP - distribution boundary leak fix; no architecture change
+- 2026-06-04 6efa1f3 SKIP - em-dash sweep: house style, no architectural change
+- 2026-06-04 ddf057b SKIP - wiki already updated in commit itself (pnpm-audit.md created, Code Review Audit Agent.md updated)
+- 2026-06-04 8de1c81 SKIP - defensive CI-defer source guard; implementation fix, no architecture change
+- 2026-06-04 cb4ddc4 WORTHY - mechanical TDD RED-verification: new hooks + ledger → wiki/decisions/TDD RED Verification.md, wiki/concepts/Claude Hooks.md
+- 2026-06-04 c533575 SKIP - command-position fix for existing hooks; no new architecture
+- 2026-06-04 9caa1ed SKIP - spec allocator metadata only; no code or behavior change
+- 2026-06-04 148fab7 WORTHY - new block-no-verify hook + adversarial proof gate → wiki/concepts/Claude Hooks.md, wiki/concepts/Code Review Audit Agent.md
+- 2026-06-04 618ed55 SKIP - bug fix implementing existing documented behavior; wiki already covers health-audit non-blocking residuals intent
+- 2026-06-04 5366919 SKIP - wiki: self-referential (sync commit)
 - 2026-06-03 4110bfe WORTHY: aliased bare gaia calls to repo-relative .gaia/cli/gaia across skill instructions
 - 2026-06-03 129a364 WORTHY: bumped claude-obsidian baseline v1.6.0→v1.9.2, reframed plugin skills as auxiliary
 - 2026-06-03 8015592 WORTHY: decoupled wiki-lint from upstream, added GAIA-native checks #11-#16

--- a/wiki/meta/lint-report-2026-06-05.md
+++ b/wiki/meta/lint-report-2026-06-05.md
@@ -1,0 +1,34 @@
+---
+type: meta
+title: 'Lint Report 2026-06-05'
+created: 2026-06-05
+updated: 2026-06-05
+tags: [meta, lint]
+status: developing
+---
+
+# Lint Report: 2026-06-05
+
+## #11: Wiki drift check
+
+ℹ 1 commits behind HEAD. Run /gaia-wiki sync at next opportunity.
+
+## #12: Dead repo-relative paths
+
+✓ No dead repo-relative paths detected in wiki body prose.
+
+## #13: UAT/SPEC narrative-ref drift
+
+✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.
+
+## #14: Orphan pages
+
+✓ No orphan pages (every page has at least one inbound wikilink).
+
+## #15: Frontmatter gaps
+
+✓ All wiki pages carry the required frontmatter (type, status).
+
+## #16: Empty sections
+
+✓ No empty sections detected.


### PR DESCRIPTION
## Corrective wiki sync (fixes the broken #305)

PR #305 (\`wiki: sync through d739bf2\`) advanced \`wiki/.state.json\` and appended \`wiki/log.md\` entries claiming several WORTHY page edits and a new ADR, **but never wrote any of that content to disk.** Every page it named was unchanged; two target files (the ADR, a \"Health Audit.md\" page) did not exist. The sync ran on Haiku and fabricated its summary.

This PR reverts #305's bookkeeping back to \`last_evaluated_sha=4110bfe\`, re-runs the sync **on Sonnet**, and lands the real content:

- **New ADR** \`wiki/decisions/TDD RED Verification.md\` — the RED-observation ledger + two hooks (cb4ddc4 / #297).
- **\`wiki/concepts/Claude Hooks.md\`** — documents \`block-no-verify.sh\`, \`capture-red-observations.sh\`, \`red-verify-commit-check.sh\`, and the command-position anchoring of \`block-main-destructive-git.sh\` (#296).
- **\`wiki/concepts/Code Review Audit Agent.md\`** — finding proof gate + adversarial verification pass (#294).
- **\`wiki/index.md\`** — catalog entry for the new ADR.
- **\`wiki/log.md\`** — accurate WORTHY/SKIP classifications (e.g. ddf057b correctly SKIP: that PR self-updated the wiki).

Verified on disk: every claimed edit is present and substantive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)