### PR TITLE
docs: sync wiki orchestration topology to depth-1

### DIFF
--- a/wiki/concepts/GAIA Plan.md
+++ b/wiki/concepts/GAIA Plan.md
@@ -3,7 +3,7 @@ type: concept
 title: GAIA Plan
 status: active
 created: 2026-04-30
-updated: 2026-05-01
+updated: 2026-06-11
 tags: [concept, claude, skill, orchestration]
 ---
 
@@ -14,8 +14,8 @@ tags: [concept, claude, skill, orchestration]
 ## Steps
 
 1. **Get description.** Use `$ARGUMENTS` if provided; otherwise ask "What do you want me to orchestrate?" and wait.
-2. **Pick the planner model.** If the current session is on Opus, use it. Otherwise ask "Use Opus for planning? (Y/n)"; default yes.
-3. **Spawn the planner.** Launch a `general-purpose` Agent with the chosen model and a prompt that builds the plan files in `.gaia/local/plans/{slug}/`: per-task docs, `README.md` (task graph + frozen interface contracts), `ORCHESTRATOR.md` (execution playbook), and `KICKOFF.md` (the cold-start prompt). See [[Task Orchestration]] for the artifact contract.
+2. **Pick the planner model.** The planner's model is pinned at spawn, so it runs on Opus even when the session is on Sonnet. If the session is on Opus, the planner inherits it. When the run is non-interactive (e.g. dispatched by `/gaia-spec auto`), the planner defaults to Opus without a prompt. Otherwise ask "Use Opus for planning? (Y/n)"; default yes.
+3. **Spawn the planner.** Launch a `general-purpose` Agent with the chosen model and a prompt that builds the plan files in `.gaia/local/plans/{slug}/`: per-task docs, `README.md` (task graph + frozen interface contracts), `ORCHESTRATOR.md` (execution playbook), and `KICKOFF.md` (the cold-start prompt). The planner is a leaf sub-agent: it investigates with parallel tool calls and writes the files, and it cannot spawn further sub-agents (see [[Task Orchestration#Topology]]). See [[Task Orchestration]] for the artifact contract.
 4. **Hand off.** Print a short summary of the plan, then a fenced one-line resume prompt (`Read /abs/path/to/.gaia/local/plans/{slug}/KICKOFF.md and execute it.`). The skill probes for a clipboard tool (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip.exe` / `clip`) and copies the prompt automatically when one is available, then prints either `Prompt copied to clipboard. Type /clear then paste.` or `Type /clear and paste the prompt above.` accordingly.
 
 ## Orchestrator contract

--- a/wiki/concepts/GAIA Spec.md
+++ b/wiki/concepts/GAIA Spec.md
@@ -3,7 +3,7 @@ type: concept
 title: GAIA Spec
 status: active
 created: 2026-05-06
-updated: 2026-05-06
+updated: 2026-06-11
 tags: [concept, claude, skill, orchestration, spec-kit]
 ---
 
@@ -33,7 +33,7 @@ The wrapper is implemented as a spec-kit extension plus preset; the architectura
 8. **Save** to `.gaia/local/specs/SPEC-NNN/SPEC.md`. The folder is the archival unit. Sibling artifacts (reports, evidence) live beside `SPEC.md` in the same folder; a flat `SPEC-NNN-<rest>.md` file maps to `SPEC-NNN/<REST>.md` (remainder uppercased, hyphens kept). `lib/spec-folderize.sh` applies this mapping for any legacy flat files.
 9. **`after_specify` hook.** Spec-kit fires `/speckit-gaia-lint`, which runs `lib/lint.sh` (frontmatter, frozen UAT-NNN ids, no placeholders, write-allowlist audit). For mutations of an already-saved SPEC, the lint enforces the explicit reopen ceremony: `## Reopen rationale` and `## UAT diff` sections required.
 10. **Optional GH Issue mirror.** `lib/gh-mirror.sh` creates an Issue if `gh auth status` succeeds, the repo has Issues enabled, and the viewer has write/admin permission. Otherwise appends a skip record to `.gaia/local/telemetry/gh-mirror.jsonl` and exits 0. Absence never blocks save.
-11. **Inline chain-trigger to `/gaia-plan`.** No `on_save` hook exists in spec-kit; the chain lives here, inline. `AskUserQuestion` offers "Yes, trigger /gaia-plan (Recommended)" or "No, defer". On Yes, dispatch `/gaia-plan` with the SPEC path; on No, stop.
+11. **Inline chain-trigger to `/gaia-plan`.** No `on_save` hook exists in spec-kit; the chain lives here, inline. `AskUserQuestion` offers "Yes, trigger /gaia-plan (Recommended)" or "No, defer". On Yes, the skill follows `/gaia-plan` inline on the spec thread (no wrapper sub-agent) with the SPEC path; the planner it spawns is the single Opus-pinned leaf. On No, stop. See [[Task Orchestration#Topology]] for why the chain runs inline.
 
 ## UAT divergence contract
 

--- a/wiki/concepts/Task Orchestration.md
+++ b/wiki/concepts/Task Orchestration.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-04-21
-updated: 2026-05-07
+updated: 2026-06-11
 tags: [concept, claude, workflow]
 ---
 
@@ -28,6 +28,16 @@ When the user pastes the resume prompt, the orchestrator runs through:
 3. **Stop conditions.** Any sub-agent failure or quality-gate failure halts the run; the orchestrator surfaces the error to the user, appends a `## Phase N - <title> (HALTED)` block to `SUMMARY.md` with the failure context, and does NOT commit, push, or "fix and continue."
 4. **Final summary.** After the last commit lands and before awaiting merge confirmation, the orchestrator reads `SUMMARY.md` and prints a brief summary: phases completed, sub-agents run, files touched (count), commits pushed (count + short SHAs), PR URL, quality-gate status, and the highest-signal findings/deviations/follow-ups drawn from the ledger so nothing is lost to compression. A few lines plus the surfaced notes, not a recap of every change.
 5. **Final self-cleanup.** After all implementation phases pass and the user confirms the PR is ready to merge, the orchestrator deletes its own plan folder (`rm -rf .gaia/local/plans/{slug}/`) so scaffolding does not persist locally. If `.gaia/local/plans/` is gitignored (the GAIA default, checked via `git check-ignore`), the deletion is invisible to git and no commit is needed. If the path is tracked, the orchestrator commits and pushes the deletion as the **final commit on the PR**. If the user explicitly asks to keep the folder for archival, the orchestrator skips the deletion and reports.
+
+## Topology
+
+GAIA orchestration is a depth-1 star: the main thread is the only agent that spawns, and every worker it dispatches is a leaf. Claude Code sub-agents cannot spawn further sub-agents and cannot prompt the user, so a worker never owns a team and never runs an interactive gate.
+
+- **`/gaia-plan`** runs its thin orchestration on the invoking thread and spawns one planner leaf for the deep synthesis. The planner investigates with parallel tool calls and writes the plan files; it does not spawn sub-agents.
+- **The execution orchestrator** (a fresh session started from `KICKOFF.md`) is itself a main thread, so it dispatches the per-phase implementation sub-agents as leaves and runs the pre-merge `code-review-audit`.
+- **`/gaia-spec`** chains into `/gaia-plan` by following it inline on the spec thread, not by spawning a wrapper sub-agent. A wrapper could neither spawn the planner nor run the model prompt, so the planner stays the single spawned leaf.
+
+Models pin at spawn, so the main thread, even on Sonnet, puts the synthesis on Opus by spawning the planner with `model: opus`. Interactive steps stay on the main thread because only it can prompt.
 
 ## Why
 


### PR DESCRIPTION
## Summary

Follow-up to #363 (the depth-1 orchestration fix). Brings the wiki in line with the new topology so the knowledge base matches the harness.

- **`Task Orchestration`**: new **Topology** section, the cross-cutting statement that GAIA orchestration is a depth-1 star (main thread owns every spawn; Claude Code sub-agents are leaves that cannot spawn or prompt). Covers the `/gaia-plan` planner leaf, the execution orchestrator (a fresh main-thread session dispatching per-phase sub-agents + `code-review-audit`), and the inline `/gaia-spec → /gaia-plan` chain. Notes that models pin at spawn, so synthesis runs on Opus from a Sonnet thread.
- **`GAIA Plan`**: the planner is a leaf (parallel tool calls, no nested spawn) with its model pinned at spawn; non-interactive runs default it to Opus.
- **`GAIA Spec`**: step 11 follows `/gaia-plan` inline on the spec thread (no wrapper sub-agent); the planner is the single Opus-pinned leaf.

## Scope notes

- The maintainer-only `health-audit` command and `runbook.md` are not in the wiki (the runbook is their source of truth, already updated in #363).
- `Claude Integration Fitness` was already depth-1 correct (Orchestrator dispatches Auditors/Fixers, no middle layer), so it is unchanged.

## Test plan

- Wiki body prose only; no source touched, Quality Gate N/A.
- Wiki-style audit clean on the three pages: no UAT/SPEC refs, no historical phrasing, no em dashes.
- `gaia wiki dead-paths` exits 0 with no findings.
- `updated:` frontmatter bumped on the three edited pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)