### PR TITLE
chore(release): wiki sync + track TDD RED Verification.md in manifest

### DIFF
--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -468,6 +468,7 @@
     "wiki/decisions/pnpm.md": "wiki-owned",
     "wiki/decisions/Quality Gate.md": "wiki-owned",
     "wiki/decisions/spec-kit Extension Strategy.md": "wiki-owned",
+    "wiki/decisions/TDD RED Verification.md": "wiki-owned",
     "wiki/decisions/Thin Routes.md": "wiki-owned",
     "wiki/decisions/TypeScript Language Files.md": "wiki-owned",
     "wiki/decisions/Wiki Management.md": "wiki-owned",
@@ -518,6 +519,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-06-04T16:18:41.047Z",
+  "generated": "2026-06-04T19:07:17.339Z",
   "version": "1.4.0"
 }

--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "f7f6d9f530d56b562e635aef60450c0cea59ff23",
-  "last_evaluated_at": "2026-06-04T18:33:43Z",
+  "last_evaluated_sha": "26740f178a4320cc721c9e83fe18241602a4c4f7",
+  "last_evaluated_at": "2026-06-04T19:25:14Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/concepts/Wiki Sync.md
+++ b/wiki/concepts/Wiki Sync.md
@@ -81,6 +81,8 @@ For each commit since `last_evaluated_sha`:
 4. **Advance state** to current HEAD.
 5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`. The landing strategy is branch-aware: on `main` (push-protected), it creates `wiki/sync-YYYY-MM-DD`, pushes, opens a PR, and squash-merges; on any other branch (feature/fix/release/worktree), it commits in place so the maintainer's working state isn't fragmented.
 
+`sync land` uses `git status --porcelain=v1` to inspect the working tree. Git wraps paths containing spaces or special characters in double quotes; the CLI strips that quoting before classifying paths as wiki or non-wiki changes. Nearly every GAIA wiki page has a space in its filename, so this normalization is required for `sync land` to recognize wiki edits and proceed.
+
 The skip-with-reason audit trail is load-bearing: a project that always says "skipped: typo" tells you the system is running. A project with no log entries tells you the system has stopped. `/gaia-wiki lint` check #11 surfaces this drift.
 
 ## Consolidation gate

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-04 1eb85b9 WORTHY - fix git-quoted path stripping in inspectWorkingTree (sync land) → wiki/concepts/Wiki Sync.md
+- 2026-06-04 0404aeb SKIP - wiki: self-referential (sync commit)
+- 2026-06-04 26740f1 SKIP - chore(release): manifest update only; no architecture change
 - 2026-06-04 f7f6d9f WORTHY - fabrication guard + Sonnet dispatch for wiki-sync → wiki/concepts/Wiki Sync.md
 - 2026-06-04 4f9b17e SKIP - wiki: self-referential (sync commit)
 - 2026-06-04 e68dbfd SKIP - wiki: self-referential (sync commit)


### PR DESCRIPTION
Release-prep branch bundling two changes surfaced while prepping the release.

## Commits
- `26740f1` chore(release): track `wiki/decisions/TDD RED Verification.md` in manifest. Regenerated `.gaia/manifest.json` so the new wiki-owned decision page is tracked. Surfaced by `/health-audit` (`release manifest --check`).
- `e45c8ba` wiki: sync through 26740f1. Evaluated `f7f6d9f..HEAD` (3 commits, 1 worthy): documented the `inspectWorkingTree` git-quoted-path fix in `wiki/concepts/Wiki Sync.md`, advanced wiki state, logged decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)