### PR TITLE
wiki: sync through 971b9e0 + hot cache for Policy-Memory Loop

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "6bf37e8ad60e0aef9989275120ce69c3d69d12a9",
-  "last_evaluated_at": "2026-06-05T04:30:16.219Z",
+  "last_evaluated_sha": "971b9e06f7630afce08e26fddc7c7d0309325f73",
+  "last_evaluated_at": "2026-06-05T13:22:15Z",
   "last_consolidated_sha": "e022c9da2466063c3c8e1e510b96364e07d1f69c",
   "last_consolidated_at": "2026-06-03T17:05:28Z"
 }

--- a/wiki/concepts/Code Review Audit Agent.md
+++ b/wiki/concepts/Code Review Audit Agent.md
@@ -55,6 +55,14 @@ To swap a library: remove its extension file, add one for the replacement. The m
 | `react-i18next.md`   | `react-i18next`      |
 | `form-components.md` | GAIA Form Components |
 
+## Finding emission
+
+After the human-readable report, the agent appends a machine-readable telemetry trailer as the last fenced `---` block of its Task return. The PostToolUse Task hook parses this block; `findings_json` carries one entry per eligible finding with `finding_class`, `severity`, and `area_tags`. The cross-machine tally in [[Policy-Memory Loop]] reads these findings (plus the identical CI findings block written to the PR comment) when computing recurring-finding candidates.
+
+`finding_class` follows a per-bucket convention: oracle buckets use the tool's own id prefixed (`react-doctor/...`, `axe/...`, `knip/...`, `cve/...`); holistic and rule-subagent buckets draw from a constrained vocabulary seeded in the agent definition. A finding with no stable class is omitted from the trailer but may still appear in the prose report.
+
+The CI workflow appends the same structured findings as an HTML-comment block at the end of its PR comment (framed by `<!-- gaia-harden:findings:start -->` / `<!-- gaia-harden:findings:end -->` sentinel lines), so the tally can read findings from both local and CI runs via `gh`.
+
 ## Trigger
 
 Always before `gh pr merge` ([[PR Merge Workflow]]), enforced by the `pr-merge-audit-check.sh` advisory hook ([[Claude Hooks]]). Also on demand for any review.

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Release Workflow
 status: active
 created: 2026-04-22
-updated: 2026-05-12
+updated: 2026-06-05
 tags: [release, claude, maintainer, versioning]
 ---
 
@@ -33,7 +33,7 @@ How GAIA cuts a public release. Two surfaces (the template repo (`gaia-react/gai
 
 ## Cutting a release
 
-Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
+Run `/gaia-release` on a clean `main`. The command is a 15-step orchestrator:
 
 1. Verify clean working tree + on `main`.
 2. Verify `wiki/.state.json` is current: either `last_evaluated_sha == HEAD`, or the only drift commits are wiki-sync squash artifacts (subjects starting with `wiki:`). Substantive non-wiki drift STOPs the release; the wiki is stale and would ship out-of-date adopter docs. Maintainer runs `/gaia-wiki sync` first. The `wiki:`-prefix bypass exists because PR squash-merging always rewrites the SHA, so the standard flow (`/gaia-wiki sync` → merge → `/gaia-release`) leaves the state pointer one squash-commit behind even when content is current; without the bypass the gate is unsatisfiable. When a squash orphans `last_evaluated_sha` outright (`reachable:false`), `gaia wiki state` reports a hardcoded `commits_ahead:0`, a silent zero that would hide the un-evaluated window. Preflight catches this: it re-derives the drift over `suggested_base..HEAD` (the newest HEAD-reachable commit at or before `last_evaluated_at`) and applies the same wiki-artifact classification, so an orphaned state still blocks on substantive drift instead of green-lighting on the zero. See [[Wiki Sync]].
@@ -48,6 +48,8 @@ Run `/gaia-release` on a clean `main`. The command is a 13-step orchestrator:
 11. Commit on the release branch: `chore(release): vX.Y.Z`. The pre-commit dance updates `wiki/.state.json`'s `last_evaluated_sha` to the new commit's own SHA via amend, so adopters' state files match their release commit on first scaffold.
 12. Push branch, open PR via `gh`. The release PR is subject to the same CI gate (`Vitest and Playwright`, `Run Chromatic`) and `code-review-audit` merge handshake as any other PR; see [[PR Merge Workflow]]. `gh pr merge --merge --auto` is the normal path: base-branch protection rejects a plain `--merge`, and `--auto` lets GitHub complete the merge once checks pass.
 13. Once the PR shows `MERGED`, pull `main`, tag the merge commit (`v<NEW_VERSION>`), push the tag.
+14. Lockstep `create-gaia` and the website. The website update includes bumping three version constants, invoking the `release-notes` skill to generate the public changelog entry (`<version>.ts`) for the site, and overwriting the GitHub release body with adopter-facing notes rendered from that file via `render-release-md.mjs` (so the GitHub release and the website changelog stay in sync).
+15. Lockstep the docs site (`../docs` sibling checkout): update the sidebar version constant and commit directly to `main`.
 
 The tag push triggers [`release.yml`](../../.github/workflows/release.yml), which produces the scrubbed tarball.
 

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -11,8 +11,19 @@ tags: [meta, cache]
 
 ## Last Updated
 
-2026-06-05. Released as GAIA v1.5.0. Fresh slate.
+2026-06-05. SPEC-004 Policy-Memory Loop shipped (PRs #321, #322 merged to main).
 
 ## Active Threads
 
-- None.
+- None open. The Policy-Memory Loop is live: `code-review-audit` emits a stable
+  `finding_class` per finding (schema-enforced) into its telemetry trailer and the
+  CI PR comment; the TTL refresher tallies classes across the 90-day merged-PR
+  window and raises a `Run /gaia-harden review (N)` statusline nudge at >=3 distinct
+  PRs; `/gaia-harden` judges the lowest-context-weight form (deterministic check /
+  skill / path-scoped prose rule) and drafts on approve, records machine-local
+  declines, or defers, all under human gate; `/gaia-audit` prunes a promoted rule
+  only on obsolescence/redundancy/supersession/duplication, never for non-recurrence.
+  The CLI bundle is rebuilt so `harden-tally` / `harden-ledger` ship in the binary.
+  See [[Policy-Memory Loop]].
+- Open follow-up: widen the holistic/rule finding-class seed vocabulary as real
+  recurrence data shows which classes the agent assigns reliably.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,26 @@ tags: [meta, log]
 
 ## 2026-06-05 | Policy-Memory Loop
 
+- 2026-06-05 971b9e0 SKIP - merge commit (Merge pull request #322)
+- 2026-06-05 f56e872 SKIP - chore: generic chore (code review audit passed)
+- 2026-06-05 5e134db WORTHY - chore(gaia-harden): rebuild CLI bundle; binary rebuild, no wiki update
+- 2026-06-05 6d61404 SKIP - merge commit (Merge pull request #321)
+- 2026-06-05 e2e5d0e WORTHY - fix(gaia-harden): rename result variables in tally.ts; internal refactor, no wiki update
+- 2026-06-05 a5005e8 SKIP - chore: generic chore (code review audit passed)
+- 2026-06-05 16287e7 WORTHY - feat(gaia-harden): /gaia-harden command; created wiki/concepts/Policy-Memory Loop.md (already in wiki)
+- 2026-06-05 5f0e10c WORTHY - feat(gaia-harden): decline ledger + TTL tally; covered by wiki/concepts/Policy-Memory Loop.md (created in same batch)
+- 2026-06-05 837224b WORTHY - feat(gaia-harden): finding-class emission contract + CI findings block -> wiki/concepts/Code Review Audit Agent.md
+- 2026-06-05 389341e SKIP - merge commit (Merge pull request #320)
+- 2026-06-05 a46eeaf WORTHY - fix(gaia-fitness): drop leading '> ' from report card header; wiki/decisions/Claude Integration Fitness.md updated by commit itself
+- 2026-06-05 a155efa WORTHY - feat(gaia-fitness): render-card subcommand; wiki/decisions/Claude Integration Fitness.md updated by commit itself
+- 2026-06-05 b59f0f4 SKIP - merge commit (Merge pull request #319)
+- 2026-06-05 73fcb89 WORTHY - docs(gaia-release): GitHub release body overwrite + Step 15 docs lockstep -> wiki/concepts/Release Workflow.md
+- 2026-06-05 1984425 SKIP - merge commit (Merge pull request #318)
+- 2026-06-05 a2682c6 WORTHY - docs(gaia-release): wire release-notes into website lockstep -> wiki/concepts/Release Workflow.md step count updated to 15
+- 2026-06-05 055b085 SKIP - merge commit (Merge pull request #317)
+- 2026-06-05 9885184 WORTHY - fix(ci): trigger CLI tests on code-review-audit.yml edits; internal CI path-filter fix, no wiki update
+- 2026-06-05 22e2a6d SKIP - merge commit (Merge pull request #316)
+- 2026-06-05 5f793d2 WORTHY - fix(ci): sync code-review-audit install template with live workflow; no wiki page update needed (internal template sync)
 Prune-first self-improvement loop landed: recurring `finding_class` -> TTL tally -> statusline nudge -> `/gaia-harden` judges the form and drafts a path-scoped, provenance-marked rule for approve/decline/defer. `/gaia-audit` prunes promoted rules on obsolescence/redundancy/supersession/duplication only, never for non-recurrence. New concept page `wiki/concepts/Policy-Memory Loop.md`; documents the mentorship boundary (this loop keys finding_class+count / N>=3 / 90-day PR window; the sealed mentorship detector keys area_tag+strength / N>=10 / 30-day window and is never read by the loop).
 
 ## [v1.5.0] 2026-06-05 | Released


### PR DESCRIPTION
Wiki maintenance sync covering merged work through `971b9e0` (SPEC-004 Policy-Memory Loop: PRs #321, #322).

## Changes
- **`wiki/concepts/Code Review Audit Agent.md`** — documents the structured finding emission (stable `finding_class` per finding, telemetry trailer + CI PR-comment block).
- **`wiki/concepts/Release Workflow.md`** — sync touch-ups from the merged range.
- **`wiki/log.md`** — appended sync ledger entries.
- **`wiki/.state.json`** — advanced sync state to `971b9e0`.
- **`wiki/hot.md`** — refreshed the recent-context cache to reflect the Policy-Memory Loop shipping (excluded from the automated sync scope, updated directly).

Generated by `/gaia-wiki sync` plus a hot-cache refresh. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)