### PR TITLE
feat(gaia-harden): SPEC-004 Policy-Memory Loop

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -186,6 +186,39 @@ Every suggestion must be resolved before the audit passes:
 
 Include only when there are specific, concrete patterns worth reinforcing. Skip the section entirely if there's nothing substantive, don't pad with generic praise.
 
+## Finding emission (telemetry trailer)
+
+After the human-readable report, append a machine-readable telemetry trailer as the **last** fenced `---` block of your Task return. The PostToolUse Task hook parses this block to record each finding for the recurring-finding policy-memory loop, which raises a `/gaia-harden` nudge when the same `finding_class` recurs across distinct PRs. The human report and this trailer are independent channels: a finding can appear in the prose report without appearing here.
+
+Trailer shape (the closing `---` must be the final fence in your return):
+
+```
+---
+findings_json: [{"finding_class":"react-doctor/no-generic-handler-names","severity":"warning","area_tags":["app/components"]}, {"finding_class":"holistic/missing-auth-check","severity":"error","area_tags":["app/routes"]}]
+pr_number: 1234
+---
+```
+
+Rules for the block:
+
+- **One entry per eligible finding** you report. `findings_json` is a JSON array; emit `[]` when you classified nothing.
+- **Carry ONLY `finding_class`, `severity`, and `area_tags`** per entry. Never code, never file contents, never a path beyond a coarse area tag (`app/components`, `app/routes`). `pr_number` is a sibling scalar on the trailer, not on each entry.
+- **`severity`** is one of `error`, `warning`, `suggestion`, the same tiers as the report (`Critical`/`Important`/`Suggestion`).
+- **Assign `finding_class` by the per-bucket convention** below. A finding you cannot assign a stable class to is simply omitted from `findings_json`; it can still appear in the prose report. A finding with no stable class is not a countable finding.
+
+### Per-bucket `finding_class` convention
+
+- **Oracle buckets (deterministic tools): the tool's own id, prefixed.** The tool owns the id space, so any well-formed id after the prefix is valid.
+  - react-doctor: the rule id, prefixed `react-doctor/` (e.g. `react-doctor/no-generic-handler-names`).
+  - axe (accessibility): the axe rule id, prefixed `axe/` (e.g. `axe/color-contrast`).
+  - knip: the issue type, prefixed `knip/` (e.g. `knip/exports`, `knip/types`, `knip/dependencies`).
+  - dependency-CVE (`pnpm audit`): the advisory id, prefixed `cve/` (e.g. `cve/1098765`).
+- **Holistic / rule-subagent buckets: a controlled vocabulary.** Use one of the seeded members below verbatim; do not invent new members. If a holistic or rule finding does not map to a seeded member, omit it from `findings_json`.
+  - Holistic (your own cross-cutting findings): `holistic/missing-auth-check`, `holistic/secret-exposure`, `holistic/n-plus-one`, `holistic/unnecessary-rerender`, `holistic/unhandled-promise-rejection`, `holistic/swallowed-error`, `holistic/over-permissive-zod`, `holistic/business-logic-in-component`, `holistic/hardcoded-string`, `holistic/non-null-assertion`.
+  - Rule (line-level subagent findings): `rule/use-effect-derived-state`, `rule/use-effect-state-reset`, `rule/unnecessary-use-callback`, `rule/missing-effect-cleanup`, `rule/generic-handler-name`, `rule/switch-statement`, `rule/interface-declaration`, `rule/z-enum`, `rule/array-generic-syntax`, `rule/thin-route-violation`.
+
+The schema enforces this convention: an entry whose `finding_class` is free text or an unseeded holistic/rule member is dropped before it reaches the tally, so a misclassified entry is silently lost rather than miscounted. When in doubt, omit the entry.
+
 ## Methodology
 
 1. **Read the code carefully**: understand the intent before critiquing the implementation

--- a/.claude/commands/gaia-harden.md
+++ b/.claude/commands/gaia-harden.md
@@ -1,0 +1,9 @@
+---
+name: gaia-harden
+description: Judge-the-form, human-gated hardening. Reviews recurring code-review-audit findings and, with approval, drafts the lowest-context-weight form (deterministic check / skill / path-scoped prose rule) into the working tree. Pass `list` to see live candidates or `why <finding_class>` to explain one.
+argument-hint: [review|list|why <finding_class>]
+---
+
+Run the GAIA **harden** workflow with these arguments: `$ARGUMENTS`
+
+Read `.claude/skills/gaia/references/harden.md` from the project root and follow it exactly. That reference is written to consume an argument string, treat the arguments above as that input (the leading token selects the subcommand: `review`, `list`, or `why <finding_class>`). If no arguments were provided, follow the reference's no-argument path (which defaults to `review`).

--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -156,6 +156,18 @@ For every memory entry and every rules file, check whether the same fact lives i
 
 Rules-vs-wiki: a `.claude/rules/*.md` file is allowed to duplicate wiki content **only** if it exists to enforce auto-loading for a specific `paths:` glob. Otherwise it should link to the wiki page.
 
+### Provenance-marked rules (`gaia-harden:`)
+
+A `.claude/rules/*.md` rule whose first line after frontmatter is the provenance marker
+
+```
+<!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
+```
+
+is an **ordinary rule** for this audit: inventory it, word-budget it, and apply DUPLICATE / obsolescence / supersession exactly as for a hand-authored rule. The marker grants **no policy-memory exemption**. Such a rule always carries a `paths:` glob, so it is the path-scoped case the Rules-vs-wiki note already permits to duplicate wiki content, no special-casing needed.
+
+The marker is documentation of WHY the rule exists, not a magic token. It also encodes one guardrail: **do NOT classify the rule STALE merely because its anti-pattern is no longer recurring.** A suppressed pattern going quiet is the rule working, not evidence it is stale, and lessons do not expire. The STALE definition already keys on "references a file/branch/feature no longer present", which does not include "the pattern stopped recurring"; non-recurrence is never a prune signal. Prune a provenance-marked rule only on **obsolescence** (its `paths:`-governed surface was removed), **redundancy** (a lint rule, hook, or test now enforces the same thing), **supersession**, or **duplication**.
+
 ## Step 3, Auto-load budget
 
 Targets (flag anything over):

--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -1,0 +1,177 @@
+# /gaia-harden
+
+Human-gated hardening for the policy-memory loop. `/gaia-harden` is the ONLY code path that authors or activates anything in this loop, and it runs only under explicit human invocation. For each recurring finding it judges the lowest-context-weight form that fits, checks edit-vs-new first, recommends exactly one form with rationale, and presents an approve / decline / defer / redirect choice. Nothing is authored or activated unattended.
+
+v1 owns prose-rule create/edit end to end. Skills and deterministic checks are recommended and scaffolded only (a skill-creator handoff; a hook+script sketch), never auto-authored or auto-activated.
+
+## Execution model, READ FIRST
+
+Execute the playbook yourself in the current conversation. This is an interactive, human-gated flow: each candidate's approve / decline / defer / redirect choice is the human's, never the agent's. Do not dispatch a subagent to make those calls and do not auto-advance past a candidate without a human answer.
+
+The agent never runs `git add`, `git commit`, or `git push` anywhere in this flow. Approved work lands in the working tree only; it ships through normal PR review. A decline writes one bounded entry to the machine-local, gitignored ledger and nowhere else. A defer persists nothing.
+
+## Argument parsing
+
+Tokenize the first whitespace-separated word of `$ARGUMENTS`:
+
+- `review` (or empty `$ARGUMENTS`) → the full interactive flow. This is the default the statusline nudge (`Run /gaia-harden review (N)`) points at.
+- `list` → print the live candidates with their distinct-PR counts and the recommended form. No authoring, no prompts.
+- `why` → the remainder of `$ARGUMENTS` is a `finding_class`. Explain that one candidate: the PRs it recurred on, the recommended form, and the rationale. No authoring, no prompts.
+
+If the first token is none of `review` / `list` / `why` and `$ARGUMENTS` is non-empty, treat the whole string as if it were a `why <finding_class>` target only when it parses as a single finding_class; otherwise default to `review`.
+
+## Fetch the live candidate list (all subcommands)
+
+Every subcommand reads the live list from the tally primitive. Re-run it; never trust a stale count.
+
+```bash
+.gaia/cli/gaia harden-tally
+```
+
+It prints JSON to stdout:
+
+```jsonc
+{
+  "candidate_count": 2,
+  "window_days": 90,
+  "candidates": [
+    {
+      "finding_class": "rule/use-effect-derived-state",
+      "distinct_pr_count": 4,
+      "pr_numbers": [311, 314, 318, 320],
+      "area_tags": ["app/components"],
+      "severity_max": "warning"
+    }
+  ]
+}
+```
+
+Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error. If `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop.
+
+## Judge-the-form logic (the heart of the command)
+
+For each candidate decide two axes and recommend EXACTLY ONE form with a one-line rationale. Bias to the lowest-context-weight form the pattern admits. Do not default to a prose rule without considering the alternatives.
+
+### Axis 1, edit vs new (check this FIRST)
+
+Before choosing a form, check whether an existing artifact already covers the class's territory. Grep the candidate surfaces:
+
+```bash
+grep -rln "<keywords derived from the finding_class>" .claude/rules .claude/skills .claude/hooks
+```
+
+Also check whether the quality gate (`wiki/decisions/Quality Gate.md`) already lists a step for it. If an existing rule, skill, or hook covers the territory, recommend EDITING that artifact, not creating a new one. Name the artifact to edit and what to add.
+
+### Axis 2, which form (lowest context weight that fits)
+
+Inspect the `finding_class` prefix and the pattern's nature:
+
+- **Oracle-class finding** (the `finding_class` is a tool id: it starts with `react-doctor/`, `axe/`, `knip/`, or `cve/`). A deterministic check already exists for it. Recommend making that check BLOCKING or adding it to the quality gate, an enforcement edit, NOT a new prose rule. Point at `wiki/decisions/Quality Gate.md` and the tool's wiring (`.claude/rules/knip.md`, `.claude/rules/dep-audit.md`, the `code-review-audit` agent, or the relevant CI workflow). Never draft prose for an oracle class.
+
+- **Mechanizable holistic/rule pattern** (the pattern can be caught by a lint rule, a hook, or a test). Recommend a DETERMINISTIC CHECK. v1 produces a hook+script SKETCH only; it activates nothing, writes no `.claude/rules/` file for it, and claims no prune lifecycle over it.
+
+- **A correct procedure** (the lesson is "do these steps in this order"). Recommend a SKILL via skill-creator. v1 produces a skill-creator invocation/scaffold only; it activates nothing.
+
+- **Judgment-based pattern** (a human-judgment anti-pattern with no reliable mechanization, e.g. a holistic/rule class about a design call). Recommend a PROSE RULE. v1 OWNS this end to end: it drafts the path-scoped rule with the provenance marker into the working tree.
+
+When a pattern is mechanizable, the recommendation is the deterministic check, not a skill and not a prose rule.
+
+### Present and act
+
+For each candidate, present: the finding_class, its distinct-PR count and the PRs it recurred on, the recommended form, and the one-line rationale. Then offer the action set: **approve / decline / defer / redirect**.
+
+`redirect` means the engineer overrides the form choice (e.g. "make it a prose rule even though you recommended a skill"). Honor the override and run that form's action handling.
+
+## Per-form action handling
+
+### approve, prose rule
+
+Draft the rule file into the working tree using the template below. The rule is MANDATORILY path-scoped: a `paths:` frontmatter glob is always present, derived from the candidate's `area_tags`. Never write a frontmatter-less / always-loaded rule. Immediately after the frontmatter, write the provenance marker verbatim (see the frozen marker below). Then write present-tense body prose describing the anti-pattern and the correct pattern.
+
+After writing, tell the engineer the rule is in the working tree and ships through normal PR review. NEVER `git add`, `git commit`, or `git push`.
+
+### approve, deterministic check
+
+Produce ONLY a hook+script SKETCH (a proposed hook entry and a script outline the engineer can finish). Activate nothing: do not wire it into `.claude/settings.json`, do not make any file executable, and write no `.claude/rules/` file for it. Make clear the loop claims no prune lifecycle over it. Hand the sketch to the engineer to finish and wire up themselves.
+
+### approve, skill
+
+Produce ONLY a skill-creator handoff. Invoke the `skill-creator` skill (the scaffolding tool) with the captured intent (what the skill should enable, when it should trigger, the expected output), or print a ready-to-run scaffold invocation. Activate nothing and write no `.claude/rules/` file for it.
+
+### approve, enforcement edit (oracle class)
+
+Make the existing deterministic check blocking or add it to the quality gate. This is an edit to existing enforcement wiring (the tool's rule file, the `code-review-audit` agent, the quality gate doc, or the CI workflow), not a new prose rule. Land the edit in the working tree only; never commit.
+
+### decline
+
+Record one bounded entry to the machine-local ledger, passing the candidate's current distinct-PR count:
+
+```bash
+.gaia/cli/gaia harden-ledger record --finding-class "<finding_class>" --pr-count <distinct_pr_count>
+```
+
+State that the decline is machine-local only (the ledger is gitignored) and never shared: a teammate still sees the nudge and can approve. The decline re-surfaces on evidence, the ledger handles that; once at least 3 more distinct PRs carrying the class merge, the candidate returns.
+
+### defer
+
+Persist nothing. The candidate stays in the next tally pass and ages out of the rolling 90-day window if it stops recurring and no one acts. Do not write the ledger, do not draft a file.
+
+## The prose-rule template (fill in, then write)
+
+Write to `.claude/rules/<slug>.md`, where `<slug>` is a short kebab-case name derived from the finding_class (e.g. `use-effect-derived-state`). Use this exact shape:
+
+```markdown
+---
+paths:
+  - '<glob derived from area_tags, e.g. app/components/**/*>'
+---
+
+<!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
+
+# <Rule Title>
+
+<Present-tense prose: name the anti-pattern, then state the correct pattern. No UAT/SPEC IDs, no PR/commit/date references. Describe what the rule enforces and why.>
+
+## Anti-pattern
+
+<the wrong shape>
+
+## Correct pattern
+
+<the right shape>
+```
+
+Rules for filling it in:
+
+- **`paths:` is mandatory.** Derive the glob from the candidate's `area_tags` (e.g. an `area_tags` of `["app/components"]` becomes `app/components/**/*`). One or more single-quoted globs, one per line. A rule with no `paths:` frontmatter is never produced; path-scoping is what bounds per-task context weight regardless of how many promoted rules accumulate.
+- **The provenance marker is verbatim and single-line**, placed immediately after the closing `---` of the frontmatter, with `<class>` replaced by the actual finding_class. It references the `finding_class`, never a SPEC or UAT id.
+- **Body prose is present tense** and follows `.claude/rules/wiki-style.md`: no UAT/SPEC references, no inline PR/commit/date references. Use repo-relative paths only (`.claude/rules/coding-guidelines.md`).
+
+### Frozen provenance marker (PROVENANCE-MARKER CONTRACT)
+
+The marker is this exact line, with `<class>` substituted:
+
+```
+<!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
+```
+
+`/gaia-audit` recognizes this marker only to apply its existing obsolescence / redundancy / supersession / duplication signals without a policy-memory exemption, and to explicitly NOT treat non-recurrence as a prune signal. The marker grants no special lifecycle. Do not alter its wording: `/gaia-audit` binds to this string.
+
+## list subcommand
+
+Run `harden-tally`, then for each candidate print one line: `finding_class`, distinct-PR count, the PRs, and the recommended form (from judge-the-form, edit-vs-new + which-form). Author nothing and prompt for nothing.
+
+## why subcommand
+
+Run `harden-tally`, find the candidate whose `finding_class` matches the argument. Explain it: what the finding is, the distinct PRs it recurred on (`pr_numbers`), its max severity, the recommended form, and the rationale (including whether an existing artifact should be edited instead). If no candidate matches, say so and list the open candidates. Author nothing and prompt for nothing.
+
+## Guardrails
+
+- `/gaia-harden` is the only writer in this loop, and only under explicit human invocation. The background refresher and the audit emit never author.
+- Never `git add`, `git commit`, or `git push`. Approved work lands in the working tree for human review and ships through normal PR review.
+- Never auto-activate a skill or a deterministic check. v1 owns only prose-rule create/edit end to end; the other two forms are scaffold-only.
+- Every drafted prose rule is mandatorily path-scoped (`paths:` frontmatter), and carries the verbatim provenance marker.
+- A decline is machine-local only (gitignored ledger); it never vetoes the candidate for a teammate.
+- A defer persists nothing.
+- Recommend exactly one form per candidate, with rationale; check edit-vs-new first; bias to the lowest-context-weight form. Never reflexively author a prose rule.
+- Do not read the privacy-sealed mentorship event store to make any of these decisions; this loop keys only on `finding_class` recurrence from the PR window.

--- a/.gaia/cli/src/automation/__tests__/audit-template-dogfood.test.ts
+++ b/.gaia/cli/src/automation/__tests__/audit-template-dogfood.test.ts
@@ -52,4 +52,16 @@ describe('audit-template dogfood drift-guard', () => {
 
     expect(inTree).toBe(template);
   });
+
+  it('instructs the audit agent to emit the machine-readable findings block', () => {
+    const template = readFileSync(workflowAuditTemplatePath(), 'utf8');
+
+    // The tally pass parses findings from the PR comment via these stable
+    // sentinels; freezing them in the prompt is the contract anchor.
+    expect(template).toContain('<!-- gaia-harden:findings:start -->');
+    expect(template).toContain('<!-- gaia-harden:findings:end -->');
+    // The finding_class values come from the per-bucket convention in the
+    // agent definition, not a second one re-derived in the workflow.
+    expect(template).toContain('.claude/agents/code-review-audit.md');
+  });
 });

--- a/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
@@ -281,6 +281,31 @@ jobs:
             stamp helper. After the audit and stamp, post a single PR comment
             summarizing findings (and whether self-heal commits were pushed).
 
+            FINDINGS BLOCK: append a machine-readable findings block to the END
+            of that same PR comment, after the human-readable summary. The block
+            is a JSON object wrapped INSIDE an HTML comment so it does not render,
+            framed by two stable sentinel lines. The cross-machine tally pass
+            parses it; the sentinels are the parse anchors, emit them verbatim:
+
+            <!-- gaia-harden:findings:start -->
+            <!--
+            {"schema":1,"pr_number":PR_NUMBER,"auditor":"ci","findings":[
+              {"finding_class":"react-doctor/no-generic-handler-names","severity":"warning","area_tags":["app/components"]},
+              {"finding_class":"holistic/missing-auth-check","severity":"error","area_tags":["app/routes"]}
+            ]}
+            -->
+            <!-- gaia-harden:findings:end -->
+
+            Substitute PR_NUMBER with this PR's number. One object per finding you
+            assigned a stable `finding_class`, using the per-bucket convention in
+            `.claude/agents/code-review-audit.md` (oracle ids verbatim with the
+            tool prefix; the controlled holistic/rule vocabulary otherwise). Carry
+            only `finding_class`, `severity` (error/warning/suggestion), and
+            `area_tags` per finding, never code or file contents. Omit any finding
+            with no stable class (it stays in the prose summary). If you classified
+            zero findings, still emit the block with `"findings":[]`, an explicit
+            empty block is parseable, a missing one is ambiguous.
+
             SELF-HEAL CONSTRAINTS: read before making any edits:
             1. Run `git diff --name-only origin/main...HEAD` first. Self-heal edits
                are ONLY permitted on files that appear in this list. Never edit a

--- a/.gaia/cli/src/harden/__tests__/compute-tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/compute-tally.test.ts
@@ -1,0 +1,277 @@
+import {describe, expect, it} from 'vitest';
+import {
+  computeTally,
+  type TallyPrRecord,
+  windowClasses,
+} from '../compute-tally.js';
+
+const pr = (
+  prNumber: number,
+  findings: TallyPrRecord['findings']
+): TallyPrRecord => ({findings, pr_number: prNumber});
+
+const noCover = (): boolean => false;
+const noSuppress = (): boolean => false;
+
+describe('computeTally', () => {
+  it('surfaces a class seen on 3 distinct PRs at warning severity', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [
+        pr(1201, [
+          {
+            area_tags: ['app/components'],
+            finding_class: 'react-doctor/no-generic-handler-names',
+            severity: 'warning',
+          },
+        ]),
+        pr(1188, [
+          {
+            area_tags: ['app/components'],
+            finding_class: 'react-doctor/no-generic-handler-names',
+            severity: 'warning',
+          },
+        ]),
+        pr(1175, [
+          {
+            area_tags: ['app/hooks'],
+            finding_class: 'react-doctor/no-generic-handler-names',
+            severity: 'warning',
+          },
+        ]),
+      ],
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(1);
+    expect(result.window_days).toBe(90);
+
+    const [candidate] = result.candidates;
+    expect(candidate?.finding_class).toBe(
+      'react-doctor/no-generic-handler-names'
+    );
+    expect(candidate?.distinct_pr_count).toBe(3);
+    expect(candidate?.severity_max).toBe('warning');
+    expect(candidate?.pr_numbers).toEqual([1201, 1188, 1175]);
+    expect(candidate?.area_tags).toEqual(['app/components', 'app/hooks']);
+  });
+
+  it('does not surface a class on only 2 distinct PRs', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [
+        pr(2, [
+          {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+        ]),
+        pr(1, [
+          {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+        ]),
+      ],
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(0);
+  });
+
+  it('does not surface a class repeated 3 times within ONE PR', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [
+        pr(1, [
+          {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+          {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+          {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+        ]),
+      ],
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(0);
+  });
+
+  it('ignores suggestion-only findings but counts the same class at warning', () => {
+    const suggestionOnly = computeTally({
+      coveredClass: noCover,
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'holistic/hardcoded-string',
+            severity: 'suggestion',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+    expect(suggestionOnly.candidate_count).toBe(0);
+
+    const atWarning = computeTally({
+      coveredClass: noCover,
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'holistic/hardcoded-string',
+            severity: 'warning',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+    expect(atWarning.candidate_count).toBe(1);
+  });
+
+  it('combines CI-run and local-run findings for the same class across distinct PRs', () => {
+    // Each PR contributes one comment block (CI or local); the core only sees a
+    // per-PR finding list, so auditor location never changes eligibility.
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [
+        pr(10, [
+          {
+            area_tags: ['app'],
+            finding_class: 'rule/switch-statement',
+            severity: 'warning',
+          },
+        ]),
+        pr(11, [
+          {
+            area_tags: ['app'],
+            finding_class: 'rule/switch-statement',
+            severity: 'error',
+          },
+        ]),
+        pr(12, [
+          {
+            area_tags: ['app'],
+            finding_class: 'rule/switch-statement',
+            severity: 'warning',
+          },
+        ]),
+      ],
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(1);
+    expect(result.candidates[0]?.severity_max).toBe('error');
+  });
+
+  it('collapses two same-class findings in one PR to a single distinct-PR count', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [30, 20, 10].map((n) =>
+        pr(n, [
+          {
+            area_tags: ['app/routes'],
+            finding_class: 'holistic/missing-auth-check',
+            severity: 'error',
+          },
+          {
+            area_tags: ['app/pages'],
+            finding_class: 'holistic/missing-auth-check',
+            severity: 'warning',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidates[0]?.distinct_pr_count).toBe(3);
+    expect(result.candidates[0]?.severity_max).toBe('error');
+    expect(result.candidates[0]?.area_tags).toEqual([
+      'app/routes',
+      'app/pages',
+    ]);
+  });
+
+  it('ignores class-less / invalid findings entirely', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {area_tags: [], finding_class: '', severity: 'error'},
+          {area_tags: [], finding_class: 'not-a-real-prefix/x', severity: 'error'},
+          {
+            area_tags: [],
+            finding_class: 'holistic/something-made-up',
+            severity: 'error',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(0);
+  });
+
+  it('drops a class a promoted rule already covers', () => {
+    const result = computeTally({
+      coveredClass: (c) => c === 'rule/switch-statement',
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'rule/switch-statement',
+            severity: 'warning',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(0);
+  });
+
+  it('drops a class the ledger reports suppressed and passes the live PR count', () => {
+    const seen: number[] = [];
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'axe/color-contrast',
+            severity: 'error',
+          },
+        ])
+      ),
+      suppressedClass: (_c, currentPrCount) => {
+        seen.push(currentPrCount);
+
+        return true;
+      },
+      windowDays: 90,
+    });
+
+    expect(result.candidate_count).toBe(0);
+    expect(seen).toContain(3);
+  });
+
+  it('windowClasses returns classes with >= threshold recurrence regardless of suppression', () => {
+    const prs = [
+      ...[3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'axe/color-contrast',
+            severity: 'warning',
+          },
+        ])
+      ),
+      pr(99, [
+        {area_tags: [], finding_class: 'knip/types', severity: 'warning'},
+      ]),
+    ];
+
+    expect(windowClasses(prs)).toEqual(['axe/color-contrast']);
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/covered-classes.test.ts
+++ b/.gaia/cli/src/harden/__tests__/covered-classes.test.ts
@@ -1,0 +1,57 @@
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {coveredClassesFromRules} from '../covered-classes.js';
+
+describe('coveredClassesFromRules', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'gaia-rules-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, {force: true, recursive: true});
+  });
+
+  it('reads the promoted finding_class from a provenance-marked rule', () => {
+    writeFileSync(
+      path.join(dir, 'switch-statement.md'),
+      [
+        '---',
+        'paths: app/**/*.ts',
+        '---',
+        '<!-- gaia-harden: promoted from recurring finding_class rule/switch-statement; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->',
+        '',
+        '# Rule body',
+      ].join('\n')
+    );
+
+    expect(coveredClassesFromRules(dir).has('rule/switch-statement')).toBe(true);
+  });
+
+  it('returns an empty set for a directory with no marked rules', () => {
+    writeFileSync(path.join(dir, 'plain.md'), '# Just a rule\nno marker here');
+    expect(coveredClassesFromRules(dir).size).toBe(0);
+  });
+
+  it('returns an empty set when the directory does not exist', () => {
+    expect(coveredClassesFromRules(path.join(dir, 'nope')).size).toBe(0);
+  });
+
+  it('collects markers across multiple rule files', () => {
+    writeFileSync(
+      path.join(dir, 'a.md'),
+      '<!-- gaia-harden: promoted from recurring finding_class axe/color-contrast; never for non-recurrence -->'
+    );
+    writeFileSync(
+      path.join(dir, 'b.md'),
+      '<!-- gaia-harden: promoted from recurring finding_class knip/exports; never for non-recurrence -->'
+    );
+
+    const covered = coveredClassesFromRules(dir);
+    expect(covered.has('axe/color-contrast')).toBe(true);
+    expect(covered.has('knip/exports')).toBe(true);
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/ledger-bridge.test.ts
+++ b/.gaia/cli/src/harden/__tests__/ledger-bridge.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it, vi} from 'vitest';
+import {
+  type LedgerRunner,
+  makeLedgerSuppressionPredicate,
+  pruneLedger,
+} from '../ledger-bridge.js';
+import type {ProcessResult} from '../../ci/util/run-process.js';
+
+const ok = (stdout = ''): ProcessResult => ({exitCode: 0, stderr: '', stdout});
+const notSuppressed = (): ProcessResult => ({
+  exitCode: 1,
+  stderr: '',
+  stdout: '',
+});
+
+describe('makeLedgerSuppressionPredicate', () => {
+  it('treats exit 0 as suppressed and passes the class + live count to the ledger', () => {
+    const calls: string[][] = [];
+    const predicate = makeLedgerSuppressionPredicate({
+      cwd: '/repo',
+      runLedger: (argv) => {
+        calls.push([...argv]);
+
+        return ok();
+      },
+    });
+
+    expect(predicate('axe/color-contrast', 5)).toBe(true);
+
+    const args = calls.at(-1) ?? [];
+    expect(args).toContain('harden-ledger');
+    expect(args).toContain('is-suppressed');
+    const classIdx = args.indexOf('--finding-class');
+    expect(args[classIdx + 1]).toBe('axe/color-contrast');
+    const countIdx = args.indexOf('--current-pr-count');
+    expect(args[countIdx + 1]).toBe('5');
+  });
+
+  it('treats a non-zero exit as not suppressed (re-surface)', () => {
+    const predicate = makeLedgerSuppressionPredicate({
+      cwd: '/repo',
+      runLedger: notSuppressed,
+    });
+
+    expect(predicate('axe/color-contrast', 5)).toBe(false);
+  });
+});
+
+describe('pruneLedger', () => {
+  it('invokes prune with the comma-joined window classes', () => {
+    const runLedger = vi.fn<LedgerRunner>(() => ok());
+
+    pruneLedger({
+      cwd: '/repo',
+      runLedger,
+      windowClasses: ['axe/color-contrast', 'knip/exports'],
+    });
+
+    const args = runLedger.mock.calls[0]?.[0] ?? [];
+    expect(args).toContain('harden-ledger');
+    expect(args).toContain('prune');
+    const idx = args.indexOf('--window-classes');
+    expect(args[idx + 1]).toBe('axe/color-contrast,knip/exports');
+  });
+
+  it('invokes prune with an empty value when no classes remain in the window', () => {
+    const runLedger = vi.fn<LedgerRunner>(() => ok());
+
+    pruneLedger({cwd: '/repo', runLedger, windowClasses: []});
+
+    const args = runLedger.mock.calls[0]?.[0] ?? [];
+    const idx = args.indexOf('--window-classes');
+    expect(args[idx + 1]).toBe('');
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/ledger.test.ts
+++ b/.gaia/cli/src/harden/__tests__/ledger.test.ts
@@ -1,0 +1,289 @@
+import {execFileSync} from 'node:child_process';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {EXIT_CODES} from '../../exit.js';
+import {
+  declineLedgerPath,
+  type DeclineLedger,
+} from '../../schemas/decline-ledger.js';
+import {run} from '../ledger.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  ledgerPath: string;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-harden-ledger-'));
+  // The handler calls resolveRepoRoot, so we need a real git repo.
+  execFileSync('git', ['init', '-q', '-b', 'main'], {cwd: root});
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    ledgerPath: declineLedgerPath(root),
+    root,
+  };
+};
+
+const captureStdio = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      err.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    err,
+    out,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+const readLedger = (ledgerPath: string): DeclineLedger =>
+  JSON.parse(readFileSync(ledgerPath, 'utf8')) as DeclineLedger;
+
+const FIXED_NOW = new Date('2026-06-05T14:32:00.000Z');
+
+describe('harden-ledger', () => {
+  let sandbox: Sandbox;
+  let io: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    io = captureStdio();
+  });
+
+  afterEach(() => {
+    io.restore();
+    sandbox.cleanup();
+  });
+
+  describe('list', () => {
+    it('prints the empty ledger and exits 0 on a fresh repo', () => {
+      const code = run(['list'], {cwd: sandbox.root});
+
+      expect(code).toBe(EXIT_CODES.OK);
+      expect(io.out.join('')).toBe('{"version":1,"declines":[]}\n');
+    });
+  });
+
+  describe('record', () => {
+    it('creates exactly one entry with an ISO timestamp and pr count', () => {
+      const code = run(
+        ['record', '--finding-class', 'react-doctor/no-generic-handler-names', '--pr-count', '7'],
+        {cwd: sandbox.root, now: () => FIXED_NOW}
+      );
+
+      expect(code).toBe(EXIT_CODES.OK);
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(1);
+      expect(ledger.declines[0]).toEqual({
+        declined_at: '2026-06-05T14:32:00.000Z',
+        declined_at_pr_count: 7,
+        finding_class: 'react-doctor/no-generic-handler-names',
+      });
+    });
+
+    it('upserts: re-recording the same class overwrites count and timestamp', () => {
+      run(['record', '--finding-class', 'axe/color-contrast', '--pr-count', '7'], {
+        cwd: sandbox.root,
+        now: () => new Date('2026-06-01T00:00:00.000Z'),
+      });
+      run(['record', '--finding-class', 'axe/color-contrast', '--pr-count', '9'], {
+        cwd: sandbox.root,
+        now: () => new Date('2026-06-05T00:00:00.000Z'),
+      });
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(1);
+      expect(ledger.declines[0]).toEqual({
+        declined_at: '2026-06-05T00:00:00.000Z',
+        declined_at_pr_count: 9,
+        finding_class: 'axe/color-contrast',
+      });
+    });
+
+    it('keeps distinct classes as separate entries', () => {
+      run(['record', '--finding-class', 'knip/exports', '--pr-count', '3'], {
+        cwd: sandbox.root,
+      });
+      run(['record', '--finding-class', 'cve/1098765', '--pr-count', '5'], {
+        cwd: sandbox.root,
+      });
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(2);
+    });
+
+    it('creates the harden dir with mode 755', () => {
+      run(['record', '--finding-class', 'knip/types', '--pr-count', '1'], {
+        cwd: sandbox.root,
+      });
+
+      const mode = statSync(path.dirname(sandbox.ledgerPath)).mode & 0o777;
+      expect(mode).toBe(0o755);
+    });
+
+    it('exits non-zero when --finding-class is missing', () => {
+      const code = run(['record', '--pr-count', '7'], {cwd: sandbox.root});
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+    });
+
+    it('exits non-zero when --pr-count is missing', () => {
+      const code = run(['record', '--finding-class', 'knip/exports'], {
+        cwd: sandbox.root,
+      });
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+    });
+  });
+
+  describe('is-suppressed', () => {
+    beforeEach(() => {
+      run(['record', '--finding-class', 'rule/switch-statement', '--pr-count', '7'], {
+        cwd: sandbox.root,
+        now: () => FIXED_NOW,
+      });
+    });
+
+    it('exits 0 when below the re-surface threshold', () => {
+      const code = run(
+        ['is-suppressed', '--finding-class', 'rule/switch-statement', '--current-pr-count', '8'],
+        {cwd: sandbox.root}
+      );
+
+      expect(code).toBe(EXIT_CODES.OK);
+    });
+
+    it('exits non-zero at the re-surface threshold (>= 3)', () => {
+      const code = run(
+        ['is-suppressed', '--finding-class', 'rule/switch-statement', '--current-pr-count', '10'],
+        {cwd: sandbox.root}
+      );
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+    });
+
+    it('exits non-zero for an unknown class', () => {
+      const code = run(
+        ['is-suppressed', '--finding-class', 'holistic/n-plus-one', '--current-pr-count', '99'],
+        {cwd: sandbox.root}
+      );
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+    });
+  });
+
+  describe('prune', () => {
+    beforeEach(() => {
+      run(['record', '--finding-class', 'knip/exports', '--pr-count', '3'], {
+        cwd: sandbox.root,
+      });
+      run(['record', '--finding-class', 'knip/types', '--pr-count', '4'], {
+        cwd: sandbox.root,
+      });
+    });
+
+    it('removes entries not in the window-classes set, keeps those in it', () => {
+      const code = run(['prune', '--window-classes', 'knip/exports'], {
+        cwd: sandbox.root,
+      });
+
+      expect(code).toBe(EXIT_CODES.OK);
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(1);
+      expect(ledger.declines[0]?.finding_class).toBe('knip/exports');
+    });
+
+    it('is idempotent: a second prune with the same set is a no-op', () => {
+      run(['prune', '--window-classes', 'knip/exports'], {cwd: sandbox.root});
+      const code = run(['prune', '--window-classes', 'knip/exports'], {
+        cwd: sandbox.root,
+      });
+
+      expect(code).toBe(EXIT_CODES.OK);
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(1);
+    });
+
+    it('prunes all entries when given an empty set', () => {
+      const code = run(['prune', '--window-classes', ''], {cwd: sandbox.root});
+
+      expect(code).toBe(EXIT_CODES.OK);
+
+      const ledger = readLedger(sandbox.ledgerPath);
+      expect(ledger.declines).toHaveLength(0);
+    });
+  });
+
+  describe('corrupt file', () => {
+    it('list fails loud (non-zero, structured error) rather than treating as empty', () => {
+      run(['record', '--finding-class', 'knip/exports', '--pr-count', '1'], {
+        cwd: sandbox.root,
+      });
+      writeFileSync(sandbox.ledgerPath, '{ not valid json', 'utf8');
+
+      const code = run(['list'], {cwd: sandbox.root});
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+      expect(io.err.join('')).toContain('malformed_ledger');
+    });
+
+    it('is-suppressed fails loud rather than re-surfacing a declined class', () => {
+      // Seed a valid entry first so the harden dir exists, then corrupt it.
+      run(['record', '--finding-class', 'knip/exports', '--pr-count', '1'], {
+        cwd: sandbox.root,
+      });
+      writeFileSync(
+        sandbox.ledgerPath,
+        JSON.stringify({version: 2, declines: 'nope'}),
+        'utf8'
+      );
+
+      const code = run(
+        ['is-suppressed', '--finding-class', 'knip/exports', '--current-pr-count', '1'],
+        {cwd: sandbox.root}
+      );
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+      expect(io.err.join('')).toContain('malformed_ledger');
+    });
+  });
+
+  describe('unknown subcommand', () => {
+    it('exits non-zero', () => {
+      const code = run(['frobnicate'], {cwd: sandbox.root});
+
+      expect(code).not.toBe(EXIT_CODES.OK);
+    });
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/parse-findings-block.test.ts
+++ b/.gaia/cli/src/harden/__tests__/parse-findings-block.test.ts
@@ -1,0 +1,92 @@
+import {describe, expect, it} from 'vitest';
+import {parseFindingsBlock} from '../parse-findings-block.js';
+
+const block = (payload: string): string =>
+  [
+    'Human-readable summary line.',
+    '<!-- gaia-harden:findings:start -->',
+    '<!--',
+    payload,
+    '-->',
+    '<!-- gaia-harden:findings:end -->',
+  ].join('\n');
+
+describe('parseFindingsBlock', () => {
+  it('extracts findings from the HTML-comment payload between the sentinels', () => {
+    const body = block(
+      JSON.stringify({
+        auditor: 'ci',
+        findings: [
+          {
+            area_tags: ['app/components'],
+            finding_class: 'react-doctor/no-generic-handler-names',
+            severity: 'warning',
+          },
+          {
+            area_tags: ['app/routes'],
+            finding_class: 'holistic/missing-auth-check',
+            severity: 'error',
+          },
+        ],
+        pr_number: 42,
+        schema: 1,
+      })
+    );
+
+    const findings = parseFindingsBlock(body);
+    expect(findings).toEqual([
+      {
+        area_tags: ['app/components'],
+        finding_class: 'react-doctor/no-generic-handler-names',
+        severity: 'warning',
+      },
+      {
+        area_tags: ['app/routes'],
+        finding_class: 'holistic/missing-auth-check',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  it('returns [] for an explicit empty findings block', () => {
+    const body = block(
+      JSON.stringify({auditor: 'ci', findings: [], pr_number: 7, schema: 1})
+    );
+    expect(parseFindingsBlock(body)).toEqual([]);
+  });
+
+  it('returns null when no sentinels are present', () => {
+    expect(parseFindingsBlock('just a normal comment')).toBeNull();
+  });
+
+  it('returns null when the payload between sentinels is not valid JSON', () => {
+    const body = [
+      '<!-- gaia-harden:findings:start -->',
+      '<!-- { not json } -->',
+      '<!-- gaia-harden:findings:end -->',
+    ].join('\n');
+    expect(parseFindingsBlock(body)).toBeNull();
+  });
+
+  it('drops malformed finding entries but keeps well-formed ones', () => {
+    const body = block(
+      JSON.stringify({
+        auditor: 'local',
+        findings: [
+          {area_tags: 'not-an-array', finding_class: 5, severity: 'warning'},
+          {
+            area_tags: ['app'],
+            finding_class: 'knip/exports',
+            severity: 'warning',
+          },
+        ],
+        pr_number: 9,
+        schema: 1,
+      })
+    );
+
+    expect(parseFindingsBlock(body)).toEqual([
+      {area_tags: ['app'], finding_class: 'knip/exports', severity: 'warning'},
+    ]);
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/tally.test.ts
@@ -1,0 +1,393 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import * as runProcess from '../../ci/util/run-process.js';
+import {run} from '../tally.js';
+import type {ProcessResult} from '../../ci/util/run-process.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+  rulesDir: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-tally-'));
+  const rulesDir = path.join(root, '.claude', 'rules');
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+    rulesDir,
+  };
+};
+
+const captureStdout = () => {
+  const out: string[] = [];
+  const spy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      out.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    out,
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+};
+
+type BlockFinding = {
+  area_tags: string[];
+  finding_class: string;
+  severity: string;
+};
+
+const findingsComment = (
+  prNumber: number,
+  auditor: 'ci' | 'local',
+  findings: BlockFinding[]
+): {body: string} => ({
+  body: [
+    'Audit summary.',
+    '<!-- gaia-harden:findings:start -->',
+    '<!--',
+    JSON.stringify({auditor, findings, pr_number: prNumber, schema: 1}),
+    '-->',
+    '<!-- gaia-harden:findings:end -->',
+  ].join('\n'),
+});
+
+const ghPr = (prNumber: number, comments: Array<{body: string}>) => ({
+  comments,
+  number: prNumber,
+});
+
+const stubGh = (prs: unknown[]): ProcessResult => ({
+  exitCode: 0,
+  stderr: '',
+  stdout: JSON.stringify(prs),
+});
+
+const parseStdout = (out: string[]): Record<string, unknown> =>
+  JSON.parse(out.join('').trim()) as Record<string, unknown>;
+
+describe('harden-tally run', () => {
+  let sandbox: Sandbox;
+  let stdout: ReturnType<typeof captureStdout>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    stdout = captureStdout();
+  });
+
+  afterEach(() => {
+    stdout.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('emits a candidate for a class on 3 distinct merged PRs at warning', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1201, [
+          findingsComment(1201, 'ci', [
+            {
+              area_tags: ['app/components'],
+              finding_class: 'react-doctor/no-generic-handler-names',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(1188, [
+          findingsComment(1188, 'local', [
+            {
+              area_tags: ['app/hooks'],
+              finding_class: 'react-doctor/no-generic-handler-names',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(1175, [
+          findingsComment(1175, 'ci', [
+            {
+              area_tags: ['app/components'],
+              finding_class: 'react-doctor/no-generic-handler-names',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+      ])
+    );
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+    expect(exit).toBe(0);
+
+    const printed = parseStdout(stdout.out);
+    expect(printed.candidate_count).toBe(1);
+    expect(printed.window_days).toBe(90);
+    const candidates = printed.candidates as Array<Record<string, unknown>>;
+    expect(candidates[0]?.finding_class).toBe(
+      'react-doctor/no-generic-handler-names'
+    );
+    expect(candidates[0]?.distinct_pr_count).toBe(3);
+  });
+
+  it('CI+local findings for the same class across distinct PRs combine into one candidate', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1, [
+          findingsComment(1, 'ci', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(2, [
+          findingsComment(2, 'local', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'error',
+            },
+          ]),
+        ]),
+        ghPr(3, [
+          findingsComment(3, 'ci', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    const printed = parseStdout(stdout.out);
+    expect(printed.candidate_count).toBe(1);
+    const candidates = printed.candidates as Array<Record<string, unknown>>;
+    expect(candidates[0]?.severity_max).toBe('error');
+  });
+
+  it('does not surface a class on only 2 distinct PRs', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1, [
+          findingsComment(1, 'ci', [
+            {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+          ]),
+        ]),
+        ghPr(2, [
+          findingsComment(2, 'ci', [
+            {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+  });
+
+  it('does not surface a class found 3 times in a single PR', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1, [
+          findingsComment(1, 'ci', [
+            {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+            {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+            {area_tags: [], finding_class: 'knip/exports', severity: 'warning'},
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+  });
+
+  it('does not surface a suggestion-only class', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh(
+        [3, 2, 1].map((n) =>
+          ghPr(n, [
+            findingsComment(n, 'ci', [
+              {
+                area_tags: [],
+                finding_class: 'holistic/hardcoded-string',
+                severity: 'suggestion',
+              },
+            ]),
+          ])
+        )
+      )
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+  });
+
+  it('drops a class a promoted rule already covers', () => {
+    mkdirSync(sandbox.rulesDir, {recursive: true});
+    writeFileSync(
+      path.join(sandbox.rulesDir, 'switch.md'),
+      '<!-- gaia-harden: promoted from recurring finding_class rule/switch-statement; never for non-recurrence -->'
+    );
+
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh(
+        [3, 2, 1].map((n) =>
+          ghPr(n, [
+            findingsComment(n, 'ci', [
+              {
+                area_tags: [],
+                finding_class: 'rule/switch-statement',
+                severity: 'warning',
+              },
+            ]),
+          ])
+        )
+      )
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+  });
+
+  it('drops a ledger-suppressed class, then re-surfaces once it crosses the threshold again', () => {
+    const gh = stubGh(
+      [3, 2, 1].map((n) =>
+        ghPr(n, [
+          findingsComment(n, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'error',
+            },
+          ]),
+        ])
+      )
+    );
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(gh);
+
+    // Ledger says suppressed (exit 0): no candidate.
+    run([], {
+      cwd: sandbox.root,
+      runLedger: (argv) =>
+        argv.includes('is-suppressed')
+          ? {exitCode: 0, stderr: '', stdout: ''}
+          : {exitCode: 0, stderr: '', stdout: ''},
+    });
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+
+    // Fresh evidence: ledger now says NOT suppressed (exit 1): re-surfaces.
+    stdout.out.length = 0;
+    run([], {
+      cwd: sandbox.root,
+      runLedger: (argv) =>
+        argv.includes('is-suppressed')
+          ? {exitCode: 1, stderr: '', stdout: ''}
+          : {exitCode: 0, stderr: '', stdout: ''},
+    });
+    expect(parseStdout(stdout.out).candidate_count).toBe(1);
+  });
+
+  it('prunes the ledger with the classes still recurring in the window', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh(
+        [3, 2, 1].map((n) =>
+          ghPr(n, [
+            findingsComment(n, 'ci', [
+              {
+                area_tags: [],
+                finding_class: 'axe/color-contrast',
+                severity: 'warning',
+              },
+            ]),
+          ])
+        )
+      )
+    );
+
+    const ledgerCalls: string[][] = [];
+    run([], {
+      cwd: sandbox.root,
+      runLedger: (argv) => {
+        ledgerCalls.push([...argv]);
+
+        return {exitCode: 1, stderr: '', stdout: ''};
+      },
+    });
+
+    const pruneCall = ledgerCalls.find((c) => c.includes('prune'));
+    expect(pruneCall).toBeDefined();
+    const idx = (pruneCall ?? []).indexOf('--window-classes');
+    expect((pruneCall ?? [])[idx + 1]).toBe('axe/color-contrast');
+  });
+
+  it('falls back to candidate_count 0 when gh fails (non-fatal)', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue({
+      exitCode: 4,
+      stderr: 'gh: not authenticated',
+      stdout: '',
+    });
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+    expect(exit).toBe(0);
+    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+  });
+
+  it('queries the 90-day merged-PR window via gh', () => {
+    const ghSpy = vi
+      .spyOn(runProcess, 'runGh')
+      .mockReturnValue(stubGh([]));
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    const args = ghSpy.mock.calls[0]?.[0] ?? [];
+    expect(args).toContain('pr');
+    expect(args).toContain('list');
+    expect(args).toContain('merged');
+    const searchIdx = args.indexOf('--search');
+    expect(args[searchIdx + 1]).toMatch(/^merged:>=\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/.gaia/cli/src/harden/compute-tally.ts
+++ b/.gaia/cli/src/harden/compute-tally.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure tally core for the policy-memory loop.
+ *
+ * Turns recorded code-review-audit findings (already extracted from the
+ * machine-readable PR-comment blocks of the rolling window) into the candidate
+ * list the statusline nudge and `/gaia-harden review` consume. No I/O lives
+ * here: the caller resolves the PR window, parses the comment blocks, and wires
+ * the suppression inputs (promoted rules, the decline ledger) as predicates.
+ *
+ * A class becomes a candidate only when it recurs across at least
+ * `RECURRENCE_THRESHOLD` DISTINCT PRs at error or warning severity, is not
+ * already covered by a promoted rule, and is not currently suppressed by the
+ * decline ledger. Suggestion-severity findings and findings repeated within a
+ * single PR never qualify.
+ */
+import {isValidFindingClass} from '../schemas/finding-class.js';
+
+export const RECURRENCE_THRESHOLD = 3;
+
+export type CountableSeverity = 'error' | 'warning';
+
+type Severity = 'error' | 'suggestion' | 'warning';
+
+export type TallyFinding = {
+  area_tags: readonly string[];
+  finding_class: string;
+  severity: Severity;
+};
+
+export type TallyPrRecord = {
+  findings: readonly TallyFinding[];
+  pr_number: number;
+};
+
+export type TallyCandidate = {
+  area_tags: string[];
+  distinct_pr_count: number;
+  finding_class: string;
+  pr_numbers: number[];
+  severity_max: CountableSeverity;
+};
+
+export type TallyResult = {
+  candidate_count: number;
+  candidates: TallyCandidate[];
+  window_days: number;
+};
+
+export type ComputeTallyArgs = {
+  /** True when a promoted rule already covers the class (drop it). */
+  coveredClass: (findingClass: string) => boolean;
+  prs: readonly TallyPrRecord[];
+  /** True when the decline ledger suppresses the class at this PR count. */
+  suppressedClass: (findingClass: string, currentPrCount: number) => boolean;
+  windowDays: number;
+};
+
+const isCountableSeverity = (severity: Severity): severity is CountableSeverity =>
+  severity === 'error' || severity === 'warning';
+
+type ClassAggregate = {
+  areaTags: string[];
+  prNumbers: number[];
+  severityMax: CountableSeverity;
+};
+
+/**
+ * Folds the window's PRs into a per-class aggregate. A class is counted at most
+ * once per PR (same-class collapse): repeated findings of one class inside a
+ * single PR contribute a single distinct-PR increment. Class-less / invalid and
+ * suggestion-severity findings are dropped before counting.
+ */
+const aggregateByClass = (
+  prs: readonly TallyPrRecord[]
+): Map<string, ClassAggregate> => {
+  const byClass = new Map<string, ClassAggregate>();
+
+  for (const pr of prs) {
+    // Collapse within the PR first so a class counts once per PR regardless of
+    // how many findings carry it; track the strongest severity seen for it.
+    const perPrSeverity = new Map<string, CountableSeverity>();
+    const perPrAreaTags = new Map<string, Set<string>>();
+
+    for (const finding of pr.findings) {
+      if (!isCountableSeverity(finding.severity)) continue;
+      if (!isValidFindingClass(finding.finding_class)) continue;
+
+      const existing = perPrSeverity.get(finding.finding_class);
+
+      if (existing !== 'error') {
+        perPrSeverity.set(finding.finding_class, finding.severity);
+      }
+
+      const tags =
+        perPrAreaTags.get(finding.finding_class) ?? new Set<string>();
+
+      for (const tag of finding.area_tags) tags.add(tag);
+      perPrAreaTags.set(finding.finding_class, tags);
+    }
+
+    for (const [findingClass, severity] of perPrSeverity) {
+      const aggregate = byClass.get(findingClass) ?? {
+        areaTags: [],
+        prNumbers: [],
+        severityMax: 'warning' as CountableSeverity,
+      };
+
+      aggregate.prNumbers.push(pr.pr_number);
+
+      if (severity === 'error') aggregate.severityMax = 'error';
+
+      const seenTags = new Set(aggregate.areaTags);
+
+      for (const tag of perPrAreaTags.get(findingClass) ?? []) {
+        if (!seenTags.has(tag)) {
+          aggregate.areaTags.push(tag);
+          seenTags.add(tag);
+        }
+      }
+
+      byClass.set(findingClass, aggregate);
+    }
+  }
+
+  return byClass;
+};
+
+export const computeTally = ({
+  coveredClass,
+  prs,
+  suppressedClass,
+  windowDays,
+}: ComputeTallyArgs): TallyResult => {
+  const byClass = aggregateByClass(prs);
+
+  const candidates: TallyCandidate[] = [];
+
+  for (const [findingClass, aggregate] of byClass) {
+    const distinctPrCount = aggregate.prNumbers.length;
+
+    if (distinctPrCount < RECURRENCE_THRESHOLD) continue;
+    if (coveredClass(findingClass)) continue;
+    if (suppressedClass(findingClass, distinctPrCount)) continue;
+
+    candidates.push({
+      area_tags: aggregate.areaTags,
+      distinct_pr_count: distinctPrCount,
+      finding_class: findingClass,
+      pr_numbers: aggregate.prNumbers,
+      severity_max: aggregate.severityMax,
+    });
+  }
+
+  return {
+    candidate_count: candidates.length,
+    candidates,
+    window_days: windowDays,
+  };
+};
+
+/**
+ * The set of classes with qualifying recurrence evidence (>= threshold distinct
+ * PRs at countable severity) in the window, before any suppression/coverage
+ * filtering. The ledger-prune pass consumes this so it can drop decline entries
+ * whose class no longer recurs.
+ */
+export const windowClasses = (prs: readonly TallyPrRecord[]): string[] => {
+  const byClass = aggregateByClass(prs);
+  const classes: string[] = [];
+
+  for (const [findingClass, aggregate] of byClass) {
+    if (aggregate.prNumbers.length >= RECURRENCE_THRESHOLD) {
+      classes.push(findingClass);
+    }
+  }
+
+  return classes;
+};

--- a/.gaia/cli/src/harden/covered-classes.ts
+++ b/.gaia/cli/src/harden/covered-classes.ts
@@ -1,0 +1,49 @@
+/**
+ * Detects which finding classes a promoted rule already covers.
+ *
+ * An approved policy-memory rule under `.claude/rules/` carries a provenance
+ * marker naming the class it was promoted from:
+ *
+ *   <!-- gaia-harden: promoted from recurring finding_class <class>; ... -->
+ *
+ * v1 keys coverage on that marker alone: a class with a marker present is
+ * already enforced, so the tally drops it. Reading rule bodies is cheap and the
+ * marker is a single line, so this scans every `*.md` under the rules dir.
+ */
+import {readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+
+const MARKER_RE =
+  /gaia-harden: promoted from recurring finding_class\s+(\S+?)\s*(?:;|-->)/g;
+
+export const coveredClassesFromRules = (rulesDir: string): Set<string> => {
+  const covered = new Set<string>();
+
+  let entries: string[];
+
+  try {
+    entries = readdirSync(rulesDir).filter((name) => name.endsWith('.md'));
+  } catch {
+    return covered;
+  }
+
+  for (const name of entries) {
+    let body: string;
+
+    try {
+      body = readFileSync(path.join(rulesDir, name), 'utf8');
+    } catch {
+      continue;
+    }
+
+    for (const match of body.matchAll(MARKER_RE)) {
+      const findingClass = match[1];
+
+      if (findingClass !== undefined && findingClass.length > 0) {
+        covered.add(findingClass);
+      }
+    }
+  }
+
+  return covered;
+};

--- a/.gaia/cli/src/harden/ledger-bridge.ts
+++ b/.gaia/cli/src/harden/ledger-bridge.ts
@@ -1,0 +1,85 @@
+/**
+ * Bridge from the tally pass to the machine-local decline ledger.
+ *
+ * The ledger is a sibling subcommand of this same binary
+ * (`gaia harden-ledger`), so the bridge re-invokes the running binary rather
+ * than importing the ledger module directly: it keeps the tally bound to the
+ * frozen ledger CLI contract (the verbs + exit codes), not to ledger internals.
+ *
+ * Contract consumed:
+ *   - `harden-ledger is-suppressed --finding-class <c> --current-pr-count <n>`
+ *     exits 0 when suppressed, non-zero when the class should re-surface.
+ *   - `harden-ledger prune --window-classes <c1,c2,...>` self-cleans the ledger.
+ *
+ * The runner is injectable so the tally tests drive suppression deterministically
+ * without spawning a process.
+ */
+import {spawnSync} from 'node:child_process';
+import type {ProcessResult} from '../ci/util/run-process.js';
+
+export type LedgerRunner = (
+  argv: readonly string[],
+  cwd: string
+) => ProcessResult;
+
+/**
+ * Default runner: re-invokes the running binary so the ledger subcommand runs
+ * against the same install. `process.argv[1]` is the entry script (the bundled
+ * `gaia` under node, or the `tsx` entry in dev), `process.execPath` is the node
+ * runtime.
+ */
+export const defaultLedgerRunner: LedgerRunner = (argv, cwd) => {
+  const entry = process.argv[1] ?? '';
+  const result = spawnSync(process.execPath, [entry, ...argv], {
+    cwd,
+    encoding: 'utf8',
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return {
+    exitCode: result.status ?? 1,
+    stderr: result.stderr ?? '',
+    stdout: result.stdout ?? '',
+  };
+};
+
+type BridgeOptions = {
+  cwd: string;
+  runLedger?: LedgerRunner;
+};
+
+export const makeLedgerSuppressionPredicate = ({
+  cwd,
+  runLedger = defaultLedgerRunner,
+}: BridgeOptions): ((findingClass: string, currentPrCount: number) => boolean) =>
+  (findingClass, currentPrCount) => {
+    const result = runLedger(
+      [
+        'harden-ledger',
+        'is-suppressed',
+        '--finding-class',
+        findingClass,
+        '--current-pr-count',
+        String(currentPrCount),
+      ],
+      cwd
+    );
+
+    return result.exitCode === 0;
+  };
+
+type PruneOptions = BridgeOptions & {
+  windowClasses: readonly string[];
+};
+
+export const pruneLedger = ({
+  cwd,
+  runLedger = defaultLedgerRunner,
+  windowClasses,
+}: PruneOptions): void => {
+  runLedger(
+    ['harden-ledger', 'prune', '--window-classes', windowClasses.join(',')],
+    cwd
+  );
+};

--- a/.gaia/cli/src/harden/ledger.ts
+++ b/.gaia/cli/src/harden/ledger.ts
@@ -1,0 +1,457 @@
+/**
+ * `gaia harden-ledger {list|record|is-suppressed|prune}`
+ *
+ * The machine-local decline ledger CLI. When an engineer declines a hardening
+ * candidate the decline is recorded only on their machine (gitignored), so it
+ * never vetoes the rule for a teammate. Re-surfacing is evidence-based, not a
+ * timer: a declined class stays suppressed for that engineer until at least 3
+ * distinct PRs carrying the class merge after the decline.
+ *
+ * The tally refresher READS this surface (`is-suppressed`, `prune`); the
+ * `/gaia-harden` command WRITES to it (`record`) on decline. Both bind to the
+ * verbs and exit-code semantics below.
+ *
+ * Ledger file: `.gaia/local/harden/declines.json` (gitignored). Schema and
+ * atomic writer in `schemas/decline-ledger.ts`.
+ */
+import {EXIT_CODES} from '../exit.js';
+import {
+  emptyDeclineLedger,
+  readDeclineLedger,
+  writeDeclineLedger,
+  type DeclineLedger,
+} from '../schemas/decline-ledger.js';
+import {structuredError} from '../stderr.js';
+import {resolveRepoRoot} from '../wiki/util/git.js';
+
+const HELP_TEXT = `Usage: gaia harden-ledger <subcommand> [args]
+
+  list
+    Print the decline ledger as JSON to stdout
+    ({"version":1,"declines":[]} when absent).
+
+  record --finding-class <c> --pr-count <n>
+    Upsert one bounded entry keyed by finding_class (re-record overwrites the
+    timestamp and PR count). One entry per class.
+
+  is-suppressed --finding-class <c> --current-pr-count <n>
+    Exit 0 (suppressed) when an entry exists and current-pr-count minus its
+    declined_at_pr_count is below the re-surface threshold (3); exit 1
+    (not suppressed) otherwise.
+
+  prune --window-classes <c1,c2,...>
+    Remove any decline entry whose finding_class is not in the comma-separated
+    set (no qualifying evidence left in the window). Idempotent.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+// Re-surface threshold: a declined class stays suppressed until at least this
+// many distinct PRs carrying the class merge after the decline.
+const RESURFACE_THRESHOLD = 3;
+
+type RunOptions = {
+  cwd?: string;
+  now?: () => Date;
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  if (argv.length === 0 || HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+
+  const sub = argv[0] as string;
+  const rest = argv.slice(1);
+
+  if (sub === 'list') return handleList(rest, options);
+  if (sub === 'record') return handleRecord(rest, options);
+  if (sub === 'is-suppressed') return handleIsSuppressed(rest, options);
+  if (sub === 'prune') return handlePrune(rest, options);
+
+  structuredError({
+    code: 'unknown_subcommand',
+    message: `unknown harden-ledger subcommand: ${sub}`,
+    subcommand: 'harden-ledger',
+  });
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
+const parseCountFlag = (value: string | undefined): number | undefined => {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed < 0) return undefined;
+
+  return parsed;
+};
+
+const resolveRoot = (
+  options: RunOptions,
+  subcommand: string
+): string | null => {
+  try {
+    return resolveRepoRoot(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: `gaia harden-ledger ${subcommand} must run inside a git repository`,
+      subcommand: `harden-ledger ${subcommand}`,
+    });
+
+    return null;
+  }
+};
+
+/**
+ * Read the ledger, translating the discriminated result into the in-memory
+ * ledger or `null` on a malformed file (after surfacing a structured error).
+ * A missing file resolves to the empty ledger.
+ */
+const loadLedger = (
+  repoRoot: string,
+  subcommand: string
+): DeclineLedger | null => {
+  const result = readDeclineLedger(repoRoot);
+
+  if (result.status === 'malformed') {
+    structuredError({
+      code: 'malformed_ledger',
+      message: result.error,
+      subcommand: `harden-ledger ${subcommand}`,
+    });
+
+    return null;
+  }
+
+  if (result.status === 'missing') return emptyDeclineLedger();
+
+  return result.ledger;
+};
+
+// --- list ----------------------------------------------------------------
+
+const handleList = (argv: readonly string[], options: RunOptions): number => {
+  if (argv.length > 0) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: `unknown argument: ${argv[0] as string}`,
+      subcommand: 'harden-ledger list',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'list');
+
+  if (repoRoot === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+
+  const ledger = loadLedger(repoRoot, 'list');
+
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+
+  process.stdout.write(`${JSON.stringify(ledger)}\n`);
+
+  return EXIT_CODES.OK;
+};
+
+// --- record --------------------------------------------------------------
+
+type RecordArgs = {
+  findingClass: string | undefined;
+  prCount: number | undefined;
+};
+
+const parseRecordArgs = (argv: readonly string[]): RecordArgs | string => {
+  let findingClass: string | undefined;
+  let prCount: number | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--finding-class') {
+      findingClass = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--pr-count') {
+      prCount = parseCountFlag(argv[index + 1]);
+      index += 1;
+
+      continue;
+    }
+
+    return `unknown argument: ${token}`;
+  }
+
+  return {findingClass, prCount};
+};
+
+const handleRecord = (argv: readonly string[], options: RunOptions): number => {
+  const parsed = parseRecordArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'harden-ledger record',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {findingClass, prCount} = parsed;
+
+  if (findingClass === undefined || findingClass === '') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'harden-ledger record requires --finding-class <c>',
+      subcommand: 'harden-ledger record',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (prCount === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message:
+        'harden-ledger record requires --pr-count <n> (non-negative integer)',
+      subcommand: 'harden-ledger record',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'record');
+
+  if (repoRoot === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+
+  const ledger = loadLedger(repoRoot, 'record');
+
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+
+  const declinedAt = (options.now ?? (() => new Date()))().toISOString();
+  const entry = {
+    declined_at: declinedAt,
+    declined_at_pr_count: prCount,
+    finding_class: findingClass,
+  };
+
+  // Upsert: one bounded entry per class. Re-record overwrites in place.
+  const existingIndex = ledger.declines.findIndex(
+    (decline) => decline.finding_class === findingClass
+  );
+
+  if (existingIndex === -1) {
+    ledger.declines.push(entry);
+  } else {
+    ledger.declines[existingIndex] = entry;
+  }
+
+  writeDeclineLedger(repoRoot, ledger);
+
+  return EXIT_CODES.OK;
+};
+
+// --- is-suppressed -------------------------------------------------------
+
+type IsSuppressedArgs = {
+  currentPrCount: number | undefined;
+  findingClass: string | undefined;
+};
+
+const parseIsSuppressedArgs = (
+  argv: readonly string[]
+): IsSuppressedArgs | string => {
+  let findingClass: string | undefined;
+  let currentPrCount: number | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--finding-class') {
+      findingClass = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    if (token === '--current-pr-count') {
+      currentPrCount = parseCountFlag(argv[index + 1]);
+      index += 1;
+
+      continue;
+    }
+
+    return `unknown argument: ${token}`;
+  }
+
+  return {currentPrCount, findingClass};
+};
+
+const handleIsSuppressed = (
+  argv: readonly string[],
+  options: RunOptions
+): number => {
+  const parsed = parseIsSuppressedArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'harden-ledger is-suppressed',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {currentPrCount, findingClass} = parsed;
+
+  if (findingClass === undefined || findingClass === '') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: 'harden-ledger is-suppressed requires --finding-class <c>',
+      subcommand: 'harden-ledger is-suppressed',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  if (currentPrCount === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message:
+        'harden-ledger is-suppressed requires --current-pr-count <n> (non-negative integer)',
+      subcommand: 'harden-ledger is-suppressed',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'is-suppressed');
+
+  if (repoRoot === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+
+  const ledger = loadLedger(repoRoot, 'is-suppressed');
+
+  // Fail loud on a corrupt file rather than treating it as empty (which would
+  // wrongly re-surface a declined candidate).
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+
+  const entry = ledger.declines.find(
+    (decline) => decline.finding_class === findingClass
+  );
+
+  // No entry: not suppressed (re-surface).
+  if (entry === undefined) {
+    structuredError({
+      code: 'not_suppressed',
+      finding_class: findingClass,
+      reason: 'no_decline_entry',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  // Evidence-based, not a timer: compare distinct PRs merged after the decline
+  // against the re-surface threshold.
+  const mergedSinceDecline = currentPrCount - entry.declined_at_pr_count;
+  const suppressed = mergedSinceDecline < RESURFACE_THRESHOLD;
+
+  if (!suppressed) {
+    structuredError({
+      code: 'not_suppressed',
+      finding_class: findingClass,
+      merged_since_decline: mergedSinceDecline,
+      reason: 'threshold_reached',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  return EXIT_CODES.OK;
+};
+
+// --- prune ---------------------------------------------------------------
+
+const parsePruneArgs = (
+  argv: readonly string[]
+): {windowClasses: string | undefined} | string => {
+  let windowClasses: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index] as string;
+
+    if (token === '--window-classes') {
+      windowClasses = argv[index + 1];
+      index += 1;
+
+      continue;
+    }
+
+    return `unknown argument: ${token}`;
+  }
+
+  return {windowClasses};
+};
+
+const handlePrune = (argv: readonly string[], options: RunOptions): number => {
+  const parsed = parsePruneArgs(argv);
+
+  if (typeof parsed === 'string') {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed,
+      subcommand: 'harden-ledger prune',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const {windowClasses} = parsed;
+
+  if (windowClasses === undefined) {
+    structuredError({
+      code: 'invalid_arguments',
+      message:
+        'harden-ledger prune requires --window-classes <c1,c2,...> (use an empty string to prune all)',
+      subcommand: 'harden-ledger prune',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const repoRoot = resolveRoot(options, 'prune');
+
+  if (repoRoot === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+
+  const ledger = loadLedger(repoRoot, 'prune');
+
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+
+  const keep = new Set(
+    windowClasses
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+  );
+
+  const kept = ledger.declines.filter((decline) =>
+    keep.has(decline.finding_class)
+  );
+
+  // Idempotent: only write when the prune actually removes an entry.
+  if (kept.length !== ledger.declines.length) {
+    writeDeclineLedger(repoRoot, {...ledger, declines: kept});
+  }
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/harden/parse-findings-block.ts
+++ b/.gaia/cli/src/harden/parse-findings-block.ts
@@ -1,0 +1,107 @@
+/**
+ * Deterministic parser for the machine-readable findings block CI (and a local
+ * audit run) appends to a PR comment.
+ *
+ * Shape (frozen by the comment-block contract):
+ *
+ *   <!-- gaia-harden:findings:start -->
+ *   <!--
+ *   {"schema":1,"pr_number":N,"auditor":"ci","findings":[
+ *     {"finding_class":"...","severity":"warning","area_tags":["..."]}
+ *   ]}
+ *   -->
+ *   <!-- gaia-harden:findings:end -->
+ *
+ * The JSON payload lives INSIDE an inner HTML comment so it does not render. The
+ * parser locates the sentinels, strips the inner comment framing, and
+ * `JSON.parse`s the payload. Anything malformed yields `null` (no block) so the
+ * caller treats the PR as carrying no countable findings rather than crashing
+ * the refresher.
+ */
+const START_SENTINEL = '<!-- gaia-harden:findings:start -->';
+const END_SENTINEL = '<!-- gaia-harden:findings:end -->';
+
+export type ParsedFinding = {
+  area_tags: string[];
+  finding_class: string;
+  severity: 'error' | 'suggestion' | 'warning';
+};
+
+const SEVERITIES = new Set(['error', 'suggestion', 'warning']);
+
+const parseFinding = (value: unknown): ParsedFinding | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.finding_class !== 'string' || v.finding_class.length === 0) {
+    return null;
+  }
+
+  if (typeof v.severity !== 'string' || !SEVERITIES.has(v.severity)) {
+    return null;
+  }
+
+  if (
+    !Array.isArray(v.area_tags) ||
+    !v.area_tags.every((tag): tag is string => typeof tag === 'string')
+  ) {
+    return null;
+  }
+
+  return {
+    area_tags: v.area_tags,
+    finding_class: v.finding_class,
+    severity: v.severity as ParsedFinding['severity'],
+  };
+};
+
+/**
+ * Returns the well-formed findings in `body`, `[]` for an explicit empty block,
+ * or `null` when no parseable block is present.
+ */
+export const parseFindingsBlock = (body: string): ParsedFinding[] | null => {
+  const startIndex = body.indexOf(START_SENTINEL);
+
+  if (startIndex === -1) return null;
+
+  const endIndex = body.indexOf(END_SENTINEL, startIndex);
+
+  if (endIndex === -1) return null;
+
+  const between = body.slice(startIndex + START_SENTINEL.length, endIndex);
+
+  // Strip the inner HTML-comment framing (`<!--` ... `-->`) around the JSON.
+  const openIndex = between.indexOf('<!--');
+
+  if (openIndex === -1) return null;
+
+  const closeIndex = between.lastIndexOf('-->');
+
+  if (closeIndex === -1 || closeIndex <= openIndex) return null;
+
+  const payload = between.slice(openIndex + '<!--'.length, closeIndex).trim();
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+
+  const findings = (parsed as Record<string, unknown>).findings;
+
+  if (!Array.isArray(findings)) return null;
+
+  const result: ParsedFinding[] = [];
+
+  for (const entry of findings) {
+    const finding = parseFinding(entry);
+
+    if (finding !== null) result.push(finding);
+  }
+
+  return result;
+};

--- a/.gaia/cli/src/harden/tally.ts
+++ b/.gaia/cli/src/harden/tally.ts
@@ -1,0 +1,174 @@
+/**
+ * `gaia harden-tally` - the deterministic, TTL-bounded recurrence tally for the
+ * policy-memory loop.
+ *
+ * Resolves the rolling 90-day merged-PR window via `gh`, extracts each PR's
+ * machine-readable findings block, counts distinct PRs per `finding_class` at
+ * error/warning severity, drops classes a promoted rule already covers or the
+ * decline ledger suppresses, self-cleans the ledger, and prints the candidate
+ * list as JSON to stdout. The statusline refresher mirrors `candidate_count`
+ * into the cache; `/gaia-harden review` re-runs this to get the live list.
+ *
+ * No LLM, no drafting, no writes other than (indirectly) the ledger prune. The
+ * window read is the only network access and it is non-fatal: a gh failure
+ * yields an empty candidate list rather than aborting the refresher.
+ */
+import path from 'node:path';
+import {runGh, type ProcessResult} from '../ci/util/run-process.js';
+import {EXIT_CODES} from '../exit.js';
+import {
+  computeTally,
+  type TallyPrRecord,
+  windowClasses,
+} from './compute-tally.js';
+import {coveredClassesFromRules} from './covered-classes.js';
+import {
+  defaultLedgerRunner,
+  makeLedgerSuppressionPredicate,
+  pruneLedger,
+  type LedgerRunner,
+} from './ledger-bridge.js';
+import {parseFindingsBlock} from './parse-findings-block.js';
+
+const HELP_TEXT = `Usage: gaia harden-tally
+
+  Tallies recurring code-review-audit findings across the rolling 90-day
+  merged-PR window and prints the candidate list as JSON. A class is a
+  candidate when it recurs across >= 3 distinct PRs at error/warning severity,
+  no promoted rule covers it, and the decline ledger does not suppress it.
+
+  Network failures are non-fatal: gh errors yield an empty candidate list.
+`;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+const WINDOW_DAYS = 90;
+
+type RunOptions = {
+  cwd?: string;
+  runLedger?: LedgerRunner;
+};
+
+const windowStartDate = (now: Date): string => {
+  const start = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  return start.toISOString().slice(0, 10);
+};
+
+type GhPr = {
+  comments: Array<{body: string}>;
+  number: number;
+};
+
+const parseGhPr = (value: unknown): GhPr | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.number !== 'number' || !Number.isFinite(v.number)) return null;
+  if (!Array.isArray(v.comments)) return null;
+
+  const comments: Array<{body: string}> = [];
+
+  for (const comment of v.comments) {
+    if (
+      typeof comment === 'object' &&
+      comment !== null &&
+      typeof (comment as Record<string, unknown>).body === 'string'
+    ) {
+      comments.push({body: (comment as Record<string, unknown>).body as string});
+    }
+  }
+
+  return {comments, number: v.number};
+};
+
+/**
+ * Reads the merged-PR window via gh. Returns one record per PR that carries a
+ * parseable findings block (the latest such comment wins so a re-run audit
+ * supersedes an earlier one). Returns an empty array on any gh failure so the
+ * refresher never blocks.
+ */
+const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
+  const search = `merged:>=${windowStartDate(now)}`;
+  const result: ProcessResult = runGh(
+    [
+      'pr',
+      'list',
+      '--state',
+      'merged',
+      '--search',
+      search,
+      '--limit',
+      '200',
+      '--json',
+      'number,comments',
+    ],
+    {cwd}
+  );
+
+  if (result.exitCode !== 0) return [];
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) return [];
+
+  const records: TallyPrRecord[] = [];
+
+  for (const value of parsed) {
+    const pr = parseGhPr(value);
+
+    if (pr === null) continue;
+
+    // The latest comment carrying a block wins (a re-run audit supersedes an
+    // earlier one on the same PR).
+    let findings: TallyPrRecord['findings'] | undefined;
+
+    for (const comment of pr.comments) {
+      const block = parseFindingsBlock(comment.body);
+
+      if (block !== null) findings = block;
+    }
+
+    if (findings !== undefined) {
+      records.push({findings, pr_number: pr.number});
+    }
+  }
+
+  return records;
+};
+
+export const run = (argv: readonly string[], options: RunOptions = {}): number => {
+  if (argv.length > 0 && HELP_TOKENS.has(argv[0] as string)) {
+    process.stdout.write(HELP_TEXT);
+
+    return EXIT_CODES.OK;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const runLedger = options.runLedger ?? defaultLedgerRunner;
+  const now = new Date();
+
+  const prs = fetchWindowPrs(cwd, now);
+  const covered = coveredClassesFromRules(
+    path.join(cwd, '.claude', 'rules')
+  );
+
+  const result = computeTally({
+    coveredClass: (findingClass) => covered.has(findingClass),
+    prs,
+    suppressedClass: makeLedgerSuppressionPredicate({cwd, runLedger}),
+    windowDays: WINDOW_DAYS,
+  });
+
+  // Self-clean the ledger: drop declines whose class no longer recurs.
+  pruneLedger({cwd, runLedger, windowClasses: windowClasses(prs)});
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+
+  return EXIT_CODES.OK;
+};

--- a/.gaia/cli/src/harden/tally.ts
+++ b/.gaia/cli/src/harden/tally.ts
@@ -89,7 +89,7 @@ const parseGhPr = (value: unknown): GhPr | null => {
  */
 const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
   const search = `merged:>=${windowStartDate(now)}`;
-  const result: ProcessResult = runGh(
+  const ghResult: ProcessResult = runGh(
     [
       'pr',
       'list',
@@ -105,12 +105,12 @@ const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
     {cwd}
   );
 
-  if (result.exitCode !== 0) return [];
+  if (ghResult.exitCode !== 0) return [];
 
   let parsed: unknown;
 
   try {
-    parsed = JSON.parse(result.stdout);
+    parsed = JSON.parse(ghResult.stdout);
   } catch {
     return [];
   }
@@ -158,7 +158,7 @@ export const run = (argv: readonly string[], options: RunOptions = {}): number =
     path.join(cwd, '.claude', 'rules')
   );
 
-  const result = computeTally({
+  const tallyResult = computeTally({
     coveredClass: (findingClass) => covered.has(findingClass),
     prs,
     suppressedClass: makeLedgerSuppressionPredicate({cwd, runLedger}),
@@ -168,7 +168,7 @@ export const run = (argv: readonly string[], options: RunOptions = {}): number =
   // Self-clean the ledger: drop declines whose class no longer recurs.
   pruneLedger({cwd, runLedger, windowClasses: windowClasses(prs)});
 
-  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.stdout.write(`${JSON.stringify(tallyResult)}\n`);
 
   return EXIT_CODES.OK;
 };

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -15,6 +15,8 @@ import {run as runCiRevert} from './ci/revert.js';
 import {run as runCiStaleCheck} from './ci/stale-check.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runFitness} from './fitness/index.js';
+import {run as runHardenLedger} from './harden/ledger.js';
+import {run as runHardenTally} from './harden/tally.js';
 import {run as runInit} from './init/index.js';
 import {run as runMentorship} from './mentorship/index.js';
 import {run as runScaffold} from './scaffold/index.js';
@@ -35,6 +37,8 @@ const HELP_TEXT = `Usage: gaia <subcommand> [args]
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
   fitness render-card [--cols N]
+  harden-ledger list|record|is-suppressed|prune
+  harden-tally
   automation read-config|read-state|init-state|bump-state|cron-decide|record-run|record-overage|clear-overage
   ci-stale-check --label <name> --base <branch> [--author <login>] [--json]
   ci-revert open|mark-failed|is-cap-reached
@@ -62,6 +66,8 @@ const SUBCOMMAND_HANDLERS: Readonly<
   'ci-revert': runCiRevert,
   'ci-stale-check': runCiStaleCheck,
   fitness: runFitness,
+  'harden-ledger': runHardenLedger,
+  'harden-tally': runHardenTally,
   init: runInit,
   mentorship: runMentorship,
   scaffold: runScaffold,

--- a/.gaia/cli/src/schemas/__tests__/cloud-projection.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/cloud-projection.test.ts
@@ -107,8 +107,20 @@ describe('schemas/cloud-projection', () => {
         CodeReviewAuditFindingCloudPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'axe/color-contrast',
           ip: '127.0.0.1',
+          pr_number: 42,
+          severity: 'warning',
+        })
+      ).toThrow();
+    });
+
+    it('rejects a free-text finding_class on CodeReviewAuditFindingCloudPayload', () => {
+      expect(() =>
+        CodeReviewAuditFindingCloudPayload.parse({
+          area_tags: ['typescript'],
+          auditor_type: 'code-review-audit',
+          finding_class: 'type_hole',
           pr_number: 42,
           severity: 'warning',
         })
@@ -126,7 +138,7 @@ describe('schemas/cloud-projection', () => {
         CodeReviewAuditFindingCloudPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'cve/1098765',
           pr_number: 42,
           severity: 'warning',
         })

--- a/.gaia/cli/src/schemas/__tests__/finding-class.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/finding-class.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from 'vitest';
+import {
+  FINDING_CLASS_PREFIXES,
+  FindingClassSchema,
+  HOLISTIC_FINDING_CLASSES,
+  isValidFindingClass,
+  RULE_FINDING_CLASSES,
+} from '../finding-class.js';
+
+describe('schemas/finding-class', () => {
+  describe('oracle buckets (open id space after the prefix)', () => {
+    it.each([
+      'react-doctor/no-generic-handler-names',
+      'axe/color-contrast',
+      'knip/exports',
+      'knip/types',
+      'knip/dependencies',
+      'cve/1098765',
+    ])('accepts a well-formed oracle id: %s', (value) => {
+      expect(FindingClassSchema.safeParse(value).success).toBe(true);
+      expect(isValidFindingClass(value)).toBe(true);
+    });
+
+    it('rejects an oracle prefix with an empty slug', () => {
+      expect(FindingClassSchema.safeParse('react-doctor/').success).toBe(false);
+      expect(isValidFindingClass('axe/')).toBe(false);
+    });
+  });
+
+  describe('closed holistic/rule buckets (controlled vocabulary)', () => {
+    it.each(HOLISTIC_FINDING_CLASSES)(
+      'accepts seeded holistic member: %s',
+      (value) => {
+        expect(FindingClassSchema.safeParse(value).success).toBe(true);
+      }
+    );
+
+    it.each(RULE_FINDING_CLASSES)(
+      'accepts seeded rule member: %s',
+      (value) => {
+        expect(FindingClassSchema.safeParse(value).success).toBe(true);
+      }
+    );
+
+    it('rejects an unseeded holistic member (closed bucket)', () => {
+      expect(
+        FindingClassSchema.safeParse('holistic/something-made-up').success
+      ).toBe(false);
+      expect(isValidFindingClass('holistic/something-made-up')).toBe(false);
+    });
+
+    it('rejects an unseeded rule member (closed bucket)', () => {
+      expect(
+        FindingClassSchema.safeParse('rule/totally-invented').success
+      ).toBe(false);
+    });
+  });
+
+  describe('free-text drift', () => {
+    it.each(['just free text', '', 'no-prefix-slug', 'unknown/whatever'])(
+      'rejects: %j',
+      (value) => {
+        expect(FindingClassSchema.safeParse(value).success).toBe(false);
+        expect(isValidFindingClass(value)).toBe(false);
+      }
+    );
+  });
+
+  describe('exported vocabulary', () => {
+    it('exposes the six known prefixes', () => {
+      expect(new Set(FINDING_CLASS_PREFIXES)).toEqual(
+        new Set(['axe', 'cve', 'holistic', 'knip', 'react-doctor', 'rule'])
+      );
+    });
+  });
+});

--- a/.gaia/cli/src/schemas/__tests__/mentorship-payloads.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/mentorship-payloads.test.ts
@@ -255,7 +255,7 @@ describe('schemas/mentorship-payloads', () => {
         CodeReviewAuditFindingPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'react-doctor/no-generic-handler-names',
           pr_number: 42,
           severity: 'warning',
           spec_id: 'SPEC-014',
@@ -268,7 +268,7 @@ describe('schemas/mentorship-payloads', () => {
         CodeReviewAuditFindingPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'holistic/missing-auth-check',
           pr_number: 42,
           severity: 'warning',
         })
@@ -280,7 +280,7 @@ describe('schemas/mentorship-payloads', () => {
         CodeReviewAuditFindingPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'axe/color-contrast',
           pr_number: 0,
           severity: 'warning',
         })
@@ -292,9 +292,33 @@ describe('schemas/mentorship-payloads', () => {
         CodeReviewAuditFindingPayload.parse({
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'axe/color-contrast',
           pr_number: 42,
           severity: 'critical',
+        })
+      ).toThrow();
+    });
+
+    it('rejects a free-text finding_class (drift)', () => {
+      expect(() =>
+        CodeReviewAuditFindingPayload.parse({
+          area_tags: ['typescript'],
+          auditor_type: 'code-review-audit',
+          finding_class: 'type_hole',
+          pr_number: 42,
+          severity: 'warning',
+        })
+      ).toThrow();
+    });
+
+    it('rejects an unseeded holistic finding_class', () => {
+      expect(() =>
+        CodeReviewAuditFindingPayload.parse({
+          area_tags: ['typescript'],
+          auditor_type: 'code-review-audit',
+          finding_class: 'holistic/something-made-up',
+          pr_number: 42,
+          severity: 'warning',
         })
       ).toThrow();
     });

--- a/.gaia/cli/src/schemas/cloud-projection.ts
+++ b/.gaia/cli/src/schemas/cloud-projection.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod';
+import {FindingClassSchema} from './finding-class.js';
 
 // Cloud payloads strip identity-bearing fields. Mirror the mentorship payloads
 // minus any field that could re-identify the developer.
@@ -95,7 +96,7 @@ export type TimeToResolvedSpecCloudPayload = z.infer<
 export const CodeReviewAuditFindingCloudPayload = z.strictObject({
   area_tags: z.array(z.string()),
   auditor_type: z.string(),
-  finding_class: z.string(),
+  finding_class: FindingClassSchema,
   pr_number: z.number().int(),
   severity: z.string(),
   spec_id: z.string().optional(),

--- a/.gaia/cli/src/schemas/decline-ledger.ts
+++ b/.gaia/cli/src/schemas/decline-ledger.ts
@@ -1,0 +1,100 @@
+/**
+ * Zod schema + read/write helpers for the machine-local decline ledger.
+ *
+ * When an engineer declines a hardening candidate, that decline is recorded
+ * only on their machine so it never vetoes the rule for a teammate. The
+ * ledger holds one bounded entry per `finding_class`; re-recording a class
+ * overwrites its timestamp and PR count.
+ *
+ * The file lives at `.gaia/local/harden/declines.json` (gitignored). A
+ * corrupt or hand-edited file fails loud (the discriminated `read*` result
+ * carries `status: 'malformed'`) rather than being silently treated as
+ * empty, which would wrongly re-surface or wrongly suppress a candidate.
+ */
+import {existsSync, mkdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {z} from 'zod';
+import {atomicWriteFileSync} from '../util/atomic-write.js';
+import {summarizeZodError} from './zod-error.js';
+
+export const declineLedgerPath = (repoRoot: string): string =>
+  path.join(repoRoot, '.gaia', 'local', 'harden', 'declines.json');
+
+export const DeclineEntrySchema = z.object({
+  declined_at: z.iso.datetime(),
+  declined_at_pr_count: z.number().int().nonnegative(),
+  finding_class: z.string().min(1),
+});
+export type DeclineEntry = z.infer<typeof DeclineEntrySchema>;
+
+// `version` is declared first so JSON serialization emits it first, matching
+// the frozen ledger shape (`{"version":1,"declines":[]}`).
+export const DeclineLedgerSchema = z.object({
+  version: z.literal(1),
+  declines: z.array(DeclineEntrySchema),
+});
+export type DeclineLedger = z.infer<typeof DeclineLedgerSchema>;
+
+export const emptyDeclineLedger = (): DeclineLedger => ({
+  version: 1,
+  declines: [],
+});
+
+export type ReadDeclineLedgerResult =
+  | {ledger: DeclineLedger; status: 'ok'}
+  | {status: 'missing'}
+  | {error: string; status: 'malformed'};
+
+export const readDeclineLedger = (
+  repoRoot: string
+): ReadDeclineLedgerResult => {
+  const filePath = declineLedgerPath(repoRoot);
+
+  if (!existsSync(filePath)) return {status: 'missing'};
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    return {
+      error: `${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      error: `${filePath}: invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      status: 'malformed',
+    };
+  }
+
+  const result = DeclineLedgerSchema.safeParse(parsed);
+
+  if (!result.success) {
+    return {
+      error: summarizeZodError(filePath, result.error),
+      status: 'malformed',
+    };
+  }
+
+  return {ledger: result.data, status: 'ok'};
+};
+
+export const writeDeclineLedger = (
+  repoRoot: string,
+  ledger: DeclineLedger
+): void => {
+  const target = declineLedgerPath(repoRoot);
+  // Mode 755 matches the in-project dir convention (`ensureInProjectDirectory`
+  // in storage/paths.ts).
+  mkdirSync(path.dirname(target), {mode: 0o755, recursive: true});
+
+  const serialized = `${JSON.stringify(ledger, null, 2)}\n`;
+  atomicWriteFileSync(target, serialized);
+};

--- a/.gaia/cli/src/schemas/finding-class.ts
+++ b/.gaia/cli/src/schemas/finding-class.ts
@@ -1,0 +1,121 @@
+import {z} from 'zod';
+
+/**
+ * A `finding_class` is a stable, machine-stable identifier for a kind of
+ * code-review-audit finding. Recurrence (the policy-memory loop) keys on it,
+ * so it must reject free-text drift.
+ *
+ * Per-bucket convention:
+ *
+ * - Oracle buckets (deterministic tools) carry the tool's own id verbatim
+ *   after the prefix; the tool owns that id space, so any well-formed slug is
+ *   accepted: `react-doctor/<rule-id>`, `axe/<rule-id>`, `knip/<issue-type>`,
+ *   `cve/<advisory-id>`.
+ * - Holistic / rule-subagent buckets carry a CLOSED controlled vocabulary
+ *   (the `as const` unions below). A holistic or rule finding only becomes a
+ *   countable class once it has a seeded member; an unseeded member is
+ *   rejected so free-text drift never reaches the tally.
+ */
+
+export const FINDING_CLASS_PREFIXES = [
+  'react-doctor',
+  'axe',
+  'knip',
+  'cve',
+  'holistic',
+  'rule',
+] as const;
+
+export type FindingClassPrefix = (typeof FINDING_CLASS_PREFIXES)[number];
+
+// Open oracle buckets: the deterministic tool owns the id space after the
+// prefix, so any non-empty slug is valid.
+const ORACLE_PREFIXES: readonly FindingClassPrefix[] = [
+  'react-doctor',
+  'axe',
+  'knip',
+  'cve',
+];
+
+/**
+ * Closed-vocabulary members for the holistic bucket. Seeded from the audit
+ * agent's stable cross-cutting dimensions and the project-specific rules it
+ * enforces. Deliberately small: seed only classes the agent can reliably and
+ * repeatably assign. When in doubt, leave a class out.
+ */
+export const HOLISTIC_FINDING_CLASSES = [
+  'holistic/missing-auth-check',
+  'holistic/secret-exposure',
+  'holistic/n-plus-one',
+  'holistic/unnecessary-rerender',
+  'holistic/unhandled-promise-rejection',
+  'holistic/swallowed-error',
+  'holistic/over-permissive-zod',
+  'holistic/business-logic-in-component',
+  'holistic/hardcoded-string',
+  'holistic/non-null-assertion',
+] as const;
+
+export type HolisticFindingClass = (typeof HOLISTIC_FINDING_CLASSES)[number];
+
+/**
+ * Closed-vocabulary members for the rule bucket. Seeded from the line-level
+ * rule surfaces the specialist subagents enforce (react-code skill, typescript
+ * skill, the thin-route rule). Small and defensible by design.
+ */
+export const RULE_FINDING_CLASSES = [
+  'rule/use-effect-derived-state',
+  'rule/use-effect-state-reset',
+  'rule/unnecessary-use-callback',
+  'rule/missing-effect-cleanup',
+  'rule/generic-handler-name',
+  'rule/switch-statement',
+  'rule/interface-declaration',
+  'rule/z-enum',
+  'rule/array-generic-syntax',
+  'rule/thin-route-violation',
+] as const;
+
+export type RuleFindingClass = (typeof RULE_FINDING_CLASSES)[number];
+
+const CLOSED_VOCABULARY: ReadonlySet<string> = new Set([
+  ...HOLISTIC_FINDING_CLASSES,
+  ...RULE_FINDING_CLASSES,
+]);
+
+const splitPrefix = (
+  value: string
+): {prefix: string; slug: string} | undefined => {
+  const separatorIndex = value.indexOf('/');
+
+  if (separatorIndex === -1) return undefined;
+
+  return {
+    prefix: value.slice(0, separatorIndex),
+    slug: value.slice(separatorIndex + 1),
+  };
+};
+
+const isOraclePrefix = (prefix: string): prefix is FindingClassPrefix =>
+  (ORACLE_PREFIXES as readonly string[]).includes(prefix);
+
+/**
+ * True when `value` matches the per-bucket convention: a well-formed oracle id
+ * (open id space after a known oracle prefix) or a seeded holistic/rule member
+ * (closed controlled vocabulary). Everything else (free text, unknown prefix,
+ * empty slug, unseeded holistic/rule member) is invalid.
+ */
+export const isValidFindingClass = (value: string): boolean => {
+  const parts = splitPrefix(value);
+
+  if (parts === undefined) return false;
+
+  if (isOraclePrefix(parts.prefix)) return parts.slug.length > 0;
+
+  return CLOSED_VOCABULARY.has(value);
+};
+
+export const FindingClassSchema = z.string().refine(isValidFindingClass, {
+  message:
+    'finding_class must match the per-bucket convention (oracle id or controlled vocabulary)',
+});

--- a/.gaia/cli/src/schemas/index.ts
+++ b/.gaia/cli/src/schemas/index.ts
@@ -10,6 +10,8 @@ export * from './cloud-projection.js';
 
 export * from './envelope.js';
 
+export * from './finding-class.js';
+
 export * from './local-automation.js';
 
 export * from './local-namespace.js';

--- a/.gaia/cli/src/schemas/mentorship-payloads.ts
+++ b/.gaia/cli/src/schemas/mentorship-payloads.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod';
+import {FindingClassSchema} from './finding-class.js';
 
 const SPEC_ID_REGEX = /^SPEC-\d{3,}$/;
 const UAT_ID_REGEX = /^UAT-\d{3,}$/;
@@ -103,7 +104,7 @@ export type TimeToResolvedSpecPayload = z.infer<
 export const CodeReviewAuditFindingPayload = z.object({
   area_tags: AreaTagsSchema,
   auditor_type: z.string(),
-  finding_class: z.string(),
+  finding_class: FindingClassSchema,
   pr_number: z.number().int().min(1),
   severity: z.enum(['error', 'warning', 'suggestion']),
   spec_id: z.string().regex(SPEC_ID_REGEX).optional(),

--- a/.gaia/cli/src/telemetry/__tests__/parse-trailer.test.ts
+++ b/.gaia/cli/src/telemetry/__tests__/parse-trailer.test.ts
@@ -72,10 +72,10 @@ describe('parseTrailer: code-review-audit', () => {
     const findings = JSON.stringify([
       {
         area_tags: ['security', 'auth'],
-        finding_class: 'sqli',
-        severity: 'high',
+        finding_class: 'holistic/missing-auth-check',
+        severity: 'error',
       },
-      {finding_class: 'race-condition', severity: 'medium'},
+      {finding_class: 'react-doctor/no-generic-handler-names', severity: 'warning'},
     ]);
     const input = buildHookInput(
       'code-review-audit',
@@ -90,9 +90,9 @@ describe('parseTrailer: code-review-audit', () => {
         '--pr-number',
         '97',
         '--finding-class',
-        'sqli',
+        'holistic/missing-auth-check',
         '--severity',
-        'high',
+        'error',
         '--area-tags',
         'security,auth',
         '--auditor-type',
@@ -103,12 +103,16 @@ describe('parseTrailer: code-review-audit', () => {
       eventType: 'code_review_audit_finding',
     });
 
-    expect(invocations[1]?.args).toContain('race-condition');
+    expect(invocations[1]?.args).toContain(
+      'react-doctor/no-generic-handler-names'
+    );
     expect(invocations[1]?.args.at(-3)).toBe('code-review-audit');
   });
 
   test('defaults pr_number to "0" when absent', () => {
-    const findings = JSON.stringify([{finding_class: 'x', severity: 'low'}]);
+    const findings = JSON.stringify([
+      {finding_class: 'axe/color-contrast', severity: 'warning'},
+    ]);
     const input = buildHookInput(
       'code-review-audit',
       trailer(`findings_json: ${findings}`)
@@ -120,9 +124,9 @@ describe('parseTrailer: code-review-audit', () => {
 
   test('skips findings missing finding_class or severity', () => {
     const findings = JSON.stringify([
-      {finding_class: 'good', severity: 'high'},
-      {severity: 'medium'},
-      {finding_class: 'no-severity'},
+      {finding_class: 'cve/1098765', severity: 'error'},
+      {severity: 'warning'},
+      {finding_class: 'knip/exports'},
       {},
     ]);
     const input = buildHookInput(
@@ -132,7 +136,38 @@ describe('parseTrailer: code-review-audit', () => {
 
     const {invocations} = parseTrailer(input);
     expect(invocations).toHaveLength(1);
-    expect(invocations[0]?.args).toContain('good');
+    expect(invocations[0]?.args).toContain('cve/1098765');
+  });
+
+  test('drops findings whose finding_class fails the controlled-set check', () => {
+    const findings = JSON.stringify([
+      {finding_class: 'axe/color-contrast', severity: 'error'},
+      {finding_class: 'type_hole', severity: 'error'},
+      {finding_class: 'holistic/something-made-up', severity: 'warning'},
+      {finding_class: 'just free text', severity: 'error'},
+    ]);
+    const input = buildHookInput(
+      'code-review-audit',
+      trailer(`findings_json: ${findings}`)
+    );
+
+    const {invocations} = parseTrailer(input);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]?.args).toContain('axe/color-contrast');
+  });
+
+  test('returns invalid_trailer_json when every finding has an invalid class', () => {
+    const findings = JSON.stringify([
+      {finding_class: 'type_hole', severity: 'error'},
+    ]);
+    const input = buildHookInput(
+      'code-review-audit',
+      trailer(`findings_json: ${findings}`)
+    );
+
+    const result = parseTrailer(input);
+    expect(result.invocations).toEqual([]);
+    expect(result.reason).toBe('invalid_trailer_json');
   });
 
   test('returns invalid_trailer_json when findings_json is not parseable', () => {

--- a/.gaia/cli/src/telemetry/__tests__/projection.test.ts
+++ b/.gaia/cli/src/telemetry/__tests__/projection.test.ts
@@ -288,7 +288,7 @@ describe('projectToCloud', () => {
         payload: {
           area_tags: ['typescript'],
           auditor_type: 'code-review-audit',
-          finding_class: 'type_hole',
+          finding_class: 'react-doctor/no-generic-handler-names',
           pr_number: 42,
           severity: 'warning',
         },
@@ -303,7 +303,7 @@ describe('projectToCloud', () => {
       expect(result.cloudEvent.event_type).toBe('code_review_audit_finding');
       expect(result.cloudEvent.payload).toMatchObject({
         area_tags: ['typescript'],
-        finding_class: 'type_hole',
+        finding_class: 'react-doctor/no-generic-handler-names',
         pr_number: 42,
       });
     });

--- a/.gaia/cli/src/telemetry/parse-trailer.ts
+++ b/.gaia/cli/src/telemetry/parse-trailer.ts
@@ -24,6 +24,8 @@
  * append-idempotent layer.
  */
 
+import {isValidFindingClass} from '../schemas/finding-class.js';
+
 export type EmitInvocation = {
   args: readonly string[];
   eventType: string;
@@ -149,6 +151,11 @@ const buildAuditFindings = (trailer: string): readonly EmitInvocation[] => {
     const severity = stringField(finding, 'severity');
 
     if (findingClass === undefined || severity === undefined) continue;
+
+    // A finding whose class is not in the controlled set is not a countable
+    // finding; drop it before it reaches an emit so free-text drift never
+    // lands in the tally.
+    if (!isValidFindingClass(findingClass)) continue;
 
     invocations.push({
       args: [

--- a/.gaia/scripts/check-updates.sh
+++ b/.gaia/scripts/check-updates.sh
@@ -35,12 +35,14 @@ prev_outdated_count=0
 prev_gaia_current=""
 prev_gaia_latest=""
 prev_gaia_has_update=false
+prev_harden_count=0
 if [ -f "$CACHE_FILE" ] && command -v jq >/dev/null 2>&1; then
   prev_checked_at=$(jq -r '.checkedAt // 0' "$CACHE_FILE" 2>/dev/null)
   prev_outdated_count=$(jq -r '.outdatedCount // 0' "$CACHE_FILE" 2>/dev/null)
   prev_gaia_current=$(jq -r '.gaiaCurrent // ""' "$CACHE_FILE" 2>/dev/null)
   prev_gaia_latest=$(jq -r '.gaiaLatest // ""' "$CACHE_FILE" 2>/dev/null)
   prev_gaia_has_update=$(jq -r '.gaiaHasUpdate // false' "$CACHE_FILE" 2>/dev/null)
+  prev_harden_count=$(jq -r '.hardenCandidateCount // 0' "$CACHE_FILE" 2>/dev/null)
   case "$prev_checked_at" in
     ''|*[!0-9]*) prev_checked_at=0 ;;
   esac
@@ -83,6 +85,28 @@ if [ -x "$GAIA_BIN" ] && command -v jq >/dev/null 2>&1; then
 fi
 case "$outdated_count" in
   ''|*[!0-9]*) outdated_count=0 ;;
+esac
+
+# ---------- hardenCandidateCount ----------
+# Recurring-finding tally for the policy-memory loop. `harden-tally` reads the
+# rolling 90-day merged-PR window via gh, counts distinct PRs per finding_class
+# at error/warning severity, drops promoted/suppressed classes, and emits the
+# candidate_count. Runs in this same TTL pass; network is non-fatal (gh failure
+# yields candidate_count 0). Falls back to the previous cached count on any
+# failure: missing binary, network error, parse error.
+harden_count="$prev_harden_count"
+if [ -x "$GAIA_BIN" ] && command -v jq >/dev/null 2>&1; then
+  tally_json="$(cd "$PROJECT_ROOT" && "$GAIA_BIN" harden-tally 2>/dev/null)"
+  if [ -n "$tally_json" ]; then
+    parsed=$(printf '%s' "$tally_json" | jq -r '.candidate_count // empty' 2>/dev/null)
+    case "$parsed" in
+      ''|*[!0-9]*) ;;
+      *) harden_count="$parsed" ;;
+    esac
+  fi
+fi
+case "$harden_count" in
+  ''|*[!0-9]*) harden_count=0 ;;
 esac
 
 # ---------- gaiaCurrent ----------
@@ -136,12 +160,13 @@ if command -v jq >/dev/null 2>&1; then
     --arg gaiaCurrent "$gaia_current" \
     --arg gaiaLatest "$gaia_latest" \
     --argjson gaiaHasUpdate "$gaia_has_update" \
-    '{checkedAt: $checkedAt, outdatedCount: $outdatedCount, gaiaCurrent: $gaiaCurrent, gaiaLatest: $gaiaLatest, gaiaHasUpdate: $gaiaHasUpdate}' \
+    --argjson hardenCandidateCount "$harden_count" \
+    '{checkedAt: $checkedAt, outdatedCount: $outdatedCount, gaiaCurrent: $gaiaCurrent, gaiaLatest: $gaiaLatest, gaiaHasUpdate: $gaiaHasUpdate, hardenCandidateCount: $hardenCandidateCount}' \
     > "$tmp_file" 2>/dev/null
 else
   # jq not available; emit valid JSON via printf.
-  printf '{"checkedAt":%s,"outdatedCount":%s,"gaiaCurrent":"%s","gaiaLatest":"%s","gaiaHasUpdate":%s}\n' \
-    "$now" "$outdated_count" "$gaia_current" "$gaia_latest" "$gaia_has_update" \
+  printf '{"checkedAt":%s,"outdatedCount":%s,"gaiaCurrent":"%s","gaiaLatest":"%s","gaiaHasUpdate":%s,"hardenCandidateCount":%s}\n' \
+    "$now" "$outdated_count" "$gaia_current" "$gaia_latest" "$gaia_has_update" "$harden_count" \
     > "$tmp_file" 2>/dev/null
 fi
 

--- a/.gaia/specs.json
+++ b/.gaia/specs.json
@@ -19,8 +19,15 @@
       "id": "SPEC-003",
       "allocated_at": "2026-06-04T09:35:37Z",
       "source": "allocated",
-      "status": "in-progress",
+      "status": "shipped",
       "intent": "GAIA's test-driven workflow already instructs the agent to write a failing"
+    },
+    {
+      "id": "SPEC-004",
+      "allocated_at": "2026-06-05T08:44:29Z",
+      "source": "allocated",
+      "status": "in-progress",
+      "intent": "GAIA's code-review-audit flags anti-patterns review after review, but each"
     }
   ]
 }

--- a/.gaia/statusline/gaia-statusline.sh
+++ b/.gaia/statusline/gaia-statusline.sh
@@ -108,6 +108,7 @@ if [ "$is_worktree" -eq 0 ]; then
       outdated_count=$(jq -r '.outdatedCount // 0' "$CACHE_FILE" 2>/dev/null)
       gaia_has_update=$(jq -r '.gaiaHasUpdate // false' "$CACHE_FILE" 2>/dev/null)
       gaia_latest=$(jq -r '.gaiaLatest // empty' "$CACHE_FILE" 2>/dev/null)
+      harden_count=$(jq -r '.hardenCandidateCount // 0' "$CACHE_FILE" 2>/dev/null)
 
       segments=()
       COACHING_FILE="$GAIA_DIR/cache/coaching-active.txt"
@@ -119,6 +120,9 @@ if [ "$is_worktree" -eq 0 ]; then
       fi
       if [ "$gaia_has_update" = "true" ] && [ -n "$gaia_latest" ]; then
         segments+=("$(printf '\033[01;36mRun /update-gaia (GAIA %s available)\033[00m' "$gaia_latest")")
+      fi
+      if [ -n "$harden_count" ] && [ "$harden_count" -gt 0 ] 2>/dev/null; then
+        segments+=("$(printf '\033[01;35mRun /gaia-harden review (%d)\033[00m' "$harden_count")")
       fi
       if [ "${#segments[@]}" -gt 0 ]; then
         right="${segments[0]}"

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -281,6 +281,31 @@ jobs:
             stamp helper. After the audit and stamp, post a single PR comment
             summarizing findings (and whether self-heal commits were pushed).
 
+            FINDINGS BLOCK: append a machine-readable findings block to the END
+            of that same PR comment, after the human-readable summary. The block
+            is a JSON object wrapped INSIDE an HTML comment so it does not render,
+            framed by two stable sentinel lines. The cross-machine tally pass
+            parses it; the sentinels are the parse anchors, emit them verbatim:
+
+            <!-- gaia-harden:findings:start -->
+            <!--
+            {"schema":1,"pr_number":PR_NUMBER,"auditor":"ci","findings":[
+              {"finding_class":"react-doctor/no-generic-handler-names","severity":"warning","area_tags":["app/components"]},
+              {"finding_class":"holistic/missing-auth-check","severity":"error","area_tags":["app/routes"]}
+            ]}
+            -->
+            <!-- gaia-harden:findings:end -->
+
+            Substitute PR_NUMBER with this PR's number. One object per finding you
+            assigned a stable `finding_class`, using the per-bucket convention in
+            `.claude/agents/code-review-audit.md` (oracle ids verbatim with the
+            tool prefix; the controlled holistic/rule vocabulary otherwise). Carry
+            only `finding_class`, `severity` (error/warning/suggestion), and
+            `area_tags` per finding, never code or file contents. Omit any finding
+            with no stable class (it stays in the prose summary). If you classified
+            zero findings, still emit the block with `"findings":[]`, an explicit
+            empty block is parseable, a missing one is ambiguous.
+
             SELF-HEAL CONSTRAINTS: read before making any edits:
             1. Run `git diff --name-only origin/main...HEAD` first. Self-heal edits
                are ONLY permitted on files that appear in this list. Never edit a

--- a/wiki/concepts/Policy-Memory Loop.md
+++ b/wiki/concepts/Policy-Memory Loop.md
@@ -1,0 +1,47 @@
+---
+type: concept
+title: Policy-Memory Loop
+status: active
+created: 2026-06-05
+updated: 2026-06-05
+tags: [concept, claude, audit, self-improvement, governance]
+---
+
+# Policy-Memory Loop
+
+The Policy-Memory Loop turns a recurring code-review finding into a durable, human-approved, path-scoped rule, prune-first and add-only by exception. It keeps GAIA's auto-loaded config from ratcheting heavier over time: a lesson becomes permanent, but its context weight stays bounded by mandatory path-scoping, never trimmed by deletion. Nothing is authored or activated unattended.
+
+## The loop end to end
+
+1. **Emission contract.** [[Code Review Audit Agent]] tags every eligible finding with a stable `finding_class` and a `severity`. Oracle buckets use tool ids verbatim (`react-doctor/...`, `axe/...`, `knip/...`, `cve/...`); holistic and rule-subagent buckets draw from a constrained vocabulary. A finding with no stable class is not emitted as a countable finding, the schema rejects free-text drift. Recurrence counts only `error` and `warning`; `suggestion` is ineligible.
+2. **PR substrate.** The pull request is the durable record, not a committed sidecar. CI posts a machine-readable finding block in its PR comment; local runs emit the same fields through the telemetry trailer. The cross-machine signal lives on GitHub, read back via `gh`.
+3. **TTL tally.** A background refresher recomputes, each TTL, how many distinct PRs carry each `finding_class` (warning-floor) across a rolling 90-day window. It drops classes already promoted (a rule exists) or locally declined without fresh evidence, and writes a candidate count to the statusline cache. The tally is an ephemeral projection: nothing is staged, an un-acted pattern decays by ageing out of the window.
+4. **Statusline nudge.** When the candidate count is above zero, the statusline shows a `Run /gaia-harden review (N)` segment, alongside the `/update-deps` and `/update-gaia` indicators and under the same worktree + setup-complete suppression.
+5. **Judge the form.** `/gaia-harden review` judges the lowest-context-weight form that fits the finding (deterministic check, skill, or path-scoped prose rule) and whether to edit an existing artifact or author a new one, then drafts it into the working tree for the engineer to **approve**, **decline**, or **defer**.
+   - **Approve** ships a prose rule under `.claude/rules/` carrying a mandatory `paths:` glob and a provenance marker (see below). It is never frontmatter-less / always-loaded. The rule goes through normal PR review and becomes the shared suppression signal.
+   - **Decline** records `finding_class -> timestamp` in machine-local, gitignored state only. It re-surfaces to that engineer once three or more distinct PRs carrying the class merge after the decline; teammates still see and can approve the same candidate.
+   - **Defer** leaves the candidate to nudge again next tally.
+6. **Permanence + bounded weight.** A promoted lesson does not expire. The no-ratchet guarantee rides on context weight, not deletion: every promoted rule is path-scoped, and deterministic checks cost zero auto-load weight, so the total never becomes a global tax.
+7. **Prune-first hygiene.** [[GAIA Audit]] is the single pruner. It treats a provenance-marked rule as an ordinary rule and prunes it only on obsolescence (its governed surface was removed), redundancy (a tool now enforces it), supersession, or duplication. Non-recurrence is never a prune signal: a quiet pattern under a live rule is the rule working.
+
+## Provenance marker
+
+An approved prose rule carries, on the first line after its frontmatter, a single HTML comment:
+
+```
+<!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
+```
+
+The marker documents why the rule exists and reminds the pruner that "quiet" is not "stale". It grants no special lifecycle: `/gaia-audit` recognizes it only to apply its existing obsolescence / duplicate / supersession signals without exemption, and to refuse non-recurrence as a staleness signal. Because the rule is path-scoped, it is the case the pruner's Rules-vs-wiki note already permits to duplicate wiki content.
+
+## Mentorship boundary
+
+This loop is adjacent to, but distinct from, the mentorship detector in [[Telemetry]]. It keys on `finding_class + count` at a threshold of three over a rolling 90-day PR window, reads the PR finding-blocks via `gh`, and is human-gated and actuating: its output is a drafted rule for approval.
+
+The mentorship detector keys on `area_tag + strength` at a threshold of ten over a rolling 30-day window. Its event store is opt-in and privacy-sealed, a display rule forbids surfacing raw events, and it produces non-actuating coaching nudges. The two are separate machinery: the loop must never read the sealed mentorship JSONL to compute its tally.
+
+## Pairs with
+
+- [[Code Review Audit Agent]]: the source of the `finding_class` emissions the loop counts
+- [[GAIA Audit]]: the single pruner; honors the provenance marker, never prunes for non-recurrence
+- [[Telemetry]]: home of the adjacent, privacy-sealed mentorship detector

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -130,6 +130,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Task Orchestration]]
 - [[Code Review Audit Agent]]
 - [[Code Review Audit CI]]: pre-merge GitHub Actions gate; `GAIA-Audit:` trailer skip logic; adopter-tunable knobs at `.gaia/audit-ci.yml`.
+- [[Policy-Memory Loop]]: prune-first self-improvement; recurring finding_class -> statusline nudge -> `/gaia-harden` -> path-scoped rule -> `/gaia-audit` prunes only on obsolescence/redundancy/supersession/duplication.
 - [[Incremental CI Skipping]]: required checks skip when the delta since they last passed green has no relevant files; `resolve-check-base.sh` / `resolve-audit-base.sh`.
 - [[Claude Hooks]]
 - [[Claude Integration Conventions]]: Conventions for Claude's config surface: extension points, monorepo retrofit, service swaps, domain isolation.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -9,6 +9,10 @@ tags: [meta, log]
 
 # Log
 
+## 2026-06-05 | Policy-Memory Loop
+
+Prune-first self-improvement loop landed: recurring `finding_class` -> TTL tally -> statusline nudge -> `/gaia-harden` judges the form and drafts a path-scoped, provenance-marked rule for approve/decline/defer. `/gaia-audit` prunes promoted rules on obsolescence/redundancy/supersession/duplication only, never for non-recurrence. New concept page `wiki/concepts/Policy-Memory Loop.md`; documents the mentorship boundary (this loop keys finding_class+count / N>=3 / 90-day PR window; the sealed mentorship detector keys area_tag+strength / N>=10 / 30-day window and is never read by the loop).
+
 ## [v1.5.0] 2026-06-05 | Released
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
Ships the prune-first self-improvement loop: when `code-review-audit` flags the same anti-pattern across >=3 distinct PRs (local or CI), at warning severity or above, within a rolling 90-day window, GAIA raises a statusline nudge; the human-invoked `/gaia-harden` judges the lowest-context-weight form (deterministic check / skill / path-scoped prose rule) and drafts it for approve/decline/defer. Nothing is authored or activated unattended. Declines are machine-local; approved rules ship through normal PR review; lessons do not expire; the no-ratchet guarantee rides on mandatory path-scoping.

## Phases

- **Phase 1, foundation:** finding-class emission contract (schema-enforced `finding_class`, per-bucket vocabulary, local telemetry trailer) + machine-readable findings block in the CI PR comment.
- **Phase 2, the loop:** machine-local decline-ledger CLI + TTL tally refresher (90-day PR window) + statusline nudge.
- **Phase 3, command + pruner:** `/gaia-harden` command/reference (judge-the-form, approve/decline/defer) + `/gaia-audit` provenance-marker handling (non-recurrence is never a prune signal) + wiki docs.

Derived from SPEC-004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)