### PR TITLE
feat(ci): public-safe audit progress breadcrumbs

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -219,6 +219,32 @@ Rules for the block:
 
 The schema enforces this convention: an entry whose `finding_class` is free text or an unseeded holistic/rule member is dropped before it reaches the tally, so a misclassified entry is silently lost rather than miscounted. When in doubt, omit the entry.
 
+## Progress breadcrumbs (CI observability)
+
+The agent runs in CI with `show_full_output: false` (a deliberate public-repo safety choice). To give the CI step summary a post-hoc phase timeline, write ONE curated line per review phase to a fixed gitignored file using the `Write` or `Edit` tool (both are in the CI `allowedTools`).
+
+**File path (fixed, never sha-keyed):** `.gaia/local/audit/progress.log`
+
+**Line format:** `<phase label>, <counts>` -- phase label and integer counts only. Never include file contents, code, raw tool output, file paths beyond coarse counts, or anything secret-shaped. This is the public-safety crux: the workflow print step exposes this file in the GitHub Actions step summary.
+
+**Five phases, in run order:**
+
+| # | Label | Counts |
+|---|-------|--------|
+| 1 | `scope resolved` | number of changed files in scope |
+| 2 | `oracles done` | per-oracle counts: `react-doctor N, knip N, audit N` |
+| 3 | `holistic review done` | count of candidate Critical/Important holistic findings |
+| 4 | `adversarial verify done` | count that STAND (survived refutation) |
+| 5 | `report stamped` | marker state + self-heal state, e.g. `marker written, self-heal none` |
+
+**Truncate-on-first-write:** the first breadcrumb (`scope resolved`) overwrites the file using `Write` so a stale prior run's breadcrumbs never appear. Breadcrumbs 2-5 append using `Edit` (insert after the last line) so each phase accumulates in order.
+
+**Best-effort, never blocking:** wrap every breadcrumb write so that a `Write`/`Edit` failure is swallowed and never aborts or alters the audit result. A missing or partial progress file is harmless -- the workflow print step handles it gracefully. Do NOT harden a breadcrumb write into a blocking step.
+
+**Directory:** `.gaia/local/audit/` is already gitignored via `.gaia/local/` in `.gitignore`. The marker step creates the directory with `mkdir -p .gaia/local/audit` before writing the `<sha>.ok` file; your first breadcrumb write must also ensure the directory exists (run `mkdir -p .gaia/local/audit` before the `Write` call, wrapped in the same best-effort guard).
+
+**Locally harmless:** when the agent runs locally the file is simply written to a gitignored path. No behavioral change, no secrets risk.
+
 ## Methodology
 
 1. **Read the code carefully**: understand the intent before critiquing the implementation
@@ -228,9 +254,9 @@ The schema enforces this convention: an entry whose `finding_class` is free text
 5. **Be specific**: never say "this could be improved" without saying exactly how and why
 6. **Be proportionate**: don't nitpick formatting when there are security holes; focus energy on what matters most
 7. **Respect existing patterns**: if the codebase has an established way of doing something, don't suggest alternatives unless there's a concrete benefit
-8. **Dispatch in parallel**: once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor`, `pnpm knip --reporter json`, and `pnpm audit --json` from a single tool-call message so they run concurrently with your own review
-9. **Verify Critical/Important survivors adversarially**: after your own review produces candidate findings and before finalizing the report, run each surviving holistic Critical/Important finding through a fresh-context refuter per the Finding Proof Gate, then drop, demote, or keep it on the refuter's verdict. The report is not produced until this pass completes.
-10. **Resolve suggestions before writing the marker**: after the report is produced and before deciding on the marker, attempt to auto-fix every item in the Suggestions section. For each: if the fix is surgical (touches `app/` source only, ≤10 files, no convention surface), apply it in a self-heal commit and set `AUDIT_SELF_HEALED="true"`. If a suggestion requires a human tradeoff (architectural restructuring, breaking change, conflicting convention), mark it **Escalated** with explicit rationale, escalated suggestions unconditionally block the marker. Never proceed to the marker with any suggestion that is neither fixed in the working tree nor explicitly escalated.
+8. **Dispatch in parallel**: once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor`, `pnpm knip --reporter json`, and `pnpm audit --json` from a single tool-call message so they run concurrently with your own review. When the parallel dispatch returns: (a) emit the `oracles done` breadcrumb with per-oracle finding counts; (b) after you have produced your own holistic candidate findings from the cross-cutting review dimensions, emit the `holistic review done` breadcrumb with the count of candidate Critical/Important holistic findings. Both breadcrumbs are emitted before the adversarial pass (see Progress breadcrumbs).
+9. **Verify Critical/Important survivors adversarially**: after your own review produces candidate findings and before finalizing the report, run each surviving holistic Critical/Important finding through a fresh-context refuter per the Finding Proof Gate, then drop, demote, or keep it on the refuter's verdict. The report is not produced until this pass completes. When the adversarial pass is complete, emit the `adversarial verify done` breadcrumb (see Progress breadcrumbs).
+10. **Resolve suggestions before writing the marker**: after the report is produced and before deciding on the marker, attempt to auto-fix every item in the Suggestions section. For each: if the fix is surgical (touches `app/` source only, ≤10 files, no convention surface), apply it in a self-heal commit and set `AUDIT_SELF_HEALED="true"`. If a suggestion requires a human tradeoff (architectural restructuring, breaking change, conflicting convention), mark it **Escalated** with explicit rationale, escalated suggestions unconditionally block the marker. Never proceed to the marker with any suggestion that is neither fixed in the working tree nor explicitly escalated. When the marker decision is made and recorded, emit the `report stamped` breadcrumb (see Progress breadcrumbs).
 
 ## Rules-Based Audit (Specialist Subagents + react-doctor + knip + pnpm audit)
 
@@ -242,6 +268,7 @@ Rule-based line-level checks are done by specialist subagents in parallel with `
    - Resolve the base: if the invoking context provides one (CI passes `<base>...HEAD` in the agent prompt), use it; otherwise run `.github/audit/resolve-audit-base.sh`. It returns the most recent ancestor that already passed a clean audit under the current `.gaia/VERSION` (via a GAIA-Audit trailer or commit status), or `origin/main` when none exists.
    - List changed files: `git diff --name-only "$(.github/audit/resolve-audit-base.sh)" -- '*.ts' '*.tsx'`. The two-dot form (`<base>`, not `<base>...HEAD`) includes uncommitted working-tree changes, the right scope for a pre-commit/pre-merge review.
    - When the base is an audited ancestor, everything before it was already cleared; only the delta needs review. **For any exported symbol whose signature or contract changed in the delta, grep its importers and check them even if unchanged**, a cleared caller can still break from a delta change.
+   - Once the changed-file list is resolved and before dispatching subagents, emit the `scope resolved` breadcrumb (see Progress breadcrumbs).
 2. **Gate each subagent** on file scope, don't spawn a subagent that has nothing to review:
    - No `.tsx` files changed → skip Subagent 1 (React Patterns & Accessibility)
    - No `.ts` or `.tsx` files changed → skip Subagent 2 (TypeScript & Architecture)
@@ -515,6 +542,8 @@ if [ "$stamp_line" = "stamp: empty commit (created locally)" ]; then
   fi
 fi
 ```
+
+After the marker decision is made (marker written or not, self-heal applied or not), emit the `report stamped` breadcrumb (see Progress breadcrumbs). Example counts: `marker written, self-heal none` or `marker not written, self-heal applied`.
 
 Then surface, as the final line of your report, pick the line that matches the `stamp_line` + `push_status` combination:
 

--- a/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
@@ -325,6 +325,39 @@ jobs:
             --allowedTools Edit,Write,Bash(git:*),Bash(pnpm:*),Bash(node:*),Bash(npm:*)
             --verbose
 
+      - name: Print audit progress breadcrumbs
+        # Public-safe observability. The agent (show_full_output:false hides its
+        # SDK output) writes curated per-phase breadcrumbs to a gitignored file
+        # via Write/Edit; this step surfaces them in the step summary AFTER the
+        # agent runs. Gate MIRRORS the agent step exactly (not always(), not
+        # success()) so partial breadcrumbs surface even on an aborted audit.
+        # Always exits 0: a missing/empty file must never fail the required check.
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
+          steps.workflow-self-mod.outputs.self_modified == 'false' &&
+          steps.trailer.outputs.skip == 'false'
+        run: |
+          set +e
+          progress=".gaia/local/audit/progress.log"
+          {
+            echo "## code-review-audit progress"
+            echo ""
+            if [ -s "$progress" ]; then
+              echo '```'
+              cat "$progress"
+              echo '```'
+            else
+              echo "_No breadcrumbs recorded (audit wrote none, or aborted before the first phase)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null
+          # Mirror to the step log for log-only consumers.
+          if [ -s "$progress" ]; then
+            echo "code-review-audit progress:"
+            cat "$progress"
+          fi
+          exit 0
+
       - name: Commit and push self-heal
         id: push-fixes
         if: |

--- a/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
@@ -325,6 +325,39 @@ jobs:
             --allowedTools Edit,Write,Bash(git:*),Bash(pnpm:*),Bash(node:*),Bash(npm:*)
             --verbose
 
+      - name: Print audit progress breadcrumbs
+        # Public-safe observability. The agent (show_full_output:false hides its
+        # SDK output) writes curated per-phase breadcrumbs to a gitignored file
+        # via Write/Edit; this step surfaces them in the step summary AFTER the
+        # agent runs. Gate MIRRORS the agent step exactly (not always(), not
+        # success()) so partial breadcrumbs surface even on an aborted audit.
+        # Always exits 0: a missing/empty file must never fail the required check.
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
+          steps.workflow-self-mod.outputs.self_modified == 'false' &&
+          steps.trailer.outputs.skip == 'false'
+        run: |
+          set +e
+          progress=".gaia/local/audit/progress.log"
+          {
+            echo "## code-review-audit progress"
+            echo ""
+            if [ -s "$progress" ]; then
+              echo '```'
+              cat "$progress"
+              echo '```'
+            else
+              echo "_No breadcrumbs recorded (audit wrote none, or aborted before the first phase)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null
+          # Mirror to the step log for log-only consumers.
+          if [ -s "$progress" ]; then
+            echo "code-review-audit progress:"
+            cat "$progress"
+          fi
+          exit 0
+
       - name: Commit and push self-heal
         id: push-fixes
         if: |

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -325,6 +325,39 @@ jobs:
             --allowedTools Edit,Write,Bash(git:*),Bash(pnpm:*),Bash(node:*),Bash(npm:*)
             --verbose
 
+      - name: Print audit progress breadcrumbs
+        # Public-safe observability. The agent (show_full_output:false hides its
+        # SDK output) writes curated per-phase breadcrumbs to a gitignored file
+        # via Write/Edit; this step surfaces them in the step summary AFTER the
+        # agent runs. Gate MIRRORS the agent step exactly (not always(), not
+        # success()) so partial breadcrumbs surface even on an aborted audit.
+        # Always exits 0: a missing/empty file must never fail the required check.
+        if: |
+          steps.gate.outputs.gated == 'false' &&
+          steps.source-changes.outputs.has_source == 'true' &&
+          steps.workflow-self-mod.outputs.self_modified == 'false' &&
+          steps.trailer.outputs.skip == 'false'
+        run: |
+          set +e
+          progress=".gaia/local/audit/progress.log"
+          {
+            echo "## code-review-audit progress"
+            echo ""
+            if [ -s "$progress" ]; then
+              echo '```'
+              cat "$progress"
+              echo '```'
+            else
+              echo "_No breadcrumbs recorded (audit wrote none, or aborted before the first phase)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null
+          # Mirror to the step log for log-only consumers.
+          if [ -s "$progress" ]; then
+            echo "code-review-audit progress:"
+            cat "$progress"
+          fi
+          exit 0
+
       - name: Commit and push self-heal
         id: push-fixes
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Added
+
+- CI audit progress breadcrumbs: the `code-review-audit` workflow prints a curated
+  per-phase timeline (scope resolved, oracles done, holistic review done, adversarial
+  verify done, report stamped) into the GitHub Actions step summary, giving the
+  otherwise-silent CI run (the action hides agent output on public repos) a public-safe
+  signal of progress. Opt-in observability only: no raw tool output, no secrets, and a
+  breadcrumb write never blocks the audit
+
 ### Fixed
 
 - the bare-test guard no longer false-positives on quoted prose: `block-bare-test.sh` anchors detection to command position (splits on pipeline separators, strips leading env-var prefixes, acts only when `pnpm`/`npm` is the command word and `test` is the script position), so the phrase appearing inside a commit message (`git commit -m "run pnpm test"`) or a `--body` string (`gh pr create --body "...pnpm test --run..."`) is no longer blocked, and the `--run` opt-out is scoped to the matched segment; the sibling `capture-red-observations.sh` gate is anchored the same way so a prose mention no longer triggers a spurious full-suite vitest re-run

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-08
-updated: 2026-06-05
+updated: 2026-06-11
 tags: [concept, ci, audit, claude]
 ---
 
@@ -58,6 +58,26 @@ A genuinely-clean audit that produces no self-heal commits and no empty trailer 
 The `Write GAIA-Audit commit status (clean, no push)` step closes this gap: it stamps the `GAIA-Audit` commit status directly on the current PR HEAD with no empty commit. A proven-clean guard prevents false passes: the audit agent writes `.gaia/local/audit/<HEAD>.ok` only on a clean pass (no Critical Issues, all Important Issues addressed, all Suggestions resolved). The step checks for this marker before stamping; a dirty audit that pushed nothing has no marker and receives no status, keeping the merge blocked until the audit clears.
 
 This is the audit's instance of the cross-workflow mechanism in [[Incremental CI Skipping]].
+
+## Progress breadcrumbs
+
+The workflow runs the [[Code Review Audit Agent]] with `show_full_output: false`. This is deliberate: `gaia-react/gaia` is a public repo and full output would expose tool results that may contain secrets. As a result, the agent's own output is invisible in the Actions log.
+
+To provide a public-safe, post-hoc view of audit progress, the agent writes a curated per-phase breadcrumb line to `.gaia/local/audit/progress.log` (runner-local, gitignored; the same directory as the `<sha>.ok` clean marker) via its `Write`/`Edit` tool. Each line is a phase label plus integer counts only: no code, no file contents, no raw tool output, no secrets. These writes are best-effort: a write failure never blocks or fails the audit.
+
+A trailing workflow step (`Print audit progress breadcrumbs`) reads that file after the agent step completes and prints it into `$GITHUB_STEP_SUMMARY`. Its gate mirrors the agent step's gate exactly (gate label present, source changes present, no workflow self-modification, no matching trailer), so breadcrumbs surface whenever the audit ran. Partial breadcrumbs appear even when the audit aborts due to max-turns or an SDK error. The step always exits successfully, so it never affects the required `code-review-audit` check status.
+
+The agent itself cannot write directly to the runner log because its `Bash` tool is captured by the SDK and bare `echo`/`cat` commands are not in the workflow `allowedTools` globs. The progress file plus trailing print step is the split that makes runner-log output possible.
+
+Five phases emit a breadcrumb, in run order:
+
+| # | Phase label | Emitted when |
+|---|---|---|
+| 1 | `scope resolved` | Changed-file list resolved against the incremental base, before dispatch |
+| 2 | `oracles done` | Parallel oracle dispatch returns (react-doctor, pnpm knip, pnpm audit, rule subagents) |
+| 3 | `holistic review done` | Cross-cutting review produces candidate findings, before the adversarial pass |
+| 4 | `adversarial verify done` | Finding Proof Gate adversarial refuter pass completes |
+| 5 | `report stamped` | Audit-marker decision complete: marker written or not, self-heal applied or not |
 
 ## Adopter knobs
 
@@ -120,6 +140,7 @@ Editing HEAD between the local stamp and `gh pr merge` invalidates the trailer (
 - Config reader: `.gaia/scripts/read-audit-ci-config.sh`
 - Default config: `.gaia/audit-ci.yml`
 - Frozen contracts (trailer format, skip logic, check name, event triggers): `.gaia/local/plans/code-review-audit-ci/trailer-format.md`
+- Progress breadcrumb file (runner-local, gitignored): `.gaia/local/audit/progress.log`
 
 ## See also
 


### PR DESCRIPTION
## What

Give the public-repo `code-review-audit` CI run a **public-safe, post-hoc per-phase breadcrumb timeline** in the Actions step summary. Today the agent runs with `show_full_output: false` (kept off deliberately: full output would dump tool results that may contain secrets into publicly visible logs), so a CI audit run is a blackout.

This is **Option B (breadcrumbs)**, not a rearchitecture. Option A (decomposing the audit into sequential `claude-code-action` steps for live progress) is explicitly deferred.

## How

- The agent appends **one curated line per review phase** (label + integer counts only, never secrets/code/tool output) to the gitignored file `.gaia/local/audit/progress.log` via its `Write`/`Edit` tool. Best-effort: a write failure never blocks or alters the audit. Truncate-on-first-write so a fresh run never shows stale breadcrumbs.
- Five breadcrumbs, in run order: `scope resolved`, `oracles done`, `holistic review done`, `adversarial verify done`, `report stamped`.
- A trailing workflow step prints that file into `$GITHUB_STEP_SUMMARY` **after** the agent step. Its `if:` mirrors the agent step's gate **exactly** (not `always()`, not `success()`, not keyed on audit outcome), so partial breadcrumbs surface even on an aborted audit. The step always exits 0 and never changes the job pass/fail.

## Byte-identity

The print step is applied byte-identically to all three workflow copies: the in-tree `.github/workflows/code-review-audit.yml`, the bundled CLI template, and the **source** CLI template under `src/automation/templates/` (the copy the byte-identity dogfood test actually reads). `pnpm exec vitest run audit-template-dogfood` is green; the full CLI suite passes.

## Verification note

Editing the workflow self-skips the audit on this PR (the workflow-self-modification guardrail), so the feature cannot be verified on its own PR. Verification is a two-PR dance: land on main, open a throwaway `app/`-touching PR to observe the breadcrumbs, then discard it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)