### PR TITLE
docs(gaia-release): wire release-notes into the website lockstep

### DIFF
--- a/.claude/commands/gaia-release.md
+++ b/.claude/commands/gaia-release.md
@@ -218,7 +218,7 @@ npm view create-gaia@<NEW_VERSION> version    # registry CDN may lag a minute
 
 ### 14. Lockstep website
 
-The marketing/docs site (`../website` relative to this repo) embeds three version references that must match the release just cut. Update all three before considering the release complete.
+The marketing/docs site (`../website` relative to this repo) embeds three version references plus a public changelog entry that must match the release just cut. Update all of them before considering the release complete.
 
 ```bash
 WEB="$(git rev-parse --show-toplevel)/../website"
@@ -246,12 +246,21 @@ Example: current is `installed=1.2.0, available=1.2.2`. On `1.3.0` → `installe
 
 - `$WEB/index.html` → `"softwareVersion": "<NEW_VERSION>",`
 
+**Public changelog page (release notes).** The three edits above are version strings; the human-readable "what's new" entry on the site's changelog page is a separate artifact owned by the `release-notes` skill. Generate it for the version just cut:
+
+- Invoke the `release-notes` skill with `<NEW_VERSION>` (no leading `v`). It reads the graduated `## [<NEW_VERSION>]` block from `CHANGELOG.md`, translates it to adopter-facing notes, writes `$WEB/src/pages/changelog/releases/<NEW_VERSION>.ts` (the page auto-discovers the file via `import.meta.glob`; there is no index to update), and prints an editorial-decisions report.
+- The report is a human gate: review the **Dropped** and **Consolidated** lists and resolve every **Needs a human ruling** item before accepting, then adjust the file per the maintainer's rulings.
+- The skill only reads `CHANGELOG.md`; never edit the changelog here.
+
+Stage the generated `<NEW_VERSION>.ts` alongside the three version edits so all four land in one website commit.
+
 Commit and push directly to `main` in the website repo (no branch protection on `website`). Apply the sibling-repo push protocol from Step 13: the `add`/`commit` chain keeps `$WEB` and combines freely, but the `git push` runs in its **own Bash tool invocation** with the **literal path inlined**. A `git -C "$WEB" push origin main` resolves the target to the literal string `$WEB`, fails closed, and is denied as a home-repo push to `main`.
 
 ```bash
 git -C "$WEB" add src/pages/get-started/sections/GetStarted.tsx \
                src/pages/features/sections/Fitness.tsx \
-               index.html
+               index.html \
+               src/pages/changelog/releases/<NEW_VERSION>.ts
 git -C "$WEB" commit -m "chore: lockstep GAIA v<NEW_VERSION>"
 ```
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -190,6 +190,6 @@ Use this only for an internal-only release or a genuinely one-line story. Anythi
 
 ## See
 
-- `.claude/commands/gaia-release.md`, the release process this feeds; Step 14 already locksteps other website version sites.
+- `.claude/commands/gaia-release.md`, the release process this feeds: Step 14 invokes this skill for the changelog page entry and locksteps the other website version sites.
 - `CHANGELOG.md`, the source. Read-only. Never edited here.
 - `eval/probe.py`, trigger-boundary validation harness (maintainer-only, excluded from the tarball). After editing the frontmatter `description`, re-run `python3 .claude/skills/release-notes/eval/probe.py --runs 3` to confirm the boundary still holds (target: 100% recall, 0% false-positive). Options in its docstring.


### PR DESCRIPTION
## Problem

`/gaia-release` Step 14 (website lockstep) bumps the three website version strings (`GAIA_VERSION`, the Fitness detail, and `index.html` `softwareVersion`) but never generates the public changelog page entry. That entry is the `release-notes` skill's job, and the command never invoked it, so every release shipped without adopter-facing notes unless a maintainer remembered to run the skill by hand. (v1.5.0 hit exactly this.)

## Fix

- Add a **Public changelog page (release notes)** sub-step to Step 14: invoke the `release-notes` skill for the cut version, gate on its editorial-decisions report (resolve every "Needs a human ruling" item), and fold the generated `<version>.ts` into the same website lockstep commit.
- Update the `git add` block and the Step 14 intro accordingly.
- Update the `release-notes` skill's cross-reference so the two docs point at each other accurately.

Docs-only (`.claude/`); out of audit scope.