### PR TITLE
docs: align skeleton-loader placeholders with the translation rule + a11y (Opus 4.8)

### DIFF
--- a/.claude/agents/code-review-audit.md
+++ b/.claude/agents/code-review-audit.md
@@ -99,7 +99,7 @@ Beyond general best practices, verify adherence to these project-specific patter
 - No `eslint-disable react-hooks/exhaustive-deps` to hide missing fetcher deps, fix the deps instead
 - No `.catch(() => {})`, use `void` for fire-and-forget promises
 - Route files (`app/routes/`) are thin shells, loader, action, meta, and a one-line page import. UI belongs in `app/pages/`.
-- Localization: every user-facing string comes from `t()`. Hardcoded JSX strings are bugs.
+- Localization: every user-facing string comes from `t()`. Hardcoded JSX strings are bugs (except approximate skeleton-loader placeholders standing in for dynamic values).
 
 ## Finding Proof Gate (holistic reviewer)
 
@@ -430,7 +430,7 @@ Prompt the subagent with these rules to check:
 
 **From `.claude/rules/i18n.md`:**
 
-- Every user-visible string in JSX, labels, headings, placeholders, button text, error messages, tooltips, status text, `aria-label`, `alt`, `title`, must come from a `t()` call. Flag hardcoded English strings. Exceptions: punctuation-only strings, single-character symbols, developer-facing content (console.log, comments, test assertions).
+- Every user-visible string in JSX, labels, headings, placeholders, button text, error messages, tooltips, status text, `aria-label`, `alt`, `title`, must come from a `t()` call. Flag hardcoded English strings. Exceptions: punctuation-only strings, single-character symbols, developer-facing content (console.log, comments, test assertions), and approximate skeleton-loader placeholder text standing in for a dynamic runtime value (skeleton text mirroring static `t()` content must still use `t()`).
 
 **Library-specific rules (injected from extensions):**
 

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -9,7 +9,7 @@ paths:
 
 ## Usage
 
-Use `t()` from `useTranslation()` for all user-facing strings. Never hardcode text in JSX.
+Use `t()` from `useTranslation()` for all user-facing strings. Never hardcode text in JSX. (Exception: in skeleton loaders, approximate placeholders standing in for dynamic values stay hardcoded; static skeleton text still uses `t()`. See the skeleton-loaders skill.)
 
 ```tsx
 const {t} = useTranslation('pages', {keyPrefix: 'index'});

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -70,7 +70,7 @@ See `references/conform-forms.md` for full Conform + Zod wiring. Beyond the impo
 
 **Before writing ANY user-visible string in JSX:**
 
-Every string a user can see or hear, labels, headings, placeholders, button text, error messages, tooltips, descriptions, status text, `aria-label` attributes, `alt` text, and `title` attributes, must come from a `t()` call. Hard-coded English strings in JSX are bugs. This applies to new components, new UI sections, and modifications that add visible text. The only exceptions are punctuation-only strings, single-character symbols, and developer-facing content (console.log, comments, test assertions).
+Every string a user can see or hear, labels, headings, placeholders, button text, error messages, tooltips, descriptions, status text, `aria-label` attributes, `alt` text, and `title` attributes, must come from a `t()` call. Hard-coded English strings in JSX are bugs. This applies to new components, new UI sections, and modifications that add visible text. The only exceptions are punctuation-only strings, single-character symbols, developer-facing content (console.log, comments, test assertions), and approximate skeleton-loader placeholder text standing in for a dynamic runtime value. Skeleton text that mirrors static `t()` content must still use `t()` (see the skeleton-loaders skill).
 
 1. Add the translation key to the appropriate namespace file in `app/languages/en/` (and any other locale folders present, copying the English string verbatim as a placeholder)
 2. Use `t('key')` in the component, never a string literal

--- a/.claude/skills/skeleton-loaders/SKILL.md
+++ b/.claude/skills/skeleton-loaders/SKILL.md
@@ -23,18 +23,23 @@ const shimmer =
 
 ### Text elements
 
-Copy the real component's element type and font classes, add `shimmer`, use placeholder text of similar character count:
+Copy the real component's element type and font classes, add `shimmer`. How you fill the text depends on whether the real text is static or dynamic:
+
+- **Static, translatable text** (labels, headings, button text): use the same `t()` value the real component uses. The text is transparent, but reusing `t()` makes the skeleton width match the revealed text exactly.
+- **Dynamic runtime values** (`{data.name}`, API content): you cannot know the real value, so use hardcoded placeholder text of similar character count to approximate its width.
 
 ```tsx
 import {twJoin} from 'tailwind-merge';
 
 // Real component
-<p className="truncate text-sm font-semibold text-white">{data.name}</p>
-<p className="text-xs text-slate-400">{data.value}</p>
+<h2 className="text-lg font-bold text-white">{t('profile.heading')}</h2>   // static
+<p className="truncate text-sm font-semibold text-white">{data.name}</p>   // dynamic
+<p className="text-xs text-slate-400">{data.value}</p>                     // dynamic
 
 // Skeleton
-<p className={twJoin('truncate text-sm font-semibold', shimmer)}>Name</p>
-<p className={twJoin('text-xs', shimmer)}>Example value</p>
+<h2 className={twJoin('text-lg font-bold', shimmer)}>{t('profile.heading')}</h2>  // same t(), exact width
+<p className={twJoin('truncate text-sm font-semibold', shimmer)}>Name</p>         // approximate
+<p className={twJoin('text-xs', shimmer)}>Example value</p>                        // approximate
 ```
 
 ### Non-text elements (images, icons, avatars)
@@ -47,7 +52,7 @@ Keep as empty divs with the shimmer class, no text needed:
 
 ### Interactive elements (buttons)
 
-Use the real element type with `tabIndex={-1}` to prevent focus:
+Use the real element type with `tabIndex={-1}` to prevent focus. Button labels are static text, so use the real `t()` value (exact width on reveal):
 
 ```tsx
 <button
@@ -55,7 +60,7 @@ Use the real element type with `tabIndex={-1}` to prevent focus:
   tabIndex={-1}
   type="button"
 >
-  Click me
+  {t('common.submit')}
 </button>
 ```
 
@@ -84,6 +89,13 @@ return <MySkeleton />;
 - Async data sections (lists, profiles, detail views)
 - Route transitions with pending loader data
 
+## Accessibility
+
+Skeleton text is transparent, but screen readers still announce it (placeholder text and any `t()` labels). Hide the skeleton from assistive tech and announce loading instead:
+
+- Put `aria-hidden` on the skeleton's root element so assistive tech skips the decorative placeholders.
+- Mark the region that will receive the content with `aria-busy="true"` while loading, or render a visually-hidden `role="status"` "Loading" message so screen-reader users know content is on the way.
+
 ## Full Example Implementation
 
 ```tsx
@@ -93,7 +105,7 @@ const shimmer =
   'animate-shimmer rounded-sm bg-linear-to-r from-slate-950 via-slate-900 to-slate-950 bg-size-[200%_100%] text-transparent select-none';
 
 const ExampleSkeleton = () => (
-  <div className="border border-slate-700 bg-slate-900">
+  <div aria-hidden className="border border-slate-700 bg-slate-900">
     <div className="flex items-center gap-3 p-3">
       <div className={twJoin('size-14 shrink-0', shimmer)} />
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## What

Next Action #4 from the Opus 4.8 harness audit: a genuine cross-rule contradiction (independent of Opus 4.8), plus an a11y gap it surfaced.

**The contradiction.** The skeleton-loaders skill taught writing hardcoded English text in JSX (`Name`, `Example value`, `Click me`), while four enforcement points banned hardcoded JSX strings with no carve-out either way:

- `.claude/rules/i18n.md` (path-scoped, auto-loads on `app/components/**` and `app/pages/**`, i.e. exactly when building a skeleton)
- `.claude/skills/react-code/SKILL.md` Gate 3
- `.claude/agents/code-review-audit.md` translation subagent rule + the Localization dimension one-liner

**The correct rule** (per maintainer): the split is static vs dynamic, not "all skeleton text is exempt."

- **Static, translatable text** (labels, headings, button text): the skeleton uses the *same* `t()` value the real component uses. Transparent, but it makes the skeleton width match the revealed text exactly. **Not exempt.**
- **Dynamic runtime values** (`{data.name}`, API content): the real component interpolates data, so the skeleton uses an approximate-length hardcoded placeholder. **This is the only exemption.**

The skeleton-loaders skill now teaches the distinction (and its button example, previously hardcoded `Click me`, now uses `t()` since button labels are static). The four enforcement points exempt only dynamic-value placeholders, so the audit still correctly flags a hardcoded static label and does not flag an approximate placeholder for `{data.name}`.

## Accessibility

The exemption is sound only because no sighted user sees transparent placeholders, but screen readers still announce them. Added an Accessibility section: `aria-hidden` on the skeleton root so AT skips the decorative text, plus `aria-busy`/`role="status"` guidance to announce loading. The Full Example now carries `aria-hidden`.

## Scope

4 files, prose + doc-example only. No app source, no behavior change. Gate is a no-op (markdown only).

## Review gate

Do not merge. Part of the `harness/opus48-*` review-gate family; holds open for maintainer batch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)