### PR TITLE
fix(harness): main-thread orchestrator owns every spawn (depth-1)

### DIFF
--- a/.claude/commands/health-audit.md
+++ b/.claude/commands/health-audit.md
@@ -20,17 +20,19 @@ if .gaia/local/audit/ exists: mv it to .gaia/local/audit.prev-$(date +%s)/
 mkdir -p .gaia/local/audit
 
 For cycle in 1..3:
-  spawn fresh Triager → Triager runs Audit Team in parallel (buckets A–E)
-  Triager writes findings to .gaia/local/audit/c<N>/findings.json
+  you create c<N>/ and bucket sub-dirs
+  you spawn the five Audit buckets (A–E) as parallel, model-pinned leaf subagents
+    each writes its raw output to disk under c<N>/ and returns a summary + path
+  you spawn a fresh Adjudicator leaf for this cycle: it reads the c<N> bucket
+    artifacts from disk, classifies, and writes c<N>/findings.json
     (includes shared_fitness_grade from Bucket E and overall_grade)
   if clean (no open findings + Bucket D = A+ readiness + effective Bucket E shared_fitness_grade = A+; non-blocking residuals exempt, see runbook §Termination):
     report honest overall grade (A+ when no findings at all, else the floor that residual info may cap at A), exit
-  Triager classifies findings
   you compare open-finding (action=real-fix) fingerprints between
     c<N>/findings.json and c<N-1>/findings.json (jq + comm); escalate on intersection
-  Triager dispatches parallel Fixers (lane-aware); fitness findings → claude-surface lane
-  Fixers complete, Triager reports post-fix state to you
-  shut down the team, start the next cycle
+  you spawn parallel Fixers (lane-aware) as leaf subagents; fitness findings → claude-surface lane
+  Fixers complete and report post-fix state to you
+  start the next cycle
 After cycle 3 without clean: escalate (max loops hit)
 
 On clean exit: rm -rf .gaia/local/audit/c* (whitelisted)
@@ -39,9 +41,11 @@ On escalation: preserve all c*/ dirs; surface paths in escalation report
 
 **Oscillation threshold (definition).** The loop is oscillating when any fingerprint is present in both this cycle's and the prior cycle's open-finding set, where the open-finding set is the `action=real-fix` findings recorded in `c<N>/findings.json`. The check is a set intersection of those fingerprints against `c<N-1>/findings.json` (`jq` + `comm`); a non-empty intersection means a fix attempt left the finding unchanged. On any such intersection, escalate with reason `oscillation` rather than spending another cycle.
 
-Bucket E runs the shared Claude-integration fitness protocol defined in `wiki/decisions/Claude Integration Fitness.md` over the seven fitness categories. The Triager does not re-specify those checks, it reads the wiki page and runs its protocol. Fitness findings route to the existing `claude-surface` Fixer lane.
+Bucket E runs the shared Claude-integration fitness protocol defined in `wiki/decisions/Claude Integration Fitness.md` over the seven fitness categories. The Bucket E auditor does not re-specify those checks, it reads the wiki page and runs its protocol. Fitness findings route to the existing `claude-surface` Fixer lane.
 
-A fresh Triager per cycle keeps prior-cycle findings from bleeding into this cycle's verification: the Triager never reads a prior cycle's `findings.json` (you, the Orchestrator, own the cross-cycle oscillation compare), so every cycle's Triager starts on clean context. Within a cycle, the Triager may execute buckets directly via parallel tool calls or dispatch fresh subagents (see runbook §Roles), with one exception that **always requires a fresh subagent**: **Bucket E**, which runs the full seven-category fitness protocol whose raw check output must stay isolated from the Triager's context.
+You spawn the five buckets, the Adjudicator, and the Fixers, and every one is a leaf subagent, because a subagent cannot spawn another subagent (the hard depth-1 limit). So you, the Orchestrator on this main thread, own every spawn. Stay mechanical: counters, directory creation, disk reads, the `jq`/`comm` oscillation compare, and dispatch. You never audit, adjudicate, or fix in your own context, so whatever session state you inherit cannot bias a grade.
+
+A fresh Adjudicator per cycle keeps prior-cycle findings from bleeding into this cycle's verification: it never reads a prior cycle's `findings.json` (you own the cross-cycle oscillation compare), so every cycle's Adjudicator starts on clean context. **Bucket E** runs as its own leaf so its voluminous raw fitness output stays on disk and out of the Adjudicator's context: the Adjudicator reads only Bucket E's findings JSON. Each bucket is spawned with its assigned model (Haiku for the mechanical buckets, Sonnet for the judgment-bearing ones; see the runbook's model table), which pins per-bucket models correctly now that the Orchestrator dispatches them directly.
 
 ## Step 3, Honor the circuit breakers
 
@@ -87,7 +91,7 @@ The overall grade is F-to-A+ and is never higher than the shared-fitness grade. 
 ## What you do NOT do
 
 - Do not fix anything yourself. Fixers fix; you orchestrate.
-- Do not re-grade between cycles, only on a clean Triager report or on escalation.
+- Do not re-grade between cycles, only on a clean Adjudicator report or on escalation.
 - Do not commit. Fixers leave the working tree dirty; the human commits.
 - Do not write to `wiki/log.md` or `wiki/hot.md`.
 - Do not edit the runbook mid-loop. If the runbook needs changing, escalate first.

--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -31,17 +31,18 @@ If no SPEC reference is detected, `SPEC_SLUG_SEED` and `SPEC_PATH` are unset; st
 
 ### 2. Check model
 
-Check your current model from session context.
+The deep synthesis runs in the planner spawned at step 4, and the planner's model is pinned at spawn time, so it can be Opus even when this orchestration runs on Sonnet. Decide the planner's model:
 
-- If you are on Opus, skip to step 3.
-- If not, call `AskUserQuestion` with:
+- If you are on Opus, the planner inherits Opus; skip to step 3.
+- If you are running non-interactively (no user to prompt, e.g. dispatched by `/gaia-spec auto`), default the planner to Opus: spawn it with `model: opus` at step 4. Skip to step 3.
+- Otherwise call `AskUserQuestion` with:
   - question: `"You're on [model name]. Use Opus for planning?"`
   - header: `"Model"`
   - options:
-    - `{ label: "Use Opus (Recommended)", description: "Spawn the planning agent on Opus 4.7 for higher-quality plans." }`
+    - `{ label: "Use Opus (Recommended)", description: "Spawn the planning agent on Opus for higher-quality plans." }`
     - `{ label: "Use [model name]", description: "Keep the current model." }`
-  - If user picks option 1: spawn the agent with `model: opus`.
-  - If user picks option 2: spawn without a model override (inherit current).
+  - If the user picks option 1: spawn the agent with `model: opus`.
+  - If the user picks option 2: spawn without a model override (inherit current).
 
 ### 3. Resolve plan directory
 
@@ -70,7 +71,7 @@ Launch a `general-purpose` Agent with the model determined above and this prompt
 
 ---
 
-You are planning a feature using task orchestration. Do not implement anything. Investigate the codebase, then write the plan files directly to disk.
+You are planning a feature using task orchestration. Do not implement anything. Investigate the codebase, then write the plan files directly to disk. You are a leaf subagent and cannot spawn further subagents; parallelize investigation with parallel tool calls (batch reads and greps in one step), not sub-agent dispatch.
 
 **Plan directory:** `{PLAN_DIR}`
 
@@ -80,8 +81,7 @@ You are planning a feature using task orchestration. Do not implement anything. 
 
 - You may write only under `{PLAN_DIR}/`. Never edit source files, configs, or anything outside this directory.
 - Final plan artifacts go directly under `{PLAN_DIR}/` (no subdirectories for deliverables).
-- For ephemeral scratch (mid-investigation notes, intermediate research dumps), create a unique subdirectory under `{PLAN_DIR}/.work/` via `mktemp -d "{PLAN_DIR}/.work/<role>.XXXXXX"`. Never write directly to `.work/`, and never touch another subdir there, peer agents may own it. Delete your own subdir before returning.
-- If you spawn sub-subagents in parallel, each must create its own `mktemp -d` scratch subdir under `{PLAN_DIR}/.work/`. The parent does a defensive cleanup of `{PLAN_DIR}/.work` after you return; treat that as belt-and-suspenders, not as your cleanup.
+- For ephemeral scratch (mid-investigation notes, intermediate research dumps), create a unique subdirectory under `{PLAN_DIR}/.work/` via `mktemp -d "{PLAN_DIR}/.work/<role>.XXXXXX"`. Never write directly to `.work/` itself. Delete your scratch subdir before returning; the parent also runs a defensive cleanup of `{PLAN_DIR}/.work` after you return, as belt-and-suspenders.
 
 **Feature:** {feature description from step 1}
 

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -612,7 +612,7 @@ There is no `on_save` hook in spec-kit. The chain-trigger lives here, inline, af
 
 On `No`, stop and report to the user that the SPEC is saved and `/gaia-plan` can be invoked when ready. On `Yes`, enter the plan-dispatch loop. All plans dispatched through the loop share the slug prefix `spec-NNN-*`, so `ls .gaia/local/plans/ | grep ^spec-NNN-` discovers them as a group.
 
-**Each `/gaia-plan` invocation runs in its own `general-purpose` Agent**, not in-session. The wrapper's context stays bounded regardless of plan count, each Agent reads the SPEC, runs the plan skill end-to-end, and returns only the resolved `PLAN_DIR` and the kickoff prompt. The wrapper never sees the planner's investigation, the per-task docs, or any intermediate output.
+**Each `/gaia-plan` invocation is followed inline on this (the spec) main thread**, not delegated to a wrapper subagent. Subagents are leaf nodes: a spawned wrapper could not spawn the planner, and could not run plan.md step 2's `AskUserQuestion`. So this main thread runs plan.md's thin orchestration directly, and the planner it spawns at plan.md step 4 is the single Opus-pinned leaf. The heavy synthesis stays isolated in that planner (it returns only a two-field payload), so this thread's context grows by at most plan.md's thin orchestration per slice, which keeps the multi-plan loop bounded.
 
 #### 11a. First plan dispatch
 
@@ -626,18 +626,7 @@ where:
 - `<intent first line>` is the first sentence of the SPEC's `intent` paragraph (truncated at the first period or newline)
 - `<absolute path…>` is the absolute path to the saved SPEC artifact
 
-Spawn a `general-purpose` Agent with this prompt (interpolate the dispatch input):
-
-> Read `.claude/skills/gaia/references/plan.md` and follow its steps using this feature description as `$ARGUMENTS`:
->
->     <dispatch input>
->
-> Run the entire plan skill end-to-end, including spawning the planner sub-Agent at its step 4. When complete, return ONLY this two-field payload, no narrative, no file lists, no recap of the plan contents:
->
->     PLAN_DIR: <absolute path>
->     KICKOFF_PROMPT: <verbatim copy of the kickoff prompt the plan skill printed to its user>
-
-When the Agent returns, parse the two fields. Append the `PLAN_DIR` to a running `PLAN_DIRS[]`. Print the kickoff prompt to the user as a fenced code block. Append `plan_dispatched` telemetry with `plan_idx: 1` and the `PLAN_DIR`.
+**Read `.claude/skills/gaia/references/plan.md` and follow its steps on this main thread**, using the dispatch input above as `$ARGUMENTS`. Do not spawn a wrapper subagent to run plan.md. Auto mode is non-interactive: at plan.md step 2 take its non-interactive branch (default the planner to Opus without prompting); plan.md step 4 spawns that planner as the single leaf. When plan.md finishes it has resolved a `PLAN_DIR` (step 3) and printed a kickoff prompt (step 5); both are visible on this thread. Append the `PLAN_DIR` to a running `PLAN_DIRS[]`. Print the kickoff prompt to the user as a fenced code block. Append `plan_dispatched` telemetry with `plan_idx: 1` and the `PLAN_DIR`.
 
 #### 11b. Subsequent plans (multi-plan loop)
 
@@ -655,9 +644,9 @@ On `Plan another slice`, ask via plain prompt (open-ended, not `AskUserQuestion`
 
     SPEC-NNN: <user's slice description>, see <absolute path to SPEC>
 
-Spawn a fresh Agent with the same template as 11a. Parse its return, append the resolved `PLAN_DIR` to `PLAN_DIRS[]`, print the kickoff prompt as a fenced block, append `plan_dispatched` telemetry with `plan_idx: <next>`. Loop until the user picks `Done`.
+**Follow `.claude/skills/gaia/references/plan.md` inline again** with the fresh dispatch input (same as 11a, no wrapper subagent). Append the resolved `PLAN_DIR` to `PLAN_DIRS[]`, print the kickoff prompt as a fenced block, append `plan_dispatched` telemetry with `plan_idx: <next>`. Loop until the user picks `Done`.
 
-**Output note.** The plan skill prints each kickoff prompt only into its own Agent's context, which the user never sees. The wrapper-printed fenced blocks are the authoritative source the user copies from.
+**Output note.** Run inline, plan.md prints each kickoff prompt directly to the user at its step 5; the fenced blocks recorded here are the same content, captured so 11c can list every plan slice in one place.
 
 #### 11c. Final confirmation
 

--- a/.gaia/cli/health/runbook.md
+++ b/.gaia/cli/health/runbook.md
@@ -10,26 +10,28 @@ Operational protocol for the autonomous audit + auto-heal loop, invoked by `/hea
 
 ## Roles
 
-- **Orchestrator**: top-level coordinator. Owns the cycle loop, the circuit breakers, and the final verdict. Spawns a Triager per cycle. Never fixes anything itself.
-- **Triager** (per cycle); runs the Audit Team (buckets A–E), waits for reports, classifies findings, updates the taxonomy directly for non-fix cases, and either reports clean to Orchestrator or dispatches Fixers.
-- **Auditors**: bucket executors. The Triager MAY execute the five buckets directly via parallel tool calls, OR dispatch fresh `general-purpose` subagents (one per bucket). Both modes are acceptable so long as: each bucket's spec below is followed verbatim, the five buckets run in parallel (not serially), and outputs are captured as independently-checkable artifacts (stdout, file reads). The verifiable property is the artifact, not the dispatch mechanism. **Bucket E** is the one exception to this free choice: it always runs as a fresh subagent (never inline), because its seven-category fitness protocol produces voluminous raw output that must stay isolated from the Triager's context. Prefer fresh-subagent dispatch when a bucket is expected to produce high finding volume (preserves Triager context budget) or when the human explicitly requests strict isolation (e.g. compliance audit). Auditors write raw outputs to `.gaia/local/audit/c<N>/<bucket>/` (paths specified per bucket below) and return summary + file path in their report; not raw content. The Triager reads files on demand for triage. This avoids subagent return-budget truncation in dirty cycles.
-- **Fixers**: fix agents, lane-aware so multiple run in parallel without merge conflicts.
+Subagents are leaf nodes: a spawned subagent cannot spawn another subagent (the hard depth-1 limit, independent of its tools config). So the Orchestrator on the main thread owns every spawn; the Auditors, the Adjudicator, and the Fixers are all leaves it dispatches directly. No middle layer spawns workers.
+
+- **Orchestrator**: top-level coordinator, runs on the main thread. Owns the cycle loop, per-cycle directory creation, spawning the Audit buckets, spawning the Adjudicator, the cross-cycle oscillation compare, the circuit breakers, spawning the Fixers, and the final verdict. Stays mechanical (counters, disk reads, `jq`/`comm`, dispatch); it never audits, adjudicates, or fixes in its own context, so session state it inherits cannot bias a grade. Never fixes anything itself.
+- **Auditors**: bucket executors, one fresh `general-purpose` leaf subagent per bucket (A–E), spawned in parallel by the Orchestrator with each bucket's assigned model (see §Model selection). Each follows its bucket spec below verbatim, runs in parallel (not serially), writes raw output to disk under `.gaia/local/audit/c<N>/<bucket>/` (paths per bucket below), and returns summary + file path in its report, not raw content. The verifiable property is the artifact, not the dispatch mechanism. This avoids subagent return-budget truncation in dirty cycles. **Bucket E** is spawned the same way; its seven-category fitness protocol produces voluminous raw output, which is exactly why it is its own leaf writing JSON to disk: the Adjudicator reads that JSON, never Bucket E's raw context.
+- **Adjudicator** (per cycle): a fresh `general-purpose` leaf subagent the Orchestrator spawns once the buckets return. It reads the cycle's bucket artifacts from disk, classifies findings, updates the taxonomy Issue Classes directly for non-fix cases (circuit-breaker-gated edits route back to the Orchestrator, see §Finding classification), and writes `c<N>/findings.json`. A fresh context per cycle keeps prior-cycle findings from bleeding into this cycle's verification; it never reads a prior cycle's `findings.json` (the Orchestrator owns the cross-cycle compare). It does not spawn anything and does not dispatch Fixers.
+- **Fixers**: fix agents, lane-aware leaf subagents the Orchestrator spawns so multiple run in parallel without merge conflicts.
 
 ## Cycle loop
 
 ```
 Orchestrator initializes .gaia/local/audit/ (archives any stale prior run)
 For cycle in 1..3:
-  Triager creates c<N>/ and bucket sub-dirs under .gaia/local/audit/
-  spawn Triager → Triager runs Audit Team in parallel (buckets A–E) → reports
+  Orchestrator creates c<N>/ and bucket sub-dirs under .gaia/local/audit/
+  Orchestrator spawns the Audit buckets (A–E) as parallel leaf subagents → each writes artifacts, returns summary + path
+  Orchestrator spawns a fresh Adjudicator leaf → it reads the c<N> bucket artifacts, classifies, writes c<N>/findings.json → reports
   if clean (no open findings, Bucket D verdict A+ readiness, effective shared-fitness grade = A+; see §Termination):
     Orchestrator removes .gaia/local/audit/c* (whitelisted; top-level dir kept as marker)
     report the honest overall grade (A+ when no findings of any kind, else the floor that non-blocking residuals may cap at A), exit
-  Triager classifies findings → writes c<N>/findings.json
   Orchestrator checks open-finding fingerprints vs prior cycle (mechanical diff via jq; non-blocking residuals excluded, see §Termination) → if oscillation: escalate (Orchestrator preserves all c*/ dirs, surfaces paths in escalation report)
-  Triager dispatches parallel Fixers (lane-aware)
-  Fixers complete, Triager reports post-fix state to Orchestrator
-  Orchestrator shuts down the team, starts the next cycle
+  Orchestrator spawns parallel Fixers (lane-aware leaf subagents)
+  Fixers complete and report post-fix state to Orchestrator
+  Orchestrator starts the next cycle
 After cycle 3 without clean: escalate (max loops hit; Orchestrator preserves all c*/ dirs, surfaces paths in escalation report)
 ```
 
@@ -62,8 +64,8 @@ Human refuses → escalate.
 
 | Role                                                                                                              | Model  |
 | ----------------------------------------------------------------------------------------------------------------- | ------ |
-| Orchestrator                                                                                                      | Sonnet |
-| Triager                                                                                                           | Sonnet |
+| Orchestrator                                                                                                      | main thread (session model) |
+| Adjudicator                                                                                                      | Sonnet |
 | Bucket A (static checks)                                                                                          | Haiku  |
 | Bucket B (source greps)                                                                                           | Haiku  |
 | Bucket C (bundle simulation)                                                                                      | Haiku  |
@@ -75,7 +77,7 @@ Human refuses → escalate.
 | Fixer: wiki-content                                                                                               | Sonnet |
 | Fixer: claude-surface                                                                                             | Sonnet |
 
-Promote a role to Opus only on Triager flag for high-complexity fixes (cross-module refactor, tricky type inference, > 300-line change).
+Promote a role to Opus only on Adjudicator flag for high-complexity fixes (cross-module refactor, tricky type inference, > 300-line change): the Adjudicator records the flag in `findings.json` and the Orchestrator spawns that Fixer with `model: opus`.
 
 Bucket E model assignments follow the wiki page's spec: mechanical category checks (file-exists, JSON parse, hash-diff, `gaia wiki` invocations) on Haiku; judgment-bearing checks (frontmatter substantiveness, content-vs-glob coherence, size evaluation) and grade synthesis on Sonnet. See `wiki/decisions/Claude Integration Fitness.md` §Triage phase for the per-category model table.
 
@@ -227,7 +229,7 @@ The wiki page defines:
 - The F-to-A+ per-category grading rubric (every band; including `A−` and `C−`; reachable; `shared_fitness_grade` may be any of them).
 - The bounded loop (default 3 cycles) with oscillation detection; which the wiki page's own "Composed inside a deeper loop" note hands off to the outer harness when this protocol runs as a bucket. See the loop-nesting rule below.
 
-**Loop nesting.** Bucket E does not run the wiki page's bounded heal loop. The outer `/health-audit` cycle loop _is_ that loop: each outer cycle, Bucket E runs the wiki page's triage phase once (audit the seven categories, adjudicate, grade) and returns a `shared_fitness_grade` (F-to-A+, the floor of the seven category grades) plus per-category grades to the Triager; it does not heal or verify on its own. The Triager folds Bucket E's findings into `c<N>/findings.json` alongside the other buckets' findings, so fitness fingerprints participate in the **outer** oscillation guard (no separate inner guard), and routes the fitness fixes to the `claude-surface` Fixer lane (or `settings`/`gitignore`/`manifest` as appropriate) in the outer heal phase. The verify step for a cycle's fitness fixes is the next outer cycle's fresh Bucket E run. No new Fixer lane is introduced, and there is no inner cycle count to tune; the outer `1..3` bound covers fitness too.
+**Loop nesting.** Bucket E does not run the wiki page's bounded heal loop. The outer `/health-audit` cycle loop _is_ that loop: each outer cycle, Bucket E runs the wiki page's triage phase once (audit the seven categories, grade) and writes its per-category findings JSON plus a `shared_fitness_grade` (F-to-A+, the floor of the seven category grades) to disk; it does not heal or verify on its own. The Adjudicator folds Bucket E's findings into `c<N>/findings.json` alongside the other buckets' findings, so fitness fingerprints participate in the **outer** oscillation guard (no separate inner guard), and tags the fitness fixes for the `claude-surface` Fixer lane (or `settings`/`gitignore`/`manifest` as appropriate); the Orchestrator dispatches them in the outer heal phase. The verify step for a cycle's fitness fixes is the next outer cycle's fresh Bucket E run. No new Fixer lane is introduced, and there is no inner cycle count to tune; the outer `1..3` bound covers fitness too.
 
 **Outputs:** `.gaia/local/audit/c<N>/bucket-e/`; per-category findings JSON and the per-category + overall fitness grade report, following the same structure as the wiki page's Findings Schema.
 
@@ -245,7 +247,7 @@ The wiki page defines:
     wiki-fitness.json
 ```
 
-Crash-safety: Bucket E writes incrementally per category; a crash mid-run leaves partial output. The Triager treats a missing `shared_fitness_grade.txt` as Bucket E incomplete; re-spawn Bucket E on the next cycle (the outer loop handles this).
+Crash-safety: Bucket E writes incrementally per category; a crash mid-run leaves partial output. The Adjudicator treats a missing `shared_fitness_grade.txt` as Bucket E incomplete; the Orchestrator re-spawns Bucket E on the next cycle (the outer loop handles this).
 
 ## Fixer lanes
 
@@ -266,12 +268,12 @@ If a single finding's fix straddles multiple lanes, dispatch one Fixer with mult
 
 ## Finding classification
 
-Each finding fits one bucket:
+The Adjudicator assigns each finding one action and records it in `findings.json`; the Orchestrator executes the action (dispatching Fixers, gating circuit breakers, applying breaker-gated edits). Each finding fits one action:
 
-- **real-fix** → dispatch Fixer in the appropriate lane.
-- **taxonomy-update** (new genuine class) → Triager edits `.gaia/cli/health/taxonomy.md` directly: add an Issue Class entry under the right section. Then dispatch Fixer for the fix.
-- **false-positive** → dispatch config-yaml-md Fixer to tighten pattern or extend allowlist with a written justification.
-- **decided-not-finding** → the finding matches a "Decided / not findings" entry (in `.gaia/cli/health/taxonomy.md` or the fitness spec). **If the entry already exists**, record the match and move on (no edit, no circuit breaker); it becomes a non-blocking residual (see §Termination), retained in `findings.json` but excluded from the clean gate and the oscillation guard. **If it is a new not-a-finding class**, the Triager adds the entry to the appropriate list directly (this trips a circuit breaker; pause for human-confirm before writing), after which it is likewise a non-blocking residual.
+- **real-fix** → the Orchestrator dispatches a Fixer in the appropriate lane.
+- **taxonomy-update** (new genuine class) → the Adjudicator adds an Issue Class entry under the right section of `.gaia/cli/health/taxonomy.md` (this section is not circuit-breaker-gated). The Orchestrator then dispatches a Fixer for the fix.
+- **false-positive** → the Orchestrator dispatches a config-yaml-md Fixer to tighten the pattern or extend the allowlist with a written justification.
+- **decided-not-finding** → the finding matches a "Decided / not findings" entry (in `.gaia/cli/health/taxonomy.md` or the fitness spec). **If the entry already exists**, the Adjudicator records the match and moves on (no edit, no circuit breaker); it becomes a non-blocking residual (see §Termination), retained in `findings.json` but excluded from the clean gate and the oscillation guard. **If it is a new not-a-finding class**, the Adjudicator records the proposed entry in `findings.json` rather than writing it (a leaf subagent cannot pause for human-confirm). The Orchestrator gates it on the circuit breaker, gets human-confirm, and writes the entry, after which it is likewise a non-blocking residual.
 
 ## Escalation
 
@@ -280,7 +282,7 @@ Orchestrator escalates to human (returns control with structured report) on:
 - N=3 cycles without a clean report.
 - Oscillation (same fingerprint two consecutive cycles).
 - Any circuit-breaker trip the human declines.
-- Triager can't classify a finding (not in taxonomy, not allowlist, not structural).
+- Adjudicator can't classify a finding (not in taxonomy, not allowlist, not structural).
 - Fixer reports unable to fix (e.g. test failure that requires a product decision).
 
 ## Audit artifacts
@@ -328,9 +330,9 @@ The `verdict` field stores Bucket D's verdict verbatim. It is _not_ a synthesize
 Lifecycle:
 
 - **At `/health-audit` start**: Orchestrator runs `[ -d .gaia/local/audit ] && mv .gaia/local/audit .gaia/local/audit.prev-$(date +%s) ; mkdir -p .gaia/local/audit`. Archives stale dirs from prior interrupted runs.
-- **At cycle start**: Triager creates `c<N>/` and bucket sub-dirs.
+- **At cycle start**: Orchestrator creates `c<N>/` and bucket sub-dirs.
 - **Auditors**: write raw outputs to their per-cycle paths; return summary + file path in their report (not the full content).
-- **Triager**: reads bucket files for triage; writes `c<N>/findings.json`.
+- **Adjudicator**: reads bucket files, classifies, writes `c<N>/findings.json`.
 - **Orchestrator (oscillation detection)**: mechanical diff via `jq -r '.findings[].fingerprint' .gaia/local/audit/c<N>/findings.json | sort` against the prior cycle's same. Non-empty intersection → oscillation, escalate.
 - **Clean exit**: Orchestrator computes `overall_grade` = floor of (Bucket D verdict, open-findings-count signal, Bucket E `shared_fitness_grade`). A clean exit requires no open findings and an _effective_ shared-fitness A+ (non-blocking residuals exempt); the reported grade may be A. On a clean exit: Orchestrator runs `rm -rf .gaia/local/audit/c*` (whitelisted; safe). Top-level dir kept as run marker.
 - **Escalation**: Orchestrator preserves all `c*/` dirs and surfaces their paths in the escalation report for human review.


### PR DESCRIPTION
## Summary

Collapses the spawned-orchestrator layer across the four orchestration commands to a **main-thread orchestrator dispatching model-pinned leaf workers** (star topology, depth-1).

The driving fact, confirmed against the Claude Code docs: subagents are hard leaf nodes (depth-1, independent of `tools:` config), cannot call `AskUserQuestion`, and model-pinning at spawn beats the session model. So a spawned *middle* layer that itself spawns workers describes **a topology that cannot execute as written on stock Claude Code**: the leaf has no spawn tool, so the step either silently degrades to running the work inline (losing the isolation/freshness guarantees the structure exists for) or stalls. Two of the four commands were in that state.

| Command | Before | After |
|---|---|---|
| **health-audit** | Orchestrator(main) → **spawned Triager** → Auditors/Fixers (depth-2; Bucket E "must be a subagent" dispatched *by* the Triager could not execute) | Orchestrator(main) owns every spawn; Triager → **fresh leaf Adjudicator** per cycle |
| **gaia-spec → gaia-plan** | spec → **spawned plan-runner** → planner (depth-2; plan-runner also hit `AskUserQuestion`, which a subagent cannot call) | spec follows `plan.md` **inline**; Opus planner is the single leaf |
| **gaia-plan** (standalone) | dead "planner spawns sub-sub-agents" clauses | leaf planner parallelizes via parallel tool calls; non-interactive model branch for the spec-auto chain |
| **gaia-fitness** | already depth-1 | unchanged (reference shape the others now match) |

#356's fresh-per-cycle adjudication intent is preserved at depth-1 (the Adjudicator is a fresh leaf each cycle, reads only the current cycle's bucket artifacts; the Orchestrator owns the mechanical cross-cycle oscillation compare and all circuit-breaker gating). Side benefit: per-bucket Haiku/Sonnet pinning is now actually applied, since the Orchestrator dispatches each bucket directly.

## Design decisions (the three open questions)

1. **Deep synthesis** runs in an Opus-pinned leaf dispatched by the main thread, in both gaia-plan and the gaia-spec chain, never on the session model. Ceiling: spec's interactive discovery stays on the session model because subagents can't prompt; only headless synthesis (research, self-review, planning) is Opus-pinnable.
2. **The main thread owns every team** (forced by depth-1).
3. **"User clears context" is not a contract**, just a token optimization. Fresh leaves guarantee clean context for all reasoning work regardless of session state; the safety rule "keep the orchestrator mechanical" is now stated explicitly in the runbook.

## Provenance / confidence

The depth-1 constraint is doc-backed (verified via the claude-code-guide agent reading the current Claude Code docs), not reproduced by running the commands. health-audit has been run before (#356 came out of it), which means it was most likely degrading silently rather than hard-failing.

## Test plan

- Markdown / harness instruction files only; no `.ts/.tsx/.js/.css` or gate-affecting config touched, so the Quality Gate has nothing to check.
- Adversarial grep sweep confirms no remaining instruction has a leaf (Adjudicator/planner/Auditor/Fixer) spawn another agent.
- Verified no absolute machine paths and no em dashes introduced in the touched files.
- `gaia-fitness` confirmed already depth-1, no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)