### PR TITLE
chore(deps): upgrade pnpm to 11.5.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-strict-peer-dependencies=false
-save-exact=true
-public-hoist-pattern[]=*stylelint*
-public-hoist-pattern[]=prettier-plugin-*
+# pnpm 11 reads only auth and registry settings from .npmrc. Resolution,
+# hoisting, and supply-chain settings live in pnpm-workspace.yaml. Add private
+# registry / auth lines here if needed; do not re-add resolution flags (pnpm
+# ignores them in this file).

--- a/package.json
+++ b/package.json
@@ -115,24 +115,11 @@
     "vite": "8.0.16",
     "vitest": "4.1.8"
   },
-  "pnpm": {
-    "overrides": {
-      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
-      "qs": ">=6.15.2",
-      "ws@>=8.0.0 <8.20.1": ">=8.20.1"
-    },
-    "onlyBuiltDependencies": [
-      "core-js-pure",
-      "esbuild",
-      "msw",
-      "unrs-resolver"
-    ]
-  },
   "msw": {
     "workerDirectory": "public"
   },
   "engines": {
     "node": ">=22.19.0"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,16 +11,18 @@ trustPolicy: no-downgrade
 
 # Acknowledge known-good packages that trip no-downgrade. Each is an old,
 # pre-provenance release that is the correct, required version for its dependent
-# (both reach us transitively through @gaia-react/lint). A newer MAJOR line later
+# (the requiring package is named per entry below). A newer MAJOR line later
 # added npm provenance, so pnpm reads the older unattested release as a trust
 # downgrade. These are not supply-chain regressions. Scope each exception to the
 # exact version; no-downgrade stays enforced for everything else.
 #   - semver@6.3.1: final 6.x release; required by eslint-plugin-import (^6.3.1)
 #   - eslint-import-resolver-typescript@3.10.1: final 3.x release; required by
 #     eslint-plugin-canonical (^3.7.0)
+#   - chokidar@4.0.3: final 4.x release; required by @react-router/dev (^4.0.0)
 trustPolicyExclude:
   - 'semver@6.3.1'
   - 'eslint-import-resolver-typescript@3.10.1'
+  - 'chokidar@4.0.3'
 
 # Exempt first-party packages from the release-age delay. The 7-day window
 # defends against malicious THIRD-party updates; @gaia-react/lint is authored,
@@ -28,3 +30,33 @@ trustPolicyExclude:
 # community-vetting rationale does not apply.
 minimumReleaseAgeExclude:
   - '@gaia-react/lint'
+
+# Resolution settings. pnpm 11 reads these from pnpm-workspace.yaml, not from
+# .npmrc (which it consults only for auth/registry). publicHoistPattern lifts
+# stylelint's shared config/plugins and prettier plugins to the root
+# node_modules so those tools resolve them; savePrefix '' pins exact versions on
+# `pnpm add`; strictPeerDependencies off keeps peer mismatches as warnings
+# rather than install failures.
+publicHoistPattern:
+  - '*stylelint*'
+  - 'prettier-plugin-*'
+savePrefix: ''
+strictPeerDependencies: false
+
+# Dependency version overrides. pnpm 11 reads these here; the package.json
+# "pnpm" field is no longer honored. Keys use pnpm's parent>child / version-range
+# syntax.
+overrides:
+  'brace-expansion@>=5.0.0 <5.0.6': '>=5.0.6'
+  'qs': '>=6.15.2'
+  'ws@>=8.0.0 <8.20.1': '>=8.20.1'
+
+# Build-script approval. pnpm 11 replaces the onlyBuiltDependencies allowlist
+# with the allowBuilds map (true = the package may run install/build scripts).
+# With strictDepBuilds on by default, an unlisted package that needs to build
+# fails the install loudly instead of silently skipping its scripts.
+allowBuilds:
+  core-js-pure: true
+  esbuild: true
+  msw: true
+  unrs-resolver: true

--- a/wiki/decisions/pnpm.md
+++ b/wiki/decisions/pnpm.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-04-26
 created: 2026-04-26
-updated: 2026-05-01
+updated: 2026-06-10
 tags: [decision, tooling, package-manager, security]
 ---
 
@@ -16,21 +16,20 @@ GAIA uses **pnpm** for installs and dependency resolution. The `packageManager` 
 
 - **Speed**: content-addressed store with hard-linking installs significantly faster than npm.
 - **Strict isolation**: flat `node_modules/` is gone. A package can only `require` what it declared. Phantom deps fail loud.
-- **Built-in supply-chain protection**: `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days), blocking installs of versions less than a week old, plus `trustPolicy: no-downgrade`, which fails the install when a package's trust level drops versus prior releases (possible takeover). The release-age delay catches the bulk of compromised-package incidents in the window between publish and detection.
+- **Built-in supply-chain protection**: `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days), blocking installs of versions less than a week old, plus `trustPolicy: no-downgrade`, which fails the install when a package's trust level drops versus prior releases (possible takeover). The release-age delay catches the bulk of compromised-package incidents in the window between publish and detection. pnpm enforces both policies against the entire lockfile on every install, including `--frozen-lockfile` runs in CI, so a latent pre-provenance transitive surfaces at install time rather than only on re-resolution. `trustPolicyExclude` acknowledges the few old, pre-provenance final-major releases that trip `no-downgrade` because a newer major later added npm provenance; each entry is scoped to an exact version and names its requiring dependent.
 - **Reproducible installs**: `pnpm-lock.yaml` + CI `--frozen-lockfile` guarantees the lockfile is the only source of truth.
 
 ## How
 
 - `package.json` declares `"packageManager": "pnpm@<version>"`.
-- `package.json` declares `"pnpm": { "overrides": { ... } }` using pnpm's `parent>child` syntax (the previous npm `overrides.parent.child` shape does not apply).
-- `.npmrc` carries only what pnpm 10.x+ still reads from it: registry/auth and a few resolution flags: `strict-peer-dependencies=false` (keeps the npm `legacy-peer-deps=true` semantics, so peer-dep mismatches warn instead of erroring), `save-exact=true`, and `public-hoist-pattern[]` entries for tools that need flat resolution (stylelint, prettier plugins).
-- `pnpm-workspace.yaml` carries everything else pnpm reads, including supply-chain hardening; it lives here, not `.npmrc`:
-  ```
-  minimumReleaseAge: 10080
-  trustPolicy: no-downgrade
-  ```
+- `pnpm-workspace.yaml` carries every non-auth setting pnpm reads:
+  - supply-chain hardening: `minimumReleaseAge`, `trustPolicy`, `trustPolicyExclude`, `minimumReleaseAgeExclude`;
+  - dependency `overrides`, using pnpm's `parent>child` / version-range key syntax;
+  - the `allowBuilds` map, which names the packages permitted to run install scripts (`true` = allowed); with `strictDepBuilds` on by default, an unlisted package that needs to build fails the install loudly instead of silently skipping;
+  - resolution flags: `strictPeerDependencies: false` (peer-dep mismatches warn instead of erroring), `savePrefix: ''` (pin exact versions on `pnpm add`), and `publicHoistPattern` (lift stylelint's shared config/plugins and prettier plugins to the root `node_modules` so those tools resolve them).
+- pnpm reads none of the above from the `package.json` `pnpm` field or from `.npmrc`. `.npmrc` carries only registry and auth settings; resolution and supply-chain keys placed there are ignored.
 - `pnpm-lock.yaml` is committed. `package-lock.json` is forbidden: delete on sight.
-- CI workflows install pnpm via `pnpm/action-setup@v4` (which reads `packageManager`), use `cache: 'pnpm'` in `actions/setup-node`, and install with `pnpm install --frozen-lockfile`.
+- CI workflows install pnpm via `pnpm/action-setup` (pinned by commit SHA, no `version:` input, so it reads the `packageManager` field), use `cache: 'pnpm'` in `actions/setup-node`, and install with `pnpm install --frozen-lockfile`. Because the action keys off `packageManager`, bumping that one field moves CI's pnpm version in lockstep.
 - Adopters bootstrap pnpm with `corepack enable pnpm`. `/gaia-init` does this in Step 0 with a `npm install -g pnpm` fallback for environments without corepack.
 
 ## Pinning
@@ -39,7 +38,7 @@ Caret ranges (`^x.y.z`) are kept in `package.json`. The lockfile is the authorit
 
 ## Override audit
 
-Overrides drift. The `update-deps` skill's Phase 0 toggles each `pnpm.overrides` key out, runs `pnpm install`, scans `pnpm ls` for peer-dep errors, and removes any override that is no longer needed. Phase 6 re-checks retained overrides after a wave updates surrounding packages.
+Overrides drift. The `update-deps` skill's Phase 0 toggles each `overrides` key out, runs `pnpm install`, scans `pnpm ls` for peer-dep errors, and removes any override that is no longer needed. Phase 6 re-checks retained overrides after a wave updates surrounding packages.
 
 ## Release-age-aware version selection
 


### PR DESCRIPTION
Upgrades pnpm 10.33.0 -> 11.5.2 (the headline of 1.6.0). Tooling upgrade only; the version bump is deferred to `/gaia-release minor`.

## Changes

- **`packageManager` -> `pnpm@11.5.2`** (corepack). CI's `pnpm/action-setup` reads `packageManager` (no `version:` field), so the toolchain moves in lockstep.
- **Settings migrated into `pnpm-workspace.yaml`** (pnpm 11 reads neither the `package.json` `pnpm` field nor `.npmrc` resolution flags):
  - `overrides` (was `pnpm.overrides`)
  - `allowBuilds` map `{core-js-pure, esbuild, msw, unrs-resolver}` (v11 removed `onlyBuiltDependencies`; `strictDepBuilds` fails the install otherwise)
  - `publicHoistPattern`, `savePrefix: ''`, `strictPeerDependencies: false` (were in `.npmrc`); the `public-hoist-pattern` move is what keeps stylelint resolving its shared config.
- **`chokidar@4.0.3` added to `trustPolicyExclude`**: v11 enforces `trustPolicy: no-downgrade` against the whole lockfile on every install (including `--frozen-lockfile`). chokidar 4.0.3 (final 4.x, via `@react-router/dev`, pre-provenance) trips it; 5.0.0 added provenance. Verified benign, scoped to the exact version.
- Decision recorded in `wiki/decisions/pnpm.md`.

Lockfile unchanged (`lockfileVersion: '9.0'` is v11-compatible).

## Verification

Full quality gate green locally under pnpm 11.5.2: typecheck, lint, unit (120), Playwright (2), build, stylelint. `pnpm install --frozen-lockfile` re-validates the whole tree against the supply-chain policies and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)