### PR TITLE
fix(ci): trigger CLI tests on code-review-audit.yml edits

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -26,6 +26,12 @@ jobs:
             code:
               - '.gaia/cli/**'
               - '.github/workflows/cli-tests.yml'
+              # The audit-template dogfood drift-guard compares this in-tree
+              # workflow against the bundled .tmpl. Editing the .tmpl already
+              # lands under .gaia/cli/**; the live workflow is the other side
+              # of that equality, so a workflow-only edit must re-run the guard
+              # or template drift lands silently.
+              - '.github/workflows/code-review-audit.yml'
       - if: steps.filter.outputs.code == 'true'
         # Pinned to v4.4.0 (not v6.0.5 like the other workflows), bumping
         # to v6 surfaces an ERR_PNPM_IGNORED_BUILDS regression on the


### PR DESCRIPTION
## Problem

The `audit-template-dogfood` drift-guard (in `Vitest (.gaia/cli)`) asserts the in-tree `.github/workflows/code-review-audit.yml` is byte-identical to the bundled install template `.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl`.

The `.tmpl` side lands under `.gaia/cli/**` (covered by the path filter), but the **live workflow** was not in the filter. So a PR that edits only `.github/workflows/code-review-audit.yml` skips the CLI test job, and template drift lands silently. This is exactly how the v1.5.0 release surfaced a latent drift from an earlier audit-gate fix: it was only caught when an unrelated CLI-touching PR re-ran the job.

## Fix

Add `.github/workflows/code-review-audit.yml` to the `dorny/paths-filter` `code` filter in `cli-tests.yml`, so any edit to the live workflow re-runs the drift-guard at its source.

One-line behavior change (plus explanatory comment). Verified the inner filter still parses to the expected path list.