### PR TITLE
fix(harness): make .specify dispatch explicit, not prose (Opus 4.8)

### DIFF
--- a/.specify/extensions/gaia/commands/constitution-check.md
+++ b/.specify/extensions/gaia/commands/constitution-check.md
@@ -13,7 +13,7 @@ Fired automatically by spec-kit on the `before_specify` event (mandatory hook). 
 
 ## Step 1: version-pin drift detection
 
-Run the version-check helper and capture its result:
+Run the version-check helper using the Bash tool, and capture its result:
 
 ```bash
 bash .specify/extensions/gaia/lib/version-check.sh
@@ -42,10 +42,10 @@ If both checks pass, emit a single confirmation line and let `/speckit-specify` 
 
 > `before_specify` ok: constitution populated, spec-kit version matches pin.
 
-This hook has no return value to spec-kit; control returns to the running `/speckit-specify` (or `/speckit-gaia-spec`) skill on completion.
+This hook has no return value to spec-kit. After emitting the confirmation line, **return control to the caller**, end this hook's turn and let the running `/speckit-specify` (or `/speckit-gaia-spec`) skill continue. Do not call any further tool on the pass-through path.
 
 ## Notes
 
 - The check is read-only. No writes to `.specify/memory/`, no writes to `.gaia/local/`.
 - The helper script is the single source of truth for the version-pin format; this skill never inlines version constants.
-- "Block" here means: the agent reads this skill's output, sees the block message, and chooses not to call `/speckit-specify`. Spec-kit does not enforce a hard halt, discipline is in the prompt.
+- "Block" here means: the agent emits the block message and then **STOPS**, it does not call `/speckit-specify` or any further tool. Spec-kit does not enforce a hard halt, so the STOP is the discipline: end the turn after the block message rather than continuing the lifecycle.

--- a/.specify/extensions/gaia/commands/lint.md
+++ b/.specify/extensions/gaia/commands/lint.md
@@ -22,6 +22,8 @@ If no candidate resolves, surface:
 
 ## Run the lint helper
 
+Run using the Bash tool:
+
 ```bash
 bash .specify/extensions/gaia/lib/lint.sh <resolved-spec-path>
 ```
@@ -53,6 +55,7 @@ The helper emits a JSON result on stdout: `{"ok": true, "findings": []}` on pass
 
 ## Notes
 
-- This hook is read-only; it never edits the SPEC.
+- This hook is read-only. Its only action is to emit the helper's findings and stop, it never edits, deletes, moves, or auto-fixes the SPEC. Fixing the SPEC is the `/gaia-spec` wrapper's job (looping back to the user); lint only reports.
 - "Block save" semantics: a failing lint surfaces the findings to the agent driving `/gaia-spec`; that agent is responsible for halting before the on-disk save and looping back to the user.
 - The helper is pure: same SPEC in, same JSON out. Any mutation logic belongs in `/gaia-spec` (the wrapper command), never here.
+- On completion (pass, fail, or skip) this hook returns control to the running `/gaia-spec` (or `/speckit-specify`) wrapper; it performs no further action and calls no further tool itself.

--- a/.specify/extensions/gaia/commands/spec-close.md
+++ b/.specify/extensions/gaia/commands/spec-close.md
@@ -79,6 +79,8 @@ Surface via `AskUserQuestion`:
 
 Update the `.gaia/specs.json` row for `<spec_id>` to record the merge: set `status: merged` and stamp `merged_at` with the current UTC timestamp. Disposition lives on the artifact (and in telemetry); the ledger tracks SPEC lifecycle independently of artifact location.
 
+Run using the Bash tool:
+
 ```bash
 PATCH=$(jq -nc --arg ts "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
   '{status: "merged", merged_at: $ts}')

--- a/.specify/extensions/gaia/commands/spec-close.md
+++ b/.specify/extensions/gaia/commands/spec-close.md
@@ -37,7 +37,7 @@ Test for `.gaia/local/cache/wiki-promote/<spec_id>.json`.
 
 1. Read the cache. Run `gh pr list --head "$branch" --state merged --json number,mergedAt,url,body --limit 1`.
 2. If still unmerged: report `<spec_id>: PR for branch <branch> not yet merged. Re-run after merge.` and exit. Do not delete the cache. Do not proceed to disposition, the SPEC is not closed yet.
-3. If merged: re-invoke `/speckit-gaia-wiki-promote` with the SPEC ID as context. Wiki-promote's Step 3 detects the merged PR, runs Steps 4–7, and deletes the cache. **Wiki-promote's Step 8 chain is suppressed in this drain context** to avoid re-entering spec-close, pass `drained: true` in the chain context (see wiki-promote Step 8 for the guard).
+3. If merged: re-invoke `/speckit-gaia-wiki-promote` by calling the Skill tool to run that command with the SPEC ID as its argument, and include the exact literal string `drained: true` in the invoking message. Wiki-promote's Step 3 detects the merged PR, runs Steps 4–7, and deletes the cache. **Wiki-promote's Step 8 chain is suppressed in this drain context** to avoid re-entering spec-close: its Step 8 suppression guard matches that literal `drained: true` token in the invocation, so emit it verbatim, not a paraphrase, and do not rely on the surrounding conversation to convey it (see wiki-promote Step 8 for the guard).
 
 **If no cache exists** (immediate-merge or never-promoted path): skip drain. Proceed to Step 3.
 

--- a/.specify/extensions/gaia/commands/uat-write.md
+++ b/.specify/extensions/gaia/commands/uat-write.md
@@ -21,6 +21,8 @@ The GAIA preset's `/speckit-specify` wrapper relocates and stamps the SPEC immed
 
 ## Run the render helper
 
+Run using the Bash tool:
+
 ```bash
 bash .specify/extensions/gaia/lib/uat-write.sh <resolved-spec-path>
 ```
@@ -39,7 +41,7 @@ The helper emits a JSON summary on stdout. Capture it verbatim; do NOT pipe thro
 
   > Suggested first action: `pnpm pw .playwright/e2e/<spec-dir>/`, confirms red-state baseline.
 
-- **Operational failure (`ok: false`, exit `1`).** Emit the helper's `error` message verbatim. Do NOT proceed to `/speckit-implement`'s source edits, the implementer agent is responsible for reading the failure and halting the lifecycle.
+- **Operational failure (`ok: false`, exit `1`).** Emit the helper's `error` message verbatim, then **stop**, do not proceed to `/speckit-implement`'s source edits and do not call any further tool. End the turn on the failure so the lifecycle halts here rather than relying on a downstream agent to notice and stop.
 
 - **Usage error (exit `2`).** Treat as a tooling problem, not a SPEC problem. Report the stderr message and skip without blocking the lifecycle. The user's `/speckit-implement` continues, but without a generated harness, the implementer should write tests inline as fallback and acknowledge the harness was not available.
 
@@ -52,3 +54,4 @@ The helper emits a JSON summary on stdout. Capture it verbatim; do NOT pipe thro
 - The hook fires only on `before_implement`. It is not invoked by any other lifecycle event.
 - Pluggability: only Playwright is supported in this SPEC. Vitest e2e / Cypress is a future SPEC.
 - The helper is pure: same SPEC in, same JSON out. Any rendering logic belongs in `lib/uat-write.sh`, never inline in this command body.
+- On completion (success, failure, or skip) this hook returns control to the lifecycle; it touches only `.playwright/e2e/<spec-dir>/` and its cache file, and performs no other action.

--- a/.specify/extensions/gaia/commands/wiki-promote.md
+++ b/.specify/extensions/gaia/commands/wiki-promote.md
@@ -33,13 +33,13 @@ Branch on `wiki_promote_default`:
 
 ## Step 3 - Detect merged PR
 
-Determine the current branch:
+Determine the current branch using the Bash tool:
 
 ```bash
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 ```
 
-Probe for a merged PR matching the branch:
+Probe for a merged PR matching the branch using the Bash tool:
 
 ```bash
 pr_json=$(gh pr list --head "$current_branch" --state merged --json number,mergedAt,url,body --limit 1 2>/dev/null || echo '[]')
@@ -224,7 +224,7 @@ Render the body in the following sections, in order, immediately after the closi
    Substitutions:
    - `SPEC-NNN`, the SPEC ID from Step 1.
    - The repo-relative path uses `../../` because promoted wiki pages live at `wiki/<subdomain>/<page>.md` (two segments deep from the repo root).
-   - `<owner>/<repo>`, resolved once per run via:
+   - `<owner>/<repo>`, resolved once per run by running, via the Bash tool:
 
      ```bash
      repo_slug=$(gh repo view --json owner,name -q '"\(.owner.login)/\(.name)"' 2>/dev/null)
@@ -290,9 +290,9 @@ Emit a structured payload to stdout (the next agent reads it as conversation con
 }
 ```
 
-Then invoke `/gaia-wiki sync` directly:
+Then invoke `/gaia-wiki sync` by calling the Skill tool (skill `gaia-wiki`, args `sync`), do not merely print the line below; it states the intent, it is not the call:
 
-`Invoke /gaia-wiki sync now to handle the branch-aware commit step for these pages.`
+> Invoking `/gaia-wiki sync` to handle the branch-aware commit step for these pages.
 
 (`/gaia-wiki sync` will read the staged-but-uncommitted wiki changes from `git status`, write to `wiki/log.md` and `wiki/.state.json`, then commit per its branch-aware rules.)
 
@@ -320,11 +320,11 @@ If any pages were skipped due to hand-edit detection, include a one-line note:
 
 This step fires only when Step 3 found a merged PR and Steps 4–7 ran full. On the deferred path, Step 3 exits before reaching here. On the silent-skip path (`wiki_promote_default: no`) and the preview path (`--preview`), Step 2 exits before reaching here. So an unconditional invoke at this step is safe, the only way to land here is the immediate-merge full-run.
 
-**Suppression guard.** If wiki-promote was re-fired from `/speckit-gaia-spec-close` Step 2's drain (deferred path), spec-close passes the context flag `drained: true` to wiki-promote. Detect that flag in the invoking conversation context, if present, skip this step (spec-close is the parent in that case and will handle disposition itself once wiki-promote returns).
+**Suppression guard.** If wiki-promote was re-fired from `/speckit-gaia-spec-close` Step 2's drain (deferred path), spec-close passes the literal flag `drained: true` in the invocation that triggered this run. Skip this step **only when** the invoking message contains the exact string `drained: true`, match the literal token; do not infer "drained" from the surrounding conversation or from the fact that a cache was cleared. When `drained: true` is present, spec-close is the parent and will handle disposition itself once wiki-promote returns; skip Step 8.
 
-Otherwise, invoke `/speckit-gaia-spec-close` directly:
+Otherwise, invoke `/speckit-gaia-spec-close` directly by calling the Skill tool to run that command with `<spec_id>` as its argument, the line below states the intent, it is not a substitute for the call:
 
-`Invoke /speckit-gaia-spec-close <spec_id> now. wiki-promote completed inline; the cache is already cleared. Spec-close will skip drain and go straight to the disposition prompt.`
+> Invoking `/speckit-gaia-spec-close <spec_id>`. wiki-promote completed inline; the cache is already cleared. Spec-close will skip drain and go straight to the disposition prompt.
 
 This presents the user with the archive / delete / keep prompt for the local SPEC artifact. The wiki content is already committed (Step 6's wiki-sync handoff); the disposition only affects `.gaia/local/specs/<spec_id>/`.
 

--- a/.specify/extensions/gaia/templates/clarify-prompts.md
+++ b/.specify/extensions/gaia/templates/clarify-prompts.md
@@ -153,8 +153,11 @@ Slot semantics:
   topic order is fluid, the PO names the topic with the highest
   remaining question count.
 
-The exhaustion checkpoint never collapses into a default-advance -
-the user's choice is required.
+The exhaustion checkpoint never collapses into a default-advance, the
+user's choice is required. After firing the `AskUserQuestion`, await
+the user's reply before any further action, do not advance topics,
+dispatch research, or author anything on the assumption the recommended
+option was taken.
 
 ---
 
@@ -176,8 +179,11 @@ Slot semantics:
   Quote it back so the user knows what was sent and can correct
   scope before the subagent runs.
 
-Findings are folded into `research_summary` of the SPEC. The PO
-never asks the human to do the research themselves.
+After announcing, the PO performs the dispatch by calling the Agent
+tool (`subagent_type: general-purpose`) with `<question>` as the task,
+the announce line above is narration, not the dispatch itself. Findings
+are folded into `research_summary` of the SPEC. The PO never asks the
+human to do the research themselves.
 
 ---
 

--- a/.specify/extensions/gaia/templates/system-prompt.md
+++ b/.specify/extensions/gaia/templates/system-prompt.md
@@ -67,8 +67,10 @@ rules for the Socratic loop:
 4. **Research subagent dispatch is your job, not the human's.** When
    a question needs prior-art lookup, repo-convention inspection, or
    competitive comparison, announce `"Dispatching research agent for
-<question>"` and dispatch. Fold findings into `research_summary`.
-   Never punt the research to the human.
+<question>"`, then actually dispatch by calling the Agent tool
+   (`subagent_type: general-purpose`) with that question, the announce
+   line is narration, not the dispatch. Fold the returned findings into
+   `research_summary`. Never punt the research to the human.
 5. **Two-gate ceremony.** After discovery is materially complete:
    - **Gate 1: shape confirmation.** Present intent + UATs in plain
      English. Wait for explicit confirmation before authoring the
@@ -79,12 +81,17 @@ rules for the Socratic loop:
    text, scope drift relative to gate 1, internal inconsistency
    between fields, and ambiguous UAT phrasing. Fix before you show
    the human.
-7. **Block save while `clarifications.pending` is non-empty** unless
-   each pending item is explicitly deferred with rationale recorded.
+7. **Block save while `clarifications.pending` is non-empty.** Do not
+   write the SPEC artifact while any item remains pending. For each
+   pending item, surface it via `AskUserQuestion` (resolve it, or defer
+   it with a recorded rationale); proceed to save only once every
+   pending item is resolved or explicitly deferred with rationale.
 8. **No machine-local memory for project decisions.** Spec-relevant
    decisions live in the SPEC artifact. Do not stash them in
-   `~/.claude/projects/.../memory/`. Personal tone preferences are
-   the only allowed exception.
+   `~/.claude/projects/.../memory/`. The only exception is a literal
+   formatting preference (e.g. "no em dashes", "terse over
+   grammatical"); nothing about the feature, its scope, or any
+   decision the SPEC records may go to machine-local memory.
 
 ---
 


### PR DESCRIPTION
## Opus 4.8 harness audit, Group 3 (C7 dispatch-as-prose in .specify)

gaia repo only. C7 finding: Opus 4.8 emits chained invocations written as sentences as chat text instead of actually calling them, and follows soft "block"/"choose not to" directives literally. These edits convert dispatch prose into explicit tool/skill invocations, harden the control-flow stops, and name the Bash tool on command blocks. Docs-only (.md); Quality Gate is a no-op.

### Dispatch prose -> explicit invocation
- **system-prompt.md Rule 4** and **clarify-prompts.md Rule 6**: research dispatch now calls the Agent tool (`subagent_type: general-purpose`); the announce line is labeled narration.
- **wiki-promote.md Step 6**: `/gaia-wiki sync` invoked via the Skill tool (skill `gaia-wiki`, args `sync`).
- **wiki-promote.md Step 8**: `/speckit-gaia-spec-close` invoked via the Skill tool with `<spec_id>`.

### Control-flow stops
- **system-prompt.md Rule 7**: block-save expressed as the concrete `AskUserQuestion` action.
- **system-prompt.md Rule 8**: machine-local-memory exception narrowed to literal formatting preferences only.
- **clarify-prompts.md Rule 5**: exhaustion checkpoint must await the user's reply before any further action.
- **constitution-check.md**: "block" means emit the message then STOP (no further tools); explicit return on the pass-through path.
- **lint.md**: only action is emit findings and stop, never mutate the SPEC; explicit return.
- **uat-write.md**: operational failure emits the error and stops, rather than relying on a downstream agent to halt; explicit return.
- **wiki-promote.md Step 8**: `drained: true` suppression guard now matches the literal token, not free-form context.

### Cross-cutting
- Every fenced bash block in the command files now names the Bash tool ("Run using the Bash tool").
- Each hook command ends by explicitly returning control to its caller.

Do not merge: this PR is the review gate per the audit handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
