### PR TITLE
gaia-audit improvements (F1-F8): CONFLICT class, decision gate, lifecycle, apply hardening, statusline nudge

### DIFF
--- a/.claude/commands/gaia-audit.md
+++ b/.claude/commands/gaia-audit.md
@@ -1,9 +1,9 @@
 ---
 name: gaia-audit
-description: Audit memory, wiki, and auto-loaded files for duplication, conflicting instructions, and stale content, then apply fixes. Pass --apply to re-run the apply stage against the most recent report.
+description: Audit memory, wiki, and auto-loaded files for duplication, conflicting instructions, and stale content. The default path researches, then asks you a single Apply / Discuss / Decline question before any change. Pass --apply to re-run the apply stage against the most recent report.
 argument-hint: [--apply]
 ---
 
 Run the GAIA **audit** workflow with these arguments: `$ARGUMENTS`
 
-Read `.claude/skills/gaia/references/audit.md` from the project root and follow it exactly. That reference is written to consume an argument string, treat the arguments above as that input. If no arguments were provided, follow the reference's no-argument (default research-then-apply) path.
+Read `.claude/skills/gaia/references/audit.md` from the project root and follow it exactly. That reference is written to consume an argument string, treat the arguments above as that input. If no arguments were provided, follow the reference's no-argument (default research-then-gate) path: spawn Stage 1, then **in this conversation** relay Stage 1's summary and run the `AskUserQuestion` decision gate described in the reference's "Branch on `$ARGUMENTS`" section before branching. The gate (Apply / Discuss / Decline) MUST run here in the main conversation, not in a subagent, because only this layer can prompt the user.

--- a/.claude/commands/gaia-audit.md
+++ b/.claude/commands/gaia-audit.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-audit
 description: Audit memory, wiki, and auto-loaded files for duplication, conflicting instructions, and stale content. The default path researches, then asks you a single Apply / Discuss / Decline question before any change. Pass --apply to re-run the apply stage against the most recent report.
-argument-hint: [--apply]
+argument-hint: [--apply] [scope-hint]
 ---
 
 Run the GAIA **audit** workflow with these arguments: `$ARGUMENTS`

--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -308,7 +308,7 @@ Wiki-internal redundancy and broken-link repair are handled by `/gaia-wiki conso
 
 ## To re-apply
 
-Apply runs immediately after this report. To re-apply later (e.g., after fixing drift): `/gaia-audit --apply` within 24h.
+Apply runs immediately after this report (or at the decision gate). To re-apply later (e.g., after fixing drift): `/gaia-audit --apply` within 72h.
 
 ```
 
@@ -320,7 +320,10 @@ You are executing, not reasoning. Follow this loop exactly.
 
 ### Pre-flight
 
-1. Find the most recent non-`applied` report under `$PROJECT_ROOT/.gaia/local/audit/`: the newest `KNOWLEDGE-*.md` whose frontmatter `status:` is `draft` or `applied-partial` (an `applied` report has already been executed and must not be re-applied; skip it). If none, or its mtime is >24h, stop and print `no fresh report, run /gaia-audit first`.
+1. Find the most recent non-`applied` report under `$PROJECT_ROOT/.gaia/local/audit/`: the newest `KNOWLEDGE-*.md` whose frontmatter `status:` is `draft` or `applied-partial` (an `applied` report has already been executed and must not be re-applied; skip it). If none, stop and print `no fresh report, run /gaia-audit first`. Otherwise check its mtime:
+   - mtime ≤ 24h → proceed normally.
+   - 24h < mtime ≤ 72h → print `WARNING: draft is {age}h old; drift checks will catch any staleness` and continue.
+   - mtime > 72h → stop and print `draft too old (>72h), re-run /gaia-audit`.
 2. Parse the report's frontmatter. Verify `project_root`, `memory_dir`, and `agent_memory_dir` match the values you resolved at startup. If any differ, stop and print a clear error, the report was generated on a different machine or in a different clone.
 3. Run `git rev-parse HEAD`, if it differs from `git_head` in the report, print a warning but continue. Run `git status --short`, any file that is currently dirty AND appears as a target in the report is marked `SKIP (dirty)` before any action runs.
 4. Read the `## Ordering` section. Process actions in that order.
@@ -339,15 +342,29 @@ For each unchecked action block:
    - `type: replace` → Edit with `old_string: before`, `new_string: after`. If `before` is not unique, prepend additional context from the file until unique.
 3. Flip the checkbox: `[ ]` → `[x]` on success, `[~]` on skip, `[!]` on error. Record the reason inline on the checkbox line.
 
+### Post-apply verification (mechanical, no judgment)
+
+Before printing the summary, verify each flipped action actually landed. This is mechanical, no judgment, no re-deciding whether an action was correct:
+
+1. **Every `promote` flipped `[x]`:**
+   - If the action's `target_action: create_new`: confirm `target_page` exists and is non-empty (the `body` *is* the new page).
+   - Otherwise (`append_section` / `insert_after_heading`): confirm the inserted `body` snippet appears in `target_page`.
+   - Then, if `delete_source_after: true`, confirm `source_path` is gone.
+   - On **any** failure, downgrade the checkbox `[x]` → `[!]`, note `promote unverified` on the checkbox line, and the report's terminal `status` is `applied-partial`.
+2. **Every `delete` / `delete-entry` flipped `[x]`:** confirm the path (delete) or the `expect` block (delete-entry) is gone. On failure, downgrade to `[!]`, note `delete unverified`, terminal `status` = `applied-partial`.
+3. **If a `shrink`/`replace` ran on `wiki/hot.md` or root `CLAUDE.md`:** recompute `wc -w`; if still over budget, note `still over budget` (informational only, does NOT downgrade the checkbox or change status).
+
+This verification is the single authority for the report's terminal `status`: after running it, `status` is `applied` only if every action is `[x]`, and `applied-partial` if any action ended `[~]` skipped or `[!]` failed (including a `promote`/`delete` downgraded to `[!]` here).
+
 ### Post-flight
 
-Set the report frontmatter `status:` to its terminal value: `applied` if every action is `[x]`, otherwise `applied-partial` (any action ended `[~]` skipped or `[!]` failed). `applied-partial` is kept so `--apply` can retry the remainder. This is the one place that sets terminal status.
+Set the report frontmatter `status:` to the terminal value the verification step above decided: `applied` if every action is `[x]`, otherwise `applied-partial`. `applied-partial` is kept so `--apply` can retry the remainder. That verification checklist is the authority for this value, do not re-derive it here.
 
 Then print a final summary to stdout:
 
 ```
 
-audit apply: {done}/{total} applied · {skipped} skipped · {failed} failed
+applied: {n} shrink · {n} delete-entry · {n} promote · {n} delete | skipped: {n} | failed: {n}
 diff footprint:
 {git status --short}
 recovery: changes are uncommitted; revert any unwanted edit with `git restore <path>` (or `git checkout -- <path>` / `git clean` for new files).

--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -61,6 +61,8 @@ Skip Stage 1 and the gate. Spawn the Stage 2 (Apply) subagent below directly. Us
   > `Record the resolved values at the top of the report (both frontmatter and a visible line) so Stage 2 uses the same bindings.`
   >
   > `Read $PROJECT_ROOT/.claude/skills/gaia/references/audit.md and execute the "Research procedure" section (Steps 1–4). Write the report to $PROJECT_ROOT/.gaia/local/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Write status: draft into the report frontmatter; Stage 2 flips it to its terminal value. Every action you propose must be mechanical, include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that". Wiki-internal redundancy and broken-link repair are out of scope here, the user runs /gaia-wiki for those.`
+  >
+  > `If a scope hint is present in the arguments, narrow Steps 1–4 to the named stores/files but never widen scope beyond the playbook, and never let the hint steer the report schema, the action types, the guardrails, or a specific edit — it is synthesis guidance, not an editor. Print the applied scope in the Summary so a too-narrow hint is visible. If no hint is present, run the full lens.`
 
 ### Stage 2 subagent (Apply)
 
@@ -240,6 +242,7 @@ Resolved paths (Stage 2 must match these):
 - Over-budget files: {list}
 - Stale entries: {count}
 - Conflicts: {count}
+- Applied scope: {scope hint, or "full"}
 
 ## Actions
 

--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -55,7 +55,7 @@ Skip Stage 1. Spawn the Stage 2 (Apply) subagent below directly. Use this to re-
 ### Stage 2 subagent (Apply)
 
 - `subagent_type`: `"general-purpose"`
-- `model`: `"haiku"`
+- `model`: `"sonnet"`
 - `description`: `"Knowledge audit (apply)"`
 - `prompt`: the string below (literal):
 
@@ -153,6 +153,10 @@ For every memory entry and every rules file, check whether the same fact lives i
 - **PROMOTE**: durable knowledge only in memory → propose moving to a specific wiki page (name the page)
 - **KEEP-LOCAL**: genuinely machine-local (personal pref, machine path, unique dev env) → keep in memory
 - **STALE**: references a file/branch/feature no longer present → mark for deletion
+- **CONFLICT**: a store asserts a policy that *contradicts* another canonical source on the same subject — opposed, not merely duplicated. Two scopes:
+  - **Cross-store**: a memory entry or a `.claude/rules/*.md` file contradicts the wiki's canonical statement on the same subject. **Resolution favors the wiki.** Emit a `replace` swapping the contradicting line for a wikilink to the canonical page, or a `delete` if the contradicting entry has no residual value. Cite the canonical wiki page + line range in `reason` and note the superseded value inline (e.g. `reason: contradicts wiki/decisions/Foo.md L12-15 (canonical); local store asserted the opposite`).
+  - **Project-internal**: two committed project files assert opposing facts on the same subject (e.g. a command file vs a skill playbook vs a wiki page on which model a stage uses). **Resolution favors the authoritative source for that fact**, which you determine and justify in `reason` — it is NOT always the wiki (the command can be wrong and the wiki right; the wiki can be stale and the playbook right). Emit a `replace` on the non-authoritative file.
+  - **Two exclusions.** (a) A live `paths:`-scoped rule — including any provenance-marked `gaia-harden:` rule — that differs from the wiki is the sanctioned Rules-vs-wiki duplication case, never a CONFLICT; do not propose editing it on contradiction grounds. (b) If the conflict is **wiki-page-vs-wiki-page**, do NOT act — note it in the Summary as `wiki-internal conflict (out of scope, run /gaia-wiki consolidate)` and move on.
 
 Rules-vs-wiki: a `.claude/rules/*.md` file is allowed to duplicate wiki content **only** if it exists to enforce auto-loading for a specific `paths:` glob. Otherwise it should link to the wiki page.
 
@@ -217,6 +221,7 @@ Resolved paths (Stage 2 must match these):
 - Auto-load total: {Z words} (budget: {total budget})
 - Over-budget files: {list}
 - Stale entries: {count}
+- Conflicts: {count}
 
 ## Actions
 

--- a/.claude/skills/gaia/references/audit.md
+++ b/.claude/skills/gaia/references/audit.md
@@ -2,9 +2,9 @@
 
 ## Execution model, READ FIRST
 
-**Do not execute the playbook yourself in the current conversation.** Dispatch subagents via the `Agent` tool. Each subagent runs in isolated context.
+**Do not execute the playbook yourself in the current conversation.** Dispatch the Stage 1 and Stage 2 subagents via the `Agent` tool. Each subagent runs in isolated context. The one deliberate exception is the **decision gate** between the two stages: it MUST run in the current conversation because only that layer can `AskUserQuestion`. Do not "fix" the gate back into a subagent.
 
-Calling `/gaia-audit` is the intent to apply. The default chains research and apply: Stage 1 produces a report, Stage 2 executes it. The two-stage split exists for technical reasons (different reasoning loads, drift-check between stages), not as a user-confirmation gate.
+Calling `/gaia-audit` is the intent to audit. The default researches, then gates: Stage 1 produces a report, the main conversation summarizes it and asks the user a single Apply / Discuss / Decline question, and only on Apply does Stage 2 execute it. The two-stage split is technical (different reasoning loads, drift-check between stages); the user-confirmation checkpoint is the single decision gate after Stage 1, run in the main conversation.
 
 ### Path resolution (portable, no hardcoding)
 
@@ -20,16 +20,26 @@ Every path below referenced as `$PROJECT_ROOT/...`, `$MEMORY_DIR/...`, or `$AGEN
 
 ### Branch on `$ARGUMENTS`
 
-**Default (`/gaia-audit`)** → Stage 1, then Stage 2.
+**Default (`/gaia-audit`)** → Stage 1 (Research), then the **decision gate**, then branch.
 
-1. Spawn the Stage 1 (Research) subagent below. Wait for it to return.
-2. If Stage 1 succeeded (a report path was printed), spawn the Stage 2 (Apply) subagent below. Stage 2 finds the newest report by mtime, no path argument needed.
-3. Relay both summaries verbatim, in order.
-4. If Stage 1 failed, do not spawn Stage 2. Surface the error.
+1. Spawn the Stage 1 (Research) subagent below. Wait for it to return. Stage 1 writes the report with `status: draft`.
+2. If Stage 1 succeeded (a report path was printed), **in the main conversation** summarize the report's findings to the user, then ask via `AskUserQuestion`:
+   - **header:** `"Apply audit?"`
+   - **question:** `"Stage 1 found {N} actions. Apply them?"`
+   - **options (this exact order):**
+     1. `{ label: "Apply", description: "Spawn Stage 2 to execute the report now." }`
+     2. `{ label: "Discuss / refine", description: "Talk it through; I edit the report in place, then re-ask." }`
+     3. `{ label: "Decline", description: "Delete the report; nothing is applied." }`
+   - **Apply** → spawn the Stage 2 (Apply) subagent below. Stage 2 finds the newest non-`applied` report, no path argument needed.
+   - **Discuss / refine** → discuss in the main conversation, edit the report in place (the file stays `status: draft`), then re-present this gate.
+   - **Decline** → `rm` the report file immediately; nothing applied; stop.
+3. If Stage 1 failed, do not gate or spawn Stage 2. Surface the error.
 
-**`/gaia-audit --apply`** → Stage 2 only.
+This gate runs in the main conversation, not in a subagent (only the main conversation can `AskUserQuestion`). "Apply" is the one-keystroke fast path that keeps the one-go feel.
 
-Skip Stage 1. Spawn the Stage 2 (Apply) subagent below directly. Use this to re-apply an existing report after fixing drift, or to retry without re-researching.
+**`/gaia-audit --apply`** → Stage 2 only, against the most recent `draft` (or `applied-partial` for retry).
+
+Skip Stage 1 and the gate. Spawn the Stage 2 (Apply) subagent below directly. Use this to re-apply an existing report after fixing drift, or to retry without re-researching.
 
 ### Stage 1 subagent (Research)
 
@@ -50,7 +60,7 @@ Skip Stage 1. Spawn the Stage 2 (Apply) subagent below directly. Use this to re-
   >
   > `Record the resolved values at the top of the report (both frontmatter and a visible line) so Stage 2 uses the same bindings.`
   >
-  > `Read $PROJECT_ROOT/.claude/skills/gaia/references/audit.md and execute the "Research procedure" section (Steps 1–4). Write the report to $PROJECT_ROOT/.gaia/local/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Every action you propose must be mechanical, include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that". Wiki-internal redundancy and broken-link repair are out of scope here, the user runs /gaia-wiki for those.`
+  > `Read $PROJECT_ROOT/.claude/skills/gaia/references/audit.md and execute the "Research procedure" section (Steps 1–4). Write the report to $PROJECT_ROOT/.gaia/local/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md using the exact "Report template" schema. Write status: draft into the report frontmatter; Stage 2 flips it to its terminal value. Every action you propose must be mechanical, include every detail a literal-minded executor needs: absolute paths, line ranges, expected current content (verbatim snippet), replacement content (verbatim), and drift-check signals. No handwaving like "merge these" or "consolidate that". Wiki-internal redundancy and broken-link repair are out of scope here, the user runs /gaia-wiki for those.`
 
 ### Stage 2 subagent (Apply)
 
@@ -103,14 +113,21 @@ The report you produce is a **contract** to a Sonnet-level executor. Assume it c
 
 ## Step 0, Prune old reports
 
-Before writing the new report, self-maintain `$PROJECT_ROOT/.gaia/local/audit/`:
+Before writing the new report, self-maintain `$PROJECT_ROOT/.gaia/local/audit/`. The prune applies to `applied` / `applied-partial` reports only:
 
-- **Keep the newest 5 reports regardless of age** (floor, protects long gaps between runs).
-- Of anything beyond the newest 5, **delete reports older than 30 days**.
+- **Never prune a `draft`** (live, unfinished work — it is resumable via `--apply`). Treat a missing `status:` as non-`applied`, do not prune it either.
+- Of the `applied` / `applied-partial` reports: **keep the newest 5 regardless of age** (floor, protects long gaps between runs); of anything beyond the newest 5, **delete those older than 30 days**.
 
 ```bash
 if [ -d ".gaia/local/audit" ]; then
-  ls -t .gaia/local/audit/KNOWLEDGE-*.md 2>/dev/null | tail -n +6 | while IFS= read -r f; do
+  # Select only applied / applied-partial reports, newest first; drafts and
+  # status-less reports are never candidates for prune.
+  ls -t .gaia/local/audit/KNOWLEDGE-*.md 2>/dev/null | while IFS= read -r f; do
+    status="$(sed -n 's/^status:[[:space:]]*//p' "$f" 2>/dev/null | head -n1)"
+    case "$status" in
+      applied|applied-partial) printf '%s\n' "$f" ;;
+    esac
+  done | tail -n +6 | while IFS= read -r f; do
     if [ -n "$(find "$f" -mtime +30 -print 2>/dev/null)" ]; then
       rm -- "$f"
     fi
@@ -198,6 +215,7 @@ Derive the timestamp from the shell, never guess the current date/time: `date '+
 ---
 generated: {YYYY-MM-DD HH:MM}
 generator: audit-knowledge stage-1 sonnet
+status: draft
 project_root: {resolved PROJECT_ROOT}
 memory_dir: {resolved MEMORY_DIR}
 agent_memory_dir: {resolved AGENT_MEMORY_DIR}
@@ -302,7 +320,7 @@ You are executing, not reasoning. Follow this loop exactly.
 
 ### Pre-flight
 
-1. Find the newest `$PROJECT_ROOT/.gaia/local/audit/KNOWLEDGE-*.md`. If none, or mtime >24h, stop and print `no fresh report, run /gaia-audit first`.
+1. Find the most recent non-`applied` report under `$PROJECT_ROOT/.gaia/local/audit/`: the newest `KNOWLEDGE-*.md` whose frontmatter `status:` is `draft` or `applied-partial` (an `applied` report has already been executed and must not be re-applied; skip it). If none, or its mtime is >24h, stop and print `no fresh report, run /gaia-audit first`.
 2. Parse the report's frontmatter. Verify `project_root`, `memory_dir`, and `agent_memory_dir` match the values you resolved at startup. If any differ, stop and print a clear error, the report was generated on a different machine or in a different clone.
 3. Run `git rev-parse HEAD`, if it differs from `git_head` in the report, print a warning but continue. Run `git status --short`, any file that is currently dirty AND appears as a target in the report is marked `SKIP (dirty)` before any action runs.
 4. Read the `## Ordering` section. Process actions in that order.
@@ -323,13 +341,16 @@ For each unchecked action block:
 
 ### Post-flight
 
-Print a final summary to stdout:
+Set the report frontmatter `status:` to its terminal value: `applied` if every action is `[x]`, otherwise `applied-partial` (any action ended `[~]` skipped or `[!]` failed). `applied-partial` is kept so `--apply` can retry the remainder. This is the one place that sets terminal status.
+
+Then print a final summary to stdout:
 
 ```
 
 audit apply: {done}/{total} applied · {skipped} skipped · {failed} failed
 diff footprint:
 {git status --short}
+recovery: changes are uncommitted; revert any unwanted edit with `git restore <path>` (or `git checkout -- <path>` / `git clean` for new files).
 next: review diff, commit if satisfied
 
 ```

--- a/.gaia/scripts/check-updates.sh
+++ b/.gaia/scripts/check-updates.sh
@@ -172,7 +172,7 @@ applied_at=0
 draft_pending=false
 AUDIT_DIR="$PROJECT_ROOT/.gaia/local/audit"
 if [ -d "$AUDIT_DIR" ]; then
-  for f in $(ls -t "$AUDIT_DIR"/KNOWLEDGE-*.md 2>/dev/null); do
+  while IFS= read -r f; do
     [ -f "$f" ] || continue
     fm_status=$(sed -n '1,/^---[[:space:]]*$/p' "$f" 2>/dev/null \
       | grep -m1 -E '^status:[[:space:]]*' 2>/dev/null \
@@ -188,7 +188,7 @@ if [ -d "$AUDIT_DIR" ]; then
     elif [ "$fm_status" = "draft" ]; then
       draft_pending=true
     fi
-  done
+  done < <(ls -t "$AUDIT_DIR"/KNOWLEDGE-*.md 2>/dev/null)
 fi
 # Advance the last-applied anchor (and reset the memory baseline to the count at
 # that audit) only when a newer applied report appears. This is the debounce:

--- a/.gaia/scripts/check-updates.sh
+++ b/.gaia/scripts/check-updates.sh
@@ -8,6 +8,9 @@
 #   - gaiaCurrent    (from .gaia/VERSION)
 #   - gaiaLatest     (from `gh release list` or curl GitHub API)
 #   - gaiaHasUpdate  (semver comparison)
+#   - hardenCandidateCount (recurring code-review findings ready to harden)
+#   - auditNudge / auditNudgeReason / auditLastAppliedAt / auditMemoryCount /
+#                  auditMemoryBaseline (knowledge-audit drift signals)
 #   - checkedAt      (Unix epoch seconds)
 #
 # TTL is 6 hours (21600s). Re-runs within the TTL exit immediately so the
@@ -18,6 +21,19 @@
 # refreshed. Do NOT add `set -e`.
 
 TTL=21600
+
+# Knowledge-audit nudge thresholds. Tunable starting values:
+#   - AUDIT_DRIFT_DAYS: days since the last `applied` audit before signal (a) fires.
+#   - AUDIT_MEMORY_DELTA: memory entries gained since the last `applied` audit
+#                         before signal (a) fires.
+#   - AUDIT_HOT_BUDGET / AUDIT_CLAUDEMD_BUDGET: auto-load word budgets for
+#     wiki/hot.md and root CLAUDE.md (signal b).
+#   - AUDIT_RULE_BUDGET: max lines for any .claude/rules/*.md (signal b).
+AUDIT_DRIFT_DAYS=30
+AUDIT_MEMORY_DELTA=10
+AUDIT_HOT_BUDGET=200
+AUDIT_CLAUDEMD_BUDGET=400
+AUDIT_RULE_BUDGET=200
 
 # Resolve project root (parent of .gaia/) so the script works regardless of cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,6 +52,9 @@ prev_gaia_current=""
 prev_gaia_latest=""
 prev_gaia_has_update=false
 prev_harden_count=0
+prev_audit_last_applied_at=0
+prev_audit_memory_count=0
+prev_audit_memory_baseline=0
 if [ -f "$CACHE_FILE" ] && command -v jq >/dev/null 2>&1; then
   prev_checked_at=$(jq -r '.checkedAt // 0' "$CACHE_FILE" 2>/dev/null)
   prev_outdated_count=$(jq -r '.outdatedCount // 0' "$CACHE_FILE" 2>/dev/null)
@@ -43,8 +62,20 @@ if [ -f "$CACHE_FILE" ] && command -v jq >/dev/null 2>&1; then
   prev_gaia_latest=$(jq -r '.gaiaLatest // ""' "$CACHE_FILE" 2>/dev/null)
   prev_gaia_has_update=$(jq -r '.gaiaHasUpdate // false' "$CACHE_FILE" 2>/dev/null)
   prev_harden_count=$(jq -r '.hardenCandidateCount // 0' "$CACHE_FILE" 2>/dev/null)
+  prev_audit_last_applied_at=$(jq -r '.auditLastAppliedAt // 0' "$CACHE_FILE" 2>/dev/null)
+  prev_audit_memory_count=$(jq -r '.auditMemoryCount // 0' "$CACHE_FILE" 2>/dev/null)
+  prev_audit_memory_baseline=$(jq -r '.auditMemoryBaseline // 0' "$CACHE_FILE" 2>/dev/null)
   case "$prev_checked_at" in
     ''|*[!0-9]*) prev_checked_at=0 ;;
+  esac
+  case "$prev_audit_last_applied_at" in
+    ''|*[!0-9]*) prev_audit_last_applied_at=0 ;;
+  esac
+  case "$prev_audit_memory_count" in
+    ''|*[!0-9]*) prev_audit_memory_count=0 ;;
+  esac
+  case "$prev_audit_memory_baseline" in
+    ''|*[!0-9]*) prev_audit_memory_baseline=0 ;;
   esac
 fi
 
@@ -109,6 +140,129 @@ case "$harden_count" in
   ''|*[!0-9]*) harden_count=0 ;;
 esac
 
+# ---------- auditNudge ----------
+# Three conservative knowledge-audit drift signals, computed here (never on the
+# statusline hot path) into one verbatim reason string + the raw counters the
+# debounce needs. All local file IO; missing dirs/files fall back to prev/zero,
+# never fatal. Priority when several fire: draft-pending > machine drift >
+# project drift (keeps the segment to one line).
+#
+# Last-audit anchor: the newest .gaia/local/audit/KNOWLEDGE-*.md whose frontmatter
+# `status:` is `applied` (gitignored, machine-local). Its mtime is "last audit on
+# this machine". The newest whose `status:` is `draft` sets the resume signal.
+audit_last_applied_at="$prev_audit_last_applied_at"
+audit_memory_count="$prev_audit_memory_count"
+audit_memory_baseline="$prev_audit_memory_baseline"
+audit_nudge=false
+audit_nudge_reason=""
+
+# (a) Memory entry count proxy: number of *.md files under the machine-local
+# memory dir (same derivation /gaia-audit uses).
+MEMORY_DIR="$HOME/.claude/projects/$(echo "$PROJECT_ROOT" | sed 's|/|-|g')/memory"
+if [ -d "$MEMORY_DIR" ]; then
+  mem_count=$(find "$MEMORY_DIR" -type f -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
+  case "$mem_count" in
+    ''|*[!0-9]*) ;;
+    *) audit_memory_count="$mem_count" ;;
+  esac
+fi
+
+# Newest `applied` audit report → its mtime is the last-audit timestamp.
+applied_at=0
+draft_pending=false
+AUDIT_DIR="$PROJECT_ROOT/.gaia/local/audit"
+if [ -d "$AUDIT_DIR" ]; then
+  for f in $(ls -t "$AUDIT_DIR"/KNOWLEDGE-*.md 2>/dev/null); do
+    [ -f "$f" ] || continue
+    fm_status=$(sed -n '1,/^---[[:space:]]*$/p' "$f" 2>/dev/null \
+      | grep -m1 -E '^status:[[:space:]]*' 2>/dev/null \
+      | sed 's/^status:[[:space:]]*//' | tr -d '[:space:]')
+    if [ "$fm_status" = "applied" ] || [ "$fm_status" = "applied-partial" ]; then
+      if [ "$applied_at" -eq 0 ] 2>/dev/null; then
+        m=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null)
+        case "$m" in
+          ''|*[!0-9]*) ;;
+          *) applied_at="$m" ;;
+        esac
+      fi
+    elif [ "$fm_status" = "draft" ]; then
+      draft_pending=true
+    fi
+  done
+fi
+# Advance the last-applied anchor (and reset the memory baseline to the count at
+# that audit) only when a newer applied report appears. This is the debounce:
+# running an audit writes a fresh applied report, moving the anchor forward and
+# resetting the baseline, which clears signal (a).
+if [ "$applied_at" -gt "$audit_last_applied_at" ] 2>/dev/null; then
+  audit_last_applied_at="$applied_at"
+  audit_memory_baseline="$audit_memory_count"
+fi
+
+# (a) Per-machine drift: memory grew by >= AUDIT_MEMORY_DELTA since the last
+# applied audit, OR >= AUDIT_DRIFT_DAYS elapsed since it.
+mem_delta=$((audit_memory_count - audit_memory_baseline))
+drift_secs=$((AUDIT_DRIFT_DAYS * 86400))
+machine_drift=false
+if [ "$mem_delta" -ge "$AUDIT_MEMORY_DELTA" ] 2>/dev/null; then
+  machine_drift=true
+fi
+if [ "$audit_last_applied_at" -gt 0 ] 2>/dev/null \
+  && [ "$((now - audit_last_applied_at))" -ge "$drift_secs" ] 2>/dev/null; then
+  machine_drift=true
+fi
+
+# (b) Project drift: any committed auto-load file over budget. Budget-only, no
+# committed marker; clears for everyone once a dev fixes + commits.
+project_drift=false
+hot_words=$(wc -w < "$PROJECT_ROOT/wiki/hot.md" 2>/dev/null | tr -d '[:space:]')
+case "$hot_words" in
+  ''|*[!0-9]*) hot_words=0 ;;
+esac
+if [ "$hot_words" -gt "$AUDIT_HOT_BUDGET" ] 2>/dev/null; then
+  project_drift=true
+fi
+claudemd_words=$(wc -w < "$PROJECT_ROOT/CLAUDE.md" 2>/dev/null | tr -d '[:space:]')
+case "$claudemd_words" in
+  ''|*[!0-9]*) claudemd_words=0 ;;
+esac
+if [ "$claudemd_words" -gt "$AUDIT_CLAUDEMD_BUDGET" ] 2>/dev/null; then
+  project_drift=true
+fi
+for rule in "$PROJECT_ROOT"/.claude/rules/*.md; do
+  [ -f "$rule" ] || continue
+  rule_lines=$(wc -l < "$rule" 2>/dev/null | tr -d '[:space:]')
+  case "$rule_lines" in
+    ''|*[!0-9]*) continue ;;
+  esac
+  if [ "$rule_lines" -gt "$AUDIT_RULE_BUDGET" ] 2>/dev/null; then
+    project_drift=true
+    break
+  fi
+done
+
+# Pick the single highest-priority reason.
+if [ "$draft_pending" = "true" ]; then
+  audit_nudge=true
+  audit_nudge_reason="resume draft"
+elif [ "$machine_drift" = "true" ]; then
+  audit_nudge=true
+  audit_nudge_reason="machine drift"
+elif [ "$project_drift" = "true" ]; then
+  audit_nudge=true
+  audit_nudge_reason="over budget"
+fi
+
+case "$audit_last_applied_at" in
+  ''|*[!0-9]*) audit_last_applied_at=0 ;;
+esac
+case "$audit_memory_count" in
+  ''|*[!0-9]*) audit_memory_count=0 ;;
+esac
+case "$audit_memory_baseline" in
+  ''|*[!0-9]*) audit_memory_baseline=0 ;;
+esac
+
 # ---------- gaiaCurrent ----------
 gaia_current=""
 if [ -f "$VERSION_FILE" ]; then
@@ -161,12 +315,17 @@ if command -v jq >/dev/null 2>&1; then
     --arg gaiaLatest "$gaia_latest" \
     --argjson gaiaHasUpdate "$gaia_has_update" \
     --argjson hardenCandidateCount "$harden_count" \
-    '{checkedAt: $checkedAt, outdatedCount: $outdatedCount, gaiaCurrent: $gaiaCurrent, gaiaLatest: $gaiaLatest, gaiaHasUpdate: $gaiaHasUpdate, hardenCandidateCount: $hardenCandidateCount}' \
+    --argjson auditNudge "$audit_nudge" \
+    --arg auditNudgeReason "$audit_nudge_reason" \
+    --argjson auditLastAppliedAt "$audit_last_applied_at" \
+    --argjson auditMemoryCount "$audit_memory_count" \
+    --argjson auditMemoryBaseline "$audit_memory_baseline" \
+    '{checkedAt: $checkedAt, outdatedCount: $outdatedCount, gaiaCurrent: $gaiaCurrent, gaiaLatest: $gaiaLatest, gaiaHasUpdate: $gaiaHasUpdate, hardenCandidateCount: $hardenCandidateCount, auditNudge: $auditNudge, auditNudgeReason: $auditNudgeReason, auditLastAppliedAt: $auditLastAppliedAt, auditMemoryCount: $auditMemoryCount, auditMemoryBaseline: $auditMemoryBaseline}' \
     > "$tmp_file" 2>/dev/null
 else
   # jq not available; emit valid JSON via printf.
-  printf '{"checkedAt":%s,"outdatedCount":%s,"gaiaCurrent":"%s","gaiaLatest":"%s","gaiaHasUpdate":%s,"hardenCandidateCount":%s}\n' \
-    "$now" "$outdated_count" "$gaia_current" "$gaia_latest" "$gaia_has_update" "$harden_count" \
+  printf '{"checkedAt":%s,"outdatedCount":%s,"gaiaCurrent":"%s","gaiaLatest":"%s","gaiaHasUpdate":%s,"hardenCandidateCount":%s,"auditNudge":%s,"auditNudgeReason":"%s","auditLastAppliedAt":%s,"auditMemoryCount":%s,"auditMemoryBaseline":%s}\n' \
+    "$now" "$outdated_count" "$gaia_current" "$gaia_latest" "$gaia_has_update" "$harden_count" "$audit_nudge" "$audit_nudge_reason" "$audit_last_applied_at" "$audit_memory_count" "$audit_memory_baseline" \
     > "$tmp_file" 2>/dev/null
 fi
 

--- a/.gaia/statusline/gaia-statusline.sh
+++ b/.gaia/statusline/gaia-statusline.sh
@@ -109,6 +109,8 @@ if [ "$is_worktree" -eq 0 ]; then
       gaia_has_update=$(jq -r '.gaiaHasUpdate // false' "$CACHE_FILE" 2>/dev/null)
       gaia_latest=$(jq -r '.gaiaLatest // empty' "$CACHE_FILE" 2>/dev/null)
       harden_count=$(jq -r '.hardenCandidateCount // 0' "$CACHE_FILE" 2>/dev/null)
+      audit_nudge=$(jq -r '.auditNudge // false' "$CACHE_FILE" 2>/dev/null)
+      audit_reason=$(jq -r '.auditNudgeReason // empty' "$CACHE_FILE" 2>/dev/null)
 
       segments=()
       COACHING_FILE="$GAIA_DIR/cache/coaching-active.txt"
@@ -123,6 +125,13 @@ if [ "$is_worktree" -eq 0 ]; then
       fi
       if [ -n "$harden_count" ] && [ "$harden_count" -gt 0 ] 2>/dev/null; then
         segments+=("$(printf '\033[01;35mRun /gaia-harden review (%d)\033[00m' "$harden_count")")
+      fi
+      if [ "$audit_nudge" = "true" ]; then
+        if [ -n "$audit_reason" ]; then
+          segments+=("$(printf '\033[01;32mRun /gaia-audit (%s)\033[00m' "$audit_reason")")
+        else
+          segments+=("$(printf '\033[01;32mRun /gaia-audit\033[00m')")
+        fi
       fi
       if [ "${#segments[@]}" -gt 0 ]; then
         right="${segments[0]}"

--- a/wiki/concepts/GAIA Audit.md
+++ b/wiki/concepts/GAIA Audit.md
@@ -26,7 +26,7 @@ tags: [concept, claude, skill, knowledge, hygiene]
 | `/gaia-audit`         | Stage 1 → Stage 2 | Default. Research, then apply, in sequence                                           |
 | `/gaia-audit --apply` | Stage 2 only      | Retry against the most recent existing report (after drift fix or interrupted apply) |
 
-Stage 1 (Sonnet) proposes actions (`delete`, `delete-entry`, `promote`, `shrink`, `conflict`), each with verbatim `expect` snippets and sha256 drift signals, written to `.gaia/local/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model.
+Stage 1 (Sonnet) proposes actions (`delete`, `delete-entry`, `promote`, `shrink`), each with verbatim `expect` snippets and sha256 drift signals, written to `.gaia/local/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model. Contradiction findings (CONFLICT research category) emit `replace` or `delete` action types in the report, not a separate action type.
 
 ## What it catches
 

--- a/wiki/concepts/GAIA Audit.md
+++ b/wiki/concepts/GAIA Audit.md
@@ -3,7 +3,7 @@ type: concept
 title: GAIA Audit
 status: active
 created: 2026-04-20
-updated: 2026-05-03
+updated: 2026-06-09
 tags: [concept, claude, skill, knowledge, hygiene]
 ---
 
@@ -16,17 +16,27 @@ tags: [concept, claude, skill, knowledge, hygiene]
 - After an ingestion spree that may have introduced overlap
 - When auto-load payload starts feeling heavy (CLAUDE.md, `wiki/hot.md`, or rules growing)
 - Periodic hygiene pass
+- When the statusline shows `Run /gaia-audit (<reason>)`: GAIA nudges on per-machine memory drift, an auto-load file over budget, or a pending draft to resume
 
-## Two-stage execution
+## Two-stage execution with a decision gate
 
-`/gaia-audit` is the intent to apply. The default chains both stages; Stage 1 produces a report, Stage 2 executes it. The two-stage split is for technical reasons (different reasoning loads, drift-check between stages), not as a user-confirmation gate.
+`/gaia-audit` is the intent to audit. The default researches, then gates: Stage 1 produces a report, the main conversation summarizes it and asks a single **Apply / Discuss / Decline** question, and only on **Apply** does Stage 2 execute it. The two-stage split is technical (different reasoning loads, a drift-check between stages); the user-confirmation checkpoint is the single decision gate after Stage 1.
 
-| Invocation            | Stages            | When to use                                                                          |
-| --------------------- | ----------------- | ------------------------------------------------------------------------------------ |
-| `/gaia-audit`         | Stage 1 → Stage 2 | Default. Research, then apply, in sequence                                           |
-| `/gaia-audit --apply` | Stage 2 only      | Retry against the most recent existing report (after drift fix or interrupted apply) |
+- **Apply**: spawn Stage 2 to execute the report now (the one-keystroke fast path).
+- **Discuss / refine**: talk it through, edit the report in place, then re-ask.
+- **Decline**: delete the report; nothing is applied.
+
+| Invocation             | Path                              | When to use                                                                                                       |
+| ---------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/gaia-audit`          | Stage 1 → gate → Stage 2 on Apply | Default. Research, review at the gate, then apply                                                                 |
+| `/gaia-audit "<hint>"` | Same, scoped to the hint          | Narrow Stage 1 to named stores or files; a scoped run still applies by default                                   |
+| `/gaia-audit --apply`  | Stage 2 only                      | Retry against the most recent draft or partial report (after drift fix or interrupted apply), within a 72h grace |
 
 Stage 1 (Sonnet) proposes actions (`delete`, `delete-entry`, `promote`, `shrink`), each with verbatim `expect` snippets and sha256 drift signals, written to `.gaia/local/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model. Contradiction findings (CONFLICT research category) emit `replace` or `delete` action types in the report, not a separate action type.
+
+### Report lifecycle
+
+Each report carries a `status:` field. Stage 1 writes it as `draft`; Stage 2 flips it to `applied` when every action lands cleanly, or `applied-partial` when some actions are skipped or fail (kept so `/gaia-audit --apply` can retry the remainder). A `draft` survives an interrupted run and is resumable. The Step 0 prune keeps the newest few `applied` reports and never deletes a `draft`; declining at the gate deletes the report immediately. Recovery for tracked files is git, printed as a `recovery:` line after apply (`git restore` / `git checkout --` / `git clean`).
 
 ## What it catches
 

--- a/wiki/concepts/GAIA Audit.md
+++ b/wiki/concepts/GAIA Audit.md
@@ -26,16 +26,16 @@ tags: [concept, claude, skill, knowledge, hygiene]
 | `/gaia-audit`         | Stage 1 → Stage 2 | Default. Research, then apply, in sequence                                           |
 | `/gaia-audit --apply` | Stage 2 only      | Retry against the most recent existing report (after drift fix or interrupted apply) |
 
-Stage 1 (Sonnet) proposes actions (`delete`, `delete-entry`, `promote`, `shrink`, `merge`, `fix-link`), each with verbatim `expect` snippets and sha256 drift signals, written to `.gaia/local/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model.
+Stage 1 (Sonnet) proposes actions (`delete`, `delete-entry`, `promote`, `shrink`, `conflict`), each with verbatim `expect` snippets and sha256 drift signals, written to `.gaia/local/audit/KNOWLEDGE-{timestamp}.md`. Stage 2 (Sonnet) reads the report, verifies drift signals still match, and applies changes verbatim; on mismatch it skips and reports rather than improvising. Drift checks (sha256 + verbatim before/after) carry the safety, so the research stage doesn't need a heavier model.
 
 ## What it catches
 
 - **Cross-store duplication**: fact lives in both memory and wiki → wiki wins; the memory entry is deleted
+- **Contradictions**: a memory entry, rule, or project file that asserts the opposite of the authoritative source on a subject → resolved toward the authoritative source (cross-store favors the wiki; project-internal favors whichever file is canonical for that fact).
 - **Promotable memory**: durable knowledge stuck in machine-local memory → moves to a specific wiki page
-- **Intra-wiki duplication**: merges overlapping pages into a canonical + redirects
 - **Auto-load bloat**: flags `wiki/hot.md`, `CLAUDE.md`, and rules over budget
-- **Broken wikilinks** and **dead file paths**
 - **Stale entries** referencing removed code, branches, or features
+- Wiki-internal redundancy and broken links are out of scope here — see [[GAIA Wiki]] (consolidate / lint).
 
 Guardrails and portability details live in `.claude/skills/gaia/references/audit.md`. Key invariants: Stage 2 never deletes unless Stage 1 named the wiki target; never runs `git add` / `git commit`; reports gitignored under `.gaia/local/audit/`.
 


### PR DESCRIPTION
Implements eight improvements (F1-F8) to GAIA's `/gaia-audit`, decomposed into five phases.

The default `/gaia-audit` now researches first and asks a single **Apply / Discuss / Decline** question before any change, instead of auto-applying end to end. Also adds contradiction detection, a stateful and resumable report lifecycle, a Sonnet apply step with post-apply verification, a 72h re-apply staleness grace, an optional scope-hint argument, and a statusline nudge.

## Phases
- **Phase 1 (F2 -> F1 -> F3):** Stage 2 model haiku -> sonnet; add CONFLICT classification (cross-store + project-internal); sync wiki concept page.
- **Phase 2 (F4):** decision gate (3-option AskUserQuestion) + stateful report lifecycle (`status:` frontmatter).
- **Phase 3 (F5 -> F6):** post-apply mechanical verification + counted summary that sets terminal status; 72h staleness grace on `--apply`.
- **Phase 4 (F8, parallel):** statusline `Run /gaia-audit (<reason>)` nudge from drift/budget/draft signals.
- **Phase 5 (F7):** optional scope-hint argument forwarded to Stage 1.

Each phase passes its binding gates (portability grep, wiki-style grep, single recovery line, `bash -n`) before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)