### PR TITLE
fix(cli): strip git-quoted paths in inspectWorkingTree

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -28402,7 +28402,8 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
   for (const rawLine of out.split("\n")) {
     const line = rawLine.replace(/\r$/u, "");
     if (line.length === 0) continue;
-    const payload = line.slice(3);
+    const rawPayload = line.slice(3);
+    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
     const renameSplit = payload.indexOf(" -> ");
     if (renameSplit === -1) {
       paths.push(payload);

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -30918,7 +30918,8 @@ var inspectWorkingTree = (cwd, runner = defaultRunner5) => {
   for (const rawLine of out.split("\n")) {
     const line = rawLine.replace(/\r$/u, "");
     if (line.length === 0) continue;
-    const payload = line.slice(3);
+    const rawPayload = line.slice(3);
+    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
     const renameSplit = payload.indexOf(" -> ");
     if (renameSplit === -1) {
       paths.push(payload);

--- a/.gaia/cli/src/wiki/util/branch.test.ts
+++ b/.gaia/cli/src/wiki/util/branch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for `inspectWorkingTree`.
+ *
+ * Focus: git's porcelain v1 output wraps paths containing spaces (and other
+ * unusual characters) in double quotes. Nearly every GAIA wiki page has a
+ * space in its filename, so the helper must strip that quoting before the
+ * `wiki/` prefix check, otherwise a real wiki edit is misread as a non-wiki
+ * change and `sync land` refuses to land it.
+ */
+import type {SpawnSyncReturns} from 'node:child_process';
+import {describe, expect, test} from 'vitest';
+import {inspectWorkingTree, type CommandRunner} from './branch.js';
+
+const okResult = (stdout: string): SpawnSyncReturns<string> => ({
+  output: ['', stdout, ''] as never,
+  pid: 0,
+  signal: null,
+  status: 0,
+  stderr: '',
+  stdout,
+});
+
+const runnerReturning = (stdout: string): CommandRunner => () =>
+  okResult(stdout);
+
+describe('inspectWorkingTree', () => {
+  test('strips git quoting from a spaced wiki path and classifies it as a wiki change', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning(' M "wiki/concepts/Wiki Sync.md"\n')
+    );
+
+    expect(status.paths).toEqual(['wiki/concepts/Wiki Sync.md']);
+    expect(status.hasWikiChanges).toBe(true);
+    expect(status.hasNonWikiChanges).toBe(false);
+  });
+
+  test('handles an added (untracked) spaced wiki page', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning('?? "wiki/decisions/TDD RED Verification.md"\n')
+    );
+
+    expect(status.paths).toEqual(['wiki/decisions/TDD RED Verification.md']);
+    expect(status.hasWikiChanges).toBe(true);
+  });
+
+  test('leaves an unquoted path untouched', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning(' M wiki/log.md\n')
+    );
+
+    expect(status.paths).toEqual(['wiki/log.md']);
+    expect(status.hasWikiChanges).toBe(true);
+    expect(status.hasNonWikiChanges).toBe(false);
+  });
+
+  test('strips quoting on a spaced non-wiki path and flags it as non-wiki', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning(' M "app/some dir/a file.ts"\n')
+    );
+
+    expect(status.paths).toEqual(['app/some dir/a file.ts']);
+    expect(status.hasNonWikiChanges).toBe(true);
+    expect(status.hasWikiChanges).toBe(false);
+  });
+
+  test('still splits an unquoted rename into both halves', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning('R  app/old.ts -> app/new.ts\n')
+    );
+
+    expect(status.paths).toEqual(['app/old.ts', 'app/new.ts']);
+    expect(status.hasNonWikiChanges).toBe(true);
+  });
+
+  test('classifies a mix of a quoted wiki edit and a plain non-wiki edit', () => {
+    const status = inspectWorkingTree(
+      '/repo',
+      runnerReturning(' M "wiki/concepts/Wiki Sync.md"\n M package.json\n')
+    );
+
+    expect(status.paths).toEqual(['wiki/concepts/Wiki Sync.md', 'package.json']);
+    expect(status.hasWikiChanges).toBe(true);
+    expect(status.hasNonWikiChanges).toBe(true);
+  });
+});

--- a/.gaia/cli/src/wiki/util/branch.ts
+++ b/.gaia/cli/src/wiki/util/branch.ts
@@ -94,7 +94,12 @@ export const inspectWorkingTree = (
 
     if (line.length === 0) continue;
     // Porcelain v1: 2-char status, space, path. Account for renames.
-    const payload = line.slice(3);
+    // Git quotes paths that contain spaces or special chars; strip the quotes.
+    const rawPayload = line.slice(3);
+    const payload =
+      rawPayload.startsWith('"') && rawPayload.endsWith('"')
+        ? rawPayload.slice(1, -1)
+        : rawPayload;
     const renameSplit = payload.indexOf(' -> ');
 
     if (renameSplit === -1) {


### PR DESCRIPTION
## Why

`git status --porcelain=v1` wraps paths containing spaces (and other unusual chars) in double quotes, so a wiki page renders as ` M "wiki/concepts/Wiki Sync.md"`. `inspectWorkingTree` kept the quotes, so the candidate started with `"` instead of `wiki/` and `startsWith('wiki/')` failed. Result: **every spaced wiki page was misclassified as a non-wiki change, and `gaia wiki sync land` refused to land it.** Nearly every GAIA wiki page has a space in its filename, so this blocks `sync land` for essentially any content-bearing wiki sync. It surfaced during a `/gaia-wiki` run.

## Fix

- Strip surrounding double-quotes from the porcelain payload in `inspectWorkingTree`.
- **Rebuild both bundles** (`gaia`, `gaia-maintainer`) from source via esbuild. (A prior hand-patch had updated only the adopter bundle, leaving `gaia-maintainer` buggy.)
- Add `src/wiki/util/branch.test.ts` — 6 cases incl. quoted wiki/non-wiki paths, added/untracked, unquoted control, and unquoted rename. **Verified RED** against the old `line.slice(3)` (4 quoted-path cases fail), **GREEN** with the fix.

## Verification

- CLI `typecheck`: clean.
- CLI full suite: **1269 passed, 1 skipped** (incl. new test).

Note: the existing `sync-land.test.ts` fixtures used *unquoted* spaced paths (` M wiki/concepts/Foo.md`), which is not what real git emits — that unrealistic fixture is why the bug went uncaught. The new test uses the realistic quoted form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)