### PR TITLE
wiki: sync through f02e0ad

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "26740f178a4320cc721c9e83fe18241602a4c4f7",
-  "last_evaluated_at": "2026-06-04T19:25:14Z",
+  "last_evaluated_sha": "f02e0ad66fc6b8a33f658995fadd3ba0f156dbbd",
+  "last_evaluated_at": "2026-06-05T04:22:56Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/concepts/Code Review Audit Agent.md
+++ b/wiki/concepts/Code Review Audit Agent.md
@@ -44,6 +44,8 @@ The wiki (`wiki/`) is the source of truth for patterns, decisions, and conventio
 
 Library-specific audit rules live in `.claude/agents/code-review-audit/*.md`. Each file targets one or more specialist subagents via YAML frontmatter (`subagents: [react-patterns, typescript, translation]`). The agent reads all extension files at startup and injects their rules into the relevant subagent prompts.
 
+The `subagents:` values (`react-patterns`, `typescript`, `translation`) are **rule-injection labels** - metadata that selects which specialist prompt receives this file's rules. They are not skill or command names. The agent dispatches each specialist via the **Agent (Task) tool** with an explicit `subagent_type`. Routing a specialist through the Skill tool misroutes it to a fuzzy-matched command (e.g. `/gaia-audit`), which rejects the args and aborts the audit before its marker is written.
+
 To swap a library: remove its extension file, add one for the replacement. The main agent definition stays unchanged. See the `README.md` in that directory for the full format.
 
 | File                 | Library              |

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-08
-updated: 2026-06-02
+updated: 2026-06-05
 tags: [concept, ci, audit, claude]
 ---
 
@@ -50,6 +50,12 @@ The `Check for source-code changes` step diffs only the **un-audited delta**: `<
 On this skip path the `Write GAIA-Audit commit status (out-of-scope skip)` step stamps a `GAIA-Audit` commit status (`<version> <tree>`) on HEAD, mirroring the full-audit path's status. An out-of-scope PR (CLI-only, docs-only, wiki-only, `.claude`-only) therefore satisfies the [[PR Merge Workflow]] merge hook with no local audit run; the agent would find nothing in scope to review. The description carries HEAD's own tree, since the hook checks tree equality against the content being merged.
 
 The stamp fires on the out-of-scope reason only. The already-audited reason (the `GAIA-Audit:` trailer already matches, so a status is redundant) and the workflow-self-modification reason (auto-approving a change to the audit gate itself would be a security hole) do not stamp. The `has_source == 'false'` condition structurally enforces this: both other reasons require `has_source == 'true'`. A self-modifying PR (including one editing `code-review-audit.yml`) gets no auto-stamp and still needs a local marker to merge.
+
+## Clean audit, no push
+
+A genuinely-clean audit that produces no self-heal commits and no empty trailer commit leaves the `push-fixes` step with neither `pushed` nor `marker_only` set. Without intervention, HEAD carries no `GAIA-Audit` status and the merge hook blocks the merge even though the audit passed.
+
+The `Write GAIA-Audit commit status (clean, no push)` step closes this gap: it stamps the `GAIA-Audit` commit status directly on the current PR HEAD with no empty commit. A proven-clean guard prevents false passes: the audit agent writes `.gaia/local/audit/<HEAD>.ok` only on a clean pass (no Critical Issues, all Important Issues addressed, all Suggestions resolved). The step checks for this marker before stamping; a dirty audit that pushed nothing has no marker and receives no status, keeping the merge blocked until the audit clears.
 
 This is the audit's instance of the cross-workflow mechanism in [[Incremental CI Skipping]].
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,10 @@ tags: [meta, log]
 
 ## [v1.4.0] 2026-06-02 | Released
 
+- 2026-06-05 592914b SKIP - chore(release): release plumbing
+- 2026-06-05 ba30e2a SKIP - fix(hooks): exclude self-referential sync commits from drift count; implementation detail, Wiki Sync concept already covers drift-check behavior
+- 2026-06-05 f947ed9 SKIP - build(deps): @gaia-react/lint upgrade + prettier sweep; wiki changes are table alignment only, no content
+- 2026-06-05 f02e0ad WORTHY - fixed CI audit gate: specialist dispatch via Task tool (not Skill), added clean-no-push GAIA-Audit status stamp path → wiki/concepts/Code Review Audit Agent.md, wiki/concepts/Code Review Audit CI.md
 - 2026-06-04 1eb85b9 WORTHY - fix git-quoted path stripping in inspectWorkingTree (sync land) → wiki/concepts/Wiki Sync.md
 - 2026-06-04 0404aeb SKIP - wiki: self-referential (sync commit)
 - 2026-06-04 26740f1 SKIP - chore(release): manifest update only; no architecture change


### PR DESCRIPTION
Wiki sync over `0404aeb..f02e0ad` (4 commits, 1 worthy). Edits the Code Review Audit Agent and Code Review Audit CI concept pages and advances `wiki/.state.json` to f02e0ad. Prereq for cutting the next release.

Wiki-only diff: out-of-scope of the audit gate and tests/Chromatic CI.