### PR TITLE
fix(playwright): retry once locally to absorb the cold-optimize-cache flake

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,8 +63,12 @@ export default defineConfig({
   // Once you have a lot of tests, you can change this to 'github' or 'dot' on CI
   reporter: 'list',
 
-  // Retry on CI only
-  retries: process.env.CI ? 2 : 0,
+  // CI retries twice. Locally retry once: the first `pnpm pw` after a dep or
+  // Vite-config change boots the dev server with a cold dep-optimize cache, and
+  // that first request can lose the race to Vite's optimizer and fail the
+  // dynamic import of entry.client.tsx (page never hydrates). The retry runs
+  // against the now-warm server and passes.
+  retries: process.env.CI ? 2 : 1,
   testDir: './.playwright/e2e',
   testMatch: '**/*.spec.ts',
 


### PR DESCRIPTION
## Problem

The first `pnpm pw` after a dependency bump or a `vite.config.ts` change boots the
dev server with a **cold Vite dep-optimize cache**. That first navigation races
Vite's optimizer and can fail the dynamic import of `app/entry.client.tsx`
(`Failed to fetch dynamically imported module` -> `Couldn't load preload assets`),
so the page never hydrates and the `<meta name="hydrated">` wait times out. It is
exactly the scenario the `/update-deps` quality gate hits, because a dep bump
invalidates the optimize cache.

CI never sees this: it already runs `retries: 2`. Only local (`retries: 0`) was exposed.

## Fix

`retries: process.env.CI ? 2 : 1`. The retry runs against the now-warm server and
passes; a genuine failure still fails on both attempts.

## Why not `server.warmup`

Tried first. It pre-transforms the entry module but races the *same* optimizer on the
cold-optimize boot and loses, verified empirically (the cold boot still failed with
the warmup config in place). Reverted.

## Validation

Forced a cold optimize cache, then ran the gate:

- WebServer logged the exact error: `Failed to fetch dynamically imported module: .../entry.client.tsx`
- `language-switch-a11y` failed attempt 1 (11.1s hydration timeout) -> **retry #1 passed (872ms)** -> run reported `1 flaky, 1 passed` and exited green.
- Full gate: typecheck, lint, test (120/120), build, pw all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
