### PR TITLE
fix(audit): exclude .claude-pr/ from the stamp dirty check

### DIFF
--- a/.claude/hooks/audit-stamp-trailer.sh
+++ b/.claude/hooks/audit-stamp-trailer.sh
@@ -105,8 +105,16 @@ fi
 # Tree state preconditions
 # -----------------------------------------------------------------------------
 
-# Working tree must be clean.
-if [ -n "$(git -C "$repo_root" status --porcelain 2>/dev/null)" ]; then
+# Working tree must be clean, except for claude-code-action's runtime
+# working area `.claude-pr/`, a verbatim mirror of the repo the action
+# creates for sandboxed execution. It is never audit output and is always
+# untracked, so it must not count as a dirty tree. Relying on the adopter's
+# `.gitignore` to hide it is fragile: that file is manifest-class `owned` and
+# drifts, so an adopter copy can lack the entry and then decline the trailer
+# on every otherwise-clean audit. Exclude it at the check instead. A real
+# tracked modification (staged or unstaged) outside `.claude-pr/` still
+# registers as dirty and declines.
+if [ -n "$(git -C "$repo_root" status --porcelain -- . ':(exclude).claude-pr' 2>/dev/null)" ]; then
   emit_decline "tree dirty"
   exit 0
 fi

--- a/.gaia/tests/hooks/audit-stamp-trailer.bats
+++ b/.gaia/tests/hooks/audit-stamp-trailer.bats
@@ -9,6 +9,8 @@
 #   3. AUDIT_SELF_HEALED=true               -> amend regardless of push status
 #   4. detached HEAD (CI checkout)         -> empty commit (no auto-push)
 #   5. tree dirty                           -> decline "tree dirty"
+#   5b. dirty ONLY from .claude-pr/ runtime  -> stamps (artifact ignored)
+#   5c. .claude-pr/ PLUS real dirt           -> decline "tree dirty"
 #   6. .gaia/VERSION missing                -> decline "version file missing"
 #   7. .gaia/VERSION empty                  -> decline "version file empty"
 #   8. AUDIT_TREE_SHA != current tree       -> decline "tree changed since audit started"
@@ -204,6 +206,51 @@ trailer_on_head() {
   before_sha=$(git -C "$REPO" rev-parse HEAD)
   before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
 
+  echo "uncommitted" >> "$REPO/README.md"
+
+  cd "$REPO"
+  AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "stamp: declined: tree dirty" ]
+
+  after_sha=$(git -C "$REPO" rev-parse HEAD)
+  [ "$before_sha" = "$after_sha" ]
+  [ -z "$(trailer_on_head)" ]
+}
+
+@test "dirty ONLY from .claude-pr/ runtime artifacts: stamps anyway" {
+  # claude-code-action mirrors the repo into .claude-pr/ for sandboxed
+  # execution, leaving it untracked. That is not audit output and must not
+  # block the stamp. Without the exclusion this declines "tree dirty".
+  before_sha=$(git -C "$REPO" rev-parse HEAD)
+  before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
+
+  mkdir -p "$REPO/.claude-pr/.claude/agents"
+  echo "mirror" > "$REPO/.claude-pr/.claude/agents/code-review-audit.md"
+  echo "mirror" > "$REPO/.claude-pr/settings.json"
+
+  cd "$REPO"
+  AUDIT_TREE_SHA="$before_tree" AUDIT_SELF_HEALED="false" run "$HOOK_ABS"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "stamp: amended onto HEAD (un-pushed)" ]
+
+  after_sha=$(git -C "$REPO" rev-parse HEAD)
+  [ "$before_sha" != "$after_sha" ]
+
+  trailer=$(trailer_on_head)
+  [ "$trailer" = "GAIA-Audit: 1.2.3 ${before_tree}" ]
+}
+
+@test ".claude-pr/ artifacts PLUS a real dirty file: still declines" {
+  # The exclusion is scoped to .claude-pr/ only; genuine uncommitted audit
+  # work outside it must still block the stamp.
+  before_sha=$(git -C "$REPO" rev-parse HEAD)
+  before_tree=$(git -C "$REPO" rev-parse "HEAD^{tree}")
+
+  mkdir -p "$REPO/.claude-pr"
+  echo "mirror" > "$REPO/.claude-pr/x"
   echo "uncommitted" >> "$REPO/README.md"
 
   cd "$REPO"


### PR DESCRIPTION
## What

`audit-stamp-trailer.sh` declines `tree dirty` whenever claude-code-action's `.claude-pr/` runtime mirror is on disk, which it always is during a CI audit run (it left 133 untracked files in a recent adopter audit). The adopter `.gitignore` is supposed to hide it, but `.gitignore` is manifest-class `owned` and drifts, so adopter clones can lack the entry. The result: every otherwise-clean CI audit declines the durable `GAIA-Audit:` trailer and leans entirely on the per-SHA commit-status fallback.

This scopes the cleanliness probe to exclude `.claude-pr/`:

```sh
git status --porcelain -- . ':(exclude).claude-pr'
```

A real tracked modification outside `.claude-pr/` still registers as dirty and declines, so the invariant the check protects is unchanged.

## Why it matters (and what it does NOT fix)

This is a robustness/hygiene fix, not the root cause of the dogfooding incident that surfaced it. In that case the only full audit ran under an older workflow with **no** status fallback, so the trailer decline stranded the merge gate. On current workflows `check-trailer.sh` already tolerates a missing trailer via the commit-status fallback, so this does not change merge-gate outcomes. It does:

- let the durable, history-traveling trailer actually get written by CI again, instead of being silently dead on every adopter, and
- remove the dependence on a drift-prone adopter `.gitignore` for correct stamping.

## Tests

`​.gaia/tests/hooks/audit-stamp-trailer.bats` (12/12 green):
- new: dirty ONLY from `.claude-pr/` runtime artifacts -> stamps anyway
- new: `.claude-pr/` artifacts PLUS a real dirty file -> still declines

shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)