### PR TITLE
fix: close maintainer-path leaks and stale manifest (health audit)

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -86,7 +86,7 @@ out one PR per major-bump group.
 ## Companion groups (reference)
 
 The fixed table mapping each package to its group. `gaia update-deps run`
-(`.gaia/cli/src/update-deps/groups.ts`) implements it and is the source of
+resolves grouping internally and is the source of
 truth at runtime; every emitted entry already carries its resolved `group`.
 **When any member of a group is outdated, all members present in `package.json`
 update together**, so a group moves as one unit (and snoozes as one unit).

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -144,7 +144,6 @@
     ".gaia/cli/templates/workflows/partials/auto-merge.yml.tmpl": "owned",
     ".gaia/cli/templates/workflows/partials/checkout-setup.yml.tmpl": "owned",
     ".gaia/cli/templates/workflows/partials/concurrency.yml.tmpl": "owned",
-    ".gaia/cli/templates/workflows/partials/cost-accounting.yml.tmpl": "owned",
     ".gaia/cli/templates/workflows/partials/header.yml.tmpl": "owned",
     ".gaia/cli/templates/workflows/partials/pre-run-skip.yml.tmpl": "owned",
     ".gaia/cli/templates/workflows/partials/quality-gate.yml.tmpl": "owned",
@@ -521,6 +520,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-06-10T10:52:46.086Z",
+  "generated": "2026-06-11T13:56:44.463Z",
   "version": "1.5.0"
 }

--- a/wiki/decisions/pnpm.md
+++ b/wiki/decisions/pnpm.md
@@ -54,7 +54,7 @@ The verdicts come from the `gaia update merge-workspace` CLI primitive, which pa
 
 ## Source of truth
 
-This page. Mechanics: `package.json`, `.npmrc`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `.github/workflows/tests.yml`, `.github/workflows/chromatic.yml`. Bootstrap: `.claude/commands/gaia-init.md` Step 0. Migration tooling: `.claude/skills/update-deps/SKILL.md` (release-age selection implemented in the CLI binary). Field-aware workspace merge: `.claude/skills/update-gaia/SKILL.md` (Step 7b), `.gaia/cli/src/update/merge-workspace.ts`.
+This page. Mechanics: `package.json`, `.npmrc`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `.github/workflows/tests.yml`, `.github/workflows/chromatic.yml`. Bootstrap: `.claude/commands/gaia-init.md` Step 0. Migration tooling: `.claude/skills/update-deps/SKILL.md` (release-age selection implemented in the CLI binary). Field-aware workspace merge: `.claude/skills/update-gaia/SKILL.md` (Step 7b); the merge is driven by the `gaia update merge-workspace` CLI primitive.
 
 > [!key-insight] minimumReleaseAge is the cheap supply-chain win
 > Most npm supply-chain attacks are caught and yanked within hours. A 7-day quarantine cuts the dominant attack window for the cost of one config line. No infra. No subscription. No agent.


### PR DESCRIPTION
## Summary

Remediation from a `/health-audit` run (3 cycles, clean exit at A). Three real-fix findings, all on the distribution boundary / install-fitness surface.

| # | File | Lane | Fix |
|---|------|------|-----|
| 1 | `wiki/decisions/pnpm.md` | wiki-content | Replaced the maintainer-only `.gaia/cli/src/update/merge-workspace.ts` path with the adopter-facing `gaia update merge-workspace` CLI primitive. The CLI source is release-excluded, so the old reference was a dead pointer on adopter clones. |
| 2 | `.claude/skills/update-deps/SKILL.md` | claude-surface | Dropped the `.gaia/cli/src/update-deps/groups.ts` parenthetical and described the grouping behavior instead (same dead-pointer reason). |
| 3 | `.gaia/manifest.json` | manifest | Regenerated to drop the stale `cost-accounting.yml.tmpl` entry (the file was deleted when the cost-overage feature was retired). `manifest --check` now passes. |

## Why

Findings 1 and 2 are `maintainer-paths` distribution-boundary leaks: shipped surfaces naming private `.gaia/cli/src/**` paths that do not exist in an adopter's clone. Finding 3 is GAIA-install fitness: the generated manifest listed a deleted file as `owned`.

## Verification

- **Cycle 1** closed findings 1 and 2; **cycle 2** confirmed they held and closed finding 3; **cycle 3** audited clean across all five buckets (static, source greps, bundle simulation, cross-class enforcement walk A+ readiness, shared Claude-integration fitness).
- Bundle simulation reports no maintainer-path leaks; `manifest --check` clean; classifier sets coherent.
- Quality Gate: skipped per `wiki/decisions/Quality Gate.md` (no staged `*.ts/tsx/js/jsx/mjs/cjs/css` or gate-affecting config; pure markdown + generated manifest).

Overall grade **A**, capped only by the permanent non-blocking `wiki/.state.json` post-sync drift residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)