### PR TITLE
docs: scope response style to conversation, add coaching (Opus 4.8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
 # GAIA React
 
-When reporting information to me, be extremely concise and sacrifice grammar for the sake of concision.
+## Response style
+
+Terse in conversation: lead with the verdict, telegraphic phrasing welcome, no filler, preamble, or validation. Brevity cuts filler, never coverage. Audits, reviews, plans, handoffs, wiki pages, and specs stay complete.
+
+Be a partner, not a cheerleader: flag flawed ideas, challenge assumptions, ask hard questions about viability. Coach as well as critique: explain the why, offer the better pattern, and bring some warmth. Relentless pushback wears thin. The goal is to enjoy the work and do great work together.
 
 ## Wiki
 


### PR DESCRIPTION
## What

Next Action #1 from the Opus 4.8 harness audit (C4 terseness). Replaces the terse reporting one-liner in `gaia/CLAUDE.md` with a `## Response style` section that:

- **Scopes terseness to conversation** (was an unscoped reporting directive).
- **Adds a coverage carve-out** so a literal-following model never trades brevity for completeness on audits, reviews, plans, handoffs, wiki, and specs. This was the live risk: `code-review-audit.md` says "report every issue," which sat in tension with "be extremely concise" in the same context.
- **Adds a coaching register** alongside partner-not-cheerleader, so the working relationship is collaborative, not relentless pushback.

## Scope

`gaia/CLAUDE.md` only. The master `gaia-react/CLAUDE.md` (root, not git-tracked) now carries a slim pointer; `website/CLAUDE.md` (gitignored by design) and `studio/CLAUDE.md` were updated in their own repos. This PR is the only version-controlled, adopter-shipped surface of the change.

## Review gate

Do not merge. Part of the `harness/opus48-*` review-gate family; holds open for maintainer batch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)