### PR TITLE
chore(gaia-harden): rebuild CLI bundle for harden-tally/harden-ledger

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -842,10 +842,10 @@ function mergeDefs(...defs) {
 function cloneDef(schema) {
   return mergeDefs(schema._zod.def);
 }
-function getElementAtPath(obj, path51) {
-  if (!path51)
+function getElementAtPath(obj, path54) {
+  if (!path54)
     return obj;
-  return path51.reduce((acc, key) => acc?.[key], obj);
+  return path54.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -1254,11 +1254,11 @@ function explicitlyAborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path51, issues) {
+function prefixIssues(path54, issues) {
   return issues.map((iss) => {
     var _a3;
     (_a3 = iss).path ?? (_a3.path = []);
-    iss.path.unshift(path51);
+    iss.path.unshift(path54);
     return iss;
   });
 }
@@ -1405,16 +1405,16 @@ function flattenError(error51, mapper = (issue2) => issue2.message) {
 }
 function formatError(error51, mapper = (issue2) => issue2.message) {
   const fieldErrors = { _errors: [] };
-  const processError = (error52, path51 = []) => {
+  const processError = (error52, path54 = []) => {
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path51, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path54, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path54, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path54, ...issue2.path]);
       } else {
-        const fullpath = [...path51, ...issue2.path];
+        const fullpath = [...path54, ...issue2.path];
         if (fullpath.length === 0) {
           fieldErrors._errors.push(mapper(issue2));
         } else {
@@ -1441,17 +1441,17 @@ function formatError(error51, mapper = (issue2) => issue2.message) {
 }
 function treeifyError(error51, mapper = (issue2) => issue2.message) {
   const result = { errors: [] };
-  const processError = (error52, path51 = []) => {
+  const processError = (error52, path54 = []) => {
     var _a3, _b;
     for (const issue2 of error52.issues) {
       if (issue2.code === "invalid_union" && issue2.errors.length) {
-        issue2.errors.map((issues) => processError({ issues }, [...path51, ...issue2.path]));
+        issue2.errors.map((issues) => processError({ issues }, [...path54, ...issue2.path]));
       } else if (issue2.code === "invalid_key") {
-        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path54, ...issue2.path]);
       } else if (issue2.code === "invalid_element") {
-        processError({ issues: issue2.issues }, [...path51, ...issue2.path]);
+        processError({ issues: issue2.issues }, [...path54, ...issue2.path]);
       } else {
-        const fullpath = [...path51, ...issue2.path];
+        const fullpath = [...path54, ...issue2.path];
         if (fullpath.length === 0) {
           result.errors.push(mapper(issue2));
           continue;
@@ -1483,8 +1483,8 @@ function treeifyError(error51, mapper = (issue2) => issue2.message) {
 }
 function toDotPath(_path) {
   const segs = [];
-  const path51 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
-  for (const seg of path51) {
+  const path54 = _path.map((seg) => typeof seg === "object" ? seg.key : seg);
+  for (const seg of path54) {
     if (typeof seg === "number")
       segs.push(`[${seg}]`);
     else if (typeof seg === "symbol")
@@ -14176,13 +14176,13 @@ function resolveRef(ref, ctx) {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
   }
-  const path51 = ref.slice(1).split("/").filter(Boolean);
-  if (path51.length === 0) {
+  const path54 = ref.slice(1).split("/").filter(Boolean);
+  if (path54.length === 0) {
     return ctx.rootSchema;
   }
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
-  if (path51[0] === defsKey) {
-    const key = path51[1];
+  if (path54[0] === defsKey) {
+    const key = path54[1];
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }
@@ -14658,6 +14658,60 @@ var ADAPTATION_TEXT = {
   po_socratic_depth_increased: "The user has historically had trouble articulating success criteria for {{area}} work. Coach more on observable outcomes: what changes, what stays, what would prove this done? Push past 'looks right' or 'feels good' to concrete checks."
 };
 
+// src/schemas/finding-class.ts
+var ORACLE_PREFIXES = [
+  "react-doctor",
+  "axe",
+  "knip",
+  "cve"
+];
+var HOLISTIC_FINDING_CLASSES = [
+  "holistic/missing-auth-check",
+  "holistic/secret-exposure",
+  "holistic/n-plus-one",
+  "holistic/unnecessary-rerender",
+  "holistic/unhandled-promise-rejection",
+  "holistic/swallowed-error",
+  "holistic/over-permissive-zod",
+  "holistic/business-logic-in-component",
+  "holistic/hardcoded-string",
+  "holistic/non-null-assertion"
+];
+var RULE_FINDING_CLASSES = [
+  "rule/use-effect-derived-state",
+  "rule/use-effect-state-reset",
+  "rule/unnecessary-use-callback",
+  "rule/missing-effect-cleanup",
+  "rule/generic-handler-name",
+  "rule/switch-statement",
+  "rule/interface-declaration",
+  "rule/z-enum",
+  "rule/array-generic-syntax",
+  "rule/thin-route-violation"
+];
+var CLOSED_VOCABULARY = /* @__PURE__ */ new Set([
+  ...HOLISTIC_FINDING_CLASSES,
+  ...RULE_FINDING_CLASSES
+]);
+var splitPrefix = (value) => {
+  const separatorIndex = value.indexOf("/");
+  if (separatorIndex === -1) return void 0;
+  return {
+    prefix: value.slice(0, separatorIndex),
+    slug: value.slice(separatorIndex + 1)
+  };
+};
+var isOraclePrefix = (prefix) => ORACLE_PREFIXES.includes(prefix);
+var isValidFindingClass = (value) => {
+  const parts = splitPrefix(value);
+  if (parts === void 0) return false;
+  if (isOraclePrefix(parts.prefix)) return parts.slug.length > 0;
+  return CLOSED_VOCABULARY.has(value);
+};
+var FindingClassSchema = external_exports.string().refine(isValidFindingClass, {
+  message: "finding_class must match the per-bucket convention (oracle id or controlled vocabulary)"
+});
+
 // src/schemas/mentorship-payloads.ts
 var SPEC_ID_REGEX = /^SPEC-\d{3,}$/;
 var UAT_ID_REGEX = /^UAT-\d{3,}$/;
@@ -14733,7 +14787,7 @@ var TimeToResolvedSpecPayload = external_exports.object({
 var CodeReviewAuditFindingPayload = external_exports.object({
   area_tags: AreaTagsSchema,
   auditor_type: external_exports.string(),
-  finding_class: external_exports.string(),
+  finding_class: FindingClassSchema,
   pr_number: external_exports.number().int().min(1),
   severity: external_exports.enum(["error", "warning", "suggestion"]),
   spec_id: external_exports.string().regex(SPEC_ID_REGEX).optional()
@@ -17809,13 +17863,641 @@ var run17 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-// src/init/bootstrap-env.ts
-import { copyFileSync, existsSync as existsSync10 } from "node:fs";
-import path12 from "node:path";
-
-// src/init/util/state.ts
+// src/schemas/decline-ledger.ts
 import { existsSync as existsSync9, mkdirSync as mkdirSync7, readFileSync as readFileSync9 } from "node:fs";
 import path11 from "node:path";
+var declineLedgerPath = (repoRoot2) => path11.join(repoRoot2, ".gaia", "local", "harden", "declines.json");
+var DeclineEntrySchema = external_exports.object({
+  declined_at: external_exports.iso.datetime(),
+  declined_at_pr_count: external_exports.number().int().nonnegative(),
+  finding_class: external_exports.string().min(1)
+});
+var DeclineLedgerSchema = external_exports.object({
+  version: external_exports.literal(1),
+  declines: external_exports.array(DeclineEntrySchema)
+});
+var emptyDeclineLedger = () => ({
+  version: 1,
+  declines: []
+});
+var readDeclineLedger = (repoRoot2) => {
+  const filePath = declineLedgerPath(repoRoot2);
+  if (!existsSync9(filePath)) return { status: "missing" };
+  let raw;
+  try {
+    raw = readFileSync9(filePath, "utf8");
+  } catch (error51) {
+    return {
+      error: `${filePath}: ${error51 instanceof Error ? error51.message : String(error51)}`,
+      status: "malformed"
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error51) {
+    return {
+      error: `${filePath}: invalid JSON: ${error51 instanceof Error ? error51.message : String(error51)}`,
+      status: "malformed"
+    };
+  }
+  const result = DeclineLedgerSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      error: summarizeZodError(filePath, result.error),
+      status: "malformed"
+    };
+  }
+  return { ledger: result.data, status: "ok" };
+};
+var writeDeclineLedger = (repoRoot2, ledger) => {
+  const target = declineLedgerPath(repoRoot2);
+  mkdirSync7(path11.dirname(target), { mode: 493, recursive: true });
+  const serialized = `${JSON.stringify(ledger, null, 2)}
+`;
+  atomicWriteFileSync(target, serialized);
+};
+
+// src/harden/ledger.ts
+var HELP_TEXT16 = `Usage: gaia harden-ledger <subcommand> [args]
+
+  list
+    Print the decline ledger as JSON to stdout
+    ({"version":1,"declines":[]} when absent).
+
+  record --finding-class <c> --pr-count <n>
+    Upsert one bounded entry keyed by finding_class (re-record overwrites the
+    timestamp and PR count). One entry per class.
+
+  is-suppressed --finding-class <c> --current-pr-count <n>
+    Exit 0 (suppressed) when an entry exists and current-pr-count minus its
+    declined_at_pr_count is below the re-surface threshold (3); exit 1
+    (not suppressed) otherwise.
+
+  prune --window-classes <c1,c2,...>
+    Remove any decline entry whose finding_class is not in the comma-separated
+    set (no qualifying evidence left in the window). Idempotent.
+`;
+var HELP_TOKENS16 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var RESURFACE_THRESHOLD = 3;
+var run18 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS16.has(argv[0])) {
+    process.stdout.write(HELP_TEXT16);
+    return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
+  }
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  if (sub === "list") return handleList(rest, options);
+  if (sub === "record") return handleRecord(rest, options);
+  if (sub === "is-suppressed") return handleIsSuppressed(rest, options);
+  if (sub === "prune") return handlePrune(rest, options);
+  structuredError({
+    code: "unknown_subcommand",
+    message: `unknown harden-ledger subcommand: ${sub}`,
+    subcommand: "harden-ledger"
+  });
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+var parseCountFlag = (value) => {
+  if (value === void 0) return void 0;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) return void 0;
+  return parsed;
+};
+var resolveRoot2 = (options, subcommand) => {
+  try {
+    return resolveRepoRoot2(options.cwd ?? process.cwd());
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: `gaia harden-ledger ${subcommand} must run inside a git repository`,
+      subcommand: `harden-ledger ${subcommand}`
+    });
+    return null;
+  }
+};
+var loadLedger = (repoRoot2, subcommand) => {
+  const result = readDeclineLedger(repoRoot2);
+  if (result.status === "malformed") {
+    structuredError({
+      code: "malformed_ledger",
+      message: result.error,
+      subcommand: `harden-ledger ${subcommand}`
+    });
+    return null;
+  }
+  if (result.status === "missing") return emptyDeclineLedger();
+  return result.ledger;
+};
+var handleList = (argv, options) => {
+  if (argv.length > 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: `unknown argument: ${argv[0]}`,
+      subcommand: "harden-ledger list"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const repoRoot2 = resolveRoot2(options, "list");
+  if (repoRoot2 === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+  const ledger = loadLedger(repoRoot2, "list");
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+  process.stdout.write(`${JSON.stringify(ledger)}
+`);
+  return EXIT_CODES.OK;
+};
+var parseRecordArgs = (argv) => {
+  let findingClass;
+  let prCount;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--finding-class") {
+      findingClass = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--pr-count") {
+      prCount = parseCountFlag(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    return `unknown argument: ${token}`;
+  }
+  return { findingClass, prCount };
+};
+var handleRecord = (argv, options) => {
+  const parsed = parseRecordArgs(argv);
+  if (typeof parsed === "string") {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed,
+      subcommand: "harden-ledger record"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const { findingClass, prCount } = parsed;
+  if (findingClass === void 0 || findingClass === "") {
+    structuredError({
+      code: "invalid_arguments",
+      message: "harden-ledger record requires --finding-class <c>",
+      subcommand: "harden-ledger record"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (prCount === void 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: "harden-ledger record requires --pr-count <n> (non-negative integer)",
+      subcommand: "harden-ledger record"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const repoRoot2 = resolveRoot2(options, "record");
+  if (repoRoot2 === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+  const ledger = loadLedger(repoRoot2, "record");
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+  const declinedAt = (options.now ?? (() => /* @__PURE__ */ new Date()))().toISOString();
+  const entry = {
+    declined_at: declinedAt,
+    declined_at_pr_count: prCount,
+    finding_class: findingClass
+  };
+  const existingIndex = ledger.declines.findIndex(
+    (decline) => decline.finding_class === findingClass
+  );
+  if (existingIndex === -1) {
+    ledger.declines.push(entry);
+  } else {
+    ledger.declines[existingIndex] = entry;
+  }
+  writeDeclineLedger(repoRoot2, ledger);
+  return EXIT_CODES.OK;
+};
+var parseIsSuppressedArgs = (argv) => {
+  let findingClass;
+  let currentPrCount;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--finding-class") {
+      findingClass = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--current-pr-count") {
+      currentPrCount = parseCountFlag(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    return `unknown argument: ${token}`;
+  }
+  return { currentPrCount, findingClass };
+};
+var handleIsSuppressed = (argv, options) => {
+  const parsed = parseIsSuppressedArgs(argv);
+  if (typeof parsed === "string") {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed,
+      subcommand: "harden-ledger is-suppressed"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const { currentPrCount, findingClass } = parsed;
+  if (findingClass === void 0 || findingClass === "") {
+    structuredError({
+      code: "invalid_arguments",
+      message: "harden-ledger is-suppressed requires --finding-class <c>",
+      subcommand: "harden-ledger is-suppressed"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  if (currentPrCount === void 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: "harden-ledger is-suppressed requires --current-pr-count <n> (non-negative integer)",
+      subcommand: "harden-ledger is-suppressed"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const repoRoot2 = resolveRoot2(options, "is-suppressed");
+  if (repoRoot2 === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+  const ledger = loadLedger(repoRoot2, "is-suppressed");
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+  const entry = ledger.declines.find(
+    (decline) => decline.finding_class === findingClass
+  );
+  if (entry === void 0) {
+    structuredError({
+      code: "not_suppressed",
+      finding_class: findingClass,
+      reason: "no_decline_entry"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const mergedSinceDecline = currentPrCount - entry.declined_at_pr_count;
+  const suppressed = mergedSinceDecline < RESURFACE_THRESHOLD;
+  if (!suppressed) {
+    structuredError({
+      code: "not_suppressed",
+      finding_class: findingClass,
+      merged_since_decline: mergedSinceDecline,
+      reason: "threshold_reached"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  return EXIT_CODES.OK;
+};
+var parsePruneArgs = (argv) => {
+  let windowClasses2;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--window-classes") {
+      windowClasses2 = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    return `unknown argument: ${token}`;
+  }
+  return { windowClasses: windowClasses2 };
+};
+var handlePrune = (argv, options) => {
+  const parsed = parsePruneArgs(argv);
+  if (typeof parsed === "string") {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed,
+      subcommand: "harden-ledger prune"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const { windowClasses: windowClasses2 } = parsed;
+  if (windowClasses2 === void 0) {
+    structuredError({
+      code: "invalid_arguments",
+      message: "harden-ledger prune requires --window-classes <c1,c2,...> (use an empty string to prune all)",
+      subcommand: "harden-ledger prune"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const repoRoot2 = resolveRoot2(options, "prune");
+  if (repoRoot2 === null) return EXIT_CODES.STORAGE_INACCESSIBLE;
+  const ledger = loadLedger(repoRoot2, "prune");
+  if (ledger === null) return EXIT_CODES.CONFIG_INVALID;
+  const keep = new Set(
+    windowClasses2.split(",").map((value) => value.trim()).filter((value) => value.length > 0)
+  );
+  const kept = ledger.declines.filter(
+    (decline) => keep.has(decline.finding_class)
+  );
+  if (kept.length !== ledger.declines.length) {
+    writeDeclineLedger(repoRoot2, { ...ledger, declines: kept });
+  }
+  return EXIT_CODES.OK;
+};
+
+// src/harden/tally.ts
+import path13 from "node:path";
+
+// src/harden/compute-tally.ts
+var RECURRENCE_THRESHOLD = 3;
+var isCountableSeverity = (severity) => severity === "error" || severity === "warning";
+var aggregateByClass = (prs) => {
+  const byClass = /* @__PURE__ */ new Map();
+  for (const pr of prs) {
+    const perPrSeverity = /* @__PURE__ */ new Map();
+    const perPrAreaTags = /* @__PURE__ */ new Map();
+    for (const finding of pr.findings) {
+      if (!isCountableSeverity(finding.severity)) continue;
+      if (!isValidFindingClass(finding.finding_class)) continue;
+      const existing = perPrSeverity.get(finding.finding_class);
+      if (existing !== "error") {
+        perPrSeverity.set(finding.finding_class, finding.severity);
+      }
+      const tags = perPrAreaTags.get(finding.finding_class) ?? /* @__PURE__ */ new Set();
+      for (const tag of finding.area_tags) tags.add(tag);
+      perPrAreaTags.set(finding.finding_class, tags);
+    }
+    for (const [findingClass, severity] of perPrSeverity) {
+      const aggregate = byClass.get(findingClass) ?? {
+        areaTags: [],
+        prNumbers: [],
+        severityMax: "warning"
+      };
+      aggregate.prNumbers.push(pr.pr_number);
+      if (severity === "error") aggregate.severityMax = "error";
+      const seenTags = new Set(aggregate.areaTags);
+      for (const tag of perPrAreaTags.get(findingClass) ?? []) {
+        if (!seenTags.has(tag)) {
+          aggregate.areaTags.push(tag);
+          seenTags.add(tag);
+        }
+      }
+      byClass.set(findingClass, aggregate);
+    }
+  }
+  return byClass;
+};
+var computeTally = ({
+  coveredClass,
+  prs,
+  suppressedClass,
+  windowDays
+}) => {
+  const byClass = aggregateByClass(prs);
+  const candidates = [];
+  for (const [findingClass, aggregate] of byClass) {
+    const distinctPrCount = aggregate.prNumbers.length;
+    if (distinctPrCount < RECURRENCE_THRESHOLD) continue;
+    if (coveredClass(findingClass)) continue;
+    if (suppressedClass(findingClass, distinctPrCount)) continue;
+    candidates.push({
+      area_tags: aggregate.areaTags,
+      distinct_pr_count: distinctPrCount,
+      finding_class: findingClass,
+      pr_numbers: aggregate.prNumbers,
+      severity_max: aggregate.severityMax
+    });
+  }
+  return {
+    candidate_count: candidates.length,
+    candidates,
+    window_days: windowDays
+  };
+};
+var windowClasses = (prs) => {
+  const byClass = aggregateByClass(prs);
+  const classes = [];
+  for (const [findingClass, aggregate] of byClass) {
+    if (aggregate.prNumbers.length >= RECURRENCE_THRESHOLD) {
+      classes.push(findingClass);
+    }
+  }
+  return classes;
+};
+
+// src/harden/covered-classes.ts
+import { readdirSync, readFileSync as readFileSync10 } from "node:fs";
+import path12 from "node:path";
+var MARKER_RE = /gaia-harden: promoted from recurring finding_class\s+(\S+?)\s*(?:;|-->)/g;
+var coveredClassesFromRules = (rulesDir) => {
+  const covered = /* @__PURE__ */ new Set();
+  let entries;
+  try {
+    entries = readdirSync(rulesDir).filter((name) => name.endsWith(".md"));
+  } catch {
+    return covered;
+  }
+  for (const name of entries) {
+    let body;
+    try {
+      body = readFileSync10(path12.join(rulesDir, name), "utf8");
+    } catch {
+      continue;
+    }
+    for (const match of body.matchAll(MARKER_RE)) {
+      const findingClass = match[1];
+      if (findingClass !== void 0 && findingClass.length > 0) {
+        covered.add(findingClass);
+      }
+    }
+  }
+  return covered;
+};
+
+// src/harden/ledger-bridge.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+var defaultLedgerRunner = (argv, cwd) => {
+  const entry = process.argv[1] ?? "";
+  const result = spawnSync2(process.execPath, [entry, ...argv], {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? ""
+  };
+};
+var makeLedgerSuppressionPredicate = ({
+  cwd,
+  runLedger = defaultLedgerRunner
+}) => (findingClass, currentPrCount) => {
+  const result = runLedger(
+    [
+      "harden-ledger",
+      "is-suppressed",
+      "--finding-class",
+      findingClass,
+      "--current-pr-count",
+      String(currentPrCount)
+    ],
+    cwd
+  );
+  return result.exitCode === 0;
+};
+var pruneLedger = ({
+  cwd,
+  runLedger = defaultLedgerRunner,
+  windowClasses: windowClasses2
+}) => {
+  runLedger(
+    ["harden-ledger", "prune", "--window-classes", windowClasses2.join(",")],
+    cwd
+  );
+};
+
+// src/harden/parse-findings-block.ts
+var START_SENTINEL = "<!-- gaia-harden:findings:start -->";
+var END_SENTINEL = "<!-- gaia-harden:findings:end -->";
+var SEVERITIES = /* @__PURE__ */ new Set(["error", "suggestion", "warning"]);
+var parseFinding = (value) => {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value;
+  if (typeof v.finding_class !== "string" || v.finding_class.length === 0) {
+    return null;
+  }
+  if (typeof v.severity !== "string" || !SEVERITIES.has(v.severity)) {
+    return null;
+  }
+  if (!Array.isArray(v.area_tags) || !v.area_tags.every((tag) => typeof tag === "string")) {
+    return null;
+  }
+  return {
+    area_tags: v.area_tags,
+    finding_class: v.finding_class,
+    severity: v.severity
+  };
+};
+var parseFindingsBlock = (body) => {
+  const startIndex = body.indexOf(START_SENTINEL);
+  if (startIndex === -1) return null;
+  const endIndex = body.indexOf(END_SENTINEL, startIndex);
+  if (endIndex === -1) return null;
+  const between = body.slice(startIndex + START_SENTINEL.length, endIndex);
+  const openIndex = between.indexOf("<!--");
+  if (openIndex === -1) return null;
+  const closeIndex = between.lastIndexOf("-->");
+  if (closeIndex === -1 || closeIndex <= openIndex) return null;
+  const payload = between.slice(openIndex + "<!--".length, closeIndex).trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const findings = parsed.findings;
+  if (!Array.isArray(findings)) return null;
+  const result = [];
+  for (const entry of findings) {
+    const finding = parseFinding(entry);
+    if (finding !== null) result.push(finding);
+  }
+  return result;
+};
+
+// src/harden/tally.ts
+var HELP_TEXT17 = `Usage: gaia harden-tally
+
+  Tallies recurring code-review-audit findings across the rolling 90-day
+  merged-PR window and prints the candidate list as JSON. A class is a
+  candidate when it recurs across >= 3 distinct PRs at error/warning severity,
+  no promoted rule covers it, and the decline ledger does not suppress it.
+
+  Network failures are non-fatal: gh errors yield an empty candidate list.
+`;
+var HELP_TOKENS17 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var WINDOW_DAYS = 90;
+var windowStartDate = (now) => {
+  const start = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1e3);
+  return start.toISOString().slice(0, 10);
+};
+var parseGhPr = (value) => {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value;
+  if (typeof v.number !== "number" || !Number.isFinite(v.number)) return null;
+  if (!Array.isArray(v.comments)) return null;
+  const comments = [];
+  for (const comment of v.comments) {
+    if (typeof comment === "object" && comment !== null && typeof comment.body === "string") {
+      comments.push({ body: comment.body });
+    }
+  }
+  return { comments, number: v.number };
+};
+var fetchWindowPrs = (cwd, now) => {
+  const search = `merged:>=${windowStartDate(now)}`;
+  const ghResult = runGh(
+    [
+      "pr",
+      "list",
+      "--state",
+      "merged",
+      "--search",
+      search,
+      "--limit",
+      "200",
+      "--json",
+      "number,comments"
+    ],
+    { cwd }
+  );
+  if (ghResult.exitCode !== 0) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(ghResult.stdout);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const records = [];
+  for (const value of parsed) {
+    const pr = parseGhPr(value);
+    if (pr === null) continue;
+    let findings;
+    for (const comment of pr.comments) {
+      const block = parseFindingsBlock(comment.body);
+      if (block !== null) findings = block;
+    }
+    if (findings !== void 0) {
+      records.push({ findings, pr_number: pr.number });
+    }
+  }
+  return records;
+};
+var run19 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS17.has(argv[0])) {
+    process.stdout.write(HELP_TEXT17);
+    return EXIT_CODES.OK;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runLedger = options.runLedger ?? defaultLedgerRunner;
+  const now = /* @__PURE__ */ new Date();
+  const prs = fetchWindowPrs(cwd, now);
+  const covered = coveredClassesFromRules(
+    path13.join(cwd, ".claude", "rules")
+  );
+  const tallyResult = computeTally({
+    coveredClass: (findingClass) => covered.has(findingClass),
+    prs,
+    suppressedClass: makeLedgerSuppressionPredicate({ cwd, runLedger }),
+    windowDays: WINDOW_DAYS
+  });
+  pruneLedger({ cwd, runLedger, windowClasses: windowClasses(prs) });
+  process.stdout.write(`${JSON.stringify(tallyResult)}
+`);
+  return EXIT_CODES.OK;
+};
+
+// src/init/bootstrap-env.ts
+import { copyFileSync, existsSync as existsSync11 } from "node:fs";
+import path15 from "node:path";
+
+// src/init/util/state.ts
+import { existsSync as existsSync10, mkdirSync as mkdirSync8, readFileSync as readFileSync11 } from "node:fs";
+import path14 from "node:path";
 var STATE_FILE_RELATIVE = ".gaia/init-state.json";
 var emptyState = () => ({ completed_steps: [], step_args: {} });
 var isStringArray = (value) => Array.isArray(value) && value.every((entry) => typeof entry === "string");
@@ -17836,16 +18518,16 @@ var parseState = (raw) => {
   const stepArgs = args !== null && typeof args === "object" && !Array.isArray(args) ? args : {};
   return { completed_steps: completedSteps, step_args: stepArgs };
 };
-var stateFilePath = (cwd) => path11.join(cwd, STATE_FILE_RELATIVE);
+var stateFilePath = (cwd) => path14.join(cwd, STATE_FILE_RELATIVE);
 var readState = (cwd) => {
   const target = stateFilePath(cwd);
-  if (!existsSync9(target)) return emptyState();
-  const raw = readFileSync9(target, "utf8");
+  if (!existsSync10(target)) return emptyState();
+  const raw = readFileSync11(target, "utf8");
   return parseState(raw);
 };
 var writeState = (cwd, state) => {
   const target = stateFilePath(cwd);
-  mkdirSync7(path11.dirname(target), { recursive: true });
+  mkdirSync8(path14.dirname(target), { recursive: true });
   const serialized = `${JSON.stringify(state, null, 2)}
 `;
   atomicWriteFileSync(target, serialized);
@@ -17869,7 +18551,7 @@ var STEP_ORDER = [
 ];
 
 // src/init/bootstrap-env.ts
-var HELP_TEXT16 = `Usage: gaia init bootstrap-env
+var HELP_TEXT18 = `Usage: gaia init bootstrap-env
 
   Copy .env.example to .env when .env does not yet exist.
   No-op when .env already exists or .env.example is absent.
@@ -17878,12 +18560,12 @@ var HELP_TEXT16 = `Usage: gaia init bootstrap-env
     0  success (no stdout)
     2  unexpected filesystem failure
 `;
-var HELP_TOKENS16 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS18 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT = 2;
 var STEP_NAME = "bootstrap-env";
-var run18 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS16.has(argv[0])) {
-    process.stdout.write(HELP_TEXT16);
+var run20 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS18.has(argv[0])) {
+    process.stdout.write(HELP_TEXT18);
     return EXIT_CODES.OK;
   }
   if (argv.length > 0) {
@@ -17895,9 +18577,9 @@ var run18 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwd = options.cwd ?? process.cwd();
-  const envPath = path12.join(cwd, ".env");
-  const examplePath = path12.join(cwd, ".env.example");
-  if (!existsSync10(envPath) && existsSync10(examplePath)) {
+  const envPath = path15.join(cwd, ".env");
+  const examplePath = path15.join(cwd, ".env.example");
+  if (!existsSync11(envPath) && existsSync11(examplePath)) {
     try {
       copyFileSync(examplePath, envPath);
     } catch (error51) {
@@ -17923,12 +18605,12 @@ var run18 = (argv, options = {}) => {
 };
 
 // src/setup-ci/util/automation-write.ts
-import { mkdirSync as mkdirSync8, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
-import path13 from "node:path";
+import { mkdirSync as mkdirSync9, renameSync as renameSync4, writeFileSync as writeFileSync7 } from "node:fs";
+import path16 from "node:path";
 var writeAutomationConfig = (repoRoot2, payload) => {
   AutomationConfigSchema.parse(payload);
   const target = automationConfigPath(repoRoot2);
-  mkdirSync8(path13.dirname(target), { recursive: true });
+  mkdirSync9(path16.dirname(target), { recursive: true });
   const serialized = `${JSON.stringify(payload, null, 2)}
 `;
   const tmpPath = `${target}.tmp`;
@@ -17937,7 +18619,7 @@ var writeAutomationConfig = (repoRoot2, payload) => {
 };
 
 // src/init/configure-automation.ts
-var HELP_TEXT17 = `Usage: gaia init configure-automation \\
+var HELP_TEXT19 = `Usage: gaia init configure-automation \\
   --wiki <ci|local|off> \\
   --update-deps <ci|local|off> \\
   --pnpm-audit <ci|local|off> \\
@@ -17959,7 +18641,7 @@ var HELP_TEXT17 = `Usage: gaia init configure-automation \\
     11  schema violation (internal: built config failed schema parse)
     2   unexpected (filesystem failure)
 `;
-var HELP_TOKENS17 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS19 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT2 = 2;
 var STEP_NAME2 = "configure-automation";
 var SUBCOMMAND = "init configure-automation";
@@ -18044,9 +18726,9 @@ var buildConfig = (flags) => ({
   version: 1,
   wiki: { mode: flags.wiki }
 });
-var run19 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS17.has(argv[0])) {
-    process.stdout.write(HELP_TEXT17);
+var run21 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS19.has(argv[0])) {
+    process.stdout.write(HELP_TEXT19);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags2(argv);
@@ -18100,9 +18782,9 @@ var run19 = (argv, options = {}) => {
 };
 
 // src/init/configure-i18n.ts
-import { existsSync as existsSync11, readFileSync as readFileSync10 } from "node:fs";
-import path14 from "node:path";
-var HELP_TEXT18 = `Usage: gaia init configure-i18n --locales <list> --strip <bool>
+import { existsSync as existsSync12, readFileSync as readFileSync12 } from "node:fs";
+import path17 from "node:path";
+var HELP_TEXT20 = `Usage: gaia init configure-i18n --locales <list> --strip <bool>
 
   Configure the project's i18n surface from the user's language picks.
 
@@ -18115,7 +18797,7 @@ var HELP_TEXT18 = `Usage: gaia init configure-i18n --locales <list> --strip <boo
     1  user-correctable error (missing flags, invalid locale list)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS18 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT3 = 2;
 var STEP_NAME3 = "configure-i18n";
 var takeValue2 = (argv, index, flag) => {
@@ -18194,17 +18876,17 @@ export default {${exports}} as const;
 `;
 };
 var updateLanguagesIndex = (cwd, locales) => {
-  const target = path14.join(cwd, LANGUAGES_INDEX);
-  if (!existsSync11(target)) return;
+  const target = path17.join(cwd, LANGUAGES_INDEX);
+  if (!existsSync12(target)) return;
   const next = renderLanguagesIndex(locales);
-  const current = readFileSync10(target, "utf8");
+  const current = readFileSync12(target, "utf8");
   if (current === next) return;
   atomicWriteFileSync(target, next);
 };
 var updateI18nFallback = (cwd, fallback) => {
-  const target = path14.join(cwd, I18N_FILE);
-  if (!existsSync11(target)) return;
-  const original = readFileSync10(target, "utf8");
+  const target = path17.join(cwd, I18N_FILE);
+  if (!existsSync12(target)) return;
+  const original = readFileSync12(target, "utf8");
   let next = original.replace(
     /DEFAULT_LOCALE\s*=\s*['"][^'"]+['"]/u,
     `DEFAULT_LOCALE = '${fallback}'`
@@ -18217,9 +18899,9 @@ var updateI18nFallback = (cwd, fallback) => {
     atomicWriteFileSync(target, next);
   }
 };
-var run20 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS18.has(argv[0])) {
-    process.stdout.write(HELP_TEXT18);
+var run22 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS20.has(argv[0])) {
+    process.stdout.write(HELP_TEXT20);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags3(argv);
@@ -18264,15 +18946,15 @@ var run20 = (argv, options = {}) => {
 
 // src/init/finalize.ts
 import {
-  existsSync as existsSync12,
-  mkdirSync as mkdirSync9,
-  readFileSync as readFileSync11,
+  existsSync as existsSync13,
+  mkdirSync as mkdirSync10,
+  readFileSync as readFileSync13,
   renameSync as renameSync5,
   rmSync as rmSync2,
   writeFileSync as writeFileSync8
 } from "node:fs";
-import path15 from "node:path";
-var HELP_TEXT19 = `Usage: gaia init finalize
+import path18 from "node:path";
+var HELP_TEXT21 = `Usage: gaia init finalize
 
   Final cleanup steps for /gaia-init: remove the init interceptor hook,
   prune its settings entry, and delete the gaia-init.md command file.
@@ -18282,15 +18964,15 @@ var HELP_TEXT19 = `Usage: gaia init finalize
     1  user-correctable error (settings malformed)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS19 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS21 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT4 = 2;
 var STEP_NAME4 = "finalize";
 var INTERCEPT_HOOK = ".claude/hooks/intercept-init.sh";
 var INIT_COMMAND = ".claude/commands/gaia-init.md";
 var SETTINGS_FILE = ".claude/settings.json";
 var removeIfPresent = (cwd, relative) => {
-  const absolute = path15.join(cwd, relative);
-  if (existsSync12(absolute)) {
+  const absolute = path18.join(cwd, relative);
+  if (existsSync13(absolute)) {
     rmSync2(absolute, { force: true, recursive: true });
   }
 };
@@ -18327,8 +19009,8 @@ var pruneInterceptInit = (source) => {
   return next;
 };
 var readSettings = (target) => {
-  if (!existsSync12(target)) return {};
-  const raw = readFileSync11(target, "utf8").trim();
+  if (!existsSync13(target)) return {};
+  const raw = readFileSync13(target, "utf8").trim();
   if (raw.length === 0) return {};
   let parsed;
   try {
@@ -18342,7 +19024,7 @@ var readSettings = (target) => {
   return parsed;
 };
 var writeSettings = (target, value) => {
-  mkdirSync9(path15.dirname(target), { recursive: true });
+  mkdirSync10(path18.dirname(target), { recursive: true });
   const serialized = `${JSON.stringify(value, null, 2)}
 `;
   const tmp = `${target}.tmp`;
@@ -18350,16 +19032,16 @@ var writeSettings = (target, value) => {
   renameSync5(tmp, target);
 };
 var pruneSettings = (cwd) => {
-  const target = path15.join(cwd, SETTINGS_FILE);
-  if (!existsSync12(target)) return;
+  const target = path18.join(cwd, SETTINGS_FILE);
+  if (!existsSync13(target)) return;
   const current = readSettings(target);
   const next = pruneInterceptInit(current);
   if (next === current) return;
   writeSettings(target, next);
 };
-var run21 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS19.has(argv[0])) {
-    process.stdout.write(HELP_TEXT19);
+var run23 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS21.has(argv[0])) {
+    process.stdout.write(HELP_TEXT21);
     return EXIT_CODES.OK;
   }
   if (argv.length > 0) {
@@ -18406,9 +19088,9 @@ var run21 = (argv, options = {}) => {
 };
 
 // src/init/rename.ts
-import { existsSync as existsSync13, readFileSync as readFileSync12 } from "node:fs";
-import path16 from "node:path";
-var HELP_TEXT20 = `Usage: gaia init rename --title <T> --kebab <K>
+import { existsSync as existsSync14, readFileSync as readFileSync14 } from "node:fs";
+import path19 from "node:path";
+var HELP_TEXT22 = `Usage: gaia init rename --title <T> --kebab <K>
 
   Rename the project across package.json, CLAUDE.md, and seeded language
   files (Step 6 of /gaia-init).
@@ -18422,7 +19104,7 @@ var HELP_TEXT20 = `Usage: gaia init rename --title <T> --kebab <K>
     1  user-correctable error (missing flags, no package.json)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS22 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT5 = 2;
 var STEP_NAME5 = "rename";
 var takeValue3 = (argv, index, flag) => {
@@ -18468,11 +19150,11 @@ var CLAUDE_MD = "CLAUDE.md";
 var COMMON_TS = "app/languages/en/common.ts";
 var INDEX_PAGE_TS = "app/languages/en/pages/_index.ts";
 var renamePackageJson = (cwd, kebab) => {
-  const target = path16.join(cwd, PACKAGE_JSON);
-  if (!existsSync13(target)) {
+  const target = path19.join(cwd, PACKAGE_JSON);
+  if (!existsSync14(target)) {
     throw new Error("package.json not found at repo root");
   }
-  const raw = readFileSync12(target, "utf8");
+  const raw = readFileSync14(target, "utf8");
   const parsed = JSON.parse(raw);
   if (parsed.name === kebab) return;
   parsed.name = kebab;
@@ -18480,9 +19162,9 @@ var renamePackageJson = (cwd, kebab) => {
   atomicWriteFileSync(target, `${JSON.stringify(parsed, null, 2)}${trailing}`);
 };
 var renameClaudeMd = (cwd, title) => {
-  const target = path16.join(cwd, CLAUDE_MD);
-  if (!existsSync13(target)) return;
-  const original = readFileSync12(target, "utf8");
+  const target = path19.join(cwd, CLAUDE_MD);
+  if (!existsSync14(target)) return;
+  const original = readFileSync14(target, "utf8");
   const next = original.replace(/^#\s+.*$/mu, `# ${title}`);
   if (next !== original) {
     atomicWriteFileSync(target, next);
@@ -18510,18 +19192,18 @@ var replaceMetaTitle = (source, newValue) => {
   return source.replace(pattern, `$1$2${escaped}$2`);
 };
 var renameCommonTs = (cwd, title) => {
-  const target = path16.join(cwd, COMMON_TS);
-  if (!existsSync13(target)) return;
-  const original = readFileSync12(target, "utf8");
+  const target = path19.join(cwd, COMMON_TS);
+  if (!existsSync14(target)) return;
+  const original = readFileSync14(target, "utf8");
   const next = replaceStringPropertyAll(original, "siteName", title);
   if (next !== original) {
     atomicWriteFileSync(target, next);
   }
 };
 var renameIndexPage = (cwd, title) => {
-  const target = path16.join(cwd, INDEX_PAGE_TS);
-  if (!existsSync13(target)) return;
-  const original = readFileSync12(target, "utf8");
+  const target = path19.join(cwd, INDEX_PAGE_TS);
+  if (!existsSync14(target)) return;
+  const original = readFileSync14(target, "utf8");
   let next = original;
   next = replaceTopLevelStringProperty(next, "heroTitle", title);
   next = replaceTopLevelStringProperty(next, "title", title);
@@ -18530,9 +19212,9 @@ var renameIndexPage = (cwd, title) => {
     atomicWriteFileSync(target, next);
   }
 };
-var run22 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS20.has(argv[0])) {
-    process.stdout.write(HELP_TEXT20);
+var run24 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS22.has(argv[0])) {
+    process.stdout.write(HELP_TEXT22);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags4(argv);
@@ -18584,9 +19266,9 @@ var run22 = (argv, options = {}) => {
 };
 
 // src/init/strip-branding.ts
-import { existsSync as existsSync14, readFileSync as readFileSync13, rmSync as rmSync3 } from "node:fs";
-import path17 from "node:path";
-var HELP_TEXT21 = `Usage: gaia init strip-branding --title <T>
+import { existsSync as existsSync15, readFileSync as readFileSync15, rmSync as rmSync3 } from "node:fs";
+import path20 from "node:path";
+var HELP_TEXT23 = `Usage: gaia init strip-branding --title <T>
 
   Strip GAIA-specific branding from the project (Step 3 of /gaia-init).
 
@@ -18598,7 +19280,7 @@ var HELP_TEXT21 = `Usage: gaia init strip-branding --title <T>
     1  user-correctable error (missing flag, missing template)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS21 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS23 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT6 = 2;
 var STEP_NAME6 = "strip-branding";
 var takeValue4 = (argv, index, flag) => {
@@ -18632,30 +19314,30 @@ var README_TARGET = "README.md";
 var HEADER_FILE = "app/components/Header/index.tsx";
 var PLACEHOLDER = "{{PROJECT_TITLE}}";
 var removeIfPresent2 = (cwd, relative) => {
-  const absolute = path17.join(cwd, relative);
-  if (existsSync14(absolute)) {
+  const absolute = path20.join(cwd, relative);
+  if (existsSync15(absolute)) {
     rmSync3(absolute, { force: true, recursive: true });
   }
 };
 var writeReadme = (cwd, title) => {
-  const templatePath = path17.join(cwd, README_TEMPLATE);
-  if (!existsSync14(templatePath)) {
+  const templatePath = path20.join(cwd, README_TEMPLATE);
+  if (!existsSync15(templatePath)) {
     throw new Error(`${README_TEMPLATE} not found; cannot replace README`);
   }
-  const template = readFileSync13(templatePath, "utf8");
+  const template = readFileSync15(templatePath, "utf8");
   const rendered = template.split(PLACEHOLDER).join(title);
-  const target = path17.join(cwd, README_TARGET);
-  if (existsSync14(target)) {
-    const current = readFileSync13(target, "utf8");
+  const target = path20.join(cwd, README_TARGET);
+  if (existsSync15(target)) {
+    const current = readFileSync15(target, "utf8");
     if (current === rendered) return;
   }
   atomicWriteFileSync(target, rendered);
 };
 var WORDMARK_REPLACEMENT = `<span className="text-body text-xl font-bold">{t('meta.siteName')}</span>`;
 var stripGaiaLogoFromHeader = (cwd) => {
-  const target = path17.join(cwd, HEADER_FILE);
-  if (!existsSync14(target)) return;
-  const original = readFileSync13(target, "utf8");
+  const target = path20.join(cwd, HEADER_FILE);
+  if (!existsSync15(target)) return;
+  const original = readFileSync15(target, "utf8");
   let next = original;
   next = next.replaceAll(
     /^import\s+GaiaLogo\s+from\s+['"]~\/components\/GaiaLogo['"];?\n/gmu,
@@ -18669,9 +19351,9 @@ var stripGaiaLogoFromHeader = (cwd) => {
     atomicWriteFileSync(target, next);
   }
 };
-var run23 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS21.has(argv[0])) {
-    process.stdout.write(HELP_TEXT21);
+var run25 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS23.has(argv[0])) {
+    process.stdout.write(HELP_TEXT23);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags5(argv);
@@ -18721,15 +19403,15 @@ var run23 = (argv, options = {}) => {
 
 // src/init/wire-statusline.ts
 import {
-  existsSync as existsSync15,
-  mkdirSync as mkdirSync10,
-  readFileSync as readFileSync14,
+  existsSync as existsSync16,
+  mkdirSync as mkdirSync11,
+  readFileSync as readFileSync16,
   renameSync as renameSync6,
   writeFileSync as writeFileSync9
 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import path18 from "node:path";
-var HELP_TEXT22 = `Usage: gaia init wire-statusline --mode <global|project|skip>
+import path21 from "node:path";
+var HELP_TEXT24 = `Usage: gaia init wire-statusline --mode <global|project|skip>
 
   Wire the GAIA statusline into the relevant Claude settings file.
 
@@ -18742,7 +19424,7 @@ var HELP_TEXT22 = `Usage: gaia init wire-statusline --mode <global|project|skip>
     1  user-correctable error (missing flag, invalid JSON in target)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS22 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS24 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT7 = 2;
 var STEP_NAME7 = "wire-statusline";
 var isMode = (value) => value === "global" || value === "project" || value === "skip";
@@ -18797,8 +19479,8 @@ var insertAlphabetical = (source, key, value) => {
   return next;
 };
 var readSettings2 = (target) => {
-  if (!existsSync15(target)) return {};
-  const raw = readFileSync14(target, "utf8").trim();
+  if (!existsSync16(target)) return {};
+  const raw = readFileSync16(target, "utf8").trim();
   if (raw.length === 0) return {};
   let parsed;
   try {
@@ -18812,7 +19494,7 @@ var readSettings2 = (target) => {
   return parsed;
 };
 var writeSettings2 = (target, value) => {
-  mkdirSync10(path18.dirname(target), { recursive: true });
+  mkdirSync11(path21.dirname(target), { recursive: true });
   const serialized = `${JSON.stringify(value, null, 2)}
 `;
   const tmp = `${target}.tmp`;
@@ -18832,13 +19514,13 @@ var mergeStatusline = (source) => {
   return insertAlphabetical(source, STATUSLINE_KEY, { ...STATUSLINE_BLOCK });
 };
 var targetPathForMode = (mode, cwd, home) => {
-  if (mode === "project") return path18.join(cwd, ".claude", "settings.json");
-  if (mode === "global") return path18.join(home, ".claude", "settings.json");
+  if (mode === "project") return path21.join(cwd, ".claude", "settings.json");
+  if (mode === "global") return path21.join(home, ".claude", "settings.json");
   return null;
 };
-var run24 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS22.has(argv[0])) {
-    process.stdout.write(HELP_TEXT22);
+var run26 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS24.has(argv[0])) {
+    process.stdout.write(HELP_TEXT24);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags6(argv);
@@ -18890,7 +19572,7 @@ var run24 = (argv, options = {}) => {
 };
 
 // src/init/resume.ts
-var HELP_TEXT23 = `Usage: gaia init resume [--from-step <N>]
+var HELP_TEXT25 = `Usage: gaia init resume [--from-step <N>]
 
   Replay the gaia init sequence from step N (1-indexed). Steps already
   recorded in .gaia/init-state.json's completed_steps are skipped.
@@ -18912,7 +19594,7 @@ var HELP_TEXT23 = `Usage: gaia init resume [--from-step <N>]
     1  user-correctable error (unknown step, missing saved args)
     2  unexpected (filesystem / step failure)
 `;
-var HELP_TOKENS23 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS25 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT8 = 2;
 var takeValue6 = (argv, index, flag) => {
   const value = argv[index];
@@ -18943,13 +19625,13 @@ var parseFlags7 = (argv) => {
   return { flags: { fromStep }, ok: true };
 };
 var STEP_RUNNERS = {
-  "bootstrap-env": run18,
-  "configure-automation": run19,
-  "configure-i18n": run20,
-  finalize: run21,
-  rename: run22,
-  "strip-branding": run23,
-  "wire-statusline": run24
+  "bootstrap-env": run20,
+  "configure-automation": run21,
+  "configure-i18n": run22,
+  finalize: run23,
+  rename: run24,
+  "strip-branding": run25,
+  "wire-statusline": run26
 };
 var argvFromStepArgs = (step, saved) => {
   if (step === "finalize" || step === "bootstrap-env") return [];
@@ -19003,9 +19685,9 @@ var argvFromStepArgs = (step, saved) => {
   if (typeof mode !== "string") return null;
   return ["--mode", mode];
 };
-var run25 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS23.has(argv[0])) {
-    process.stdout.write(HELP_TEXT23);
+var run27 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS25.has(argv[0])) {
+    process.stdout.write(HELP_TEXT25);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags7(argv);
@@ -19060,7 +19742,7 @@ var run25 = (argv, options = {}) => {
 };
 
 // src/init/index.ts
-var HELP_TEXT24 = `Usage: gaia init <subcommand> [args]
+var HELP_TEXT26 = `Usage: gaia init <subcommand> [args]
 
   strip-branding --title <T>
                             Remove GAIA branding from the project.
@@ -19076,22 +19758,22 @@ var HELP_TEXT24 = `Usage: gaia init <subcommand> [args]
   finalize                  Final cleanup steps for the init runbook.
   resume [--from-step <N>]  Resume a partially-completed init via state file.
 `;
-var HELP_TOKENS24 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS26 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS3 = {
-  "bootstrap-env": run18,
-  "configure-automation": run19,
-  "configure-i18n": run20,
-  finalize: run21,
-  rename: run22,
-  resume: run25,
-  "strip-branding": run23,
-  "wire-statusline": run24
+  "bootstrap-env": run20,
+  "configure-automation": run21,
+  "configure-i18n": run22,
+  finalize: run23,
+  rename: run24,
+  resume: run27,
+  "strip-branding": run25,
+  "wire-statusline": run26
 };
-var run26 = async (argv) => {
+var run28 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS24.has(subcommand)) {
-    process.stdout.write(HELP_TEXT24);
+  if (subcommand === void 0 || HELP_TOKENS26.has(subcommand)) {
+    process.stdout.write(HELP_TEXT26);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS3[subcommand];
@@ -19108,8 +19790,8 @@ var run26 = async (argv) => {
 };
 
 // src/mentorship/display-rule-memory.ts
-import { existsSync as existsSync16, mkdirSync as mkdirSync11, readFileSync as readFileSync15, unlinkSync as unlinkSync2 } from "node:fs";
-import path19 from "node:path";
+import { existsSync as existsSync17, mkdirSync as mkdirSync12, readFileSync as readFileSync17, unlinkSync as unlinkSync2 } from "node:fs";
+import path22 from "node:path";
 
 // src/mentorship/display-rule.ts
 var DISPLAY_RULE_FILE_NAME = "feedback_mentorship_display.md";
@@ -19141,12 +19823,12 @@ Firm: no "just one event", no "summarize the last hour", no "what did I work on 
 // src/mentorship/display-rule-memory.ts
 var MEMORY_INDEX_FILE = "MEMORY.md";
 var ensureMemoryDirectory = (memoryDirectory) => {
-  if (existsSync16(memoryDirectory)) return;
-  mkdirSync11(memoryDirectory, { mode: 493, recursive: true });
+  if (existsSync17(memoryDirectory)) return;
+  mkdirSync12(memoryDirectory, { mode: 493, recursive: true });
 };
 var readIndex = (indexPath) => {
-  if (!existsSync16(indexPath)) return "";
-  return readFileSync15(indexPath, "utf8");
+  if (!existsSync17(indexPath)) return "";
+  return readFileSync17(indexPath, "utf8");
 };
 var indexContainsLine = (indexBody, line) => {
   if (indexBody === "") return false;
@@ -19177,23 +19859,23 @@ var removeIndexLine = (indexBody, line) => {
 };
 var installDisplayRule = (roots) => {
   ensureMemoryDirectory(roots.memoryDir);
-  const bodyPath = path19.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
+  const bodyPath = path22.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
   atomicWriteFileSync(bodyPath, DISPLAY_RULE_BODY);
-  const indexPath = path19.join(roots.memoryDir, MEMORY_INDEX_FILE);
+  const indexPath = path22.join(roots.memoryDir, MEMORY_INDEX_FILE);
   const indexBody = readIndex(indexPath);
   if (indexContainsLine(indexBody, DISPLAY_RULE_INDEX_LINE)) return;
   const next = appendIndexLine(indexBody, DISPLAY_RULE_INDEX_LINE);
   atomicWriteFileSync(indexPath, next);
 };
 var removeDisplayRule = (roots) => {
-  if (!existsSync16(roots.memoryDir)) return;
-  const bodyPath = path19.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
-  if (existsSync16(bodyPath)) {
+  if (!existsSync17(roots.memoryDir)) return;
+  const bodyPath = path22.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
+  if (existsSync17(bodyPath)) {
     unlinkSync2(bodyPath);
   }
-  const indexPath = path19.join(roots.memoryDir, MEMORY_INDEX_FILE);
-  if (!existsSync16(indexPath)) return;
-  const indexBody = readFileSync15(indexPath, "utf8");
+  const indexPath = path22.join(roots.memoryDir, MEMORY_INDEX_FILE);
+  if (!existsSync17(indexPath)) return;
+  const indexBody = readFileSync17(indexPath, "utf8");
   if (!indexContainsLine(indexBody, DISPLAY_RULE_INDEX_LINE)) return;
   const next = removeIndexLine(indexBody, DISPLAY_RULE_INDEX_LINE);
   if (next === "") {
@@ -19204,13 +19886,13 @@ var removeDisplayRule = (roots) => {
 };
 var assertDisplayRule = (roots) => {
   ensureMemoryDirectory(roots.memoryDir);
-  const bodyPath = path19.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
-  const previousBody = existsSync16(bodyPath) ? readFileSync15(bodyPath, "utf8") : null;
+  const bodyPath = path22.join(roots.memoryDir, DISPLAY_RULE_FILE_NAME);
+  const previousBody = existsSync17(bodyPath) ? readFileSync17(bodyPath, "utf8") : null;
   const bodyChanged = previousBody !== DISPLAY_RULE_BODY;
   if (bodyChanged) {
     atomicWriteFileSync(bodyPath, DISPLAY_RULE_BODY);
   }
-  const indexPath = path19.join(roots.memoryDir, MEMORY_INDEX_FILE);
+  const indexPath = path22.join(roots.memoryDir, MEMORY_INDEX_FILE);
   const indexBody = readIndex(indexPath);
   const lineMissing = !indexContainsLine(indexBody, DISPLAY_RULE_INDEX_LINE);
   if (lineMissing) {
@@ -19224,7 +19906,7 @@ var assertDisplayRule = (roots) => {
 };
 
 // src/mentorship/_internal-assert-memory-rules.ts
-var run27 = (_argv, options = {}) => {
+var run29 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   let enabled;
   try {
@@ -19282,7 +19964,7 @@ var run27 = (_argv, options = {}) => {
 };
 
 // src/mentorship/_internal-provision-dirs.ts
-var run28 = async (_argv, options = {}) => {
+var run30 = async (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   try {
     await ensureMentorshipDirs(roots);
@@ -19340,7 +20022,7 @@ var parseFlags8 = (argv) => {
   }
   return flags;
 };
-var run29 = (argv, options = {}) => {
+var run31 = (argv, options = {}) => {
   const flags = parseFlags8(argv);
   if (flags.enabled === void 0) {
     structuredError({
@@ -19406,7 +20088,7 @@ var run29 = (argv, options = {}) => {
 };
 
 // src/mentorship/analytics-disable.ts
-var run30 = (_argv, options = {}) => {
+var run32 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   let current;
   try {
@@ -19460,8 +20142,8 @@ var run30 = (_argv, options = {}) => {
 };
 
 // src/mentorship/analytics-dry-run.ts
-import { existsSync as existsSync17, readdirSync, readFileSync as readFileSync16 } from "node:fs";
-import path20 from "node:path";
+import { existsSync as existsSync18, readdirSync as readdirSync2, readFileSync as readFileSync18 } from "node:fs";
+import path23 from "node:path";
 
 // src/schemas/analytics-report.ts
 var AnalyticsReportSchema = external_exports.strictObject({
@@ -19520,18 +20202,18 @@ var sortAlpha = (entries) => {
   return copy.toSorted((a, b) => a.localeCompare(b));
 };
 var findLatestReport = (analyticsDir) => {
-  if (!existsSync17(analyticsDir)) return null;
+  if (!existsSync18(analyticsDir)) return null;
   let entries;
   try {
-    entries = readdirSync(analyticsDir);
+    entries = readdirSync2(analyticsDir);
   } catch {
     return null;
   }
   const matching = entries.filter((entry) => REPORT_GLOB.test(entry)).toSorted((a, b) => a.localeCompare(b));
   const last = matching.at(-1);
-  return last === void 0 ? null : path20.join(analyticsDir, last);
+  return last === void 0 ? null : path23.join(analyticsDir, last);
 };
-var run31 = (_argv, options = {}) => {
+var run33 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   const reportPath = findLatestReport(roots.analyticsDir);
   if (reportPath === null) {
@@ -19541,7 +20223,7 @@ var run31 = (_argv, options = {}) => {
   }
   let raw;
   try {
-    raw = readFileSync16(reportPath, "utf8");
+    raw = readFileSync18(reportPath, "utf8");
   } catch (error51) {
     structuredError({
       code: "storage_inaccessible",
@@ -19587,7 +20269,7 @@ var run31 = (_argv, options = {}) => {
 };
 
 // src/mentorship/analytics-enable.ts
-var run32 = (_argv, options = {}) => {
+var run34 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   let current;
   try {
@@ -19641,7 +20323,7 @@ var run32 = (_argv, options = {}) => {
 };
 
 // src/mentorship/disable.ts
-var run33 = (_argv, options = {}) => {
+var run35 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   let current;
   try {
@@ -19714,7 +20396,7 @@ var askConfirm = async (arguments_) => {
 
 // src/mentorship/enable.ts
 var hasYesFlag = (argv) => argv.includes("--yes");
-var run34 = async (argv, options = {}) => {
+var run36 = async (argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   const yesFlag = hasYesFlag(argv);
   let current;
@@ -19796,14 +20478,14 @@ var run34 = async (argv, options = {}) => {
 
 // src/mentorship/purge.ts
 import {
-  existsSync as existsSync19,
-  mkdirSync as mkdirSync12,
-  readdirSync as readdirSync2,
+  existsSync as existsSync20,
+  mkdirSync as mkdirSync13,
+  readdirSync as readdirSync3,
   rmSync as rmSync4,
   statSync as statSync2,
   unlinkSync as unlinkSync3
 } from "node:fs";
-import path21 from "node:path";
+import path24 from "node:path";
 
 // node_modules/.pnpm/ulid@3.0.2/node_modules/ulid/dist/node/index.js
 import crypto from "node:crypto";
@@ -19917,11 +20599,11 @@ function ulid3(seedTime, prng) {
 }
 
 // src/storage/install-id.ts
-import { existsSync as existsSync18, readFileSync as readFileSync17 } from "node:fs";
+import { existsSync as existsSync19, readFileSync as readFileSync19 } from "node:fs";
 var readOrCreateInstallId = (roots) => {
   const filePath = roots.installIdPath;
-  if (existsSync18(filePath)) {
-    const existing = readFileSync17(filePath, "utf8").trim();
+  if (existsSync19(filePath)) {
+    const existing = readFileSync19(filePath, "utf8").trim();
     if (existing.length === 26) {
       return existing;
     }
@@ -19935,12 +20617,12 @@ var readOrCreateInstallId = (roots) => {
 // src/mentorship/purge.ts
 var hasYesFlag2 = (argv) => argv.includes("--yes");
 var hasAnyMentorshipData = (roots) => {
-  if (existsSync19(roots.mentorshipDir)) return true;
-  if (existsSync19(roots.installIdPath)) return true;
-  if (existsSync19(roots.profilePath)) return true;
-  if (existsSync19(roots.analyticsDir)) {
+  if (existsSync20(roots.mentorshipDir)) return true;
+  if (existsSync20(roots.installIdPath)) return true;
+  if (existsSync20(roots.profilePath)) return true;
+  if (existsSync20(roots.analyticsDir)) {
     try {
-      const entries = readdirSync2(roots.analyticsDir);
+      const entries = readdirSync3(roots.analyticsDir);
       if (entries.some((entry) => entry.endsWith(".json"))) {
         return true;
       }
@@ -19950,27 +20632,27 @@ var hasAnyMentorshipData = (roots) => {
   return false;
 };
 var deleteMentorshipSubtree = (roots) => {
-  if (existsSync19(roots.mentorshipDir)) {
+  if (existsSync20(roots.mentorshipDir)) {
     rmSync4(roots.mentorshipDir, { force: true, recursive: true });
   }
-  if (existsSync19(roots.profilePath)) {
+  if (existsSync20(roots.profilePath)) {
     unlinkSync3(roots.profilePath);
   }
-  if (existsSync19(roots.installIdPath)) {
+  if (existsSync20(roots.installIdPath)) {
     unlinkSync3(roots.installIdPath);
   }
 };
 var deleteAnalyticsReports = (roots) => {
-  if (!existsSync19(roots.analyticsDir)) return;
+  if (!existsSync20(roots.analyticsDir)) return;
   let entries;
   try {
-    entries = readdirSync2(roots.analyticsDir);
+    entries = readdirSync3(roots.analyticsDir);
   } catch {
     return;
   }
   const jsonEntries = entries.filter((entry) => entry.endsWith(".json"));
   for (const entry of jsonEntries) {
-    const fullPath = path21.join(roots.analyticsDir, entry);
+    const fullPath = path24.join(roots.analyticsDir, entry);
     try {
       const stats = statSync2(fullPath);
       if (stats.isFile()) {
@@ -19980,7 +20662,7 @@ var deleteAnalyticsReports = (roots) => {
     }
   }
 };
-var run35 = async (argv, options = {}) => {
+var run37 = async (argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   const yesFlag = hasYesFlag2(argv);
   if (!hasAnyMentorshipData(roots)) {
@@ -20016,9 +20698,9 @@ var run35 = async (argv, options = {}) => {
   }
   let freshInstallId;
   try {
-    const installParent = path21.dirname(roots.installIdPath);
-    if (!existsSync19(installParent)) {
-      mkdirSync12(installParent, { mode: 448, recursive: true });
+    const installParent = path24.dirname(roots.installIdPath);
+    if (!existsSync20(installParent)) {
+      mkdirSync13(installParent, { mode: 448, recursive: true });
     }
     freshInstallId = readOrCreateInstallId(roots);
   } catch (error51) {
@@ -20041,35 +20723,35 @@ var run35 = async (argv, options = {}) => {
 };
 
 // src/mentorship/status.ts
-import { existsSync as existsSync20, readdirSync as readdirSync3, readFileSync as readFileSync18 } from "node:fs";
-import path22 from "node:path";
+import { existsSync as existsSync21, readdirSync as readdirSync4, readFileSync as readFileSync20 } from "node:fs";
+import path25 from "node:path";
 var NDJSON_GLOB = /^events-\d{4}-\d{2}-\d{2}\.jsonl$/u;
 var readInstallId = (installIdPath) => {
-  if (!existsSync20(installIdPath)) return null;
+  if (!existsSync21(installIdPath)) return null;
   try {
-    const raw = readFileSync18(installIdPath, "utf8").trim();
+    const raw = readFileSync20(installIdPath, "utf8").trim();
     return raw.length > 0 ? raw : null;
   } catch {
     return null;
   }
 };
 var findMostRecentEventsFile = (mentorshipDir) => {
-  if (!existsSync20(mentorshipDir)) return null;
+  if (!existsSync21(mentorshipDir)) return null;
   let entries;
   try {
-    entries = readdirSync3(mentorshipDir);
+    entries = readdirSync4(mentorshipDir);
   } catch {
     return null;
   }
   const matching = entries.filter((entry) => NDJSON_GLOB.test(entry)).toSorted((a, b) => a.localeCompare(b));
   const last = matching.at(-1);
-  return last === void 0 ? null : path22.join(mentorshipDir, last);
+  return last === void 0 ? null : path25.join(mentorshipDir, last);
 };
 var readLastEventTimestamp = (mentorshipDir) => {
   const filePath = findMostRecentEventsFile(mentorshipDir);
   if (filePath === null) return null;
   try {
-    const raw = readFileSync18(filePath, "utf8");
+    const raw = readFileSync20(filePath, "utf8");
     const lines = raw.split("\n").filter((line) => line.length > 0);
     const last = lines.at(-1);
     if (last === void 0) return null;
@@ -20097,11 +20779,11 @@ var countBulletsUnderHeading = (markdown, headingText) => {
   return count;
 };
 var readProfileCounts = (profilePath) => {
-  if (!existsSync20(profilePath)) {
+  if (!existsSync21(profilePath)) {
     return { activeAdaptationCount: 0, activePatternCount: 0 };
   }
   try {
-    const raw = readFileSync18(profilePath, "utf8");
+    const raw = readFileSync20(profilePath, "utf8");
     return {
       activeAdaptationCount: countBulletsUnderHeading(
         raw,
@@ -20130,7 +20812,7 @@ var buildStatus = (roots) => {
     mentorship_dir: roots.mentorshipDir
   };
 };
-var run36 = (_argv, options = {}) => {
+var run38 = (_argv, options = {}) => {
   const roots = options.roots ?? resolveStorageRoots();
   let payload;
   try {
@@ -20148,7 +20830,7 @@ var run36 = (_argv, options = {}) => {
 };
 
 // src/mentorship/index.ts
-var HELP_TEXT25 = `Usage: gaia mentorship <subcommand> [args]
+var HELP_TEXT27 = `Usage: gaia mentorship <subcommand> [args]
 
   enable                       Enable mentorship + analytics (interactive; --yes for non-interactive).
   disable                      Disable mentorship; existing files are preserved.
@@ -20158,25 +20840,25 @@ var HELP_TEXT25 = `Usage: gaia mentorship <subcommand> [args]
   analytics disable            Disable analytics; mentorship JSONL writes continue.
   analytics dry-run            Print today's analytics report JSON; never uploads.
 `;
-var HELP_TOKENS25 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS27 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TOP_LEVEL_HANDLERS = {
-  "_internal-assert-memory-rules": run27,
-  "_internal-provision-dirs": run28,
-  "_internal-write-config": run29,
-  disable: run33,
-  enable: run34,
-  purge: run35,
-  status: run36
+  "_internal-assert-memory-rules": run29,
+  "_internal-provision-dirs": run30,
+  "_internal-write-config": run31,
+  disable: run35,
+  enable: run36,
+  purge: run37,
+  status: run38
 };
 var ANALYTICS_HANDLERS = {
-  disable: run30,
-  "dry-run": run31,
-  enable: run32
+  disable: run32,
+  "dry-run": run33,
+  enable: run34
 };
 var handleAnalytics = async (rest) => {
   const subSubcommand = rest[0];
   const subRest = rest.slice(1);
-  if (subSubcommand === void 0 || HELP_TOKENS25.has(subSubcommand)) {
+  if (subSubcommand === void 0 || HELP_TOKENS27.has(subSubcommand)) {
     process.stdout.write(
       "Usage: gaia mentorship analytics <enable|disable|dry-run>\n"
     );
@@ -20193,11 +20875,11 @@ var handleAnalytics = async (rest) => {
   const result = await handler(subRest);
   return typeof result === "number" ? result : EXIT_CODES.OK;
 };
-var run37 = async (argv) => {
+var run39 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS25.has(subcommand)) {
-    process.stdout.write(HELP_TEXT25);
+  if (subcommand === void 0 || HELP_TOKENS27.has(subcommand)) {
+    process.stdout.write(HELP_TEXT27);
     return EXIT_CODES.OK;
   }
   if (subcommand === "analytics") {
@@ -20216,23 +20898,23 @@ var run37 = async (argv) => {
 };
 
 // src/scaffold/component.ts
-import { existsSync as existsSync22, statSync as statSync3 } from "node:fs";
-import path24 from "node:path";
+import { existsSync as existsSync23, statSync as statSync3 } from "node:fs";
+import path27 from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 
 // src/scaffold/fs.ts
-import { existsSync as existsSync21, mkdirSync as mkdirSync13, readFileSync as readFileSync19 } from "node:fs";
-import path23 from "node:path";
+import { existsSync as existsSync22, mkdirSync as mkdirSync14, readFileSync as readFileSync21 } from "node:fs";
+import path26 from "node:path";
 var ensureDir = (absPath) => {
-  mkdirSync13(absPath, { recursive: true });
+  mkdirSync14(absPath, { recursive: true });
 };
 var writeFileIfAbsent = (absPath, contents) => {
-  if (existsSync21(absPath)) {
-    const existing = readFileSync19(absPath, "utf8");
+  if (existsSync22(absPath)) {
+    const existing = readFileSync21(absPath, "utf8");
     if (existing === contents) return { written: false };
     throw new Error(`refusing to overwrite ${absPath}`);
   }
-  ensureDir(path23.dirname(absPath));
+  ensureDir(path26.dirname(absPath));
   atomicWriteFileSync(absPath, contents);
   return { written: true };
 };
@@ -20242,7 +20924,7 @@ var PASCAL_CASE_PATTERN = /^[A-Z][\dA-Za-z]*$/u;
 var PROP_ENTRY_PATTERN = /^([A-Za-z_][\w$]*)\s*:\s*(.+)$/u;
 var TEMPLATES_DIR = "component";
 var COMPONENTS_DEFAULT_PARENT = "app/components";
-var HELP_TEXT26 = `Usage: gaia scaffold component <Name> [flags]
+var HELP_TEXT28 = `Usage: gaia scaffold component <Name> [flags]
 
   --no-story          Skip the index.stories.tsx file
   --parent <dir>      Parent dir under app/components/ (default: app/components/)
@@ -20250,7 +20932,7 @@ var HELP_TEXT26 = `Usage: gaia scaffold component <Name> [flags]
                       Typed props rendered as a Props type alias
   --json              Emit ScaffoldResult JSON on stdout
 `;
-var HELP_TOKENS26 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseProps = (raw) => {
   const entries = raw.split(",").flatMap((entry) => {
     const trimmed = entry.trim();
@@ -20375,9 +21057,9 @@ var buildStoryTitle = (parent, componentName) => {
   if (stripped === "") return `Components/${componentName}`;
   return `Components/${stripped}/${componentName}`;
 };
-var defaultIsDirectory = (absPath) => existsSync22(absPath) && statSync3(absPath).isDirectory();
+var defaultIsDirectory = (absPath) => existsSync23(absPath) && statSync3(absPath).isDirectory();
 var renderComponentFile = (templatesRoot, componentName, props) => {
-  const templatePath = path24.join(
+  const templatePath = path27.join(
     templatesRoot,
     `${TEMPLATES_DIR}/index.tsx.tmpl`
   );
@@ -20392,7 +21074,7 @@ var renderComponentFile = (templatesRoot, componentName, props) => {
   });
 };
 var renderTestFile = (templatesRoot, componentName, withStory) => {
-  const templatePath = path24.join(
+  const templatePath = path27.join(
     templatesRoot,
     `${TEMPLATES_DIR}/index.test.tsx.tmpl`
   );
@@ -20402,7 +21084,7 @@ var renderTestFile = (templatesRoot, componentName, withStory) => {
   });
 };
 var renderStoryFile = (templatesRoot, componentName, parent) => {
-  const templatePath = path24.join(
+  const templatePath = path27.join(
     templatesRoot,
     `${TEMPLATES_DIR}/index.stories.tsx.tmpl`
   );
@@ -20413,7 +21095,7 @@ var renderStoryFile = (templatesRoot, componentName, parent) => {
 };
 var resolveTemplatesRoot = () => {
   const here = fileURLToPath2(import.meta.url);
-  return path24.join(path24.dirname(here), "templates");
+  return path27.join(path27.dirname(here), "templates");
 };
 var writeOne = (absPath, contents, result) => {
   const { written } = writeFileIfAbsent(absPath, contents);
@@ -20436,10 +21118,10 @@ var printHumanResult = (result, componentName) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run38 = (argv, options = {}) => {
+var run40 = (argv, options = {}) => {
   const subcommand = argv[0];
-  if (subcommand !== void 0 && HELP_TOKENS26.has(subcommand)) {
-    process.stdout.write(HELP_TEXT26);
+  if (subcommand !== void 0 && HELP_TOKENS28.has(subcommand)) {
+    process.stdout.write(HELP_TEXT28);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags9(argv);
@@ -20454,7 +21136,7 @@ var run38 = (argv, options = {}) => {
   const { flags } = parsed;
   const cwd = options.cwd ?? process.cwd();
   const isDirectory = options.isDirectory ?? defaultIsDirectory;
-  const parentAbs = path24.resolve(cwd, flags.parent);
+  const parentAbs = path27.resolve(cwd, flags.parent);
   if (!isDirectory(parentAbs)) {
     structuredError({
       code: "parent_not_found",
@@ -20464,11 +21146,11 @@ var run38 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const componentDir = path24.join(parentAbs, flags.name);
-  const indexPath = path24.join(componentDir, "index.tsx");
-  const testsDir = path24.join(componentDir, "tests");
-  const testPath = path24.join(testsDir, "index.test.tsx");
-  const storyPath = path24.join(testsDir, "index.stories.tsx");
+  const componentDir = path27.join(parentAbs, flags.name);
+  const indexPath = path27.join(componentDir, "index.tsx");
+  const testsDir = path27.join(componentDir, "tests");
+  const testPath = path27.join(testsDir, "index.test.tsx");
+  const storyPath = path27.join(testsDir, "index.stories.tsx");
   const templatesRoot = resolveTemplatesRoot();
   const result = { edited: [], skipped: [], written: [] };
   try {
@@ -20508,7 +21190,7 @@ var run38 = (argv, options = {}) => {
 
 // src/scaffold/hook.ts
 import { execSync as execSync2 } from "node:child_process";
-import path25 from "node:path";
+import path28 from "node:path";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 var HOOK_NAME_PATTERN = /^use[A-Z][A-Za-z0-9]*$/u;
 var TEMPLATE_DIR_NAME = "hook";
@@ -20575,8 +21257,8 @@ var sentinelForType = (type) => {
 var formatCallArgs = (params) => params.map((param) => sentinelForType(param.type)).join(", ");
 var resolveTemplateFile = (filename) => {
   const here = fileURLToPath3(import.meta.url);
-  return path25.join(
-    path25.dirname(here),
+  return path28.join(
+    path28.dirname(here),
     "templates",
     TEMPLATE_DIR_NAME,
     filename
@@ -20639,7 +21321,7 @@ var printResult = (result, jsonMode) => {
 `);
   }
 };
-var run39 = (argv, options = {}) => {
+var run41 = (argv, options = {}) => {
   let parsed;
   try {
     parsed = readFlags(argv);
@@ -20669,9 +21351,9 @@ var run39 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const repoRoot2 = options.repoRoot ?? resolveRepoRoot3();
-  const hooksDir = path25.join(repoRoot2, "app", "hooks");
-  const hookFilePath = path25.join(hooksDir, `${name}.ts`);
-  const testFilePath = path25.join(hooksDir, "tests", `${name}.test.ts`);
+  const hooksDir = path28.join(repoRoot2, "app", "hooks");
+  const hookFilePath = path28.join(hooksDir, `${name}.ts`);
+  const testFilePath = path28.join(hooksDir, "tests", `${name}.test.ts`);
   let result;
   try {
     result = emitFiles({
@@ -20694,8 +21376,8 @@ var run39 = (argv, options = {}) => {
 };
 
 // src/scaffold/route.ts
-import { existsSync as existsSync23, readFileSync as readFileSync20 } from "node:fs";
-import path26 from "node:path";
+import { existsSync as existsSync24, readFileSync as readFileSync22 } from "node:fs";
+import path29 from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 var VALID_GROUPS = /* @__PURE__ */ new Set(["_public+", "_session+"]);
 var GROUP_TO_SEGMENT = {
@@ -20703,7 +21385,7 @@ var GROUP_TO_SEGMENT = {
   "_session+": "Session"
 };
 var KEBAB_PATTERN = /^[a-z\d]+(?:-[a-z\d]+)*$/u;
-var HELP_TEXT27 = `Usage: gaia scaffold route <name> --group <_public+|_session+> [flags]
+var HELP_TEXT29 = `Usage: gaia scaffold route <name> --group <_public+|_session+> [flags]
 
   --group     required, _public+ or _session+
   --loader    emit a loader stub
@@ -20755,15 +21437,15 @@ var toCamelCase = (kebab) => {
 };
 var repoRoot = () => {
   const here = fileURLToPath4(import.meta.url);
-  return path26.resolve(path26.dirname(here), "..", "..", "..", "..");
+  return path29.resolve(path29.dirname(here), "..", "..", "..", "..");
 };
 var templateDir = () => {
   const here = fileURLToPath4(import.meta.url);
-  return path26.join(path26.dirname(here), "templates", "route");
+  return path29.join(path29.dirname(here), "templates", "route");
 };
 var insertIntoLocaleBarrel = (barrelPath, importName, folderName) => {
-  if (!existsSync23(barrelPath)) return "missing";
-  const original = readFileSync20(barrelPath, "utf8");
+  if (!existsSync24(barrelPath)) return "missing";
+  const original = readFileSync22(barrelPath, "utf8");
   const importLine = `import ${importName} from './${folderName}';`;
   if (original.includes(importLine)) return "present";
   const lines = original.split("\n");
@@ -20840,11 +21522,11 @@ var insertIntoLocaleBarrel = (barrelPath, importName, folderName) => {
 var templatePaths = () => {
   const dir = templateDir();
   return {
-    locale: path26.join(dir, "locale.ts.tmpl"),
-    pageIndex: path26.join(dir, "page.index.tsx.tmpl"),
-    pageStories: path26.join(dir, "page.stories.tsx.tmpl"),
-    pageTest: path26.join(dir, "page.test.tsx.tmpl"),
-    route: path26.join(dir, "route.tsx.tmpl")
+    locale: path29.join(dir, "locale.ts.tmpl"),
+    pageIndex: path29.join(dir, "page.index.tsx.tmpl"),
+    pageStories: path29.join(dir, "page.stories.tsx.tmpl"),
+    pageTest: path29.join(dir, "page.test.tsx.tmpl"),
+    route: path29.join(dir, "route.tsx.tmpl")
   };
 };
 var resolveNames = (kebabName, group) => {
@@ -20888,10 +21570,10 @@ var printJson = (result) => {
   process.stdout.write(`${JSON.stringify(result)}
 `);
 };
-var run40 = (rest) => {
+var run42 = (rest) => {
   const [first] = rest;
   if (first === void 0 || first === "--help" || first === "-h") {
-    process.stdout.write(HELP_TEXT27);
+    process.stdout.write(HELP_TEXT29);
     return first === void 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const name = first;
@@ -20918,7 +21600,7 @@ var run40 = (rest) => {
   const result = { edited: [], skipped: [], written: [] };
   try {
     const routeVars = buildRouteVars(names, flags, name);
-    const routeAbs = path26.join(
+    const routeAbs = path29.join(
       root,
       "app",
       "routes",
@@ -20926,7 +21608,7 @@ var run40 = (rest) => {
       `${name}.tsx`
     );
     writeFile(result, routeAbs, renderTemplate(tmpls.route, routeVars));
-    const pageDir = path26.join(
+    const pageDir = path29.join(
       root,
       "app",
       "pages",
@@ -20942,21 +21624,21 @@ var run40 = (rest) => {
     };
     writeFile(
       result,
-      path26.join(pageDir, "index.tsx"),
+      path29.join(pageDir, "index.tsx"),
       renderTemplate(tmpls.pageIndex, pageVars)
     );
     writeFile(
       result,
-      path26.join(pageDir, "tests", "index.test.tsx"),
+      path29.join(pageDir, "tests", "index.test.tsx"),
       renderTemplate(tmpls.pageTest, pageVars)
     );
     writeFile(
       result,
-      path26.join(pageDir, "tests", "index.stories.tsx"),
+      path29.join(pageDir, "tests", "index.stories.tsx"),
       renderTemplate(tmpls.pageStories, pageVars)
     );
     if (flags.i18n) {
-      const localeFile = path26.join(
+      const localeFile = path29.join(
         root,
         "app",
         "languages",
@@ -20971,7 +21653,7 @@ var run40 = (rest) => {
         routeName: name
       };
       writeFile(result, localeFile, renderTemplate(tmpls.locale, localeVars));
-      const localeBarrel = path26.join(
+      const localeBarrel = path29.join(
         root,
         "app",
         "languages",
@@ -20997,14 +21679,14 @@ var run40 = (rest) => {
 };
 
 // src/scaffold/service.ts
-import { existsSync as existsSync24, readFileSync as readFileSync21 } from "node:fs";
-import path27 from "node:path";
+import { existsSync as existsSync25, readFileSync as readFileSync23 } from "node:fs";
+import path30 from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 var KEBAB_PATTERN2 = /^[a-z][a-z\d]*(?:-[a-z\d]+)*$/u;
 var NAME_TOKEN_PATTERN = /^[a-zA-Z][a-zA-Z\d]*(?::[a-zA-Z][a-zA-Z\d]*(?:\([^)]*\))?)?$/u;
 var ALL_ENDPOINTS = ["get", "post", "put", "delete"];
 var ALL_ENDPOINTS_SET = new Set(ALL_ENDPOINTS);
-var HELP_TEXT28 = `Usage: gaia scaffold service <name> --endpoints "get,post,put,delete" --schema "id:string,name:string"
+var HELP_TEXT30 = `Usage: gaia scaffold service <name> --endpoints "get,post,put,delete" --schema "id:string,name:string"
 
   --endpoints "get,post,put,delete"  required: comma-separated subset of get/post/put/delete
   --schema "id:string,name:string"   required: comma-separated <name>:<type> pairs
@@ -21014,7 +21696,7 @@ var HELP_TEXT28 = `Usage: gaia scaffold service <name> --endpoints "get,post,put
   --json                             emit ScaffoldResult JSON on stdout
 `;
 var printHelp = () => {
-  process.stdout.write(HELP_TEXT28);
+  process.stdout.write(HELP_TEXT30);
 };
 var userError2 = (message, subcommand) => {
   structuredError({ code: "invalid_arguments", message, subcommand });
@@ -21201,7 +21883,7 @@ var composeMockBarrel = (endpoints) => {
   return { handlersArray, imports };
 };
 var updateDatabaseBarrel = (databasePath, derived) => {
-  const raw = readFileSync21(databasePath, "utf8");
+  const raw = readFileSync23(databasePath, "utf8");
   const importLine = `import {${derived.plural}, reset${derived.Plural}} from './${derived.name}/data';`;
   const resetCall = `reset${derived.Plural}()`;
   if (raw.includes(importLine)) return { written: false };
@@ -21302,11 +21984,11 @@ var applyDatabaseEdits = (source, derived, importLine, resetCall) => {
   }
   return next;
 };
-var TEMPLATES_DIR2 = path27.join(
-  path27.dirname(fileURLToPath5(import.meta.url)),
+var TEMPLATES_DIR2 = path30.join(
+  path30.dirname(fileURLToPath5(import.meta.url)),
   "templates"
 );
-var renderServiceTemplate = (templateName, vars) => renderTemplate(path27.join(TEMPLATES_DIR2, templateName), vars);
+var renderServiceTemplate = (templateName, vars) => renderTemplate(path30.join(TEMPLATES_DIR2, templateName), vars);
 var writeRendered = (absPath, contents, result) => {
   const { written } = writeFileIfAbsent(absPath, contents);
   if (written) {
@@ -21317,7 +21999,7 @@ var writeRendered = (absPath, contents, result) => {
 };
 var emitServiceFiles = (context, result) => {
   const { derived, endpoints, fields, repoRoot: repoRoot2 } = context;
-  const serviceDir = path27.join(
+  const serviceDir = path30.join(
     repoRoot2,
     "app",
     "services",
@@ -21337,9 +22019,9 @@ var emitServiceFiles = (context, result) => {
     ...baseVars,
     fields: renderClientFields(fields)
   });
-  writeRendered(path27.join(serviceDir, "parsers.ts"), parsersBody, result);
+  writeRendered(path30.join(serviceDir, "parsers.ts"), parsersBody, result);
   const typesBody = renderServiceTemplate("service/types.ts.tmpl", baseVars);
-  writeRendered(path27.join(serviceDir, "types.ts"), typesBody, result);
+  writeRendered(path30.join(serviceDir, "types.ts"), typesBody, result);
   const requestsBody = renderServiceTemplate("service/requests.ts.tmpl", {
     ...baseVars,
     hasDelete: endpoints.has("delete"),
@@ -21347,15 +22029,15 @@ var emitServiceFiles = (context, result) => {
     hasPost: endpoints.has("post"),
     hasPut: endpoints.has("put")
   });
-  writeRendered(path27.join(serviceDir, "requests.ts"), requestsBody, result);
+  writeRendered(path30.join(serviceDir, "requests.ts"), requestsBody, result);
   const urlsBody = renderServiceTemplate("service/urls.ts.tmpl", baseVars);
-  writeRendered(path27.join(serviceDir, "urls.ts"), urlsBody, result);
+  writeRendered(path30.join(serviceDir, "urls.ts"), urlsBody, result);
   const indexBody = renderServiceTemplate("service/index.ts.tmpl", baseVars);
-  writeRendered(path27.join(serviceDir, "index.ts"), indexBody, result);
+  writeRendered(path30.join(serviceDir, "index.ts"), indexBody, result);
 };
 var emitMockFiles = (context, result) => {
   const { derived, endpoints, fields, repoRoot: repoRoot2 } = context;
-  const mockDir = path27.join(repoRoot2, "test", "mocks", derived.name);
+  const mockDir = path30.join(repoRoot2, "test", "mocks", derived.name);
   ensureDir(mockDir);
   const baseVars = {
     NAME_UPPER: derived.NAME_UPPER,
@@ -21369,31 +22051,31 @@ var emitMockFiles = (context, result) => {
     ...baseVars,
     serverFields: renderServerFields(fields)
   });
-  writeRendered(path27.join(mockDir, "data.ts"), dataBody, result);
+  writeRendered(path30.join(mockDir, "data.ts"), dataBody, result);
   if (endpoints.has("get")) {
     writeRendered(
-      path27.join(mockDir, "get.ts"),
+      path30.join(mockDir, "get.ts"),
       renderServiceTemplate("service/mock.get.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("post")) {
     writeRendered(
-      path27.join(mockDir, "post.ts"),
+      path30.join(mockDir, "post.ts"),
       renderServiceTemplate("service/mock.post.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("put")) {
     writeRendered(
-      path27.join(mockDir, "put.ts"),
+      path30.join(mockDir, "put.ts"),
       renderServiceTemplate("service/mock.put.ts.tmpl", baseVars),
       result
     );
   }
   if (endpoints.has("delete")) {
     writeRendered(
-      path27.join(mockDir, "delete.ts"),
+      path30.join(mockDir, "delete.ts"),
       renderServiceTemplate("service/mock.delete.ts.tmpl", baseVars),
       result
     );
@@ -21402,15 +22084,15 @@ var emitMockFiles = (context, result) => {
     ...baseVars,
     ...composeMockBarrel(endpoints)
   });
-  writeRendered(path27.join(mockDir, "index.ts"), barrelBody, result);
-  const databasePath = path27.join(repoRoot2, "test", "mocks", "database.ts");
-  if (existsSync24(databasePath)) {
+  writeRendered(path30.join(mockDir, "index.ts"), barrelBody, result);
+  const databasePath = path30.join(repoRoot2, "test", "mocks", "database.ts");
+  if (existsSync25(databasePath)) {
     const { written } = updateDatabaseBarrel(databasePath, derived);
     if (written) result.edited.push(databasePath);
     else result.skipped.push(databasePath);
   }
 };
-var run41 = (argv, options = {}) => {
+var run43 = (argv, options = {}) => {
   if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
     printHelp();
     return EXIT_CODES.OK;
@@ -21455,35 +22137,35 @@ var run41 = (argv, options = {}) => {
 };
 
 // src/scaffold/index.ts
-var HELP_TEXT29 = `Usage: gaia scaffold <subcommand> [args]
+var HELP_TEXT31 = `Usage: gaia scaffold <subcommand> [args]
 
   component <Name>         Scaffold a new React component.
   hook <useFoo>            Scaffold a new custom hook.
   route <name>             Scaffold a new route + page.
   service <name>           Scaffold a new API service.
 `;
-var HELP_TOKENS27 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run42 = (argv) => {
+var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run44 = (argv) => {
   const subcommand = argv[0];
   if (subcommand === void 0) {
-    process.stderr.write(HELP_TEXT29);
+    process.stderr.write(HELP_TEXT31);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS27.has(subcommand)) {
-    process.stdout.write(HELP_TEXT29);
+  if (HELP_TOKENS29.has(subcommand)) {
+    process.stdout.write(HELP_TEXT31);
     return EXIT_CODES.OK;
   }
   if (subcommand === "component") {
-    return run38(argv.slice(1));
-  }
-  if (subcommand === "hook") {
-    return run39(argv.slice(1));
-  }
-  if (subcommand === "route") {
     return run40(argv.slice(1));
   }
-  if (subcommand === "service") {
+  if (subcommand === "hook") {
     return run41(argv.slice(1));
+  }
+  if (subcommand === "route") {
+    return run42(argv.slice(1));
+  }
+  if (subcommand === "service") {
+    return run43(argv.slice(1));
   }
   structuredError({
     code: "unknown_subcommand",
@@ -21496,23 +22178,23 @@ var run42 = (argv) => {
 // src/setup/util/state-file.ts
 import { execFileSync as execFileSync4 } from "node:child_process";
 import {
-  existsSync as existsSync25,
-  mkdirSync as mkdirSync14,
-  readFileSync as readFileSync22,
+  existsSync as existsSync26,
+  mkdirSync as mkdirSync15,
+  readFileSync as readFileSync24,
   renameSync as renameSync7,
   writeFileSync as writeFileSync10
 } from "node:fs";
-import path28 from "node:path";
+import path31 from "node:path";
 var STATE_FILENAME = "setup-state.json";
-var STATE_DIRECTORY_RELATIVE = path28.join(".gaia", "local");
+var STATE_DIRECTORY_RELATIVE = path31.join(".gaia", "local");
 var resolveMainWorktreeRoot = (cwd) => {
   const commonDir = execFileSync4("git", ["rev-parse", "--git-common-dir"], {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   }).trim();
-  const absoluteCommonDir = path28.isAbsolute(commonDir) ? commonDir : path28.resolve(cwd, commonDir);
-  return path28.dirname(absoluteCommonDir);
+  const absoluteCommonDir = path31.isAbsolute(commonDir) ? commonDir : path31.resolve(cwd, commonDir);
+  return path31.dirname(absoluteCommonDir);
 };
 var SETUP_STEPS = [
   "install-tools",
@@ -21523,11 +22205,11 @@ var SETUP_STEPS = [
   "mentorship-decision"
 ];
 var isSetupStep = (value) => SETUP_STEPS.includes(value);
-var resolveStateFilePath = (repoRoot2) => path28.join(repoRoot2, STATE_DIRECTORY_RELATIVE, STATE_FILENAME);
+var resolveStateFilePath = (repoRoot2) => path31.join(repoRoot2, STATE_DIRECTORY_RELATIVE, STATE_FILENAME);
 var readStateFile = (repoRoot2) => {
   const filePath = resolveStateFilePath(repoRoot2);
-  if (!existsSync25(filePath)) return null;
-  const raw = readFileSync22(filePath, "utf8");
+  if (!existsSync26(filePath)) return null;
+  const raw = readFileSync24(filePath, "utf8");
   const parsed = JSON.parse(raw);
   if (parsed.version !== 1) {
     throw new Error(
@@ -21553,9 +22235,9 @@ var readStateFile = (repoRoot2) => {
 };
 var writeStateFile2 = (repoRoot2, state) => {
   const filePath = resolveStateFilePath(repoRoot2);
-  const parent = path28.dirname(filePath);
-  if (!existsSync25(parent)) {
-    mkdirSync14(parent, { mode: 493, recursive: true });
+  const parent = path31.dirname(filePath);
+  if (!existsSync26(parent)) {
+    mkdirSync15(parent, { mode: 493, recursive: true });
   }
   const serialized = `${JSON.stringify(state, null, 2)}
 `;
@@ -21570,17 +22252,17 @@ var pendingSteps = (state) => {
 var isComplete = (state) => state?.completed_at !== null && state?.completed_at !== void 0;
 
 // src/setup/finalize.ts
-var HELP_TEXT30 = `Usage: gaia setup finalize [--force]
+var HELP_TEXT32 = `Usage: gaia setup finalize [--force]
 
   Marks .gaia/local/setup-state.json as complete (sets completed_at).
   Refuses if any step is still pending unless --force is passed.
 `;
-var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run43 = (argv, options = {}) => {
+var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run45 = (argv, options = {}) => {
   let force = false;
   for (const token of argv) {
-    if (HELP_TOKENS28.has(token)) {
-      process.stdout.write(HELP_TEXT30);
+    if (HELP_TOKENS30.has(token)) {
+      process.stdout.write(HELP_TEXT32);
       return EXIT_CODES.OK;
     }
     if (token === "--force") {
@@ -21650,16 +22332,16 @@ var run43 = (argv, options = {}) => {
 // src/setup/link-worktree.ts
 import { execFileSync as execFileSync5 } from "node:child_process";
 import {
-  existsSync as existsSync26,
+  existsSync as existsSync27,
   lstatSync,
-  mkdirSync as mkdirSync15,
+  mkdirSync as mkdirSync16,
   readlinkSync,
   realpathSync,
   renameSync as renameSync8,
   symlinkSync
 } from "node:fs";
-import path29 from "node:path";
-var HELP_TEXT31 = `Usage: gaia setup link-worktree [--json]
+import path32 from "node:path";
+var HELP_TEXT33 = `Usage: gaia setup link-worktree [--json]
 
   Idempotently create the three worktree shared-state symlinks pointing at
   the main checkout. Backs up pre-existing plain files to <path>.bak.<ts>.
@@ -21669,7 +22351,7 @@ var HELP_TEXT31 = `Usage: gaia setup link-worktree [--json]
   --json   Print a single JSON line describing the result instead of the
            human-readable summary.
 `;
-var HELP_TOKENS29 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS31 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SHARED_PATHS = [
   { ensureTargetDir: false, relativePath: ".gaia/local/setup-state.json" },
   { ensureTargetDir: true, relativePath: ".gaia/cache" },
@@ -21686,19 +22368,19 @@ var formatTimestamp = (date5) => {
   return `${String(yyyy)}${mm}${dd}-${hh}${mi}${ss}`;
 };
 var ensureParentDir = (filePath) => {
-  const parent = path29.dirname(filePath);
-  if (!existsSync26(parent)) {
-    mkdirSync15(parent, { mode: 493, recursive: true });
+  const parent = path32.dirname(filePath);
+  if (!existsSync27(parent)) {
+    mkdirSync16(parent, { mode: 493, recursive: true });
   }
 };
 var linkOne = (inputs) => {
   const { mainRoot, spec, symlink, timestamp, worktreeRoot } = inputs;
-  const sourcePath = path29.join(worktreeRoot, spec.relativePath);
-  const targetPath = path29.join(mainRoot, spec.relativePath);
+  const sourcePath = path32.join(worktreeRoot, spec.relativePath);
+  const targetPath = path32.join(mainRoot, spec.relativePath);
   try {
     ensureParentDir(sourcePath);
-    if (spec.ensureTargetDir && !existsSync26(targetPath)) {
-      mkdirSync15(targetPath, { mode: 493, recursive: true });
+    if (spec.ensureTargetDir && !existsSync27(targetPath)) {
+      mkdirSync16(targetPath, { mode: 493, recursive: true });
     }
     let sourceStat;
     try {
@@ -21719,7 +22401,7 @@ var linkOne = (inputs) => {
       renameSync8(sourcePath, backupPath2);
       symlink(targetPath, sourcePath);
       return {
-        backup: path29.relative(worktreeRoot, backupPath2),
+        backup: path32.relative(worktreeRoot, backupPath2),
         path: spec.relativePath,
         result: "linked-after-backup"
       };
@@ -21728,7 +22410,7 @@ var linkOne = (inputs) => {
     renameSync8(sourcePath, backupPath);
     symlink(targetPath, sourcePath);
     return {
-      backup: path29.relative(worktreeRoot, backupPath),
+      backup: path32.relative(worktreeRoot, backupPath),
       path: spec.relativePath,
       result: "linked-after-backup"
     };
@@ -21795,11 +22477,11 @@ var printHuman = (output) => {
 `
   );
 };
-var run44 = (argv, options = {}) => {
+var run46 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS29.has(token)) {
-      process.stdout.write(HELP_TEXT31);
+    if (HELP_TOKENS31.has(token)) {
+      process.stdout.write(HELP_TEXT33);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -21884,23 +22566,23 @@ var run44 = (argv, options = {}) => {
 };
 
 // src/setup/mark-step.ts
-var HELP_TEXT32 = `Usage: gaia setup mark-step <step>
+var HELP_TEXT34 = `Usage: gaia setup mark-step <step>
 
   <step> must be one of: ${SETUP_STEPS.join(" | ")}
 
   Records the step as complete in .gaia/local/setup-state.json. Creates
   the state file on first invocation (stamping started_at to now).
 `;
-var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS32 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var isSetupStep2 = (value) => SETUP_STEPS.includes(value);
-var run45 = (argv, options = {}) => {
+var run47 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT32);
+    process.stdout.write(HELP_TEXT34);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS30.has(first)) {
-    process.stdout.write(HELP_TEXT32);
+  if (HELP_TOKENS32.has(first)) {
+    process.stdout.write(HELP_TEXT34);
     return EXIT_CODES.OK;
   }
   if (argv.length !== 1) {
@@ -21967,12 +22649,12 @@ var run45 = (argv, options = {}) => {
 };
 
 // src/setup/status.ts
-var HELP_TEXT33 = `Usage: gaia setup status [--json]
+var HELP_TEXT35 = `Usage: gaia setup status [--json]
 
   Print the per-machine setup state. Without --json, prints a human-readable
   summary. With --json, prints a single JSON line consumed by tooling.
 `;
-var HELP_TOKENS31 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS33 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var printHuman2 = (output) => {
   if (output.complete) {
     process.stdout.write(
@@ -21993,11 +22675,11 @@ var printHuman2 = (output) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run46 = (argv, options = {}) => {
+var run48 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS31.has(token)) {
-      process.stdout.write(HELP_TEXT33);
+    if (HELP_TOKENS33.has(token)) {
+      process.stdout.write(HELP_TEXT35);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -22050,25 +22732,25 @@ var run46 = (argv, options = {}) => {
 };
 
 // src/setup/index.ts
-var HELP_TEXT34 = `Usage: gaia setup <subcommand> [args]
+var HELP_TEXT36 = `Usage: gaia setup <subcommand> [args]
 
   status [--json]            Print whether per-machine setup is complete.
   mark-step <step>           Record a setup step as complete.
   finalize [--force]         Mark setup as complete (refuses if steps pending).
   link-worktree [--json]     Create the worktree shared-state symlinks.
 `;
-var HELP_TOKENS32 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS34 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS4 = {
-  finalize: run43,
-  "link-worktree": run44,
-  "mark-step": run45,
-  status: run46
+  finalize: run45,
+  "link-worktree": run46,
+  "mark-step": run47,
+  status: run48
 };
-var run47 = async (argv) => {
+var run49 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS32.has(subcommand)) {
-    process.stdout.write(HELP_TEXT34);
+  if (subcommand === void 0 || HELP_TOKENS34.has(subcommand)) {
+    process.stdout.write(HELP_TEXT36);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS4[subcommand];
@@ -22133,12 +22815,12 @@ var runGh2 = (options) => {
 };
 
 // src/setup-ci/check-admin.ts
-var HELP_TEXT35 = `Usage: gaia setup-ci check-admin --owner <o> --repo <r> [--json]
+var HELP_TEXT37 = `Usage: gaia setup-ci check-admin --owner <o> --repo <r> [--json]
 
   Probe repo admin permission via \`gh\`. Returns admin: false for any
   non-ok auth status. Exits 0 in every branch.
 `;
-var HELP_TOKENS33 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS35 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var printHuman3 = (output) => {
   process.stdout.write(
     `admin: ${String(output.admin)}
@@ -22146,14 +22828,14 @@ auth_status: ${output.auth_status}
 `
   );
 };
-var run48 = async (argv, options = {}) => {
+var run50 = async (argv, options = {}) => {
   let json2 = false;
   let owner;
   let repo;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
-    if (HELP_TOKENS33.has(token)) {
-      process.stdout.write(HELP_TEXT35);
+    if (HELP_TOKENS35.has(token)) {
+      process.stdout.write(HELP_TEXT37);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -22233,9 +22915,9 @@ var run48 = async (argv, options = {}) => {
 };
 
 // src/setup-ci/check-audit-drift.ts
-import { readFileSync as readFileSync23 } from "node:fs";
-import path30 from "node:path";
-var HELP_TEXT36 = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>] [--json]
+import { readFileSync as readFileSync25 } from "node:fs";
+import path33 from "node:path";
+var HELP_TEXT38 = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>] [--json]
 
   Compare installed audit workflow vs template.
 
@@ -22247,7 +22929,7 @@ var HELP_TEXT36 = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>] 
   --json                   Emit machine-readable JSON instead of a human
                            report.
 `;
-var HELP_TOKENS34 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS36 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseArgs4 = (argv) => {
   let json2 = false;
   let workflowsDir;
@@ -22272,14 +22954,14 @@ var parseArgs4 = (argv) => {
 };
 var safeReadFile = (filePath) => {
   try {
-    return readFileSync23(filePath, "utf8");
+    return readFileSync25(filePath, "utf8");
   } catch {
     return null;
   }
 };
-var run49 = (argv, options = {}) => {
-  if (argv.some((token) => HELP_TOKENS34.has(token))) {
-    process.stdout.write(HELP_TEXT36);
+var run51 = (argv, options = {}) => {
+  if (argv.some((token) => HELP_TOKENS36.has(token))) {
+    process.stdout.write(HELP_TEXT38);
     return EXIT_CODES.OK;
   }
   const parsed = parseArgs4(argv);
@@ -22302,8 +22984,8 @@ var run49 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const workflowsDir = parsed.workflowsDir ?? path30.join(repoRoot2, ".github", "workflows");
-  const installedPath = path30.join(workflowsDir, "code-review-audit.yml");
+  const workflowsDir = parsed.workflowsDir ?? path33.join(repoRoot2, ".github", "workflows");
+  const installedPath = path33.join(workflowsDir, "code-review-audit.yml");
   const onDisk = safeReadFile(installedPath);
   let state;
   if (onDisk === null) {
@@ -22311,7 +22993,7 @@ var run49 = (argv, options = {}) => {
   } else {
     let template;
     try {
-      template = readFileSync23(workflowAuditTemplatePath(), "utf8");
+      template = readFileSync25(workflowAuditTemplatePath(), "utf8");
     } catch (error51) {
       structuredError({
         code: "template_unreadable",
@@ -22333,9 +23015,9 @@ var run49 = (argv, options = {}) => {
 };
 
 // src/setup-ci/check-drift.ts
-import { readFileSync as readFileSync24 } from "node:fs";
-import path31 from "node:path";
-var HELP_TEXT37 = `Usage: gaia setup-ci check-drift [--workflows-dir <path>] [--json]
+import { readFileSync as readFileSync26 } from "node:fs";
+import path34 from "node:path";
+var HELP_TEXT39 = `Usage: gaia setup-ci check-drift [--workflows-dir <path>] [--json]
 
   Compare rendered .github/workflows/gaia-ci-*.yml against a fresh render
   of the current templates + .gaia/automation.json. Reports per-tool
@@ -22347,7 +23029,7 @@ var HELP_TEXT37 = `Usage: gaia setup-ci check-drift [--workflows-dir <path>] [--
   --json                   Emit machine-readable JSON instead of a human
                            report.
 `;
-var HELP_TOKENS35 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseArgs5 = (argv) => {
   let json2 = false;
   let workflowsDir;
@@ -22372,7 +23054,7 @@ var parseArgs5 = (argv) => {
 };
 var safeReadFile2 = (filePath) => {
   try {
-    return readFileSync24(filePath, "utf8");
+    return readFileSync26(filePath, "utf8");
   } catch {
     return null;
   }
@@ -22395,9 +23077,9 @@ var printHuman4 = (output) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run50 = (argv, options = {}) => {
-  if (argv.some((token) => HELP_TOKENS35.has(token))) {
-    process.stdout.write(HELP_TEXT37);
+var run52 = (argv, options = {}) => {
+  if (argv.some((token) => HELP_TOKENS37.has(token))) {
+    process.stdout.write(HELP_TEXT39);
     return EXIT_CODES.OK;
   }
   const parsed = parseArgs5(argv);
@@ -22437,13 +23119,13 @@ var run50 = (argv, options = {}) => {
     });
     return EXIT_CODES.CONFIG_INVALID;
   }
-  const workflowsDir = parsed.workflowsDir ?? path31.join(repoRoot2, ".github", "workflows");
+  const workflowsDir = parsed.workflowsDir ?? path34.join(repoRoot2, ".github", "workflows");
   const partialsDir = workflowPartialsDirectory();
   const output = { drifted: [], in_sync: [], missing: [] };
   for (const tool of TOOL_IDS) {
     const vars = buildWorkflowVars(configRead.config, tool);
     if (vars === null) continue;
-    const renderedPath = path31.join(workflowsDir, `gaia-ci-${tool}.yml`);
+    const renderedPath = path34.join(workflowsDir, `gaia-ci-${tool}.yml`);
     const onDisk = safeReadFile2(renderedPath);
     if (onDisk === null) {
       output.missing.push(tool);
@@ -22528,12 +23210,12 @@ var parseRemoteUrl = (url2) => {
 };
 
 // src/setup-ci/detect-remote.ts
-var HELP_TEXT38 = `Usage: gaia setup-ci detect-remote [--json]
+var HELP_TEXT40 = `Usage: gaia setup-ci detect-remote [--json]
 
   Read \`git remote get-url origin\` and parse it. Returns parsed
   owner/repo/host on success; \`found: false\` on missing remote.
 `;
-var HELP_TOKENS36 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS38 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryGitRemoteUrl = (cwd) => {
   try {
     const result = execFileSync6("git", ["remote", "get-url", "origin"], {
@@ -22559,11 +23241,11 @@ repo: ${String(output.repo)}
 `
   );
 };
-var run51 = (argv, options = {}) => {
+var run53 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS36.has(token)) {
-      process.stdout.write(HELP_TEXT38);
+    if (HELP_TOKENS38.has(token)) {
+      process.stdout.write(HELP_TEXT40);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -22623,17 +23305,17 @@ var run51 = (argv, options = {}) => {
 };
 
 // src/schemas/local-automation.ts
-import { existsSync as existsSync27, readFileSync as readFileSync25 } from "node:fs";
+import { existsSync as existsSync28, readFileSync as readFileSync27 } from "node:fs";
 var LocalAutomationSchema = external_exports.object({
   version: external_exports.literal(1),
   nudge_dismissed: external_exports.boolean()
 });
 var readLocalAutomation = (repoRoot2) => {
   const filePath = localAutomationPath(repoRoot2);
-  if (!existsSync27(filePath)) return { status: "missing" };
+  if (!existsSync28(filePath)) return { status: "missing" };
   let raw;
   try {
-    raw = readFileSync25(filePath, "utf8");
+    raw = readFileSync27(filePath, "utf8");
   } catch (error51) {
     return {
       error: `${filePath}: ${error51 instanceof Error ? error51.message : String(error51)}`,
@@ -22660,12 +23342,12 @@ var readLocalAutomation = (repoRoot2) => {
 };
 
 // src/setup-ci/util/local-automation-write.ts
-import { mkdirSync as mkdirSync16, renameSync as renameSync9, writeFileSync as writeFileSync11 } from "node:fs";
-import path32 from "node:path";
+import { mkdirSync as mkdirSync17, renameSync as renameSync9, writeFileSync as writeFileSync11 } from "node:fs";
+import path35 from "node:path";
 var writeLocalAutomation = (repoRoot2, payload) => {
   LocalAutomationSchema.parse(payload);
   const target = localAutomationPath(repoRoot2);
-  mkdirSync16(path32.dirname(target), { recursive: true });
+  mkdirSync17(path35.dirname(target), { recursive: true });
   const serialized = `${JSON.stringify(payload, null, 2)}
 `;
   const tmpPath = `${target}.tmp`;
@@ -22674,15 +23356,15 @@ var writeLocalAutomation = (repoRoot2, payload) => {
 };
 
 // src/setup-ci/dismiss-personal.ts
-var HELP_TEXT39 = `Usage: gaia setup-ci dismiss-personal
+var HELP_TEXT41 = `Usage: gaia setup-ci dismiss-personal
 
   Write nudge_dismissed=true to .gaia/local/automation.json (gitignored).
 `;
-var HELP_TOKENS37 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run52 = (argv, options = {}) => {
+var HELP_TOKENS39 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run54 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS37.has(token)) {
-      process.stdout.write(HELP_TEXT39);
+    if (HELP_TOKENS39.has(token)) {
+      process.stdout.write(HELP_TEXT41);
       return EXIT_CODES.OK;
     }
     structuredError({
@@ -22720,18 +23402,18 @@ var run52 = (argv, options = {}) => {
 };
 
 // src/setup-ci/enable-delete-branch.ts
-var HELP_TEXT40 = `Usage: gaia setup-ci enable-delete-branch --owner <o> --repo <r>
+var HELP_TEXT42 = `Usage: gaia setup-ci enable-delete-branch --owner <o> --repo <r>
 
   PATCH repos/<owner>/<repo> -f delete_branch_on_merge=true via gh.
 `;
-var HELP_TOKENS38 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run53 = async (argv, options = {}) => {
+var HELP_TOKENS40 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run55 = async (argv, options = {}) => {
   let owner;
   let repo;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
-    if (HELP_TOKENS38.has(token)) {
-      process.stdout.write(HELP_TEXT40);
+    if (HELP_TOKENS40.has(token)) {
+      process.stdout.write(HELP_TEXT42);
       return EXIT_CODES.OK;
     }
     if (token === "--owner") {
@@ -22783,15 +23465,15 @@ var run53 = async (argv, options = {}) => {
 };
 
 // src/setup-ci/finalize.ts
-var HELP_TEXT41 = `Usage: gaia setup-ci finalize
+var HELP_TEXT43 = `Usage: gaia setup-ci finalize
 
   Flip setup_complete=true in .gaia/automation.json. Idempotent.
 `;
-var HELP_TOKENS39 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run54 = (argv, options = {}) => {
+var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run56 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS39.has(token)) {
-      process.stdout.write(HELP_TEXT41);
+    if (HELP_TOKENS41.has(token)) {
+      process.stdout.write(HELP_TEXT43);
       return EXIT_CODES.OK;
     }
     structuredError({
@@ -22842,16 +23524,16 @@ var run54 = (argv, options = {}) => {
 };
 
 // src/setup-ci/opt-out-team.ts
-var HELP_TEXT42 = `Usage: gaia setup-ci opt-out-team
+var HELP_TEXT44 = `Usage: gaia setup-ci opt-out-team
 
   Write setup_opted_out=true to .gaia/automation.json (committed).
   Refuses if the config is missing or malformed.
 `;
-var HELP_TOKENS40 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run55 = (argv, options = {}) => {
+var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run57 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS40.has(token)) {
-      process.stdout.write(HELP_TEXT42);
+    if (HELP_TOKENS42.has(token)) {
+      process.stdout.write(HELP_TEXT44);
       return EXIT_CODES.OK;
     }
     structuredError({
@@ -22899,14 +23581,14 @@ var run55 = (argv, options = {}) => {
 };
 
 // src/setup-ci/set-secret.ts
-var HELP_TEXT43 = `Usage: gaia setup-ci set-secret <name>
+var HELP_TEXT45 = `Usage: gaia setup-ci set-secret <name>
 
   Read a secret value from stdin and pipe it into \`gh secret set <name>\`.
   The token is never echoed, logged, or passed on the command line.
 
   <name> must be one of: CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY.
 `;
-var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS43 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUPPORTED_SECRET_NAMES = [
   "CLAUDE_CODE_OAUTH_TOKEN",
   "ANTHROPIC_API_KEY"
@@ -22939,9 +23621,9 @@ var trimTrailingWhitespace = (buf) => {
   }
   return buf.subarray(0, end);
 };
-var run56 = async (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS41.has(argv[0])) {
-    process.stdout.write(HELP_TEXT43);
+var run58 = async (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS43.has(argv[0])) {
+    process.stdout.write(HELP_TEXT45);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const name = argv[0];
@@ -23002,12 +23684,12 @@ var run56 = async (argv, options = {}) => {
 };
 
 // src/setup-ci/status.ts
-var HELP_TEXT44 = `Usage: gaia setup-ci status [--json]
+var HELP_TEXT46 = `Usage: gaia setup-ci status [--json]
 
   Print whether Phase B (GAIA CI remote integration) is configured.
   Exits 0 in every state; branch on the JSON output.
 `;
-var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS44 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var enabledTools = (config2) => {
   const result = [];
   for (const tool of TOOL_IDS) {
@@ -23035,11 +23717,11 @@ tools_enabled: ${output.tools_enabled.join(", ") || "(none)"}
 `
   );
 };
-var run57 = (argv, options = {}) => {
+var run59 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS42.has(token)) {
-      process.stdout.write(HELP_TEXT44);
+    if (HELP_TOKENS44.has(token)) {
+      process.stdout.write(HELP_TEXT46);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -23105,13 +23787,13 @@ var run57 = (argv, options = {}) => {
 };
 
 // src/setup-ci/verify-run.ts
-var HELP_TEXT45 = `Usage: gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]
+var HELP_TEXT47 = `Usage: gaia setup-ci verify-run <workflow-file> [--timeout-seconds N] [--json]
 
   Trigger a workflow_dispatch run and watch the run to completion.
   Default timeout: 600s. Default poll interval: 10s (override with
   --poll-interval-ms <ms>; intended for tests).
 `;
-var HELP_TOKENS43 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS45 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_TIMEOUT_SECONDS = 600;
 var DEFAULT_POLL_INTERVAL_MS = 1e4;
 var RACE_WINDOW_GUARD_MS = 5e3;
@@ -23141,15 +23823,15 @@ url: ${output.url ?? "(none)"}
 `
   );
 };
-var run58 = async (argv, options = {}) => {
+var run60 = async (argv, options = {}) => {
   let json2 = false;
   let workflowFile;
   let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
   let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
-    if (HELP_TOKENS43.has(token)) {
-      process.stdout.write(HELP_TEXT45);
+    if (HELP_TOKENS45.has(token)) {
+      process.stdout.write(HELP_TEXT47);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -23372,13 +24054,13 @@ var run58 = async (argv, options = {}) => {
 };
 
 // src/setup-ci/warn-existing-tools.ts
-import { existsSync as existsSync28 } from "node:fs";
-import path33 from "node:path";
-var HELP_TEXT46 = `Usage: gaia setup-ci warn-existing-tools [--json]
+import { existsSync as existsSync29 } from "node:fs";
+import path36 from "node:path";
+var HELP_TEXT48 = `Usage: gaia setup-ci warn-existing-tools [--json]
 
   Detect Dependabot or Renovate config files in the repo. Read-only.
 `;
-var HELP_TOKENS44 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS46 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEPENDABOT_PATHS = [
   [".github", "dependabot.yml"],
   [".github", "dependabot.yaml"]
@@ -23396,11 +24078,11 @@ var printHuman8 = (found) => {
   process.stdout.write(`detected: ${found.join(", ")}
 `);
 };
-var run59 = (argv, options = {}) => {
+var run61 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS44.has(token)) {
-      process.stdout.write(HELP_TEXT46);
+    if (HELP_TOKENS46.has(token)) {
+      process.stdout.write(HELP_TEXT48);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -23427,11 +24109,11 @@ var run59 = (argv, options = {}) => {
   }
   const found = [];
   const hasDependabot = DEPENDABOT_PATHS.some(
-    (segments) => existsSync28(path33.join(repoRoot2, ...segments))
+    (segments) => existsSync29(path36.join(repoRoot2, ...segments))
   );
   if (hasDependabot) found.push("dependabot");
   const hasRenovate = RENOVATE_PATHS.some(
-    (segments) => existsSync28(path33.join(repoRoot2, ...segments))
+    (segments) => existsSync29(path36.join(repoRoot2, ...segments))
   );
   if (hasRenovate) found.push("renovate");
   if (json2) {
@@ -23444,16 +24126,16 @@ var run59 = (argv, options = {}) => {
 };
 
 // src/setup-ci/write-tool-mode.ts
-var HELP_TEXT47 = `Usage: gaia setup-ci write-tool-mode <tool> <mode>
+var HELP_TEXT49 = `Usage: gaia setup-ci write-tool-mode <tool> <mode>
 
   Set a tool's mode in .gaia/automation.json.
   <tool> must be one of: ${TOOL_IDS.join(", ")}.
   <mode> must be one of: ci, local, off.
 `;
-var HELP_TOKENS45 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run60 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS45.has(argv[0])) {
-    process.stdout.write(HELP_TEXT47);
+var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run62 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS47.has(argv[0])) {
+    process.stdout.write(HELP_TEXT49);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const toolToken = argv[0];
@@ -23535,7 +24217,7 @@ var run60 = (argv, options = {}) => {
 };
 
 // src/setup-ci/index.ts
-var HELP_TEXT48 = `Usage: gaia setup-ci <subcommand> [args]
+var HELP_TEXT50 = `Usage: gaia setup-ci <subcommand> [args]
 
   status [--json]                          Print Phase B configuration status.
   check-drift [--workflows-dir <p>] [--json]
@@ -23556,27 +24238,27 @@ var HELP_TEXT48 = `Usage: gaia setup-ci <subcommand> [args]
   finalize                                 Flip setup_complete=true.
   write-tool-mode <tool> <mode>            Set a tool's mode in .gaia/automation.json.
 `;
-var HELP_TOKENS46 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS5 = {
-  "check-admin": run48,
-  "check-audit-drift": run49,
-  "check-drift": run50,
-  "detect-remote": run51,
-  "dismiss-personal": run52,
-  "enable-delete-branch": run53,
-  finalize: run54,
-  "opt-out-team": run55,
-  "set-secret": run56,
-  status: run57,
-  "verify-run": run58,
-  "warn-existing-tools": run59,
-  "write-tool-mode": run60
+  "check-admin": run50,
+  "check-audit-drift": run51,
+  "check-drift": run52,
+  "detect-remote": run53,
+  "dismiss-personal": run54,
+  "enable-delete-branch": run55,
+  finalize: run56,
+  "opt-out-team": run57,
+  "set-secret": run58,
+  status: run59,
+  "verify-run": run60,
+  "warn-existing-tools": run61,
+  "write-tool-mode": run62
 };
-var run61 = async (argv) => {
+var run63 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS46.has(subcommand)) {
-    process.stdout.write(HELP_TEXT48);
+  if (subcommand === void 0 || HELP_TOKENS48.has(subcommand)) {
+    process.stdout.write(HELP_TEXT50);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS5[subcommand];
@@ -23593,13 +24275,13 @@ var run61 = async (argv) => {
 };
 
 // src/analytics/generator.ts
-import { existsSync as existsSync30, readdirSync as readdirSync4, readFileSync as readFileSync27 } from "node:fs";
-import path35 from "node:path";
+import { existsSync as existsSync31, readdirSync as readdirSync5, readFileSync as readFileSync29 } from "node:fs";
+import path38 from "node:path";
 
 // src/storage/project-id.ts
 import { createHash } from "node:crypto";
-import { existsSync as existsSync29, mkdirSync as mkdirSync17, readFileSync as readFileSync26, writeFileSync as writeFileSync12 } from "node:fs";
-import path34 from "node:path";
+import { existsSync as existsSync30, mkdirSync as mkdirSync18, readFileSync as readFileSync28, writeFileSync as writeFileSync12 } from "node:fs";
+import path37 from "node:path";
 var UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 var formatAsUuidV4 = (hex32) => {
   const version2 = "4";
@@ -23612,18 +24294,18 @@ var deriveProjectId = (repoRootPath) => {
   const hash2 = createHash("sha256").update(repoRootPath).digest("hex");
   return formatAsUuidV4(hash2.slice(0, 32));
 };
-var repoRootFromProjectIdPath = (projectIdPath) => path34.dirname(path34.dirname(path34.dirname(projectIdPath)));
+var repoRootFromProjectIdPath = (projectIdPath) => path37.dirname(path37.dirname(path37.dirname(projectIdPath)));
 var readOrCreateProjectId = (roots) => {
   const filePath = roots.projectIdPath;
-  if (existsSync29(filePath)) {
-    const existing = readFileSync26(filePath, "utf8").trim();
+  if (existsSync30(filePath)) {
+    const existing = readFileSync28(filePath, "utf8").trim();
     if (UUID_RE.test(existing)) {
       return existing;
     }
   }
-  const parent = path34.dirname(filePath);
-  if (!existsSync29(parent)) {
-    mkdirSync17(parent, { mode: 493, recursive: true });
+  const parent = path37.dirname(filePath);
+  if (!existsSync30(parent)) {
+    mkdirSync18(parent, { mode: 493, recursive: true });
   }
   const repoRoot2 = repoRootFromProjectIdPath(filePath);
   const id = deriveProjectId(repoRoot2);
@@ -23752,10 +24434,10 @@ var isoDateUtc = (date5) => {
 };
 var readGaiaVersion = (roots) => {
   const repoRoot2 = repoRootFromProjectIdPath(roots.projectIdPath);
-  const packagePath = path35.join(repoRoot2, "package.json");
-  if (!existsSync30(packagePath)) return "unknown";
+  const packagePath = path38.join(repoRoot2, "package.json");
+  if (!existsSync31(packagePath)) return "unknown";
   try {
-    const raw = readFileSync27(packagePath, "utf8");
+    const raw = readFileSync29(packagePath, "utf8");
     const parsed = JSON.parse(raw);
     return typeof parsed.version === "string" ? parsed.version : "unknown";
   } catch {
@@ -23815,7 +24497,7 @@ var accumulateEvent = (line, bounds, counts) => {
 var consumeFile = (filePath, bounds, counts) => {
   let raw;
   try {
-    raw = readFileSync27(filePath, "utf8");
+    raw = readFileSync29(filePath, "utf8");
   } catch {
     return;
   }
@@ -23825,10 +24507,10 @@ var consumeFile = (filePath, bounds, counts) => {
 };
 var readMentorshipEngagement = (roots, bounds) => {
   const counts = newEngagementCounts();
-  if (!existsSync30(roots.mentorshipDir)) return counts;
+  if (!existsSync31(roots.mentorshipDir)) return counts;
   let entries;
   try {
-    entries = readdirSync4(roots.mentorshipDir);
+    entries = readdirSync5(roots.mentorshipDir);
   } catch {
     return counts;
   }
@@ -23837,7 +24519,7 @@ var readMentorshipEngagement = (roots, bounds) => {
     const match = MENTORSHIP_FILENAME_REGEX.exec(entry);
     const fileDate = match?.[1];
     if (fileDate !== void 0 && fileDate >= startDate) {
-      consumeFile(path35.join(roots.mentorshipDir, entry), bounds, counts);
+      consumeFile(path38.join(roots.mentorshipDir, entry), bounds, counts);
     }
   }
   return counts;
@@ -23884,17 +24566,17 @@ var generateAnalyticsReport = async (args) => {
 };
 
 // src/analytics/writer.ts
-import { existsSync as existsSync31, mkdirSync as mkdirSync18, renameSync as renameSync10, writeFileSync as writeFileSync13 } from "node:fs";
-import path36 from "node:path";
+import { existsSync as existsSync32, mkdirSync as mkdirSync19, renameSync as renameSync10, writeFileSync as writeFileSync13 } from "node:fs";
+import path39 from "node:path";
 var ANALYTICS_DIR_MODE = 493;
 var REPORT_FILE_MODE = 420;
 var writeAnalyticsReport = async (args) => {
   const { report, roots } = args;
   const generatedAt = args.generatedAt ?? /* @__PURE__ */ new Date();
   const dateSegment = isoDateUtc(generatedAt);
-  const filePath = path36.join(roots.analyticsDir, `report-${dateSegment}.json`);
-  if (!existsSync31(roots.analyticsDir)) {
-    mkdirSync18(roots.analyticsDir, {
+  const filePath = path39.join(roots.analyticsDir, `report-${dateSegment}.json`);
+  if (!existsSync32(roots.analyticsDir)) {
+    mkdirSync19(roots.analyticsDir, {
       mode: ANALYTICS_DIR_MODE,
       recursive: true
     });
@@ -24159,7 +24841,7 @@ var runAllPatternDetectors = (args) => {
 
 // src/profile/reader.ts
 import { readFile } from "node:fs/promises";
-import path37 from "node:path";
+import path40 from "node:path";
 var MS_PER_DAY2 = 864e5;
 var MENTORSHIP_TYPE_SET = new Set(
   MENTORSHIP_EVENT_TYPES
@@ -24255,7 +24937,7 @@ var readMentorshipEvents = async (args) => {
   const dates = enumerateWindowDates(now, windowDays);
   const events = [];
   for (const date5 of dates) {
-    const filePath = path37.join(roots.mentorshipDir, `events-${date5}.jsonl`);
+    const filePath = path40.join(roots.mentorshipDir, `events-${date5}.jsonl`);
     const raw = await readFileIfExists(filePath);
     if (raw !== null) events.push(...parseFileLines(raw, filePath));
   }
@@ -24374,7 +25056,7 @@ var renderProfile = (args) => {
 var atomicWriteProfile = async (profilePath, contents) => atomicWriteFile(profilePath, contents, { mode: 384 });
 
 // src/profile/index.ts
-var WINDOW_DAYS = 30;
+var WINDOW_DAYS2 = 30;
 var RECENT_WINDOW_DAYS = 7;
 var FADE_ELIGIBLE_AGE_DAYS = 7;
 var MS_PER_DAY3 = 864e5;
@@ -24444,9 +25126,9 @@ var computeProfileCore = async (args) => {
   const events = await readMentorshipEvents({
     now,
     roots,
-    windowDays: WINDOW_DAYS
+    windowDays: WINDOW_DAYS2
   });
-  const patterns = runAllPatternDetectors({ events, windowDays: WINDOW_DAYS });
+  const patterns = runAllPatternDetectors({ events, windowDays: WINDOW_DAYS2 });
   const recentPatterns = runAllPatternDetectors({
     events: eventsWithinRecentWindow(events, now),
     windowDays: RECENT_WINDOW_DAYS
@@ -24465,7 +25147,7 @@ var renderAndWriteProfile = async (args) => {
     generatedAt: now,
     mentorshipEnabled: true,
     patterns: core.patterns,
-    windowDays: WINDOW_DAYS
+    windowDays: WINDOW_DAYS2
   });
   await atomicWriteProfile(roots.profilePath, profileContents);
 };
@@ -24475,7 +25157,7 @@ var writeAnalytics = async (args) => {
     generatedAt: now,
     patternResults: core.patterns,
     roots,
-    windowDays: WINDOW_DAYS
+    windowDays: WINDOW_DAYS2
   });
   await writeAnalyticsReport({ generatedAt: now, report, roots });
 };
@@ -24555,7 +25237,7 @@ var computeProfile = async (options = {}) => {
 
 // src/telemetry/emit.ts
 import { createHash as createHash3 } from "node:crypto";
-import path38 from "node:path";
+import path41 from "node:path";
 
 // src/telemetry/envelope.ts
 import { createHash as createHash2 } from "node:crypto";
@@ -24633,7 +25315,7 @@ var buildEnvelope = (args) => {
 };
 
 // src/telemetry/ndjson-writer.ts
-import { existsSync as existsSync32, readFileSync as readFileSync28 } from "node:fs";
+import { existsSync as existsSync33, readFileSync as readFileSync30 } from "node:fs";
 import { appendFile, chmod as chmod2, stat as stat2 } from "node:fs/promises";
 var seenByFile = /* @__PURE__ */ new Map();
 var EVENT_ID_NEEDLE_REGEX = /"event_id":"([^"]+)"/gu;
@@ -24641,8 +25323,8 @@ var seenSetFor = (filePath) => {
   const cached2 = seenByFile.get(filePath);
   if (cached2 !== void 0) return cached2;
   const seen = /* @__PURE__ */ new Set();
-  if (existsSync32(filePath)) {
-    const existing = readFileSync28(filePath, "utf8");
+  if (existsSync33(filePath)) {
+    const existing = readFileSync30(filePath, "utf8");
     for (const match of existing.matchAll(EVENT_ID_NEEDLE_REGEX)) {
       seen.add(match[1]);
     }
@@ -24723,7 +25405,7 @@ var TimeToResolvedSpecCloudPayload = external_exports.strictObject({
 var CodeReviewAuditFindingCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   auditor_type: external_exports.string(),
-  finding_class: external_exports.string(),
+  finding_class: FindingClassSchema,
   pr_number: external_exports.number().int(),
   severity: external_exports.string(),
   spec_id: external_exports.string().optional()
@@ -25033,7 +25715,7 @@ var writeCloud = async (envelope, roots, now) => {
       ok: false
     };
   }
-  const cloudPath = path38.join(
+  const cloudPath = path41.join(
     roots.cloudDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -25047,7 +25729,7 @@ var writeCloud = async (envelope, roots, now) => {
 };
 var writeMentorship = async (envelope, roots, now) => {
   const mentorshipLine = JSON.stringify(envelope);
-  const mentorshipPath = path38.join(
+  const mentorshipPath = path41.join(
     roots.mentorshipDir,
     `events-${todayIsoDate(now)}.jsonl`
   );
@@ -25269,6 +25951,7 @@ var buildAuditFindings = (trailer) => {
     const findingClass = stringField(finding, "finding_class");
     const severity = stringField(finding, "severity");
     if (findingClass === void 0 || severity === void 0) continue;
+    if (!isValidFindingClass(findingClass)) continue;
     invocations.push({
       args: [
         "--pr-number",
@@ -25466,19 +26149,19 @@ var handleParseStdin = async () => {
 };
 
 // src/telemetry/index.ts
-var HELP_TEXT49 = `Usage: gaia telemetry <subcommand> [args]
+var HELP_TEXT51 = `Usage: gaia telemetry <subcommand> [args]
 
   emit <event_type> [--field value ...]   Emit one telemetry event.
   compute-profile                          Regenerate profile.md from events.
   parse-stdin                              Read PostToolUse hook JSON on stdin,
                                            dispatch emits from trailer YAML.
 `;
-var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var run62 = async (argv) => {
+var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var run64 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS47.has(subcommand)) {
-    process.stdout.write(HELP_TEXT49);
+  if (subcommand === void 0 || HELP_TOKENS49.has(subcommand)) {
+    process.stdout.write(HELP_TEXT51);
     return EXIT_CODES.OK;
   }
   if (subcommand === "emit") {
@@ -25499,16 +26182,16 @@ var run62 = async (argv) => {
 
 // src/update/merge.ts
 import {
-  existsSync as existsSync35,
-  mkdirSync as mkdirSync19,
-  readdirSync as readdirSync5,
+  existsSync as existsSync36,
+  mkdirSync as mkdirSync20,
+  readdirSync as readdirSync6,
   statSync as statSync4,
   writeFileSync as writeFileSync15
 } from "node:fs";
-import path40 from "node:path";
+import path43 from "node:path";
 
 // src/update/util/manifest.ts
-import { existsSync as existsSync33, readFileSync as readFileSync29 } from "node:fs";
+import { existsSync as existsSync34, readFileSync as readFileSync31 } from "node:fs";
 var VALID_RAW_CLASSES = /* @__PURE__ */ new Set([
   "owned",
   "shared",
@@ -25520,7 +26203,7 @@ var normalizeClass = (rawClass) => {
 };
 var isObject2 = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
 var loadManifest = (manifestPath) => {
-  if (!existsSync33(manifestPath)) {
+  if (!existsSync34(manifestPath)) {
     return {
       ok: false,
       message: `manifest not found: ${manifestPath}`
@@ -25528,7 +26211,7 @@ var loadManifest = (manifestPath) => {
   }
   let raw;
   try {
-    raw = readFileSync29(manifestPath, "utf8");
+    raw = readFileSync31(manifestPath, "utf8");
   } catch (error51) {
     return {
       ok: false,
@@ -25552,21 +26235,21 @@ var loadManifest = (manifestPath) => {
     return { ok: false, message: "manifest.files is missing or not an object" };
   }
   const files = /* @__PURE__ */ new Map();
-  for (const [path51, value] of Object.entries(shape.files)) {
+  for (const [path54, value] of Object.entries(shape.files)) {
     if (typeof value !== "string") {
       return {
         ok: false,
-        message: `manifest.files["${path51}"] is not a string`
+        message: `manifest.files["${path54}"] is not a string`
       };
     }
     if (!VALID_RAW_CLASSES.has(value)) {
       return {
         ok: false,
-        message: `manifest.files["${path51}"] has unknown class: "${value}"`
+        message: `manifest.files["${path54}"] has unknown class: "${value}"`
       };
     }
     const rawClass = value;
-    files.set(path51, {
+    files.set(path54, {
       normalizedClass: normalizeClass(rawClass),
       rawClass
     });
@@ -25579,23 +26262,23 @@ var loadManifest = (manifestPath) => {
 };
 
 // src/update/util/three-way.ts
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { spawnSync as spawnSync3 } from "node:child_process";
 import {
-  existsSync as existsSync34,
+  existsSync as existsSync35,
   mkdtempSync,
-  readFileSync as readFileSync30,
+  readFileSync as readFileSync32,
   rmSync as rmSync5,
   writeFileSync as writeFileSync14
 } from "node:fs";
 import { tmpdir } from "node:os";
-import path39 from "node:path";
+import path42 from "node:path";
 var snapshot = (absPath) => {
-  if (!existsSync34(absPath)) {
+  if (!existsSync35(absPath)) {
     return { absPath, bytes: null, exists: false };
   }
   let bytes;
   try {
-    bytes = readFileSync30(absPath);
+    bytes = readFileSync32(absPath);
   } catch {
     return { absPath, bytes: null, exists: false };
   }
@@ -25608,15 +26291,15 @@ var bytesEqual = (a, b) => {
   return a.equals(b);
 };
 var cleanMerge = (current, baseline, latest) => {
-  const dir = mkdtempSync(path39.join(tmpdir(), "gaia-merge-"));
-  const currentPath = path39.join(dir, "current");
-  const baselinePath = path39.join(dir, "baseline");
-  const latestPath = path39.join(dir, "latest");
+  const dir = mkdtempSync(path42.join(tmpdir(), "gaia-merge-"));
+  const currentPath = path42.join(dir, "current");
+  const baselinePath = path42.join(dir, "baseline");
+  const latestPath = path42.join(dir, "latest");
   try {
     writeFileSync14(currentPath, current);
     writeFileSync14(baselinePath, baseline);
     writeFileSync14(latestPath, latest);
-    const result = spawnSync2(
+    const result = spawnSync3(
       "git",
       ["merge-file", "--stdout", currentPath, baselinePath, latestPath],
       { encoding: "buffer" }
@@ -25798,7 +26481,7 @@ var buildUnifiedDiff = (fromText, toText, options) => {
 };
 
 // src/update/merge.ts
-var HELP_TEXT50 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
+var HELP_TEXT52 = `Usage: gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
 
   Three-way file compare across baseline and latest tarball trees,
   classified by .gaia/manifest.json. Replaces the prose Step 7 of the
@@ -25812,7 +26495,7 @@ var HELP_TEXT50 = `Usage: gaia update merge --baseline <dir> --latest <dir> --ma
     1  user-correctable error (missing dir, malformed manifest)
     2  unexpected (filesystem failure)
 `;
-var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT9 = 2;
 var MERGE_DIR = ".gaia-merge";
 var takeValue8 = (argv, index, flag) => {
@@ -25865,16 +26548,16 @@ var parseFlags12 = (argv) => {
 var walkRelative = (rootDir) => {
   const out = [];
   const visit = (relative) => {
-    const absolute = path40.join(rootDir, relative);
+    const absolute = path43.join(rootDir, relative);
     let names;
     try {
-      names = readdirSync5(absolute);
+      names = readdirSync6(absolute);
     } catch {
       return;
     }
     for (const name of names) {
-      const child = relative === "" ? name : path40.join(relative, name);
-      const childAbs = path40.join(rootDir, child);
+      const child = relative === "" ? name : path43.join(relative, name);
+      const childAbs = path43.join(rootDir, child);
       let info;
       try {
         info = statSync4(childAbs);
@@ -25888,29 +26571,29 @@ var walkRelative = (rootDir) => {
       if (info.isFile()) out.push(child);
     }
   };
-  if (!existsSync35(rootDir) || !statSync4(rootDir).isDirectory()) return out;
+  if (!existsSync36(rootDir) || !statSync4(rootDir).isDirectory()) return out;
   visit("");
   return out.sort();
 };
 var ensureDir2 = (absDir) => {
-  mkdirSync19(absDir, { recursive: true });
+  mkdirSync20(absDir, { recursive: true });
 };
 var writePatch = (ctx, relativePath, patch) => {
-  const mergeRoot = path40.join(ctx.cwd, MERGE_DIR);
-  const patchAbs = path40.join(mergeRoot, `${relativePath}.patch`);
-  ensureDir2(path40.dirname(patchAbs));
+  const mergeRoot = path43.join(ctx.cwd, MERGE_DIR);
+  const patchAbs = path43.join(mergeRoot, `${relativePath}.patch`);
+  ensureDir2(path43.dirname(patchAbs));
   writeFileSync15(patchAbs, patch, "utf8");
-  return path40.relative(ctx.cwd, patchAbs);
+  return path43.relative(ctx.cwd, patchAbs);
 };
 var writeWorkingTree = (ctx, relativePath, bytes) => {
-  const target = path40.join(ctx.cwd, relativePath);
-  ensureDir2(path40.dirname(target));
+  const target = path43.join(ctx.cwd, relativePath);
+  ensureDir2(path43.dirname(target));
   atomicWriteFileSync(target, bytes);
 };
 var handleManifestPath = (ctx, relativePath, klass) => {
-  const baselineSnap = snapshot(path40.join(ctx.baselineDir, relativePath));
-  const latestSnap = snapshot(path40.join(ctx.latestDir, relativePath));
-  const currentSnap = snapshot(path40.join(ctx.cwd, relativePath));
+  const baselineSnap = snapshot(path43.join(ctx.baselineDir, relativePath));
+  const latestSnap = snapshot(path43.join(ctx.latestDir, relativePath));
+  const currentSnap = snapshot(path43.join(ctx.cwd, relativePath));
   if (!latestSnap.exists) return null;
   if (!currentSnap.exists) {
     if (!baselineSnap.exists) {
@@ -26008,16 +26691,16 @@ var computeReport = (ctx) => {
   }
   for (const relativePath of [...latestPaths].toSorted()) {
     if (manifestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path40.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path43.join(ctx.cwd, relativePath));
     if (currentSnap.exists) continue;
-    const latestSnap = snapshot(path40.join(ctx.latestDir, relativePath));
+    const latestSnap = snapshot(path43.join(ctx.latestDir, relativePath));
     if (!latestSnap.exists) continue;
     writeWorkingTree(ctx, relativePath, latestSnap.bytes);
     add.push(relativePath);
   }
   for (const relativePath of [...baselinePaths].toSorted()) {
     if (latestPaths.has(relativePath)) continue;
-    const currentSnap = snapshot(path40.join(ctx.cwd, relativePath));
+    const currentSnap = snapshot(path43.join(ctx.cwd, relativePath));
     if (!currentSnap.exists) continue;
     deleteList.push(relativePath);
   }
@@ -26063,9 +26746,9 @@ var printHuman9 = (report) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run63 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS48.has(argv[0])) {
-    process.stdout.write(HELP_TEXT50);
+var run65 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS50.has(argv[0])) {
+    process.stdout.write(HELP_TEXT52);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags12(argv);
@@ -26078,10 +26761,10 @@ var run63 = (argv, options = {}) => {
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const cwd = options.cwd ?? process.cwd();
-  const baselineDir = path40.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path40.join(cwd, parsed.flags.baseline);
-  const latestDir = path40.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path40.join(cwd, parsed.flags.latest);
-  const manifestPath = path40.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path40.join(cwd, parsed.flags.manifest);
-  if (!existsSync35(baselineDir) || !statSync4(baselineDir).isDirectory()) {
+  const baselineDir = path43.isAbsolute(parsed.flags.baseline) ? parsed.flags.baseline : path43.join(cwd, parsed.flags.baseline);
+  const latestDir = path43.isAbsolute(parsed.flags.latest) ? parsed.flags.latest : path43.join(cwd, parsed.flags.latest);
+  const manifestPath = path43.isAbsolute(parsed.flags.manifest) ? parsed.flags.manifest : path43.join(cwd, parsed.flags.manifest);
+  if (!existsSync36(baselineDir) || !statSync4(baselineDir).isDirectory()) {
     structuredError({
       code: "baseline_missing",
       message: `--baseline directory not found: ${baselineDir}`,
@@ -26089,7 +26772,7 @@ var run63 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (!existsSync35(latestDir) || !statSync4(latestDir).isDirectory()) {
+  if (!existsSync36(latestDir) || !statSync4(latestDir).isDirectory()) {
     structuredError({
       code: "latest_missing",
       message: `--latest directory not found: ${latestDir}`,
@@ -26132,20 +26815,20 @@ var run63 = (argv, options = {}) => {
 };
 
 // src/update/index.ts
-var HELP_TEXT51 = `Usage: gaia update <subcommand> [args]
+var HELP_TEXT53 = `Usage: gaia update <subcommand> [args]
 
   merge --baseline <dir> --latest <dir> --manifest <path> [--json]
                                               Three-way file compare per manifest class.
 `;
-var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS6 = {
-  merge: run63
+  merge: run65
 };
-var run64 = async (argv) => {
+var run66 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS49.has(subcommand)) {
-    process.stdout.write(HELP_TEXT51);
+  if (subcommand === void 0 || HELP_TOKENS51.has(subcommand)) {
+    process.stdout.write(HELP_TEXT53);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS6[subcommand];
@@ -26162,9 +26845,9 @@ var run64 = async (argv) => {
 };
 
 // src/update-deps/run.ts
-import { spawnSync as spawnSync3 } from "node:child_process";
-import { mkdirSync as mkdirSync20, readFileSync as readFileSync31, writeFileSync as writeFileSync16 } from "node:fs";
-import path41 from "node:path";
+import { spawnSync as spawnSync4 } from "node:child_process";
+import { mkdirSync as mkdirSync21, readFileSync as readFileSync33, writeFileSync as writeFileSync16 } from "node:fs";
+import path44 from "node:path";
 
 // src/update-deps/groups.ts
 var GROUP_RULES = [
@@ -26323,7 +27006,7 @@ var resolveGroupMembers = (groupName, allPackageNames) => {
 };
 
 // src/update-deps/run.ts
-var HELP_TEXT52 = `Usage: gaia update-deps run --emit-updates <path>
+var HELP_TEXT54 = `Usage: gaia update-deps run --emit-updates <path>
 
   Discover outdated packages via \`pnpm outdated --json\`, classify each
   into Wave A (minor/patch, batched) or Wave B (major, per-group), and
@@ -26333,9 +27016,9 @@ var HELP_TEXT52 = `Usage: gaia update-deps run --emit-updates <path>
   --emit-updates <path>   Required. JSON file to write. Parent dirs are
                           created on demand.
 `;
-var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var defaultPnpmRunner = (args, options) => {
-  const result = spawnSync3("pnpm", args, {
+  const result = spawnSync4("pnpm", args, {
     cwd: options.cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
@@ -26391,13 +27074,13 @@ var compareSegments = (a, b) => {
   return 0;
 };
 var readPackageJson = (cwd) => {
-  const raw = readFileSync31(path41.join(cwd, "package.json"), "utf8");
+  const raw = readFileSync33(path44.join(cwd, "package.json"), "utf8");
   return JSON.parse(raw);
 };
 var readInstalledVersion = (cwd, name) => {
   try {
-    const raw = readFileSync31(
-      path41.join(cwd, "node_modules", name, "package.json"),
+    const raw = readFileSync33(
+      path44.join(cwd, "node_modules", name, "package.json"),
       "utf8"
     );
     const parsed = JSON.parse(raw);
@@ -26495,7 +27178,7 @@ var fetchLatestVersion = (name, cwd, pnpmRunner) => {
 var readMinimumReleaseAge = (cwd) => {
   let raw;
   try {
-    raw = readFileSync31(path41.join(cwd, "pnpm-workspace.yaml"), "utf8");
+    raw = readFileSync33(path44.join(cwd, "pnpm-workspace.yaml"), "utf8");
   } catch {
     return 0;
   }
@@ -26738,10 +27421,10 @@ var parseArgs7 = (argv) => {
   }
   return { emitUpdates };
 };
-var run65 = (argv, options = {}) => {
+var run67 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS50.has(token)) {
-      process.stdout.write(HELP_TEXT52);
+    if (HELP_TOKENS52.has(token)) {
+      process.stdout.write(HELP_TEXT54);
       return EXIT_CODES.OK;
     }
   }
@@ -26762,8 +27445,8 @@ var run65 = (argv, options = {}) => {
       pnpmRunner: options.pnpmRunner
     });
     const stamped = payload;
-    const outPath = path41.isAbsolute(parsed.emitUpdates) ? parsed.emitUpdates : path41.join(cwd, parsed.emitUpdates);
-    mkdirSync20(path41.dirname(outPath), { recursive: true });
+    const outPath = path44.isAbsolute(parsed.emitUpdates) ? parsed.emitUpdates : path44.join(cwd, parsed.emitUpdates);
+    mkdirSync21(path44.dirname(outPath), { recursive: true });
     writeFileSync16(outPath, `${JSON.stringify(stamped, null, 2)}
 `, "utf8");
     return EXIT_CODES.OK;
@@ -26778,22 +27461,22 @@ var run65 = (argv, options = {}) => {
 };
 
 // src/update-deps/index.ts
-var HELP_TEXT53 = `Usage: gaia update-deps <subcommand> [args]
+var HELP_TEXT55 = `Usage: gaia update-deps <subcommand> [args]
 
   run --emit-updates <path>                   Discover outdated packages,
                                               classify into Wave A / Wave B,
                                               and emit a JSON payload at
                                               <path>.
 `;
-var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS7 = {
-  run: run65
+  run: run67
 };
-var run66 = async (argv) => {
+var run68 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS51.has(subcommand)) {
-    process.stdout.write(HELP_TEXT53);
+  if (subcommand === void 0 || HELP_TOKENS53.has(subcommand)) {
+    process.stdout.write(HELP_TEXT55);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS7[subcommand];
@@ -26810,12 +27493,12 @@ var run66 = async (argv) => {
 };
 
 // src/wiki/commit-classify.ts
-var HELP_TEXT54 = `Usage: gaia wiki commit-classify --since <sha> [--json]
+var HELP_TEXT56 = `Usage: gaia wiki commit-classify --since <sha> [--json]
 
   Emit a deterministic WORTHY/SKIP suggestion for every commit in
   <sha>..HEAD. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var takeValue9 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0)
@@ -26983,9 +27666,9 @@ var printHuman10 = (classification) => {
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run67 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS52.has(argv[0])) {
-    process.stdout.write(HELP_TEXT54);
+var run69 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS54.has(argv[0])) {
+    process.stdout.write(HELP_TEXT56);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const parsed = parseFlags13(argv);
@@ -27044,9 +27727,9 @@ var run67 = (argv, options = {}) => {
 };
 
 // src/wiki/dead-paths.ts
-import { readdirSync as readdirSync6, readFileSync as readFileSync32, statSync as statSync5 } from "node:fs";
-import path42 from "node:path";
-var HELP_TEXT55 = `Usage: gaia wiki dead-paths [--json]
+import { readdirSync as readdirSync7, readFileSync as readFileSync34, statSync as statSync5 } from "node:fs";
+import path45 from "node:path";
+var HELP_TEXT57 = `Usage: gaia wiki dead-paths [--json]
 
   Scan wiki/**/*.md for backticked repo-relative paths under .claude/, .gaia/,
   app/, test/, wiki/ that no longer exist on disk, plus any reference to
@@ -27055,7 +27738,7 @@ var HELP_TEXT55 = `Usage: gaia wiki dead-paths [--json]
   and wiki/meta/** (audit artifacts that legitimately reference historical
   paths).
 `;
-var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TRACKED_PREFIXES = [
   ".claude/",
   ".gaia/",
@@ -27083,30 +27766,30 @@ var isTrackedPath = (token) => {
 };
 var shouldSkipFile = (relPath) => SKIP_PATH_FRAGMENTS.some((fragment) => relPath.startsWith(fragment));
 var walkMarkdown = (root, dir) => {
-  const entries = readdirSync6(dir, { withFileTypes: true });
+  const entries = readdirSync7(dir, { withFileTypes: true });
   const out = [];
   for (const entry of entries) {
-    const full = path42.join(dir, entry.name);
+    const full = path45.join(dir, entry.name);
     if (entry.isDirectory()) {
       out.push(...walkMarkdown(root, full));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(path42.relative(root, full));
+      out.push(path45.relative(root, full));
     }
   }
   return out;
 };
 var pathExists = (root, candidate) => {
   try {
-    statSync5(path42.join(root, candidate));
+    statSync5(path45.join(root, candidate));
     return true;
   } catch {
     return false;
   }
 };
 var findDeadPaths = (cwd) => {
-  const wikiDir = path42.join(cwd, "wiki");
+  const wikiDir = path45.join(cwd, "wiki");
   try {
     statSync5(wikiDir);
   } catch {
@@ -27116,7 +27799,7 @@ var findDeadPaths = (cwd) => {
   const files = walkMarkdown(cwd, wikiDir);
   for (const filePath of files) {
     if (shouldSkipFile(filePath)) continue;
-    const content = readFileSync32(path42.join(cwd, filePath), "utf8");
+    const content = readFileSync34(path45.join(cwd, filePath), "utf8");
     const lines = content.split("\n");
     for (const [index, line] of lines.entries()) {
       if (HISTORICAL_BULLET_PATTERN.test(line)) continue;
@@ -27136,11 +27819,11 @@ var findDeadPaths = (cwd) => {
   }
   return dead;
 };
-var run68 = (argv, options = {}) => {
+var run70 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS53.has(token)) {
-      process.stdout.write(HELP_TEXT55);
+    if (HELP_TOKENS55.has(token)) {
+      process.stdout.write(HELP_TEXT57);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -27179,7 +27862,7 @@ var run68 = (argv, options = {}) => {
 
 // src/wiki/diff-size.ts
 import { execFileSync as execFileSync7 } from "node:child_process";
-var HELP_TEXT56 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
+var HELP_TEXT58 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
 
   Compute wiki/** lines-changed (added + removed) between <base> (default
   HEAD~1) and HEAD as a percentage of the base tree's wiki line count.
@@ -27191,7 +27874,7 @@ var HELP_TEXT56 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>]
                       changed_lines, threshold_pct } instead of the bare
                       keyword.
 `;
-var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var WIKI_PREFIX = "wiki/";
 var git = (cwd, args) => execFileSync7("git", ["-C", cwd, ...args], {
   encoding: "utf8",
@@ -27333,10 +28016,10 @@ var emitJson = (result) => {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}
 `);
 };
-var run69 = (argv, options = {}) => {
+var run71 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS54.has(token)) {
-      process.stdout.write(HELP_TEXT56);
+    if (HELP_TOKENS56.has(token)) {
+      process.stdout.write(HELP_TEXT58);
       return EXIT_CODES.OK;
     }
   }
@@ -27374,8 +28057,8 @@ var run69 = (argv, options = {}) => {
 };
 
 // src/wiki/empty-sections.ts
-import { readdirSync as readdirSync7, readFileSync as readFileSync33, statSync as statSync6 } from "node:fs";
-import path43 from "node:path";
+import { readdirSync as readdirSync8, readFileSync as readFileSync35, statSync as statSync6 } from "node:fs";
+import path46 from "node:path";
 
 // src/wiki/util/frontmatter.ts
 var FRONTMATTER_FENCE = "---";
@@ -27437,7 +28120,7 @@ var parseFrontmatter = (raw) => {
 };
 
 // src/wiki/empty-sections.ts
-var HELP_TEXT57 = `Usage: gaia wiki empty-sections [--json]
+var HELP_TEXT59 = `Usage: gaia wiki empty-sections [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
   LEAF headings with no body, no child heading and no non-blank, non-heading
@@ -27446,23 +28129,23 @@ var HELP_TEXT57 = `Usage: gaia wiki empty-sections [--json]
   Without --json, prints one "path:line  heading" line per finding. With
   --json, emits { "empty": [ { path, line, heading } ] }.
 `;
-var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SKIP_PATH_FRAGMENTS2 = ["wiki/meta/"];
 var SKIP_PATHS = /* @__PURE__ */ new Set(["wiki/hot.md", "wiki/log.md"]);
 var ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
 var FENCE_PATTERN = /^\s*(?:```|~~~)/u;
 var shouldSkipFile2 = (relPath) => SKIP_PATHS.has(relPath) || SKIP_PATH_FRAGMENTS2.some((fragment) => relPath.startsWith(fragment));
 var walkMarkdown2 = (root, dir) => {
-  const entries = readdirSync7(dir, { withFileTypes: true });
+  const entries = readdirSync8(dir, { withFileTypes: true });
   const out = [];
   for (const entry of entries) {
-    const full = path43.join(dir, entry.name);
+    const full = path46.join(dir, entry.name);
     if (entry.isDirectory()) {
       out.push(...walkMarkdown2(root, full));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(path43.relative(root, full));
+      out.push(path46.relative(root, full));
     }
   }
   return out;
@@ -27515,7 +28198,7 @@ var findInBody = (body, bodyLineOffset, relPath) => {
   return found;
 };
 var findEmptySections = (cwd) => {
-  const wikiDir = path43.join(cwd, "wiki");
+  const wikiDir = path46.join(cwd, "wiki");
   try {
     statSync6(wikiDir);
   } catch {
@@ -27525,18 +28208,18 @@ var findEmptySections = (cwd) => {
   const files = walkMarkdown2(cwd, wikiDir).sort();
   for (const filePath of files) {
     if (shouldSkipFile2(filePath)) continue;
-    const content = readFileSync33(path43.join(cwd, filePath), "utf8");
+    const content = readFileSync35(path46.join(cwd, filePath), "utf8");
     const { body } = parseFrontmatter(content);
     const offset = content.split("\n").length - body.split("\n").length;
     empty.push(...findInBody(body, offset, filePath));
   }
   return empty;
 };
-var run70 = (argv, options = {}) => {
+var run72 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS55.has(token)) {
-      process.stdout.write(HELP_TEXT57);
+    if (HELP_TOKENS57.has(token)) {
+      process.stdout.write(HELP_TEXT59);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -27579,37 +28262,37 @@ var run70 = (argv, options = {}) => {
 };
 
 // src/wiki/frontmatter.ts
-import { readdirSync as readdirSync8, readFileSync as readFileSync34, statSync as statSync7 } from "node:fs";
-import path44 from "node:path";
-var HELP_TEXT58 = `Usage: gaia wiki frontmatter [--json]
+import { readdirSync as readdirSync9, readFileSync as readFileSync36, statSync as statSync7 } from "node:fs";
+import path47 from "node:path";
+var HELP_TEXT60 = `Usage: gaia wiki frontmatter [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
   frontmatter. Required floor is type and status. Without --json, prints one
   "path: missing a, b" line per gap. With --json, emits
   { "gaps": [ { path, missing } ] }.
 `;
-var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var REQUIRED_FIELDS = ["type", "status"];
 var SKIP_PATH_FRAGMENTS3 = ["wiki/meta/"];
 var shouldSkipFile3 = (relPath) => SKIP_PATH_FRAGMENTS3.some((fragment) => relPath.startsWith(fragment));
 var walkMarkdown3 = (root, dir) => {
-  const entries = readdirSync8(dir, { withFileTypes: true });
+  const entries = readdirSync9(dir, { withFileTypes: true });
   const out = [];
   for (const entry of entries) {
-    const full = path44.join(dir, entry.name);
+    const full = path47.join(dir, entry.name);
     if (entry.isDirectory()) {
       out.push(...walkMarkdown3(root, full));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(path44.relative(root, full));
+      out.push(path47.relative(root, full));
     }
   }
   return out;
 };
 var hasField = (frontmatter, field) => Object.prototype.hasOwnProperty.call(frontmatter, field) && frontmatter[field] !== null;
 var findFrontmatterGaps = (cwd) => {
-  const wikiDir = path44.join(cwd, "wiki");
+  const wikiDir = path47.join(cwd, "wiki");
   try {
     statSync7(wikiDir);
   } catch {
@@ -27619,7 +28302,7 @@ var findFrontmatterGaps = (cwd) => {
   const files = walkMarkdown3(cwd, wikiDir).sort();
   for (const filePath of files) {
     if (shouldSkipFile3(filePath)) continue;
-    const content = readFileSync34(path44.join(cwd, filePath), "utf8");
+    const content = readFileSync36(path47.join(cwd, filePath), "utf8");
     const { frontmatter } = parseFrontmatter(content);
     const missing = REQUIRED_FIELDS.filter(
       (field) => !hasField(frontmatter, field)
@@ -27630,11 +28313,11 @@ var findFrontmatterGaps = (cwd) => {
   }
   return gaps;
 };
-var run71 = (argv, options = {}) => {
+var run73 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS56.has(token)) {
-      process.stdout.write(HELP_TEXT58);
+    if (HELP_TOKENS58.has(token)) {
+      process.stdout.write(HELP_TEXT60);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -27677,13 +28360,13 @@ var run71 = (argv, options = {}) => {
 };
 
 // src/wiki/log-prepend.ts
-import { existsSync as existsSync36, readFileSync as readFileSync35, renameSync as renameSync11, writeFileSync as writeFileSync17 } from "node:fs";
-import path45 from "node:path";
-var HELP_TEXT59 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+import { existsSync as existsSync37, readFileSync as readFileSync37, renameSync as renameSync11, writeFileSync as writeFileSync17 } from "node:fs";
+import path48 from "node:path";
+var HELP_TEXT61 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
 var FRONTMATTER_FENCE2 = "---";
 var takeValue10 = (argv, index, flag) => {
@@ -27764,14 +28447,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run72 = (argv, options = {}) => {
+var run74 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT59);
+    process.stdout.write(HELP_TEXT61);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS57.has(first)) {
-    process.stdout.write(HELP_TEXT59);
+  if (HELP_TOKENS59.has(first)) {
+    process.stdout.write(HELP_TEXT61);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags14(argv);
@@ -27794,8 +28477,8 @@ var run72 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const logPath = path45.join(repoRoot2, "wiki", "log.md");
-  if (!existsSync36(logPath)) {
+  const logPath = path48.join(repoRoot2, "wiki", "log.md");
+  if (!existsSync37(logPath)) {
     structuredError({
       code: "log_missing",
       message: "wiki/log.md does not exist",
@@ -27803,7 +28486,7 @@ var run72 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync35(logPath, "utf8");
+  const raw = readFileSync37(logPath, "utf8");
   const lines = raw.split("\n");
   const scan = scanFrontmatter(lines);
   if (scan.kind === "missing" || scan.kind === "malformed") {
@@ -27829,14 +28512,14 @@ var run72 = (argv, options = {}) => {
 };
 
 // src/wiki/near-collisions.ts
-import { existsSync as existsSync37, readdirSync as readdirSync9, statSync as statSync8 } from "node:fs";
-import path46 from "node:path";
-var HELP_TEXT60 = `Usage: gaia wiki near-collisions [--max-distance 3]
+import { existsSync as existsSync38, readdirSync as readdirSync10, statSync as statSync8 } from "node:fs";
+import path49 from "node:path";
+var HELP_TEXT62 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS = [
   "components",
@@ -27874,9 +28557,9 @@ var levenshtein = (a, b) => {
 var collectDomainSlugs = (wikiRoot) => {
   const collected = [];
   for (const domain2 of DOMAIN_DIRS) {
-    const domainDir = path46.join(wikiRoot, domain2);
-    if (!existsSync37(domainDir) || !statSync8(domainDir).isDirectory()) continue;
-    const entries = readdirSync9(domainDir, { withFileTypes: true });
+    const domainDir = path49.join(wikiRoot, domain2);
+    if (!existsSync38(domainDir) || !statSync8(domainDir).isDirectory()) continue;
+    const entries = readdirSync10(domainDir, { withFileTypes: true });
     const slugs = [];
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -27945,9 +28628,9 @@ var parseFlags15 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run73 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS58.has(argv[0])) {
-    process.stdout.write(HELP_TEXT60);
+var run75 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS60.has(argv[0])) {
+    process.stdout.write(HELP_TEXT62);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags15(argv);
@@ -27970,7 +28653,7 @@ var run73 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path46.join(repoRoot2, "wiki");
+  const wikiRoot = path49.join(repoRoot2, "wiki");
   const domainGroups = collectDomainSlugs(wikiRoot);
   const collisions = findCollisions(domainGroups, parsed.flags.maxDistance);
   if (collisions.length === 0) return EXIT_CODES.OK;
@@ -27983,8 +28666,8 @@ var run73 = (argv, options = {}) => {
 };
 
 // src/wiki/page-index.ts
-import { existsSync as existsSync38, readdirSync as readdirSync10, readFileSync as readFileSync36, statSync as statSync9 } from "node:fs";
-import path47 from "node:path";
+import { existsSync as existsSync39, readdirSync as readdirSync11, readFileSync as readFileSync38, statSync as statSync9 } from "node:fs";
+import path50 from "node:path";
 
 // src/wiki/util/wikilinks.ts
 var WIKILINK_PATTERN = /\[\[([^\][]+)\]\]/gu;
@@ -28004,12 +28687,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT61 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT63 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS2 = [
   "components",
   "concepts",
@@ -28022,7 +28705,7 @@ var DOMAIN_DIRS2 = [
 ];
 var SKIPPED_FILES2 = /* @__PURE__ */ new Set(["_index.md", "README.md"]);
 var ROOT_LINK_SOURCES = ["index.md", "overview.md", "hot.md"];
-var slugFromPath = (filePath) => path47.basename(filePath, ".md");
+var slugFromPath = (filePath) => path50.basename(filePath, ".md");
 var extractTitle = (body, fallback) => {
   const lines = body.split("\n");
   for (const line of lines) {
@@ -28048,16 +28731,16 @@ var arrayOfStrings = (value) => {
 var collectPages = (wikiRoot) => {
   const pages = [];
   for (const domain2 of DOMAIN_DIRS2) {
-    const domainDir = path47.join(wikiRoot, domain2);
-    if (!existsSync38(domainDir) || !statSync9(domainDir).isDirectory()) continue;
-    const entries = readdirSync10(domainDir, { withFileTypes: true });
+    const domainDir = path50.join(wikiRoot, domain2);
+    if (!existsSync39(domainDir) || !statSync9(domainDir).isDirectory()) continue;
+    const entries = readdirSync11(domainDir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) continue;
       if (!entry.name.endsWith(".md")) continue;
       if (SKIPPED_FILES2.has(entry.name)) continue;
       if (entry.name.startsWith("_")) continue;
-      const absPath = path47.join(domainDir, entry.name);
-      const raw = readFileSync36(absPath, "utf8");
+      const absPath = path50.join(domainDir, entry.name);
+      const raw = readFileSync38(absPath, "utf8");
       const { body, frontmatter } = parseFrontmatter(raw);
       const slug = slugFromPath(entry.name);
       const title = extractTitle(body, slug);
@@ -28066,7 +28749,7 @@ var collectPages = (wikiRoot) => {
         body,
         domain: domain2,
         outboundTargets: targets,
-        relativePath: path47.posix.join("wiki", domain2, entry.name),
+        relativePath: path50.posix.join("wiki", domain2, entry.name),
         slug,
         status: stringValue(frontmatter.status),
         tags: arrayOfStrings(frontmatter.tags),
@@ -28080,9 +28763,9 @@ var collectPages = (wikiRoot) => {
 var collectRootLinkSources = (wikiRoot) => {
   const sources = [];
   for (const filename of ROOT_LINK_SOURCES) {
-    const absPath = path47.join(wikiRoot, filename);
-    if (!existsSync38(absPath)) continue;
-    const raw = readFileSync36(absPath, "utf8");
+    const absPath = path50.join(wikiRoot, filename);
+    if (!existsSync39(absPath)) continue;
+    const raw = readFileSync38(absPath, "utf8");
     const { body } = parseFrontmatter(raw);
     sources.push(extractWikilinks(body));
   }
@@ -28134,16 +28817,16 @@ var printHuman11 = (index) => {
 };
 var computePageIndex = (cwd) => {
   const repoRoot2 = resolveRepoRoot2(cwd);
-  const wikiRoot = path47.join(repoRoot2, "wiki");
+  const wikiRoot = path50.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run74 = (argv, options = {}) => {
+var run76 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS59.has(token)) {
-      process.stdout.write(HELP_TEXT61);
+    if (HELP_TOKENS61.has(token)) {
+      process.stdout.write(HELP_TEXT63);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -28168,7 +28851,7 @@ var run74 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path47.join(repoRoot2, "wiki");
+  const wikiRoot = path50.join(repoRoot2, "wiki");
   const pages = collectPages(wikiRoot);
   const rootSources = collectRootLinkSources(wikiRoot);
   const index = buildIndex(pages, rootSources);
@@ -28182,19 +28865,19 @@ var run74 = (argv, options = {}) => {
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT62 = `Usage: gaia wiki orphans [--json]
+var HELP_TEXT64 = `Usage: gaia wiki orphans [--json]
 
   List wiki pages with zero inbound wikilinks. Without --json, prints one
   repo-relative path per line. With --json, emits { "orphans": [ { path,
   title, domain } ] }.
 `;
-var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var isMaintainerOnly = (path51) => path51.startsWith("wiki/meta/") || path51.startsWith("wiki/entities/");
-var run75 = (argv, options = {}) => {
+var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var isMaintainerOnly = (path54) => path54.startsWith("wiki/meta/") || path54.startsWith("wiki/entities/");
+var run77 = (argv, options = {}) => {
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS60.has(token)) {
-      process.stdout.write(HELP_TEXT62);
+    if (HELP_TOKENS62.has(token)) {
+      process.stdout.write(HELP_TEXT64);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -28245,11 +28928,11 @@ var run75 = (argv, options = {}) => {
 };
 
 // src/wiki/state.ts
-import { existsSync as existsSync39, readdirSync as readdirSync11, readFileSync as readFileSync37, statSync as statSync10 } from "node:fs";
-import path48 from "node:path";
-var HELP_TEXT63 = `Usage: gaia wiki state [--json]
+import { existsSync as existsSync40, readdirSync as readdirSync12, readFileSync as readFileSync39, statSync as statSync10 } from "node:fs";
+import path51 from "node:path";
+var HELP_TEXT65 = `Usage: gaia wiki state [--json]
 `;
-var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS63 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var classifySeverity = (commitCount) => {
   if (commitCount <= 0) return "none";
   if (commitCount <= 5) return "low";
@@ -28269,12 +28952,12 @@ var DOMAIN_DIRS3 = [
 var countDomainPages = (wikiRoot) => {
   const counts = {};
   for (const domain2 of DOMAIN_DIRS3) {
-    const domainDir = path48.join(wikiRoot, domain2);
-    if (!existsSync39(domainDir) || !statSync10(domainDir).isDirectory()) {
+    const domainDir = path51.join(wikiRoot, domain2);
+    if (!existsSync40(domainDir) || !statSync10(domainDir).isDirectory()) {
       counts[domain2] = 0;
       continue;
     }
-    const entries = readdirSync11(domainDir, { withFileTypes: true });
+    const entries = readdirSync12(domainDir, { withFileTypes: true });
     let count = 0;
     for (const entry of entries) {
       if (!entry.isFile()) continue;
@@ -28287,8 +28970,8 @@ var countDomainPages = (wikiRoot) => {
   return counts;
 };
 var readStateFile2 = (statePath) => {
-  if (!existsSync39(statePath)) return null;
-  const raw = readFileSync37(statePath, "utf8");
+  if (!existsSync40(statePath)) return null;
+  const raw = readFileSync39(statePath, "utf8");
   try {
     return JSON.parse(raw);
   } catch {
@@ -28319,14 +29002,14 @@ var printHuman12 = (state, write) => {
   write(`${lines.join("\n")}
 `);
 };
-var run76 = (argv, options = {}) => {
+var run78 = (argv, options = {}) => {
   const write = options.write ?? ((chunk) => {
     process.stdout.write(chunk);
   });
   let json2 = false;
   for (const token of argv) {
-    if (HELP_TOKENS61.has(token)) {
-      write(HELP_TEXT63);
+    if (HELP_TOKENS63.has(token)) {
+      write(HELP_TEXT65);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -28351,8 +29034,8 @@ var run76 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiRoot = path48.join(repoRoot2, "wiki");
-  const statePath = path48.join(wikiRoot, ".state.json");
+  const wikiRoot = path51.join(repoRoot2, "wiki");
+  const statePath = path51.join(wikiRoot, ".state.json");
   const stateFile = readStateFile2(statePath);
   const stateSha = stateFile?.last_evaluated_sha ?? "";
   const stateAt = stateFile?.last_evaluated_at ?? "";
@@ -28386,15 +29069,15 @@ var run76 = (argv, options = {}) => {
 };
 
 // src/wiki/state-bump.ts
-import { existsSync as existsSync40, readFileSync as readFileSync38 } from "node:fs";
-import path49 from "node:path";
-var HELP_TEXT64 = `Usage: gaia wiki state-bump <field> <value>
+import { existsSync as existsSync41, readFileSync as readFileSync40 } from "node:fs";
+import path52 from "node:path";
+var HELP_TEXT66 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS64 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson2 = (raw) => {
   try {
     return JSON.parse(raw);
@@ -28416,13 +29099,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run77 = (argv, options = {}) => {
+var run79 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT64);
+    process.stdout.write(HELP_TEXT66);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS62.has(argv[0])) {
-    process.stdout.write(HELP_TEXT64);
+  if (HELP_TOKENS64.has(argv[0])) {
+    process.stdout.write(HELP_TEXT66);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -28457,8 +29140,8 @@ var run77 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const statePath = path49.join(repoRoot2, "wiki", ".state.json");
-  if (!existsSync40(statePath)) {
+  const statePath = path52.join(repoRoot2, "wiki", ".state.json");
+  if (!existsSync41(statePath)) {
     structuredError({
       code: "state_missing",
       message: "wiki/.state.json does not exist",
@@ -28466,7 +29149,7 @@ var run77 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const raw = readFileSync38(statePath, "utf8");
+  const raw = readFileSync40(statePath, "utf8");
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -28496,9 +29179,9 @@ var run77 = (argv, options = {}) => {
 
 // src/wiki/state-init.ts
 import { execFileSync as execFileSync8 } from "node:child_process";
-import { existsSync as existsSync41, mkdirSync as mkdirSync21 } from "node:fs";
-import path50 from "node:path";
-var HELP_TEXT65 = `Usage: gaia wiki state-init <sha>
+import { existsSync as existsSync42, mkdirSync as mkdirSync22 } from "node:fs";
+import path53 from "node:path";
+var HELP_TEXT67 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -28506,7 +29189,7 @@ var HELP_TEXT65 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag); it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS63 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS65 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha2 = (ref, cwd) => {
   try {
     const out = execFileSync8(
@@ -28523,13 +29206,13 @@ var resolveFullSha2 = (ref, cwd) => {
     return null;
   }
 };
-var run78 = (argv, options = {}) => {
+var run80 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT65);
+    process.stdout.write(HELP_TEXT67);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS63.has(argv[0])) {
-    process.stdout.write(HELP_TEXT65);
+  if (HELP_TOKENS65.has(argv[0])) {
+    process.stdout.write(HELP_TEXT67);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -28573,9 +29256,9 @@ var run78 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const wikiDir = path50.join(repoRoot2, "wiki");
-  const statePath = path50.join(wikiDir, ".state.json");
-  if (existsSync41(statePath)) {
+  const wikiDir = path53.join(repoRoot2, "wiki");
+  const statePath = path53.join(wikiDir, ".state.json");
+  if (existsSync42(statePath)) {
     structuredError({
       code: "state_already_exists",
       message: "wiki/.state.json already exists; use `gaia wiki state-bump` to update fields",
@@ -28583,7 +29266,7 @@ var run78 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  mkdirSync21(wikiDir, { recursive: true });
+  mkdirSync22(wikiDir, { recursive: true });
   const nowDate = (options.now ?? (() => /* @__PURE__ */ new Date()))();
   const isoNow = nowDate.toISOString();
   const payload = {
@@ -28598,8 +29281,8 @@ var run78 = (argv, options = {}) => {
 };
 
 // src/wiki/util/branch.ts
-import { spawnSync as spawnSync4 } from "node:child_process";
-var defaultRunner = (command, args, options) => spawnSync4(command, args, {
+import { spawnSync as spawnSync5 } from "node:child_process";
+var defaultRunner = (command, args, options) => spawnSync5(command, args, {
   cwd: options.cwd,
   encoding: "utf8",
   stdio: ["ignore", "pipe", "pipe"]
@@ -28655,7 +29338,7 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
 };
 
 // src/wiki/sync-land.ts
-var HELP_TEXT66 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT68 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -28666,7 +29349,7 @@ var HELP_TEXT66 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS64 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS66 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT10 = 2;
 var parseFlags16 = (argv) => {
   let branchAware = false;
@@ -28792,9 +29475,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run79 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS64.has(argv[0])) {
-    process.stdout.write(HELP_TEXT66);
+var run81 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS66.has(argv[0])) {
+    process.stdout.write(HELP_TEXT68);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags16(argv);
@@ -28879,7 +29562,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT67 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT69 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -28902,16 +29585,16 @@ var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS65 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS67 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS65.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS67.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run79(rest);
+    return run81(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -28921,25 +29604,25 @@ var runSync = async (args) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 var SUBCOMMAND_HANDLERS8 = {
-  "commit-classify": run67,
-  "dead-paths": run68,
-  "diff-size": run69,
-  "empty-sections": run70,
-  frontmatter: run71,
-  "log-prepend": run72,
-  "near-collisions": run73,
-  orphans: run75,
-  "page-index": run74,
-  state: run76,
-  "state-bump": run77,
-  "state-init": run78,
+  "commit-classify": run69,
+  "dead-paths": run70,
+  "diff-size": run71,
+  "empty-sections": run72,
+  frontmatter: run73,
+  "log-prepend": run74,
+  "near-collisions": run75,
+  orphans: run77,
+  "page-index": run76,
+  state: run78,
+  "state-bump": run79,
+  "state-init": run80,
   sync: runSync
 };
-var run80 = async (argv) => {
+var run82 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS65.has(subcommand)) {
-    process.stdout.write(HELP_TEXT67);
+  if (subcommand === void 0 || HELP_TOKENS67.has(subcommand)) {
+    process.stdout.write(HELP_TEXT69);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS8[subcommand];
@@ -28956,7 +29639,7 @@ var run80 = async (argv) => {
 };
 
 // src/index.ts
-var HELP_TEXT68 = `Usage: gaia <subcommand> [args]
+var HELP_TEXT70 = `Usage: gaia <subcommand> [args]
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -28965,6 +29648,8 @@ var HELP_TEXT68 = `Usage: gaia <subcommand> [args]
   scaffold component|hook|route|service
   wiki state|commit-classify|state-init|state-bump|log-prepend|page-index|orphans|near-collisions|dead-paths|sync land
   fitness render-card [--cols N]
+  harden-ledger list|record|is-suppressed|prune
+  harden-tally
   automation read-config|read-state|init-state|bump-state|cron-decide|record-run|record-overage|clear-overage
   ci-stale-check --label <name> --base <branch> [--author <login>] [--json]
   ci-revert open|mark-failed|is-cap-reached
@@ -28975,28 +29660,30 @@ var HELP_TEXT68 = `Usage: gaia <subcommand> [args]
   setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize|write-tool-mode
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT68);
+  process.stdout.write(HELP_TEXT70);
 };
-var HELP_TOKENS66 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS68 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS9 = {
   automation: run12,
   "ci-revert": run14,
   "ci-stale-check": run15,
   fitness: run17,
-  init: run26,
-  mentorship: run37,
-  scaffold: run42,
-  setup: run47,
-  "setup-ci": run61,
-  telemetry: run62,
-  update: run64,
-  "update-deps": run66,
-  wiki: run80
+  "harden-ledger": run18,
+  "harden-tally": run19,
+  init: run28,
+  mentorship: run39,
+  scaffold: run44,
+  setup: run49,
+  "setup-ci": run63,
+  telemetry: run64,
+  update: run66,
+  "update-deps": run68,
+  wiki: run82
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS66.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS68.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -14658,6 +14658,60 @@ var ADAPTATION_TEXT = {
   po_socratic_depth_increased: "The user has historically had trouble articulating success criteria for {{area}} work. Coach more on observable outcomes: what changes, what stays, what would prove this done? Push past 'looks right' or 'feels good' to concrete checks."
 };
 
+// src/schemas/finding-class.ts
+var ORACLE_PREFIXES = [
+  "react-doctor",
+  "axe",
+  "knip",
+  "cve"
+];
+var HOLISTIC_FINDING_CLASSES = [
+  "holistic/missing-auth-check",
+  "holistic/secret-exposure",
+  "holistic/n-plus-one",
+  "holistic/unnecessary-rerender",
+  "holistic/unhandled-promise-rejection",
+  "holistic/swallowed-error",
+  "holistic/over-permissive-zod",
+  "holistic/business-logic-in-component",
+  "holistic/hardcoded-string",
+  "holistic/non-null-assertion"
+];
+var RULE_FINDING_CLASSES = [
+  "rule/use-effect-derived-state",
+  "rule/use-effect-state-reset",
+  "rule/unnecessary-use-callback",
+  "rule/missing-effect-cleanup",
+  "rule/generic-handler-name",
+  "rule/switch-statement",
+  "rule/interface-declaration",
+  "rule/z-enum",
+  "rule/array-generic-syntax",
+  "rule/thin-route-violation"
+];
+var CLOSED_VOCABULARY = /* @__PURE__ */ new Set([
+  ...HOLISTIC_FINDING_CLASSES,
+  ...RULE_FINDING_CLASSES
+]);
+var splitPrefix = (value) => {
+  const separatorIndex = value.indexOf("/");
+  if (separatorIndex === -1) return void 0;
+  return {
+    prefix: value.slice(0, separatorIndex),
+    slug: value.slice(separatorIndex + 1)
+  };
+};
+var isOraclePrefix = (prefix) => ORACLE_PREFIXES.includes(prefix);
+var isValidFindingClass = (value) => {
+  const parts = splitPrefix(value);
+  if (parts === void 0) return false;
+  if (isOraclePrefix(parts.prefix)) return parts.slug.length > 0;
+  return CLOSED_VOCABULARY.has(value);
+};
+var FindingClassSchema = external_exports.string().refine(isValidFindingClass, {
+  message: "finding_class must match the per-bucket convention (oracle id or controlled vocabulary)"
+});
+
 // src/schemas/mentorship-payloads.ts
 var SPEC_ID_REGEX = /^SPEC-\d{3,}$/;
 var UAT_ID_REGEX = /^UAT-\d{3,}$/;
@@ -14733,7 +14787,7 @@ var TimeToResolvedSpecPayload = external_exports.object({
 var CodeReviewAuditFindingPayload = external_exports.object({
   area_tags: AreaTagsSchema,
   auditor_type: external_exports.string(),
-  finding_class: external_exports.string(),
+  finding_class: FindingClassSchema,
   pr_number: external_exports.number().int().min(1),
   severity: external_exports.enum(["error", "warning", "suggestion"]),
   spec_id: external_exports.string().regex(SPEC_ID_REGEX).optional()
@@ -27382,7 +27436,7 @@ var TimeToResolvedSpecCloudPayload = external_exports.strictObject({
 var CodeReviewAuditFindingCloudPayload = external_exports.strictObject({
   area_tags: external_exports.array(external_exports.string()),
   auditor_type: external_exports.string(),
-  finding_class: external_exports.string(),
+  finding_class: FindingClassSchema,
   pr_number: external_exports.number().int(),
   severity: external_exports.string(),
   spec_id: external_exports.string().optional()
@@ -27928,6 +27982,7 @@ var buildAuditFindings = (trailer) => {
     const findingClass = stringField(finding, "finding_class");
     const severity = stringField(finding, "severity");
     if (findingClass === void 0 || severity === void 0) continue;
+    if (!isValidFindingClass(findingClass)) continue;
     invocations.push({
       args: [
         "--pr-number",

--- a/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
@@ -281,6 +281,31 @@ jobs:
             stamp helper. After the audit and stamp, post a single PR comment
             summarizing findings (and whether self-heal commits were pushed).
 
+            FINDINGS BLOCK: append a machine-readable findings block to the END
+            of that same PR comment, after the human-readable summary. The block
+            is a JSON object wrapped INSIDE an HTML comment so it does not render,
+            framed by two stable sentinel lines. The cross-machine tally pass
+            parses it; the sentinels are the parse anchors, emit them verbatim:
+
+            <!-- gaia-harden:findings:start -->
+            <!--
+            {"schema":1,"pr_number":PR_NUMBER,"auditor":"ci","findings":[
+              {"finding_class":"react-doctor/no-generic-handler-names","severity":"warning","area_tags":["app/components"]},
+              {"finding_class":"holistic/missing-auth-check","severity":"error","area_tags":["app/routes"]}
+            ]}
+            -->
+            <!-- gaia-harden:findings:end -->
+
+            Substitute PR_NUMBER with this PR's number. One object per finding you
+            assigned a stable `finding_class`, using the per-bucket convention in
+            `.claude/agents/code-review-audit.md` (oracle ids verbatim with the
+            tool prefix; the controlled holistic/rule vocabulary otherwise). Carry
+            only `finding_class`, `severity` (error/warning/suggestion), and
+            `area_tags` per finding, never code or file contents. Omit any finding
+            with no stable class (it stays in the prose summary). If you classified
+            zero findings, still emit the block with `"findings":[]`, an explicit
+            empty block is parseable, a missing one is ambiguous.
+
             SELF-HEAL CONSTRAINTS: read before making any edits:
             1. Run `git diff --name-only origin/main...HEAD` first. Self-heal edits
                are ONLY permitted on files that appear in this list. Never edit a


### PR DESCRIPTION
Follow-up to #321 (SPEC-004 Policy-Memory Loop).

The merged feature added the `harden-tally` and `harden-ledger` CLI subcommands in `src/`, but the committed bundled binary `.gaia/cli/gaia` was stale and did not contain them, so `check-updates.sh` could not invoke `harden-tally` and the statusline nudge never fired.

This regenerates the build artifacts from the merged source via `pnpm --dir .gaia/cli bundle`:
- `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer` (esbuild bundles)
- `.gaia/cli/templates/workflows/code-review-audit.yml.tmpl` (bundled copy synced to the source template's machine-readable findings block)

No source changes; artifacts only.

Smoke-tested:
- `gaia harden-ledger list` → `{"version":1,"declines":[]}` (exit 0)
- `gaia harden-tally --help` → usage (exit 0)
- bundled template byte-identical to `src/automation/templates/workflows/code-review-audit.yml.tmpl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)