### PR TITLE
fix(skills): repoint pnpm-11 override location to pnpm-workspace.yaml

### DIFF
--- a/.claude/instructions/remove-i18n.md
+++ b/.claude/instructions/remove-i18n.md
@@ -309,7 +309,7 @@ Remove these keys from `devDependencies`:
 - `accept-language-parser`
 - `@types/accept-language-parser`
 
-Remove any keys from `pnpm.overrides` whose name starts with `remix-i18next>` (none may exist if overrides is empty `{}`, leave it that way).
+Remove any keys from the `overrides:` map in `pnpm-workspace.yaml` whose name starts with `remix-i18next>` (none may exist if the map is empty, leave it that way).
 
 Then run:
 

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -91,15 +91,15 @@ Spawn a **Haiku agent** (`model: "haiku"`) to run Phases 0–4. Pass it these in
 
 ### Phase 0: Override audit
 
-For each key in `pnpm.overrides` (in `package.json`):
+For each key in the top-level `overrides:` map in `pnpm-workspace.yaml` (pnpm 11 reads overrides here; the `package.json` `pnpm.overrides` field is no longer honored):
 
-1. Temporarily remove that single key from `pnpm.overrides`.
+1. Temporarily remove that single key from the `overrides:` map.
 2. Run `pnpm install`.
 3. Run `pnpm ls 2>&1` and scan for peer-dep errors.
 4. If no errors → override is obsolete. Leave it removed. Note as **removed** in final report.
 5. If errors → restore that key. Note as **retained** in final report.
 
-Operate on one key at a time. Always `pnpm install` after each toggle.
+Operate on one key at a time, leaving every other `pnpm-workspace.yaml` setting untouched. Always `pnpm install` after each toggle.
 
 ### Phase 1: Discover outdated packages
 
@@ -159,7 +159,7 @@ Packages not matched form singleton groups.
 1. Build install args. For each package: if `is_pinned` use exact target, else use `^<latest>`. Example: `pnpm add foo@1.2.3 bar@^4.5.0 ...`.
 2. Run the single `pnpm add` command.
 3. Run `pnpm ls 2>&1`. Scan for peer-dep errors.
-4. On error: try one targeted `pnpm.overrides` fix (e.g. add a `parent>child` pin), then `pnpm install` again.
+4. On error: try one targeted fix in the `overrides:` map in `pnpm-workspace.yaml` (e.g. add a `parent>child` pin), then `pnpm install` again.
 5. If still failing: revert the offending packages (`pnpm add <pkg>@<previous>`) and log them as **skipped** with the reason.
 6. Run the quality gate (below). If it fails, revert the entire Wave A batch.
 
@@ -228,7 +228,7 @@ You are upgrading the `{GROUP}` dependency group from `{FROM}` to `{TO}`.
 2. **Install** the group, **from project root only**:
    - `storybook` group: run `pnpm dlx storybook@latest upgrade` (Storybook's own upgrade tool migrates config alongside the version bump).
    - All others: `pnpm add <pkg1>@<latest> <pkg2>@<latest> ...` for every group member present in root `package.json`.
-3. **Conflict check**: `pnpm ls 2>&1`. On peer-dep error, attempt one `pnpm.overrides` fix. If still failing, revert the group and skip with reason.
+3. **Conflict check**: `pnpm ls 2>&1`. On peer-dep error, attempt one `overrides:` fix in `pnpm-workspace.yaml`. If still failing, revert the group and skip with reason.
 4. **Apply breaking changes** within root scope: from the migration guide, identify code-affecting changes (renamed APIs, removed exports, config schema changes). Grep `app/`, `test/`, and root config files for affected patterns. Edit only files inside root scope.
 5. **Verify root `package.json` moved**: read root `package.json` and confirm every group member you bumped now shows the new version. If `pnpm add` did not change root's spec (e.g. the dep is declared in a sibling project's `package.json` and not actually consumed by root code), revert the install and report the package as **skipped, not a root dep**. The skill does not resolve cross-project declarations; the maintainer must clean up manually. If the dep is in root `package.json` but has zero call sites in root scope, that's a phantom declaration: bump it anyway so the version stays current, and add a one-line note `phantom: no call sites in root` to the breaking-changes report so the maintainer can investigate.
 6. **Quality gate**:
@@ -272,7 +272,7 @@ Build the report **only** from the agent reports returned to you. Do not add row
 
 - **Updated packages**: every package the Haiku agent or a Wave B agent reports as `updated`. Nothing else.
 - **Breaking changes applied**: only what Wave B agents report editing in the codebase. Empty if no Wave B group ran.
-- **Overrides audited**: only what the Phase 0 / Phase 6 audit reports. If `pnpm.overrides` was empty, write "None" and move on.
+- **Overrides audited**: only what the Phase 0 / Phase 6 audit reports. If the `overrides:` map was empty, write "None" and move on.
 - **Skipped packages**: _only_ packages that were attempted and reverted mid-run (peer-dep conflict, quality-gate failure, manual revert by an agent). **Never** include packages filtered out before installation by a policy rule (e.g. the Phase 1 ESLint 9.x cap or the release-age cooldown). Those are silent by design, surfacing them is noise that adopters see every run. If nothing was actually skipped during the run, write "None" or omit the table.
 - **Quality gate**: the gate result reported by the agents, verbatim.
 

--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -235,8 +235,10 @@ Let `A` = working-tree `package.json`, `B` = `$BASELINE_DIR/package.json`, `L` =
 
 **Managed sections, three-way merged per entry:**
 
-- **Object sections, merged per entry key:** `dependencies`, `devDependencies`, `scripts`, `engines`, `pnpm.overrides`, top-level `overrides`.
-- **Scalar / whole-value keys, merged as a single value:** `packageManager`, and any non-`overrides` key under `pnpm` (e.g. `onlyBuiltDependencies`).
+- **Object sections, merged per entry key:** `dependencies`, `devDependencies`, `scripts`, `engines`.
+- **Scalar / whole-value keys, merged as a single value:** `packageManager`.
+
+Resolution, `overrides`, and build-approval (`allowBuilds`) settings live in `pnpm-workspace.yaml`, classed `owned` and merged by the generic Step 7 walk, not here. pnpm 11 reads them only from there; the `package.json` `pnpm` field and a top-level `overrides` key are not pnpm-managed `package.json` sections.
 
 For each managed entry key `k` (within its section), with `Bk` / `Lk` / `Ak` its value in baseline / latest / adopter:
 
@@ -251,7 +253,7 @@ For each managed entry key `k` (within its section), with `Bk` / `Lk` / `Ak` its
 
 **The load-bearing row is the first one:** a dependency the adopter removed (present in `B`, absent from `A`) is **never re-added** unless GAIA itself changed it this release _and_ the adopter opts in. The default everywhere is to respect the adopter's value. This is the JSON-key analog of the file-level "respect adopter deletions" rule the generic table already enforces.
 
-**Compute the per-key verdicts** with `jq` (covers the object sections including nested `pnpm.overrides`):
+**Compute the per-key verdicts** with `jq` (covers the object sections):
 
 ```bash
 jq -n \
@@ -259,7 +261,7 @@ jq -n \
   --slurpfile b "$BASELINE_DIR/package.json" \
   --slurpfile l "$LATEST_DIR/package.json" '
   ($a[0]) as $A | ($b[0]) as $B | ($l[0]) as $L
-  | [["dependencies"],["devDependencies"],["scripts"],["engines"],["overrides"],["pnpm","overrides"]] as $sections
+  | [["dependencies"],["devDependencies"],["scripts"],["engines"]] as $sections
   | [ $sections[] as $sp
       | (($B | getpath($sp)) // {}) as $bs
       | (($L | getpath($sp)) // {}) as $ls

--- a/.gaia/cli/package.json
+++ b/.gaia/cli/package.json
@@ -25,10 +25,5 @@
     "tsx": "4.21.0",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/.gaia/cli/pnpm-workspace.yaml
+++ b/.gaia/cli/pnpm-workspace.yaml
@@ -4,3 +4,10 @@
 # project instead of this standalone maintainer CLI. pnpm resolves the nearest
 # pnpm-workspace.yaml, so this keeps .gaia/cli's own pnpm-lock.yaml and
 # node_modules isolated. Maintainer-only; release-excluded.
+
+# Build-script approval. pnpm 11 replaces the onlyBuiltDependencies allowlist
+# with the allowBuilds map (true = the package may run install/build scripts).
+# esbuild builds a native binary in its postinstall; without this, the
+# --frozen-lockfile install fails with ERR_PNPM_IGNORED_BUILDS.
+allowBuilds:
+  esbuild: true

--- a/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
+++ b/.gaia/cli/src/automation/__tests__/__snapshots__/templates-snapshots.test.ts.snap
@@ -489,9 +489,10 @@ jobs:
                otherwise → \`^<latest>\`.
             2. Run a single \`pnpm add ...\` with all entries combined.
             3. Run \`pnpm ls 2>&1\`. On peer-dep error, attempt one
-               targeted \`pnpm.overrides\` fix (e.g. \`parent>child\`),
-               then \`pnpm install\` again. If still failing, revert the
-               offending package(s) and proceed with the rest.
+               targeted \`overrides:\` fix in \`pnpm-workspace.yaml\`
+               (e.g. \`parent>child\`), then \`pnpm install\` again. If
+               still failing, revert the offending package(s) and
+               proceed with the rest.
             4. Run the quality gate exactly: \`pnpm typecheck\`,
                \`pnpm lint\`, \`pnpm test --run\`, \`pnpm pw\`, \`pnpm build\`.
                If the gate fails, revert the entire wave-A batch and

--- a/.gaia/cli/src/automation/templates/workflows/gaia-ci-update-deps.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/gaia-ci-update-deps.yml.tmpl
@@ -73,9 +73,10 @@ jobs:
                otherwise → `^<latest>`.
             2. Run a single `pnpm add ...` with all entries combined.
             3. Run `pnpm ls 2>&1`. On peer-dep error, attempt one
-               targeted `pnpm.overrides` fix (e.g. `parent>child`),
-               then `pnpm install` again. If still failing, revert the
-               offending package(s) and proceed with the rest.
+               targeted `overrides:` fix in `pnpm-workspace.yaml`
+               (e.g. `parent>child`), then `pnpm install` again. If
+               still failing, revert the offending package(s) and
+               proceed with the rest.
             4. Run the quality gate exactly: `pnpm typecheck`,
                `pnpm lint`, `pnpm test --run`, `pnpm pw`, `pnpm build`.
                If the gate fails, revert the entire wave-A batch and

--- a/.gaia/cli/templates/workflows/gaia-ci-update-deps.yml.tmpl
+++ b/.gaia/cli/templates/workflows/gaia-ci-update-deps.yml.tmpl
@@ -73,9 +73,10 @@ jobs:
                otherwise → `^<latest>`.
             2. Run a single `pnpm add ...` with all entries combined.
             3. Run `pnpm ls 2>&1`. On peer-dep error, attempt one
-               targeted `pnpm.overrides` fix (e.g. `parent>child`),
-               then `pnpm install` again. If still failing, revert the
-               offending package(s) and proceed with the rest.
+               targeted `overrides:` fix in `pnpm-workspace.yaml`
+               (e.g. `parent>child`), then `pnpm install` again. If
+               still failing, revert the offending package(s) and
+               proceed with the rest.
             4. Run the quality gate exactly: `pnpm typecheck`,
                `pnpm lint`, `pnpm test --run`, `pnpm pw`, `pnpm build`.
                If the gate fails, revert the entire wave-A batch and

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -33,15 +33,7 @@ jobs:
               # or template drift lands silently.
               - '.github/workflows/code-review-audit.yml'
       - if: steps.filter.outputs.code == 'true'
-        # Pinned to v4.4.0 (not v6.0.5 like the other workflows), bumping
-        # to v6 surfaces an ERR_PNPM_IGNORED_BUILDS regression on the
-        # `pnpm -C .gaia/cli install --frozen-lockfile` invocation: pnpm 10
-        # blocks the esbuild postinstall scripts even though
-        # `.gaia/cli/package.json`'s `pnpm.onlyBuiltDependencies` lists
-        # esbuild. Other workflows install at the project root where the
-        # same allowlist works fine. Eats the Node.js 20 deprecation
-        # alone (auto-forced to Node 24 starting 2026-06-02 by GitHub).
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - if: steps.filter.outputs.code == 'true'
         name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0


### PR DESCRIPTION
Repoints every `update-deps` / `update-gaia` / instruction reference that
still named the **dead pnpm-10 override location** to where pnpm 11 reads
overrides (the top-level `overrides:` map in `pnpm-workspace.yaml`), and
fixes the related pnpm-11 build-approval breakage in the maintainer CLI.

pnpm 11 (merged in #333) no longer reads the `pnpm` field in
`package.json`; `overrides` and the `allowBuilds` map live in
`pnpm-workspace.yaml`.

## 1. update-deps override audit (primary)

`.claude/skills/update-deps/SKILL.md` — Phase 0 audit, Phase 6, Wave A step
4, Wave B step 3, and the final-report "Overrides audited" line all
targeted `pnpm.overrides` in `package.json`. With no such field present the
audit was a silent no-op. Repointed to the `overrides:` map in
`pnpm-workspace.yaml`. Also fixed the shipped CI surface
`gaia-ci-update-deps.yml.tmpl` (source + bundled copy) and regenerated its
`templates-snapshots.test.ts.snap`.

## 2. update-gaia field-aware package.json merge

`.claude/skills/update-gaia/SKILL.md` Step 7a listed `pnpm.overrides`,
top-level `overrides`, and `onlyBuiltDependencies` as managed
`package.json` sections (and in the jq `$sections` array). GAIA's template
`package.json` no longer carries any of them, so those entries were dead
no-ops. Dropped them; noted that those settings live in
`pnpm-workspace.yaml` (classed `owned`, merged by the generic Step 7 walk).
**No behavior change.**

## 3. remove-i18n instruction

`.claude/instructions/remove-i18n.md` told the agent to strip
`remix-i18next>` keys from `pnpm.overrides`; repointed to the `overrides:`
map in `pnpm-workspace.yaml`.

## 4. CLI build approval (fixes the red CLI Tests check)

`.gaia/cli/package.json` still carried `pnpm.onlyBuiltDependencies:
[esbuild]`. pnpm 11 ignores that field, so `pnpm -C .gaia/cli install
--frozen-lockfile` failed with `ERR_PNPM_IGNORED_BUILDS` (esbuild's native
postinstall blocked) — the CLI Tests workflow went red on this PR (the
first post-pnpm-11 PR to touch `.gaia/cli/**`).

- Moved esbuild build approval to the `allowBuilds` map in
  `.gaia/cli/pnpm-workspace.yaml`; dropped the dead `pnpm` field.
- Lifted `cli-tests.yml`'s `pnpm/action-setup` pin v4.4.0 → v6.0.5 (matches
  the other workflows) and removed the stale workaround comment — it pinned
  v4.4.0 solely to dodge this `ERR_PNPM_IGNORED_BUILDS`, now fixed at the
  source. Lockfile unchanged (`allowBuilds` is a setting, not a resolution
  input).

## Confirmed NOT broken (no change)

- **Statusline count path** (`gaia update-deps run` → `run.ts`): already
  reads `minimumReleaseAge` from `pnpm-workspace.yaml` and dep lists from
  `package.json`; never touches overrides.
- **update-gaia `pnpm-workspace.yaml` propagation**: the file is `owned`,
  so GAIA's settings/overrides already reach adopters via the Step 7 walk.
- `wiki/decisions/pnpm.md`: already correct; the prose had drifted from it.

## Verification

- `pnpm -C .gaia/cli install --frozen-lockfile` (the failing CI step): now
  clean — no `pnpm` field warning, no `ERR_PNPM_IGNORED_BUILDS`.
- Full `.gaia/cli` vitest suite: 1365 passed, 1 skipped. CLI typecheck and
  `pnpm bundle` (esbuild) clean. All on pnpm 11.5.2.
- App Quality Gate: nothing to check (no app `.ts/.tsx/.css` staged).

## Follow-up for maintainer review (separate PR)

**Field-aware Step 7b for `pnpm-workspace.yaml`.** That file is now a mixed
file (GAIA boilerplate + adopter-specific `overrides` / `allowBuilds`)
classed `owned`, so any adopter who adds an override drifts it and gets a
whole-file conflict patch on every release that touches it — the same noise
that justified package.json's field-aware Step 7a. A field-aware merge for
its map sections may be worth it. Design decision, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
