### PR TITLE
fix(code-review-audit): tune for Opus 4.8 recall; run holistic finder on Opus

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -1,7 +1,7 @@
 ---
 name: code-review-audit
 description: 'Comprehensive code review, security audit, performance analysis, and architectural assessment. Goes beyond linting and type-checking to identify vulnerabilities, bottlenecks, code smells, anti-patterns, and refactoring opportunities. Mandatory before PR merge.'
-model: sonnet
+model: opus
 color: orange
 ---
 
@@ -36,6 +36,8 @@ Don't duplicate work: if a subagent is going to check every `useEffect` against 
 ## Main-agent review dimensions
 
 Analyze the changed code across these dimensions. Focus on cross-cutting concerns the subagents can't see.
+
+**Optimize for coverage at this stage, not precision.** Report every issue you find, including ones you are uncertain about or judge low-severity. Do not silently drop a candidate because it feels minor or you are not certain it is real: that decision belongs to the Finding Proof Gate and the adversarial verifier downstream, not to the act of looking. For each candidate, record an estimated severity (Critical / Important / Suggestion) and a confidence (high / medium / low) so the gate can rank and filter. A finding that later gets filtered out costs less than a real bug you never surfaced. The bar for *surfacing* a candidate is "could this cause incorrect behavior, a test failure, a security exposure, or a misleading result?", not "am I certain this matters?".
 
 ### 1. Security Vulnerabilities (CRITICAL PRIORITY)
 
@@ -101,9 +103,11 @@ Beyond general best practices, verify adherence to these project-specific patter
 
 ## Finding Proof Gate (holistic reviewer)
 
-Every finding you (the main agent) report must clear this gate before it reaches the report. The gate sits **on top of** the tool-specific false-positive patterns elsewhere in this agent (the react-doctor barrel-import / multiple-useState noise called out under "Merge findings", the knip bucket classification); it does not replace them. Those patterns reject _known_ bad findings. This gate makes _every_ finding prove itself. The deterministic advisories (react-doctor, knip, pnpm audit) are oracles, not probabilistic judgments, so they pass through under their own false-positive handling and are not subject to this gate.
+The gate is a **filter stage that runs after candidate collection, not a censor you apply while looking.** First enumerate every candidate finding per the coverage mandate above (severity + confidence tagged); then run each candidate through this gate to decide what reaches the report. Keeping the two phases separate is the point: collapsing them lets a borderline-but-real finding get dropped before it is ever written down, which is exactly the recall loss this gate is _not_ meant to cause. The gate's job is to cut candidates that cannot prove themselves, never to discourage you from generating them.
 
-Before reporting a finding, run all four checks:
+The gate sits **on top of** the tool-specific false-positive patterns elsewhere in this agent (the react-doctor barrel-import / multiple-useState noise called out under "Merge findings", the knip bucket classification); it does not replace them. Those patterns reject _known_ bad findings. This gate makes _every_ candidate prove itself. The deterministic advisories (react-doctor, knip, pnpm audit) are oracles, not probabilistic judgments, so they pass through under their own false-positive handling and are not subject to this gate.
+
+Run all four checks against each collected candidate:
 
 1. **Cites an exact `file:line`.** Point at the specific line where the defect lives, not a file, a function, or a region. No line, no finding.
 2. **Names a concrete failure mode: input + state + bad outcome.** Give the input that triggers it, the state it fires in, and the wrong result that follows (for example, "when the loader returns `null` and the user submits the form twice, the second action reads a stale `id` and writes to the wrong record"). A category label on its own ("possible race condition", "potential XSS", "might leak") is not a failure mode; it names a worry, not a path.
@@ -151,7 +155,7 @@ Report exactly one verdict:
 Do not refute on intuition. If you cannot cite counter-evidence, the verdict is STANDS.
 ```
 
-**Zero findings is valid.** The gate is allowed to empty the report. If nothing survives the gate (the four checks or the adversarial pass), report no findings: that is a clean result, not a failure to look hard enough. Do not manufacture findings to fill the sections. A fabricated or unprovable finding is worse than none, because noise erodes trust in every real finding beside it.
+**Zero findings is valid, but only as a gate outcome, not a finding-stage shortcut.** The gate is allowed to empty the report: if you collected candidates and none survived the four checks or the adversarial pass, report no findings, that is a clean result. What is _not_ valid is reaching zero by never generating candidates, or by self-censoring uncertain ones before the gate sees them. "Do not manufacture findings" means do not invent a defect you have no evidence for; it does not mean "when uncertain, stay silent". An uncertain-but-evidenced candidate should be surfaced and tagged low-confidence so the gate can rule on it. A fabricated finding erodes trust; so does a silently withheld real bug.
 
 ## Output Format
 
@@ -252,7 +256,7 @@ The agent runs in CI with `show_full_output: false` (a deliberate public-repo sa
 3. **Think adversarially**: for each input and endpoint, consider what a malicious user could do
 4. **Consider the blast radius**: prioritize issues by their potential impact
 5. **Be specific**: never say "this could be improved" without saying exactly how and why
-6. **Be proportionate**: don't nitpick formatting when there are security holes; focus energy on what matters most
+6. **Be proportionate in the report, not in the search**: surface every candidate during review (coverage), then rank ruthlessly in the written report so security holes lead and minor items don't bury them. Proportionality governs ordering and emphasis in the output, never whether a real candidate gets investigated or surfaced.
 7. **Respect existing patterns**: if the codebase has an established way of doing something, don't suggest alternatives unless there's a concrete benefit
 8. **Dispatch in parallel**: once you have the file scope, spawn the rule-based subagents AND kick off `react-doctor`, `pnpm knip --reporter json`, and `pnpm audit --json` from a single tool-call message so they run concurrently with your own review. When the parallel dispatch returns: (a) emit the `oracles done` breadcrumb with per-oracle finding counts; (b) after you have produced your own holistic candidate findings from the cross-cutting review dimensions, emit the `holistic review done` breadcrumb with the count of candidate Critical/Important holistic findings. Both breadcrumbs are emitted before the adversarial pass (see Progress breadcrumbs).
 9. **Verify Critical/Important survivors adversarially**: after your own review produces candidate findings and before finalizing the report, run each surviving holistic Critical/Important finding through a fresh-context refuter per the Finding Proof Gate, then drop, demote, or keep it on the refuter's verdict. The report is not produced until this pass completes. When the adversarial pass is complete, emit the `adversarial verify done` breadcrumb (see Progress breadcrumbs).
@@ -443,15 +447,18 @@ Files to review: [list from git diff]
 
 Rules: [paste the relevant rules from above]
 
+Report every violation you find, including ones you are uncertain about. Do not filter for importance or confidence, a downstream gate does that. Your job here is coverage: it is better to surface a violation that later gets dropped than to withhold a real one.
+
 For each violation found, report:
 - **Location**: `path/to/file.tsx:42`
 - **Rule**: which specific rule
 - **Issue**: what's wrong
 - **Fix**: concrete fix (code snippet or clear instruction)
+- **Confidence**: high | medium | low
 
-Classify each finding as Critical (will cause bugs/errors), Important (convention violation with real impact), or Suggestion (minor style/consistency).
+Classify each finding as Critical (will cause bugs/errors), Important (convention violation with real impact), or Suggestion (minor style/consistency). Classify and tag confidence; do not drop a violation for being low-severity or low-confidence.
 
-If no violations are found for a rule, don't mention it. If no violations are found anywhere across all files, reply with exactly "No violations found.", no preamble, no caveats.
+If a candidate truly does not violate any listed rule, don't report it. If no violations are found anywhere across all files, reply with exactly "No violations found.", no preamble, no caveats.
 ```
 
 ## Constraints
@@ -459,7 +466,7 @@ If no violations are found for a rule, don't mention it. If no violations are fo
 - Focus on recently changed or specified code, not the entire codebase (unless explicitly asked)
 - Show targeted diffs or snippets, not large regenerated code blocks
 - Read related files only as needed for context (e.g., verifying authorization); keep the review focused on the target code
-- Prioritize ruthlessly, 5 important issues beats 50 trivial ones
+- Prioritize ruthlessly **in the final report's ordering**, 5 important issues lead over 50 trivial ones; this governs how findings are ranked and presented, not whether they are surfaced (surface everything at the finding stage, let the proof gate and verifier cut)
 - Work within the project's existing patterns when suggesting fixes; don't introduce new dependencies
 - **Self-heal scope is fix-only, not restore-only.** Do NOT recreate files the PR explicitly deleted, do NOT add files you think "should" exist (deprecation aliases, restored renames, templates the PR removed). The PR's intent is authoritative; if a removal looks wrong, raise it as a finding for human review rather than reverting it via a self-heal commit.
 - **Self-heal never touches instruction or convention surfaces.** Files under `.claude/`, `.specify/`, and `wiki/` define the project's conventions, skills, and this agent's own definition, they are never code defects to auto-fix, and editing them risks reverting deliberate work or rewriting the very rules the audit enforces. If one looks wrong, raise a finding for human review. The push gate refuses any self-heal that edits them.

--- a/wiki/concepts/Agentic Design.md
+++ b/wiki/concepts/Agentic Design.md
@@ -46,7 +46,7 @@ The [[Code Review Audit Agent]] is a manager-and-specialists system. The lead re
 
 #### Resource-Aware Optimization
 
-Model tier follows task complexity. [[GAIA Audit]] runs both stages on Sonnet; drift checks (sha256 + verbatim before/after snippets) carry the safety, so the research stage doesn't need a heavier model. `/gaia-plan` asks the user whether to use Opus for planning, defaulting to yes; per-task implementation sub-agents inherit the running model (typically Sonnet). The Code Review Audit declares `model: sonnet` in its frontmatter so the structured rule-based review runs cheaply, leaving Opus for harder reasoning. Cost and quality discipline is wired in, not left to the user.
+Model tier follows task complexity. [[GAIA Audit]] runs both stages on Sonnet; drift checks (sha256 + verbatim before/after snippets) carry the safety, so the research stage doesn't need a heavier model. `/gaia-plan` asks the user whether to use Opus for planning, defaulting to yes; per-task implementation sub-agents inherit the running model (typically Sonnet). The Code Review Audit declares `model: opus` in its frontmatter: the holistic finder does the hard cross-cutting reasoning (security, data flow, architecture) where bug-finding recall and precision matter most, and it delegates cheaper line-level rule compliance to Sonnet specialist subagents plus deterministic oracles (`react-doctor`, `knip`, `pnpm audit`). Reasoning runs on the heavier tier; mechanical rule-matching runs cheaply alongside it. Cost and quality discipline is wired in, not left to the user.
 
 ### Infrastructure & State
 

--- a/wiki/concepts/Code Review Audit Agent.md
+++ b/wiki/concepts/Code Review Audit Agent.md
@@ -8,7 +8,7 @@ tags: [concept, claude, agent, review]
 
 # Code Review Audit Agent
 
-Defined in `.claude/agents/code-review-audit.md`. Sonnet-class subagent for comprehensive code review beyond what ESLint and TypeScript catch.
+Defined in `.claude/agents/code-review-audit.md`. Opus-class holistic reviewer for comprehensive code review beyond what ESLint and TypeScript catch; it dispatches cheaper Sonnet specialist subagents for line-level rule compliance.
 
 Full spec: `.claude/agents/code-review-audit.md`.
 


### PR DESCRIPTION
## Why

Per Anthropic's Claude Code docs, Opus 4.8 follows "be conservative / only report high-severity / don't nitpick" instructions **more faithfully** than prior models. A harness tuned for an earlier model (this agent was authored under Opus 4.6) sees that as a recall drop: same investigation depth, fewer findings converted to reports. The fix is the docs' prescription, split finding from filtering, and surface everything at the finding stage.

## What changed

**`.claude/agents/code-review-audit.md`**
- **Coverage mandate** added to the holistic dimensions and the specialist-subagent template: surface every candidate (including uncertain / low-severity), each tagged with severity **and** confidence; the gate filters downstream.
- **Finding Proof Gate** reframed as a post-collection **filter** stage rather than a finding-time censor (collect all candidates first, then cut).
- Scoped "be proportionate" / "prioritize ruthlessly" to **report ordering**, not the search.
- Clarified "zero findings is valid" as a *gate outcome*, not a finding-stage shortcut; "don't manufacture" no longer reads as "stay silent when uncertain".
- **Model bumped `sonnet` → `opus`**: the holistic finder does the hard cross-cutting reasoning where Opus 4.8's bug-finding gains land; cheaper Sonnet specialists + deterministic oracles still do line-level work.

**Wiki** (`Agentic Design.md`, `Code Review Audit Agent.md`): updated the model rationale to match (reasoning on the heavier tier, mechanical rule-matching cheap alongside).

The adversarial refuter (the genuine separate-verification stage the docs bless) was already correct and is untouched.

## Validation

Dry-run smoke test against PR #196's diff (`c944ff2^..c944ff2`, XSS + error-handling), marker/commit/push disabled:
- Ran on `claude-opus-4-8`; confidence tags present on every finding; subagent gating worked (translation skipped).
- Find-then-filter visibly two-phase: *collected 6 → dedup 1 → dropped 1 → demoted 1 → 3 reported*. Wider net, precision held (0 false Criticals).
- Surfaced a real consistency gap (ErrorStack implicit-`undefined` return, same class fixed in sibling `MetaHydrated`) that the old conservative prompt could have dropped. Both that and the `handleClick` naming it flagged were in fact later fixed in #222, confirming the findings were legitimate, not noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)