### PR TITLE
chore(spec): mark SPEC-004 Policy-Memory Loop shipped

### DIFF
--- a/.gaia/specs.json
+++ b/.gaia/specs.json
@@ -26,7 +26,7 @@
       "id": "SPEC-004",
       "allocated_at": "2026-06-05T08:44:29Z",
       "source": "allocated",
-      "status": "in-progress",
+      "status": "shipped",
       "intent": "GAIA's code-review-audit flags anti-patterns review after review, but each"
     }
   ]


### PR DESCRIPTION
Flips the SPEC-004 registry entry in `.gaia/specs.json` from `in-progress` to `shipped`, matching the SPEC-001/002/003 convention, now that the Policy-Memory Loop has landed (PRs #321, #322) and its wiki is synced (#324).

One-line metadata change; no source or behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)