### PR TITLE
chore(ts): TypeScript 7 readiness — pre-adopt strict flags, drop cruft

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noEmit": true,
+    "noUncheckedSideEffectImports": true,
     "paths": {
       "~/*": ["./app/*"],
       "test/*": ["./test/*"]
@@ -16,6 +15,7 @@
     "resolveJsonModule": true,
     "rootDirs": [".", "./.react-router/types"],
     "skipLibCheck": true,
+    "stableTypeOrdering": true,
     "strict": true,
     "target": "ES2022",
     "types": ["@react-router/node", "vite/client"]

--- a/wiki/decisions/TypeScript 7 Readiness.md
+++ b/wiki/decisions/TypeScript 7 Readiness.md
@@ -1,0 +1,32 @@
+---
+type: decision
+status: active
+priority: 2
+date: 2026-06-09
+created: 2026-06-09
+updated: 2026-06-09
+tags: [decision, typescript, tooling]
+---
+
+# Decision: TypeScript 7 Readiness
+
+`tsconfig.json` tracks the TypeScript 7 strict baseline ahead of the upgrade, so adopting the native compiler (`tsgo`) is a dependency swap rather than a config migration.
+
+## Current posture
+
+- `stableTypeOrdering: true` and `noUncheckedSideEffectImports: true` are enabled under TypeScript 6, matching TS7 defaults.
+- No TS7-removed options are present: no `baseUrl`, no `downlevelIteration`, no `target: es5`, no `moduleResolution: node/classic`, and `esModuleInterop` stays `true`.
+- Baseline is already TS7-shaped: `module: ESNext`, `moduleResolution: Bundler`, `target: ES2022`, `strict: true`, explicit `types`.
+- `tsc` runs typecheck-only (`noEmit`); the bundler emits. TS7's not-yet-shipped emit, watch, and declaration features do not apply.
+
+## What gates the upgrade
+
+The lint stack ([[gaia-lint]] -> typescript-eslint) is the only consumer of TypeScript's programmatic API, which its type-aware rules depend on. TS7 stabilizes that API at 7.1, not 7.0. Until 7.1, the native compiler can only run alongside TypeScript 6 as a second toolchain, so the clean single-toolchain swap waits for 7.1.
+
+## resolveJsonModule
+
+Retained even though GAIA imports no JSON. GAIA is a foundation for [[React Router 7]] projects, JSON imports are a first-class Vite pattern, and the option is inert until an import exists. See [[TypeScript Language Files]].
+
+## allowJs
+
+Off. GAIA is strict-TS-first; type-checking JavaScript is an explicit adopter opt-in, not a clone default.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -93,6 +93,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 
 - [[No Component Library]]
 - [[TypeScript Language Files]]
+- [[TypeScript 7 Readiness]]: tsconfig pre-adopts the TS7 strict baseline; the 7.1 upgrade is a dep swap gated on typescript-eslint's programmatic API.
 - [[Thin Routes]]
 - [[Co-located Tests Folder]]
 - [[composeStory Pattern]]


### PR DESCRIPTION
## What

Get GAIA's `tsconfig.json` to the TypeScript 7 strict baseline now, under TS 6, so the eventual native-compiler (`tsgo`) upgrade is a dependency swap rather than a config migration.

## Changes

**`tsconfig.json`**
- **+ `stableTypeOrdering: true`** — TS7 prerequisite (non-overridable in TS7); enabling under TS6 avoids a compound migration.
- **+ `noUncheckedSideEffectImports: true`** — a TS7 default; the one side-effect import (`import './styles/tailwind.css'`) resolves via `vite/client`.
- **− `allowJs`** — 0 `.js`/`.jsx` files in scope; GAIA is strict-TS-first, so JS type-checking is an explicit adopter opt-in, not a clone default.
- **− `forceConsistentCasingInFileNames`** — redundant; TS already defaults it to `true`.
- **`resolveJsonModule` retained** — GAIA imports no JSON, but as a foundation for RR7/Vite projects this is a batteries-included default; the option is inert until an adopter imports a `.json`.

**Wiki**
- New `decisions/TypeScript 7 Readiness` ADR + index entry recording the posture and the 7.1 gate.

## The 7.1 gate

The lint stack (`@gaia-react/lint` → typescript-eslint) is the only consumer of TypeScript's programmatic API, which its type-aware rules depend on. TS7 stabilizes that API at **7.1**, not 7.0 — so a clean single-toolchain swap waits for 7.1. Until then `tsgo` can only run alongside TS6.

## Verification

- `pnpm typecheck` ✅ (clean with both new flags)
- `pnpm lint` ✅ (no autofix churn)
- Runtime steps (tests/E2E/build/dev) not run: these are typecheck-time flags esbuild/Vite never read, so they can't affect runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)