### PR TITLE
fix(hooks): exempt type-only tests from the RED-verification gate

### DIFF
--- a/.claude/hooks/red-verify-commit-check.sh
+++ b/.claude/hooks/red-verify-commit-check.sh
@@ -23,6 +23,14 @@
 # posture for uncomputable identity and its "edits/refactors never demand a
 # RED" spirit. A new dynamic-title test passing on first run is not blocked.
 #
+# Type-only tests are EXEMPT for a distinct, principled reason: the helper tags
+# each test kind=type-only when its assertions are all type-level (expectTypeOf
+# /assertType, or a `@ts-expect-error` proof) with no runtime expectation. Such
+# a test has no runtime failure mode, so there is no runtime red-green for this
+# gate to verify; the `tsc` Quality Gate step enforces it instead. This is the
+# correctly-keyed exemption (no runtime assertion), as opposed to the
+# dynamic-title carve-out above, which is keyed to uncomputable identity.
+#
 # Fail-open vs fail-closed (threat model: a cooperative-but-fallible agent):
 #   - git / jq / node unavailable  -> exit 0 (allow). Sibling-hook posture.
 #   - a staged test file the helper cannot parse (mid-edit syntax error)
@@ -153,7 +161,16 @@ while IFS= read -r path; do
     [ -n "$line" ] || continue
     full=$(printf '%s' "$line" | jq -r '.fullName // empty' 2>/dev/null || true)
     sig=$(printf '%s' "$line" | jq -r '.signal // empty' 2>/dev/null || true)
+    kind=$(printf '%s' "$line" | jq -r '.kind // empty' 2>/dev/null || true)
     [ -n "$full" ] && [ -n "$sig" ] || continue
+
+    # Type-only test (all assertions type-level, no runtime expectation): it
+    # has no runtime failure mode, so there is no runtime red-green for this
+    # gate to demand. The `tsc` Quality Gate step enforces its correctness;
+    # demanding a runtime RED here would be unsatisfiable. An absent kind (an
+    # older signal helper) falls through to runtime enforcement, the safe
+    # default.
+    [ "$kind" = "type-only" ] && continue
 
     # New-at-HEAD test? Present-at-HEAD fullNames are out of scope (edits,
     # renames, refactors of an existing test never demand a fresh RED), even

--- a/.gaia/scripts/red-ledger/README.md
+++ b/.gaia/scripts/red-ledger/README.md
@@ -61,11 +61,21 @@ node .gaia/scripts/red-ledger/extract-test-signals.mjs <path> --stdin
 
 Reads the file from disk (or stdin with `--stdin`) and prints one JSON object
 per discovered `test(...)`/`it(...)` call, newline-delimited:
-`{"fullName":"…","signal":"sha256:…"}`. Exit `0` on success (no output when no
-tests are found); non-zero with a one-line stderr message on a parse failure.
+`{"fullName":"…","signal":"sha256:…","kind":"runtime"|"type-only"}`. Exit `0`
+on success (no output when no tests are found); non-zero with a one-line stderr
+message on a parse failure.
 
 `fullName` is the enclosing describe titles (outermost first) plus the test
 title, single-space-joined. `signal` is `sha256:` plus the lowercase-hex
 sha256 of the test call expression's normalized source; trimmed, with internal
 whitespace runs collapsed to single spaces, so it stays stable across pure
 reformatting and changes when the title, assertion, or body changes.
+
+`kind` is `"type-only"` when the test's assertions are all type-level (an
+`expectTypeOf`/`assertType` call, or a `@ts-expect-error` proof) and it carries
+no runtime assertion (`expect`/`assert`); `"runtime"` otherwise. A type-only
+test has no runtime failure mode, so the commit check exempts it from the
+runtime-RED demand and delegates its correctness to the `tsc` Quality Gate
+step. The predicate defaults to `"runtime"` (enforce) when no type-level signal
+is present, so a no-assertion test is never silently exempted. `kind` is part
+of the helper output only; it is not stored in the ledger schema above.

--- a/.gaia/scripts/red-ledger/extract-test-signals.mjs
+++ b/.gaia/scripts/red-ledger/extract-test-signals.mjs
@@ -14,7 +14,7 @@
 //
 // Output (stdout): one JSON object per discovered test(...)/it(...) call,
 // newline-delimited:
-//   {"fullName":"...","signal":"sha256:..."}
+//   {"fullName":"...","signal":"sha256:...","kind":"runtime"|"type-only"}
 // Exit 0 on success (even when zero tests are found; emits nothing).
 // Exit non-zero with a one-line stderr message on a parse failure.
 //
@@ -29,6 +29,15 @@
 // then collapse every internal run of whitespace to a single space. Stable
 // under pure reformatting; changes when the title, assertion, or body
 // changes.
+//
+// kind: "type-only" when the test's assertions are all type-level (an
+// expectTypeOf(...)/assertType(...) call, or a `@ts-expect-error` proof
+// directive) AND it carries no runtime assertion (expect(...)/assert(...));
+// "runtime" otherwise. A type-only test has no runtime failure mode, so the
+// RED-verification commit gate has no runtime red-green to demand from it and
+// exempts it, delegating type correctness to the `tsc` Quality Gate step. The
+// predicate requires a positive type-level signal and defaults to "runtime"
+// (enforce) when unsure, so a no-assertion test is never silently exempted.
 
 import {createHash} from 'node:crypto';
 import {createRequire} from 'node:module';
@@ -141,6 +150,18 @@ function titleOf(node) {
 const TEST_NAMES = new Set(['test', 'it']);
 const DESCRIBE_NAMES = new Set(['describe', 'suite']);
 
+// Runtime assertions give a test a runtime failure mode (a RED). Type-level
+// proofs do not: they are evaluated by tsc, never by the test runner.
+const RUNTIME_ASSERTION_NAMES = new Set(['expect', 'assert']);
+const TYPE_ASSERTION_NAMES = new Set(['expectTypeOf', 'assertType']);
+
+// A `@ts-expect-error` directive is itself a type-level proof: the build fails
+// if the next line does NOT error. Matched only when anchored to a comment
+// opener on the same line, so a string literal that merely contains the token
+// is not a false signal. `@ts-ignore` is blanket suppression, not a proof, so
+// it is deliberately NOT treated as a type-only signal.
+const TS_EXPECT_ERROR_DIRECTIVE = /(?:\/\/|\/\*)[^\n]*@ts-expect-error\b/;
+
 function normalize(text) {
   return text.trim().replace(/\s+/g, ' ');
 }
@@ -150,6 +171,65 @@ function signalFor(node) {
   const normalized = normalize(text);
   const hex = createHash('sha256').update(normalized, 'utf8').digest('hex');
   return `sha256:${hex}`;
+}
+
+// Resolve the root identifier of a (possibly chained) call expression's
+// callee: expect(x).toBe(y) -> "expect"; expectTypeOf<T>().toEqualTypeOf<U>()
+// -> "expectTypeOf"; assert.equal(...) -> "assert". Unwraps call, property-
+// access, element-access, non-null, and parenthesized layers. Returns null
+// when the callee root is not a bare identifier.
+function rootCallName(callNode) {
+  let expr = callNode.expression;
+  for (;;) {
+    if (ts.isCallExpression(expr)) {
+      expr = expr.expression;
+    } else if (ts.isPropertyAccessExpression(expr)) {
+      expr = expr.expression;
+    } else if (ts.isElementAccessExpression(expr)) {
+      expr = expr.expression;
+    } else if (ts.isNonNullExpression(expr)) {
+      expr = expr.expression;
+    } else if (ts.isParenthesizedExpression(expr)) {
+      expr = expr.expression;
+    } else {
+      break;
+    }
+  }
+  return ts.isIdentifier(expr) ? expr.text : null;
+}
+
+// Classify a test as "type-only" or "runtime" by inspecting its argument
+// subtrees (title + callback body). Type-only = at least one type-level proof
+// and zero runtime assertions. Defaults to "runtime" (enforce) when unsure, so
+// a test with no assertions at all is never silently exempted from the gate.
+function classifyKind(testNode) {
+  let runtime = 0;
+  let typeLevel = 0;
+
+  const scan = (node) => {
+    if (ts.isCallExpression(node)) {
+      const name = rootCallName(node);
+      if (name && RUNTIME_ASSERTION_NAMES.has(name)) {
+        runtime += 1;
+      } else if (name && TYPE_ASSERTION_NAMES.has(name)) {
+        typeLevel += 1;
+      }
+    }
+    ts.forEachChild(node, scan);
+  };
+
+  for (const arg of testNode.arguments) {
+    scan(arg);
+  }
+
+  if (
+    typeLevel === 0 &&
+    TS_EXPECT_ERROR_DIRECTIVE.test(testNode.getText(sourceFile))
+  ) {
+    typeLevel += 1;
+  }
+
+  return runtime === 0 && typeLevel > 0 ? 'type-only' : 'runtime';
 }
 
 const lines = [];
@@ -162,7 +242,11 @@ function visit(node, ancestors) {
       if (title !== null) {
         const fullName = [...ancestors, title].join(' ');
         lines.push(
-          JSON.stringify({fullName, signal: signalFor(node)}),
+          JSON.stringify({
+            fullName,
+            signal: signalFor(node),
+            kind: classifyKind(node),
+          }),
         );
       }
       // A test call never nests further test/describe blocks worth tracking;

--- a/.gaia/tests/hooks/fixtures/red-ledger/kind-mixed.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/kind-mixed.test.ts
@@ -1,0 +1,14 @@
+import {expectTypeOf, expect, test} from 'vitest';
+
+const double = (n: number): number => n * 2;
+
+test('runtime plus expectTypeOf is runtime', () => {
+  expect(double(2)).toBe(4);
+  expectTypeOf<number>().toEqualTypeOf<number>();
+});
+
+test('runtime plus ts-expect-error is runtime', () => {
+  expect(double(2)).toBe(4);
+  // @ts-expect-error - double requires a number
+  double('not a number');
+});

--- a/.gaia/tests/hooks/fixtures/red-ledger/kind-type-only.test.ts
+++ b/.gaia/tests/hooks/fixtures/red-ledger/kind-type-only.test.ts
@@ -1,0 +1,12 @@
+import {expectTypeOf, test} from 'vitest';
+
+const double = (n: number): number => n * 2;
+
+test('type proof via expectTypeOf', () => {
+  expectTypeOf<number>().toEqualTypeOf<number>();
+});
+
+test('type proof via ts-expect-error', () => {
+  // @ts-expect-error - double requires a number
+  double('not a number');
+});

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -98,6 +98,41 @@ run_lib() {
   [ "$sig_a" != "$sig_changed" ]
 }
 
+# --- signal helper: kind classification ---
+
+@test "helper tags an expectTypeOf-only test kind=type-only" {
+  run_helper "$FIX_REL/kind-type-only.test.ts"
+  [ "$status" -eq 0 ]
+  local kind
+  kind=$(printf '%s\n' "$output" \
+    | jq -r 'select(.fullName=="type proof via expectTypeOf") | .kind')
+  [ "$kind" = "type-only" ]
+}
+
+@test "helper tags a @ts-expect-error-only test kind=type-only" {
+  run_helper "$FIX_REL/kind-type-only.test.ts"
+  [ "$status" -eq 0 ]
+  local kind
+  kind=$(printf '%s\n' "$output" \
+    | jq -r 'select(.fullName=="type proof via ts-expect-error") | .kind')
+  [ "$kind" = "type-only" ]
+}
+
+@test "helper tags a plain runtime test kind=runtime" {
+  run_helper "$FIX_REL/top-level.test.ts"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | jq -r '.kind')" = "runtime" ]
+}
+
+@test "helper tags both mixed runtime+type tests kind=runtime" {
+  run_helper "$FIX_REL/kind-mixed.test.ts"
+  [ "$status" -eq 0 ]
+  # Two tests, and every one classifies runtime (a runtime assertion present
+  # alongside a type-level proof is still runtime, never type-only).
+  [ "$(printf '%s\n' "$output" | grep -c '"fullName"')" -eq 2 ]
+  [ "$(printf '%s\n' "$output" | jq -r '.kind' | sort -u)" = "runtime" ]
+}
+
 # --- signal helper: exit codes ---
 
 @test "helper exits 0 with no output on a valid file with no tests" {

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -280,6 +280,69 @@ test(`dynamic ${n}`, () => {
   ! denied
 }
 
+# --- Type-only tests -> exempt (no runtime assertion; tsc is the enforcer) ---
+
+TYPE_ONLY_EXPECTTYPEOF='import {expectTypeOf, test} from "vitest";
+test("type matches", () => {
+  expectTypeOf<number>().toEqualTypeOf<number>();
+});
+'
+
+TYPE_ONLY_TS_EXPECT_ERROR='import {test} from "vitest";
+const double = (n: number): number => n * 2;
+test("rejects a bad arg", () => {
+  // @ts-expect-error - double requires a number
+  double("nope");
+});
+'
+
+@test "allows a new type-only test (expectTypeOf, no runtime assertion)" {
+  # No RED on record, yet the commit is allowed: a type-only test has no
+  # runtime failure mode for this gate to demand. tsc enforces it instead.
+  stage_file "app/x/index.test.ts" "$TYPE_ONLY_EXPECTTYPEOF"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+@test "allows a new type-only test (@ts-expect-error proof, no runtime assertion)" {
+  stage_file "app/x/index.test.ts" "$TYPE_ONLY_TS_EXPECT_ERROR"
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  ! denied
+}
+
+@test "exempts the type-only sibling but still denies the runtime sibling" {
+  stage_file "app/x/index.test.ts" 'import {expectTypeOf, expect, test} from "vitest";
+test("type-only sibling", () => {
+  expectTypeOf<number>().toEqualTypeOf<number>();
+});
+test("runtime sibling", () => {
+  expect(1 + 1).toBe(2);
+});
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"runtime sibling"* ]]
+  [[ "$output" != *"type-only sibling"* ]]
+}
+
+@test "denies a mixed runtime+type test (runtime assertion present) with no RED" {
+  # A type-level proof does NOT exempt a test that also carries a runtime
+  # assertion: the runtime red-green still must be observed.
+  stage_file "app/x/index.test.ts" 'import {expectTypeOf, expect, test} from "vitest";
+test("mixed assertions", () => {
+  expect(1 + 1).toBe(2);
+  expectTypeOf<number>().toEqualTypeOf<number>();
+});
+'
+  run_commit_hook
+  [ "$status" -eq 0 ]
+  denied
+  [[ "$output" == *"mixed assertions"* ]]
+}
+
 # --- Forward-compat: a ledger line with an unknown schema is ignored ---
 
 @test "ignores a ledger line with an unrecognized schema version" {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Fixed
+
+- type-only tests no longer hit an unsatisfiable TDD RED-verification gate: the signal helper classifies each test `runtime` vs `type-only`, and the commit check exempts type-only tests (assertions all type-level via `expectTypeOf`/`assertType`/`@ts-expect-error`, no runtime expectation), delegating their correctness to the `tsc` quality gate
+
 ## [1.5.0] - 2026-06-05
 
 ### Added

--- a/wiki/decisions/Quality Gate.md
+++ b/wiki/decisions/Quality Gate.md
@@ -16,7 +16,7 @@ Every change must pass the Quality Gate. Pre-commit hooks enforce a subset; Clau
 
 1. **Simplify**: run `simplify` skill; apply all endorsed changes.
 2. **Localization check**: no hardcoded user-facing strings or unfilled keys.
-3. `pnpm typecheck`: zero errors.
+3. `pnpm typecheck`: zero errors. This is the sole enforcer for type-only tests (`expectTypeOf`/`assertType`/`@ts-expect-error`), which [[TDD RED Verification]] exempts from its runtime-RED demand.
 4. `pnpm lint`: zero errors, zero warnings. Runs `eslint --fix`, so it auto-fixes every fixable lint rule **and** Prettier formatting (Prettier is wired in as an `eslint` rule via `prettier/prettier`); only non-auto-fixable issues need manual attention. Hand-formatting while authoring is wasted effort; this step normalizes it.
 5. `pnpm test --run`: all tests pass with **zero console warnings** (missing keys, HydrateFallback, etc. count as failures).
 6. `pnpm pw`: all Playwright E2E tests pass.

--- a/wiki/decisions/TDD RED Verification.md
+++ b/wiki/decisions/TDD RED Verification.md
@@ -31,11 +31,22 @@ The content signal is a normalized hash of the test body so that a cosmetic rena
 - Pre-commit check on `git commit` only. Does not gate `git push` or CI.
 - New tests only: tests that already exist at the merge base are not checked.
 - Fail-open: the hook does not block when the ledger tooling (Node, the signal extractor) is unavailable or when a test file cannot be parsed by the TS compiler API.
+- Type-only tests are exempt. A test whose assertions are all type-level and which carries no runtime expectation has no runtime failure mode, so the gate has nothing to demand; `tsc` enforces it instead. See [[#Type-only tests]].
 
 ## Infrastructure
 
-- `.gaia/scripts/red-ledger/extract-test-signals.mjs`: Node ESM helper using the TypeScript compiler API to emit `{fullName, signal}` NDJSON for each test in a file.
+- `.gaia/scripts/red-ledger/extract-test-signals.mjs`: Node ESM helper using the TypeScript compiler API to emit `{fullName, signal, kind}` NDJSON for each test in a file.
 - `.claude/hooks/lib/red-ledger.sh`: shared shell library sourced by both hooks. Owns ledger path resolution, repo-relative normalization, and signal invocation.
+
+## Type-only tests
+
+A type-level assertion is invisible to the test runner: vitest runs without `--typecheck`, so `expectTypeOf`/`assertType` calls and `@ts-expect-error` proofs neither pass nor fail at runtime. A test built only from these always passes the runner yet can never produce a failing run, so demanding a runtime RED for it is unsatisfiable. The signal helper therefore classifies every test and the commit check exempts the type-only ones, delegating their correctness to the `tsc` step of the [[Quality Gate]].
+
+The helper tags each test `kind: "type-only"` or `kind: "runtime"`. A test is `type-only` when it has at least one type-level proof (`expectTypeOf`/`assertType`, or a `@ts-expect-error` directive) **and** no runtime assertion (`expect`/`assert`); otherwise it is `runtime`. The predicate requires a positive type-level signal, so a test with no assertions at all stays `runtime` and is never silently exempted, and a test mixing a runtime assertion with a type-level proof stays `runtime` and still owes a RED.
+
+This exemption is keyed to the correct predicate (no runtime assertion), distinct from the dynamic-title carve-out, which is keyed to uncomputable identity (a computed test title emits no signal, so it never enters the checked set).
+
+Recommended idiom: prefer `expectTypeOf`/`assertType` for an honest per-assertion proof. A pure type-test file can also use the `*.test-d.ts` convention, which `tsc` checks while both vitest and this gate skip it by glob. Reserve `@ts-expect-error` for proving a specific misuse is rejected; its signal is whole-statement and inverted, holding while the error is present and breaking when the code becomes permissive enough to remove it.
 
 ## Consequences
 


### PR DESCRIPTION
## Problem

A pure **type-only test** (assertions all type-level via `expectTypeOf`/`assertType`/`@ts-expect-error`, no runtime `expect`) passes invisibly under vitest (which runs without `--typecheck`) yet can never produce a failing run. The TDD RED-verification commit gate demanded a runtime RED for any new-at-HEAD static-title test, so a valid type-only test reached an **unsatisfiable state** — blocked at commit with no honest way through. The only escapes were faking a runtime RED or abusing the dynamic-title carve-out (an exemption keyed to the wrong predicate: *uncomputable title* rather than *no runtime assertion*).

This is a GAIA-internal correctness fix, paradigm-neutral, with zero library-specific logic.

## Fix

- **Classifier** (`extract-test-signals.mjs`): the AST helper now tags each test `kind: "runtime" | "type-only"`. A test is `type-only` iff it has at least one type-level proof **and** zero runtime assertions (`expect`/`assert`). Requires a positive type signal, so a no-assertion test defaults to `runtime` (never silently exempted); a mixed runtime+type test stays `runtime` and still owes a RED. Signal logic untouched, so existing REDs stay valid.
- **Exemption** (`red-verify-commit-check.sh`): skips the runtime-RED demand for `kind == "type-only"`, delegating type correctness to the `tsc` Quality Gate step. Absent `kind` falls through to enforce (safe default). Re-keyed to the correct predicate, distinct from the dynamic-title carve-out.
- Capture hook unchanged: type-only tests never fail at runtime, so they're never recorded.

## Recommended idiom (docs)

Prefer `expectTypeOf`/`assertType`; use `*.test-d.ts` for pure type-test files (already skipped by both globs, checked by `tsc`); reserve `@ts-expect-error` for proving a misuse is rejected.

## Verification

- typecheck OK, lint (`--max-warnings=0`) OK, unit suite 120 passed, build OK
- bats `.gaia/tests/hooks/*.bats`: **143/143** (8 new: 4 helper classification, 4 commit-gate behavior)
- Live repro: pure type-only file is allowed; mixed file denies only the runtime sibling
- Manifest: zero drift from this change (only `owned` files + release-excluded `.gaia/tests/` additions)

## Scope

Defect fix only (folds into the next release as `Fixed`). The first-class `*.test-d.ts` + `--typecheck` capability is a deferred follow-up (minor, ~1.7.0); the `kind` field added here is the seam it builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
