### PR TITLE
docs: bound the autonomous + TDD loops, reconcile coding-guidelines (Opus 4.8)

### DIFF
--- a/.claude/rules/coding-guidelines.md
+++ b/.claude/rules/coding-guidelines.md
@@ -12,7 +12,7 @@ Surface assumptions explicitly, present interpretations when ambiguous, push bac
 
 ## 2. Simplicity First
 
-Write the minimum code that solves the problem, no speculative features, abstractions, or impossible-scenario error handling. If it could be 50 lines, don't write 200.
+Write the minimum code that solves the problem, no speculative features, abstractions, or impossible-scenario error handling. If it could be 50 lines, don't write 200. Impossible-scenario means a state that cannot occur; real failure modes (a command exits non-zero, a loop does not converge, a network call fails) still get handled and bounded. Simplicity governs the code you write, not the surrounding code (that is Surgical Changes).
 
 ## 3. Surgical Changes
 
@@ -20,7 +20,7 @@ Touch only what's needed: don't improve adjacent code, don't refactor unbroken t
 
 ## 4. Goal-Driven Execution
 
-Define verifiable success criteria before starting; loop until verified. For multistep tasks, state a brief plan with steps and verification checks.
+Define verifiable success criteria before starting, then loop until verified. Bound the loop: if a fixed number of attempts fails or you hit a blocker you cannot resolve, stop and surface it rather than looping indefinitely. For multistep tasks, state a brief plan with steps and verification checks.
 
 ## 5. Always Use Test Driven Development
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -66,6 +66,8 @@ Write ONE test that confirms ONE thing end-to-end for this layer. `RED → GREEN
 
 For each remaining behavior: `RED → GREEN`. One test at a time. Only enough code to pass the current test. Don't anticipate future tests.
 
+**Bound the green chase.** If a test won't pass after a few focused attempts, stop and reassess instead of thrashing the implementation: the test, the interface, or an assumption may be wrong. Surface the blocker rather than looping indefinitely to force green.
+
 ### 4. Refactor
 
 After all tests pass, look for [refactor candidates](refactoring.md):


### PR DESCRIPTION
## What

Next Actions #2 and #3 from the Opus 4.8 harness audit, batched because both are the same bounded-loop family.

### #2 - `.claude/rules/coding-guidelines.md`

Resolves three internal frictions a literal-following model could misread, especially against the bounded-stop work shipped in #355.

- **§2 impossible-scenario vs real failure modes.** The ban on "impossible-scenario error handling" could be cited to skip the real error handling (`STOP` on push failure, restore-key on install error, bounded remediation) that #355 mandates. §2 now states that impossible-scenario means a state that cannot occur, while real failure modes (a command exits non-zero, a loop does not converge, a network call fails) still get handled and bounded.
- **§2 simplicity vs §3 surgical.** "If it could be 50 lines, don't write 200" could read as license to simplify surrounding code, which §3 forbids. §2 now scopes simplicity to the code you write.
- **§4 loop-until-verified vs bounded loops.** "Loop until verified" reads as unbounded. §4 now bounds the loop: stop and surface a blocker rather than looping indefinitely chasing green.

### #3 - `.claude/skills/tdd/SKILL.md`

The red-green-refactor loop had no inner-loop bound. "Get to GREEN first" with no attempt limit drives thrashing a test that may itself be wrong. §3 Incremental Loop now carries a "bound the green chase" clause: stop and reassess after a few focused attempts rather than looping indefinitely to force green. Wording mirrors the coding-guidelines §4 bound so the two read as one philosophy.

## Scope

`.claude/rules/coding-guidelines.md` and `.claude/skills/tdd/SKILL.md`. Prose-only, no path or behavior changes.

## Review gate

Do not merge. Part of the `harness/opus48-*` review-gate family; holds open for maintainer batch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)