### PR TITLE
test: verify CI audit breadcrumbs (throwaway, do not merge)

### DIFF
--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -1,3 +1,4 @@
+// Throwaway no-op to trigger a CI audit run for breadcrumb verification. Revert.
 export const range = (start: number, end: number): number[] => {
   if (start > end) return [];
 


### PR DESCRIPTION
**Throwaway / do-not-merge.** Touches one `app/` file (a no-op comment) to clear the `has_source` gate so the `code-review-audit` workflow actually runs, so the public-safe progress breadcrumbs (merged in #350) can be observed in the step summary. Closed and branch-deleted after observation.