### PR TITLE
wiki: sync through b8f9d73

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "3946d24c1ce6d073626ad5813974abff1e90bc30",
-  "last_evaluated_at": "2026-06-11T05:01:22Z",
+  "last_evaluated_sha": "b8f9d73fcda4e256c5ac4860a62ff55cfefa1300",
+  "last_evaluated_at": "2026-06-11T13:21:34Z",
   "last_consolidated_sha": "3e090b14c0bdc9b6bcdce738833dde2d4e765e9d",
   "last_consolidated_at": "2026-06-10T18:23:05Z"
 }

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Update Workflow
 status: active
 created: 2026-04-22
-updated: 2026-06-03
+updated: 2026-06-11
 tags: [release, claude, adopter, drift]
 ---
 
@@ -38,12 +38,12 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 
 1. Read `.gaia/VERSION`. Missing → tell user to run `/gaia-init` on a fresh `create-gaia` scaffold.
 2. Resolve latest release via `gh release list --repo gaia-react/gaia` (or GitHub API fallback).
-3. Compare to baseline. Same or older → exit. Never downgrade.
-4. Show the adopter the release notes and **confirm** before touching anything.
-5. Download baseline + latest tarballs to `.gaia/cache/`.
+3. Compare to baseline. Same or older → exit, unless `.gaia/VERSION` has been bumped but not committed (an interrupted prior run), in which case surface the residual state so the adopter can commit or discard. Never downgrade.
+4. Show the adopter the release notes and **confirm** before touching anything. If on `main`/`master`, create the feature branch only after this confirmation — not before — so an early exit leaves no orphan branch.
+5. Download baseline + latest tarballs to `.gaia/cache/`. Stop on any download or extraction failure; do not proceed with a partial cache.
 6. Walk the latest manifest. For each file, apply the decision table below.
-7. Only after the full walk succeeds, bump `.gaia/VERSION` and replace `.gaia/manifest.json` with the latest version's copy.
-8. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.
+7. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.
+8. Bump `.gaia/VERSION` and replace `.gaia/manifest.json` with the latest version's copy. This happens after the summary prints so that if the walk was aborted mid-way the version stays at baseline and a re-run resumes cleanly.
 9. Remind the adopter to review `.gaia-merge/`, run the [[Quality Gate]], and commit manually.
 
 ## Decision table
@@ -91,7 +91,7 @@ The load-bearing guarantee: a dependency the adopter removed is **never re-added
 
 - **Never touch adopter-owned paths.** Anything not in the manifest is invisible.
 - **Never auto-clobber drift.** `owned` drift prompts; `shared` / `wiki-owned` drift writes a patch.
-- **Atomic version marker.** `.gaia/VERSION` flips to latest only after the full walk succeeds. Abort mid-walk → version stays at baseline, and a re-run resumes cleanly. Any already-overwritten files live in `.gaia-backup/`.
+- **Atomic version marker.** `.gaia/VERSION` flips to latest only after the summary prints (Step 8). Abort during the walk → version stays at baseline, and a re-run resumes cleanly because the merge walk is idempotent (already-merged files match latest and skip). Any already-overwritten files live in `.gaia-backup/`. If the version was bumped but not committed (e.g. an interrupted Step 8), Step 3 detects the mismatch and surfaces it.
 - **No auto-commit.** `/update-gaia` leaves the working tree dirty; the adopter reviews + commits.
 
 ## Rollback

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,19 @@ tags: [meta, log]
 
 ## 2026-06-05 | Policy-Memory Loop
 
+- 2026-06-11 460e722 SKIP - wiki sync commit; wiki pages updated directly in that commit
+- 2026-06-11 49a5f65 WORTHY - code-review-audit tuned for Opus 4.8 recall; wiki/concepts/Agentic Design.md and Code Review Audit Agent.md updated in commit
+- 2026-06-11 a661911 SKIP - docs: prose-only (scope response style to conversation)
+- 2026-06-11 ad47361 SKIP - coverage-first finding stage in .claude/skills and .specify; implementation prompt detail, no wiki-layer facts
+- 2026-06-11 5511007 SKIP - docs: prose-only (skeleton-loader placeholder alignment)
+- 2026-06-11 9363230 SKIP - docs: prose-only (bound autonomous + TDD loops)
+- 2026-06-11 dc7a40c SKIP - docs: prose-only (make load-bearing wiki fetches imperative)
+- 2026-06-11 05460df WORTHY - defer version bump past summary in update-gaia → wiki/concepts/Update Workflow.md updated
+- 2026-06-11 4868bfc SKIP - .specify dispatch made explicit; implementation detail in extension commands, no wiki-layer facts
+- 2026-06-11 07e586e SKIP - fitness.md/health-audit.md/plan.md subagent dispatch tightening; no new wiki-layer facts
+- 2026-06-11 782ec5c WORTHY - bound autonomous-loop stops in update-deps/update-gaia → wiki/concepts/Update Workflow.md updated
+- 2026-06-11 0ba9c3b SKIP - depth-1 orchestration collapse in .claude/commands and skills; wiki pages updated in b8f9d73
+- 2026-06-11 b8f9d73 WORTHY - docs: sync wiki orchestration topology to depth-1 → wiki/concepts/Task Orchestration.md, GAIA Plan.md, GAIA Spec.md updated in commit
 - 2026-06-11 3946d24 SKIP - wiki/concepts/Code Review Audit CI.md updated in the commit's own docs(ci) sub-commit
 - 2026-06-11 a5c6c3a WORTHY - playwright local retries=1 for cold-cache flake → wiki/dependencies/Playwright.md
 - 2026-06-11 c944079 SKIP - chore(deps): version bump only


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to b8f9d73.