### PR TITLE
fix(hooks): exclude self-referential wiki-sync commits from drift count

### DIFF
--- a/.claude/hooks/wiki-drift-check.sh
+++ b/.claude/hooks/wiki-drift-check.sh
@@ -41,7 +41,13 @@ esac
 # Sha must be reachable from HEAD (silently bail on rebased/unreachable history)
 git merge-base --is-ancestor "$state_sha" HEAD 2>/dev/null || exit 0
 
-drift_count=$(git rev-list --count "$state_sha..HEAD" 2>/dev/null || echo 0)
+# Exclude the sync's own bookkeeping commit. `gaia wiki sync land` records
+# last_evaluated_sha = HEAD *before* writing its `wiki: sync through <sha>`
+# commit, so that commit always lands one ahead of the SHA the sync just
+# recorded. Counting it nags the maintainer to re-sync the instant a sync
+# finishes, where the next sync only SKIPs it as self-referential. Drop it so
+# the nudge reflects genuine un-evaluated work, not the sync's own footprint.
+drift_count=$(git rev-list --count --invert-grep --grep='^wiki: sync through ' "$state_sha..HEAD" 2>/dev/null || echo 0)
 short_sha=$(git rev-parse --short "$state_sha" 2>/dev/null || echo "$state_sha")
 
 if [ "$drift_count" -gt 0 ]; then

--- a/.gaia/tests/hooks/drift-check.bats
+++ b/.gaia/tests/hooks/drift-check.bats
@@ -114,3 +114,39 @@ EOF
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "only a wiki-sync commit ahead: silent (self-referential, not real drift)" {
+  REPO=$("$HELPERS/tmp-git-repo.sh")
+  cd "$REPO"
+  base=$(git rev-parse HEAD)
+  # A `gaia wiki sync land` bookkeeping commit sitting on top of the recorded SHA.
+  echo "synced" >> wiki/index.md
+  git add wiki/index.md
+  git commit --quiet -m "wiki: sync through ${base:0:7}"
+  cat > wiki/.state.json <<EOF
+{"version":1,"last_evaluated_sha":"$base","last_evaluated_at":"2026-01-01T00:00:00Z"}
+EOF
+  input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
+  run bash -c "echo '$input' | '$HOOK_ABS'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  grep -q "drift_count=0" .claude/wiki-drift-checked
+}
+
+@test "wiki-sync commit excluded from count, real commits still counted" {
+  REPO=$("$HELPERS/tmp-git-repo.sh" --commits 2)
+  cd "$REPO"
+  base=$(git rev-list --max-parents=0 HEAD)
+  # Two real commits already exist; add a self-referential sync commit on top.
+  echo "synced" >> wiki/index.md
+  git add wiki/index.md
+  git commit --quiet -m "wiki: sync through deadbee"
+  cat > wiki/.state.json <<EOF
+{"version":1,"last_evaluated_sha":"$base","last_evaluated_at":"2026-01-01T00:00:00Z"}
+EOF
+  input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
+  run bash -c "echo '$input' | '$HOOK_ABS'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2 commits ahead"* ]]
+  grep -q "drift_count=2" .claude/wiki-drift-checked
+}


### PR DESCRIPTION
## Problem
`gaia wiki sync land` records `last_evaluated_sha = HEAD` *before* writing its own `wiki: sync through <sha>` commit (`sync-land.ts`), so that commit always lands one ahead of the SHA the sync just recorded. The `UserPromptSubmit` drift check (`wiki-drift-check.sh`) counted it, so every session right after a sync nagged the maintainer to re-sync, where the next sync only SKIPs it as self-referential. A treadmill.

## Fix
Filter `^wiki: sync through ` commits out of the `git rev-list --count` so the nudge reflects genuine un-evaluated work, not the sync's own footprint. Squash-orphaned state SHAs already silence the hook (the `--is-ancestor` bail), so this only changes the reachable case.

## Tests
- New bats cases: sync-commit-only range stays silent (`drift_count=0`); mixed range counts only the real commits (`2 commits ahead`).
- Existing `5 commits behind` case unaffected (helper commits are generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)