### PR TITLE
wiki: sync through 25d9207

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "b8f9d73fcda4e256c5ac4860a62ff55cfefa1300",
-  "last_evaluated_at": "2026-06-11T13:21:34Z",
+  "last_evaluated_sha": "25d920735f9266145e516c924c5c514b92b0ff8e",
+  "last_evaluated_at": "2026-06-11T15:23:05Z",
   "last_consolidated_sha": "3e090b14c0bdc9b6bcdce738833dde2d4e765e9d",
   "last_consolidated_at": "2026-06-10T18:23:05Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,9 @@ tags: [meta, log]
 
 ## 2026-06-05 | Policy-Memory Loop
 
+- 2026-06-11 25d9207 WORTHY - fix: maintainer-path leak in wiki/decisions/pnpm.md replaced with adopter-facing CLI primitive; edit landed in commit
+- 2026-06-11 10c7c3c SKIP - wiki: self-referential sync commit (duplicate of d812255 squash)
+- 2026-06-11 d812255 WORTHY - wiki sync commit; wiki/concepts/Update Workflow.md updated inline in commit
 - 2026-06-11 460e722 SKIP - wiki sync commit; wiki pages updated directly in that commit
 - 2026-06-11 49a5f65 WORTHY - code-review-audit tuned for Opus 4.8 recall; wiki/concepts/Agentic Design.md and Code Review Audit Agent.md updated in commit
 - 2026-06-11 a661911 SKIP - docs: prose-only (scope response style to conversation)


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 25d9207.