### PR TITLE
chore(statusline): reorder update nudges and make gaia-harden label semantic

### DIFF
--- a/.gaia/statusline/gaia-statusline.sh
+++ b/.gaia/statusline/gaia-statusline.sh
@@ -124,7 +124,9 @@ if [ "$is_worktree" -eq 0 ]; then
         segments+=("$(printf '\033[01;33mRun /update-deps (%d outdated)\033[00m' "$outdated_count")")
       fi
       if [ -n "$harden_count" ] && [ "$harden_count" -gt 0 ] 2>/dev/null; then
-        segments+=("$(printf '\033[01;35mRun /gaia-harden\033[00m')")
+        harden_noun="recurring patterns"
+        [ "$harden_count" -eq 1 ] && harden_noun="recurring pattern"
+        segments+=("$(printf '\033[01;35mRun /gaia-harden (%d %s)\033[00m' "$harden_count" "$harden_noun")")
       fi
       if [ "$audit_nudge" = "true" ]; then
         if [ -n "$audit_reason" ]; then

--- a/.gaia/statusline/gaia-statusline.sh
+++ b/.gaia/statusline/gaia-statusline.sh
@@ -117,14 +117,14 @@ if [ "$is_worktree" -eq 0 ]; then
       if [ -f "$COACHING_FILE" ] && [ "$(cat "$COACHING_FILE" 2>/dev/null)" = "1" ]; then
         segments+=("🧭")
       fi
-      if [ -n "$outdated_count" ] && [ "$outdated_count" -gt 0 ] 2>/dev/null; then
-        segments+=("$(printf '\033[01;33mRun /update-deps (%d outdated)\033[00m' "$outdated_count")")
-      fi
       if [ "$gaia_has_update" = "true" ] && [ -n "$gaia_latest" ]; then
         segments+=("$(printf '\033[01;36mRun /update-gaia (GAIA %s available)\033[00m' "$gaia_latest")")
       fi
+      if [ -n "$outdated_count" ] && [ "$outdated_count" -gt 0 ] 2>/dev/null; then
+        segments+=("$(printf '\033[01;33mRun /update-deps (%d outdated)\033[00m' "$outdated_count")")
+      fi
       if [ -n "$harden_count" ] && [ "$harden_count" -gt 0 ] 2>/dev/null; then
-        segments+=("$(printf '\033[01;35mRun /gaia-harden review (%d)\033[00m' "$harden_count")")
+        segments+=("$(printf '\033[01;35mRun /gaia-harden\033[00m')")
       fi
       if [ "$audit_nudge" = "true" ]; then
         if [ -n "$audit_reason" ]; then


### PR DESCRIPTION
## What

Three tweaks to the right-side GAIA statusline indicators (`.gaia/statusline/gaia-statusline.sh`):

1. **Reorder** — `/update-gaia` now appears before `/update-deps`.
2. **Drop the redundant `review` verb** from the gaia-harden nudge — `/gaia-harden` already defaults to the review flow (`harden.md:15-17`), and the parser only tokenizes the first word.
3. **Make the count semantic** — `Run /gaia-harden review (N)` → `Run /gaia-harden (N recurring patterns)` (singular `(1 recurring pattern)`).

## Why

`review (N)` read as if the verb and count were required arguments. The new label names the actual selection criterion: a finding only becomes a candidate after it recurs across >= 3 distinct PRs (`compute-tally.ts:141`), so "recurring patterns" is information, not an arg.

The candidate-count gate (only show when `hardenCandidateCount > 0`) is unchanged, and the count is already in the cache, so no refresher plumbing changed.

## Scope

Shell-only change. No `.ts/.tsx/.js/.css` or gate-affecting config touched, so the Quality Gate has nothing to check. Verified with `bash -n` and a render test of both singular/plural forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)