### PR TITLE
chore(cli): retire dead state_file workflow template var

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -15758,7 +15758,6 @@ var buildWorkflowVars = (config2, tool) => {
     needs_human_review_label: "needs-human-review",
     pr_label: "gaia-ci",
     schedule,
-    state_file: `.gaia/automation.state-${tool}.json`,
     tool_id: tool,
     workflow_name: WORKFLOW_NAME_BY_TOOL[tool]
   };

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -15757,7 +15757,6 @@ var buildWorkflowVars = (config2, tool) => {
     needs_human_review_label: "needs-human-review",
     pr_label: "gaia-ci",
     schedule,
-    state_file: `.gaia/automation.state-${tool}.json`,
     tool_id: tool,
     workflow_name: WORKFLOW_NAME_BY_TOOL[tool]
   };

--- a/.gaia/cli/src/automation/__tests__/render.test.ts
+++ b/.gaia/cli/src/automation/__tests__/render.test.ts
@@ -45,7 +45,6 @@ const baseVars: WorkflowTemplateVars = {
   needs_human_review_label: 'needs-human-review',
   pr_label: 'gaia-ci',
   schedule: 'daily',
-  state_file: '.gaia/automation.state-wiki.json',
   tool_id: 'wiki',
   workflow_name: 'GAIA CI - Test',
 };

--- a/.gaia/cli/src/automation/__tests__/workflow-vars.test.ts
+++ b/.gaia/cli/src/automation/__tests__/workflow-vars.test.ts
@@ -51,7 +51,6 @@ describe('buildWorkflowVars', () => {
       needs_human_review_label: 'needs-human-review',
       pr_label: 'gaia-ci',
       schedule: 'daily',
-      state_file: '.gaia/automation.state-wiki.json',
       tool_id: 'wiki',
       workflow_name: 'GAIA CI - Wiki',
     });
@@ -65,7 +64,6 @@ describe('buildWorkflowVars', () => {
       cron: '0 4 * * 0',
       enable_major_bump_split: true,
       schedule: 'weekly',
-      state_file: '.gaia/automation.state-update-deps.json',
       tool_id: 'update-deps',
       workflow_name: 'GAIA CI - Update Deps',
     });
@@ -79,7 +77,6 @@ describe('buildWorkflowVars', () => {
       cron: '0 4 * * *',
       enable_security_pr: true,
       schedule: 'daily',
-      state_file: '.gaia/automation.state-pnpm-audit.json',
       tool_id: 'pnpm-audit',
       workflow_name: 'GAIA CI - pnpm audit',
     });
@@ -94,7 +91,6 @@ describe('buildWorkflowVars', () => {
       enable_auto_merge: false,
       enable_stale_branch_delete: true,
       schedule: 'monthly',
-      state_file: '.gaia/automation.state-stale-branches.json',
       tool_id: 'stale-branches',
       workflow_name: 'GAIA CI - Stale Branches',
     });

--- a/.gaia/cli/src/automation/workflow-vars.ts
+++ b/.gaia/cli/src/automation/workflow-vars.ts
@@ -26,7 +26,6 @@ export type WorkflowTemplateVars = {
   needs_human_review_label: string;
   pr_label: string;
   schedule: WorkflowSchedule;
-  state_file: string;
   tool_id: ToolId;
   workflow_name: string;
 };
@@ -98,7 +97,6 @@ export const buildWorkflowVars = (
     needs_human_review_label: 'needs-human-review',
     pr_label: 'gaia-ci',
     schedule,
-    state_file: `.gaia/automation.state-${tool}.json`,
     tool_id: tool,
     workflow_name: WORKFLOW_NAME_BY_TOOL[tool],
   };


### PR DESCRIPTION
Follow-on to #340. The `state_file` template var (`.gaia/automation.state-<tool>.json`)
is referenced by no workflow template; the `automation.state` layer it pointed at was
removed in #340, leaving it provably dead.

- Drops `state_file` from the `WorkflowTemplateVars` type and the `buildWorkflowVars` return.
- Trims the four `state_file` expectations in `workflow-vars.test.ts` and the one in `render.test.ts`.
- Rebuilds both binaries (`gaia`, `gaia-maintainer`); no bundled template changed (none consumed the var).

Maintainer-only; `.gaia/cli` is release-excluded; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)