### PR TITLE
feat(update-gaia): auto-render stale audit workflow on update (#371, #372)

### DIFF
--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -490,18 +490,66 @@ fi
 
 If `gh` is unavailable or errors, tell the user to open the PR manually: `$branch` → `main`.
 
-### Step 12: Flag a stale CI audit workflow
+### Step 12: Refresh a stale CI audit workflow
 
-`.github/workflows/code-review-audit.yml` is **not** synced by `/update-gaia`, it installs and updates only via `/setup-gaia-ci`. A project that enabled GAIA CI on an older release therefore keeps whatever audit workflow shipped then, frozen, even after this update pulls a newer template. A stale workflow still audits in-scope PRs correctly, but an older copy may not stamp the `GAIA-Audit` status on out-of-scope (docs/metadata-only) PRs, which includes the update PR just opened. The merge gate's out-of-scope bypass keeps that PR mergeable regardless, but the workflow is worth refreshing.
+`.github/workflows/code-review-audit.yml` is **not** synced by the manifest walk (Steps 6-7); the audit workflow installs and updates through its own template, not a manifest class. A project that enabled GAIA CI on an older release therefore keeps whatever audit workflow shipped then, frozen, even after this update pulls a newer template. That stale copy is the root of an ordering trap: if this update's payload makes `has_source=true` (a dependency or config bump), CI runs a **full** audit under the **stale** workflow on the PR just opened, which cannot earn a clean `GAIA-Audit` stamp, and the operator then has to run `/setup-gaia-ci` by hand to refresh it (a second commit that self-mod-skips). Refreshing the workflow **inside this update PR** collapses that into a single, expected self-mod-skip.
 
-Probe for drift and advise only when the installed workflow is behind:
+The audit workflow is **adopter-tunable**: an adopter may have customized it (self-hosted runners, extra secrets wiring, concurrency, extra steps), so it is refreshed via a 3-way classify that never clobbers real edits. The audit template is static (no render), so the three inputs are files already on disk:
+
+- `A` = the installed workflow, `.github/workflows/code-review-audit.yml`
+- `L_old` = the prior release's template, `$BASELINE_DIR/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl`
+- `L_new` = this release's template, `$LATEST_DIR/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl`
+
+`gaia setup-ci check-audit-drift` classifies them and the SKILL acts on the verdict: `missing` (CI not installed → silent no-op, this is the opt-in guard), `in_sync` (already current, or this release did not touch the template → no-op), `clean` (`A == L_old`, stale but un-customized → safe to overwrite), or `conflict` (`A` matches neither template, or the baseline template is unavailable → never auto-write).
 
 ```bash
-audit_drift="$(.gaia/cli/gaia setup-ci check-audit-drift --json 2>/dev/null \
-  | jq -r '.state // "unknown"' 2>/dev/null || echo unknown)"
-if [ "$audit_drift" = "drifted" ]; then
-  echo "Heads up: .github/workflows/code-review-audit.yml is out of date vs the $LATEST_TAG template. Run /setup-gaia-ci to refresh it so the CI audit stamps the GAIA-Audit status correctly (including on out-of-scope PRs). The merge gate's out-of-scope bypass keeps this docs-only update PR mergeable in the meantime."
-fi
+# $BASELINE (pre-update version) and $LATEST_TAG carry from the run, as in
+# Step 11. The release tarball cache from Step 5 still holds both templates.
+BASELINE_DIR=".gaia/cache/v$BASELINE"
+LATEST_DIR=".gaia/cache/$LATEST_TAG"
+audit_tmpl=".gaia/cli/templates/workflows/code-review-audit.yml.tmpl"
+audit_wf=".github/workflows/code-review-audit.yml"
+
+audit_state="$(.gaia/cli/gaia setup-ci check-audit-drift \
+  --baseline "$BASELINE_DIR/$audit_tmpl" \
+  --latest "$LATEST_DIR/$audit_tmpl" \
+  --json 2>/dev/null | jq -r '.state // "unknown"' 2>/dev/null || echo unknown)"
+
+case "$audit_state" in
+  clean)
+    # Stale but un-customized: overwrite with the new template and land it in
+    # the update PR so CI sees the refreshed workflow from the start. The
+    # commit stages only a workflow YAML (no ts/tsx/css), so the Quality Gate
+    # has nothing to check.
+    cp "$LATEST_DIR/$audit_tmpl" "$audit_wf"
+    git add "$audit_wf"
+    if git commit -m "chore: re-render code-review-audit.yml for $LATEST_TAG" && git push; then
+      echo "Refreshed $audit_wf from the $LATEST_TAG template and pushed it to the update PR."
+    else
+      echo "Refreshed $audit_wf from the $LATEST_TAG template; commit and push it to the update PR manually."
+    fi
+    cat <<EOF
+Expectation: re-rendering $audit_wf makes this update PR self-modifying, so claude-code-action's workflow-validation guardrail refuses to run the audit on it. CI self-mod-skips the audit, one expected skip instead of a wasted full audit under the stale workflow plus a manual /setup-gaia-ci step. This does NOT earn a clean CI GAIA-Audit stamp; the merge still relies on a local audit marker / trailer or the out-of-scope bypass (see PR Merge Workflow). This is a UX/ordering cleanup, not a path to a clean stamp.
+EOF
+    ;;
+  conflict)
+    # Adopter customized the workflow, or the baseline template is missing.
+    # Never auto-write: emit a sidecar patch (installed -> latest template) and
+    # defer to a manual refresh, mirroring the Step 7 conflict handling.
+    mkdir -p .gaia-merge
+    diff -u "$audit_wf" "$LATEST_DIR/$audit_tmpl" \
+      > ".gaia-merge/code-review-audit.yml.patch" || true
+    echo "Heads up: $audit_wf has local customizations, so the $LATEST_TAG template was NOT applied. Review .gaia-merge/code-review-audit.yml.patch, reconcile, then run /setup-gaia-ci to refresh it. The merge gate's out-of-scope bypass / local audit keeps this update PR mergeable in the meantime."
+    ;;
+  missing | in_sync)
+    : # missing → GAIA CI not installed (opt-in), stay silent. in_sync → nothing to do.
+    ;;
+  *)
+    # Unknown verdict (e.g. a CLI predating 3-way support, or a probe error):
+    # fall back to the manual nudge so there is zero regression.
+    echo "Heads up: $audit_wf may be out of date vs the $LATEST_TAG template. Run /setup-gaia-ci to refresh it so the CI audit stamps the GAIA-Audit status correctly. The merge gate's out-of-scope bypass keeps this update PR mergeable in the meantime."
+    ;;
+esac
 ```
 
-`in_sync` means nothing to do; `missing` means GAIA CI is not installed (the merge gate falls back to the local `code-review-audit` agent, or the out-of-scope bypass for docs/metadata-only PRs), so stay silent. Only `drifted` warrants the nudge.
+Only `clean` auto-refreshes; `conflict` and any unknown verdict defer to the manual `/setup-gaia-ci` nudge, and `missing` / `in_sync` do nothing.

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -22014,15 +22014,27 @@ var run44 = async (argv, options = {}) => {
 // src/setup-ci/check-audit-drift.ts
 import { readFileSync as readFileSync24 } from "node:fs";
 import path32 from "node:path";
-var HELP_TEXT32 = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>] [--json]
+var HELP_TEXT32 = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>]
+                                       [--baseline <p> [--latest <p>]] [--json]
 
-  Compare installed audit workflow vs template.
+  Compare the installed audit workflow against the template(s).
 
-  Byte-compares <workflows-dir>/code-review-audit.yml against the canonical
-  template. Reports state: in_sync | drifted | missing.
+  Default (2-way): byte-compares <workflows-dir>/code-review-audit.yml
+  against the canonical bundled template. Reports state:
+  in_sync | drifted | missing.
+
+  With --baseline (3-way): classifies the installed file against the prior
+  release's template (--baseline) and this release's template (--latest,
+  defaulting to the bundled template). Reports state:
+  in_sync | clean | conflict | missing. Used by /update-gaia to refresh a
+  stale audit workflow without clobbering adopter edits.
 
   --workflows-dir <path>   Optional. Override of .github/workflows. Defaults
                            to <repoRoot>/.github/workflows.
+  --baseline <path>        Prior release's code-review-audit.yml.tmpl. Enables
+                           3-way mode.
+  --latest <path>          This release's code-review-audit.yml.tmpl. Defaults
+                           to the bundled template. Requires --baseline.
   --json                   Emit machine-readable JSON instead of a human
                            report.
 `;
@@ -22030,24 +22042,42 @@ var HELP_TOKENS30 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseArgs4 = (argv) => {
   let json3 = false;
   let workflowsDir;
+  let baseline;
+  let latest;
+  const takePath = (flag, index) => {
+    const next = argv[index + 1];
+    if (next === void 0 || next.startsWith("--")) {
+      return { error: `${flag} requires a path argument` };
+    }
+    return { value: next };
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--json") {
       json3 = true;
       continue;
     }
-    if (token === "--workflows-dir") {
-      const next = argv[index + 1];
-      if (next === void 0 || next.startsWith("--")) {
-        return { error: "--workflows-dir requires a path argument" };
+    if (token === "--workflows-dir" || token === "--baseline" || token === "--latest") {
+      const taken = takePath(token, index);
+      if ("error" in taken) {
+        return { error: taken.error };
       }
-      workflowsDir = next;
+      if (token === "--workflows-dir") {
+        workflowsDir = taken.value;
+      } else if (token === "--baseline") {
+        baseline = taken.value;
+      } else {
+        latest = taken.value;
+      }
       index += 1;
       continue;
     }
     return { error: `unknown flag: ${token}` };
   }
-  return { json: json3, workflowsDir };
+  if (latest !== void 0 && baseline === void 0) {
+    return { error: "--latest requires --baseline" };
+  }
+  return { baseline, json: json3, latest, workflowsDir };
 };
 var safeReadFile = (filePath) => {
   try {
@@ -22084,22 +22114,40 @@ var run45 = (argv, options = {}) => {
   const workflowsDir = parsed.workflowsDir ?? path32.join(repoRoot2, ".github", "workflows");
   const installedPath = path32.join(workflowsDir, "code-review-audit.yml");
   const onDisk = safeReadFile(installedPath);
-  let state;
-  if (onDisk === null) {
-    state = "missing";
-  } else {
-    let template;
+  const readTemplateOrFail = (templatePath) => {
     try {
-      template = readFileSync24(workflowAuditTemplatePath(), "utf8");
+      return { content: readFileSync24(templatePath, "utf8") };
     } catch (error51) {
       structuredError({
         code: "template_unreadable",
         error: error51 instanceof Error ? error51.message : String(error51),
         subcommand: "setup-ci check-audit-drift"
       });
-      return EXIT_CODES.STORAGE_INACCESSIBLE;
+      return { exitCode: EXIT_CODES.STORAGE_INACCESSIBLE };
     }
-    state = onDisk === template ? "in_sync" : "drifted";
+  };
+  let state;
+  if (onDisk === null) {
+    state = "missing";
+  } else if (parsed.baseline === void 0) {
+    const template = readTemplateOrFail(workflowAuditTemplatePath());
+    if ("exitCode" in template) {
+      return template.exitCode;
+    }
+    state = onDisk === template.content ? "in_sync" : "drifted";
+  } else {
+    const latest = readTemplateOrFail(parsed.latest ?? workflowAuditTemplatePath());
+    if ("exitCode" in latest) {
+      return latest.exitCode;
+    }
+    const baseline = safeReadFile(parsed.baseline);
+    if (onDisk === latest.content || baseline === latest.content) {
+      state = "in_sync";
+    } else if (baseline !== null && onDisk === baseline) {
+      state = "clean";
+    } else {
+      state = "conflict";
+    }
   }
   if (parsed.json) {
     process.stdout.write(`${JSON.stringify({ state })}
@@ -23319,8 +23367,9 @@ var HELP_TEXT44 = `Usage: gaia setup-ci <subcommand> [args]
   status [--json]                          Print Phase B configuration status.
   check-drift [--workflows-dir <p>] [--json]
                                            Compare rendered workflows vs template render.
-  check-audit-drift [--workflows-dir <p>] [--json]
-                                           Compare installed audit workflow vs template.
+  check-audit-drift [--workflows-dir <p>] [--baseline <p> [--latest <p>]] [--json]
+                                           Compare installed audit workflow vs template
+                                           (2-way), or 3-way classify vs baseline+latest.
   detect-remote [--json]                   Read git remote get-url origin.
   warn-existing-tools [--json]             Detect Dependabot / Renovate configs.
   check-admin --owner <o> --repo <r> [--json]

--- a/.gaia/cli/src/setup-ci/__tests__/check-audit-drift.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/check-audit-drift.test.ts
@@ -48,6 +48,20 @@ const writeAuditWorkflow = (sandbox: Sandbox, content?: string): void => {
   );
 };
 
+const writeTemplateFixture = (
+  sandbox: Sandbox,
+  name: string,
+  content: string
+): string => {
+  const fixturePath = path.join(sandbox.root, name);
+  writeFileSync(fixturePath, content, 'utf8');
+
+  return fixturePath;
+};
+
+const readState = (stdio: ReturnType<typeof captureStdio>): string =>
+  (JSON.parse(stdio.out.join('').trim()) as {state: string}).state;
+
 describe('setup-ci check-audit-drift', () => {
   let sandbox: Sandbox;
   let stdio: ReturnType<typeof captureStdio>;
@@ -143,5 +157,140 @@ describe('setup-ci check-audit-drift', () => {
 
     expect(exit).toBe(0);
     expect(stdio.out.join('')).toContain('Usage:');
+  });
+});
+
+describe('setup-ci check-audit-drift (3-way merge classify)', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox('gaia-setup-ci-check-audit-drift-3way-');
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const OLD = '# v1 audit workflow\n';
+  const NEW = '# v2 audit workflow\n';
+
+  it('reports in_sync when the installed file equals the latest template', () => {
+    writeAuditWorkflow(sandbox, NEW);
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--baseline', baseline, '--latest', latest, '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('in_sync');
+  });
+
+  it('reports clean when the installed file equals the baseline template (stale)', () => {
+    writeAuditWorkflow(sandbox, OLD);
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--baseline', baseline, '--latest', latest, '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('clean');
+  });
+
+  it('reports conflict when the installed file matches neither template (adopter drift)', () => {
+    writeAuditWorkflow(sandbox, '# adopter-customized\n');
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--baseline', baseline, '--latest', latest, '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('conflict');
+  });
+
+  it('reports in_sync (no-op) when the release did not change the template even if the installed file drifted', () => {
+    writeAuditWorkflow(sandbox, '# adopter-customized\n');
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', OLD);
+
+    const exit = run(['--baseline', baseline, '--latest', latest, '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('in_sync');
+  });
+
+  it('reports conflict (never auto-writes) when the baseline template is unavailable', () => {
+    writeAuditWorkflow(sandbox, OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+    const missingBaseline = path.join(sandbox.root, 'does-not-exist.tmpl');
+
+    const exit = run(
+      ['--baseline', missingBaseline, '--latest', latest, '--json'],
+      {cwd: sandbox.root}
+    );
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('conflict');
+  });
+
+  it('reports missing in 3-way mode when the installed file is absent', () => {
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--baseline', baseline, '--latest', latest, '--json'], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('missing');
+  });
+
+  it('defaults --latest to the bundled template when only --baseline is given', () => {
+    writeAuditWorkflow(sandbox);
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+
+    const exit = run(['--baseline', baseline, '--json'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+    expect(readState(stdio)).toBe('in_sync');
+  });
+
+  it('rejects --latest without --baseline', () => {
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--latest', latest, '--json'], {cwd: sandbox.root});
+
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('--latest requires --baseline');
+  });
+
+  it('errors when the latest template path is unreadable', () => {
+    writeAuditWorkflow(sandbox, OLD);
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const missingLatest = path.join(sandbox.root, 'no-latest.tmpl');
+
+    const exit = run(
+      ['--baseline', baseline, '--latest', missingLatest, '--json'],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).not.toBe(0);
+    expect(stdio.err.join('')).toContain('template_unreadable');
+  });
+
+  it('emits human-readable 3-way output without --json', () => {
+    writeAuditWorkflow(sandbox, OLD);
+    const baseline = writeTemplateFixture(sandbox, 'baseline.tmpl', OLD);
+    const latest = writeTemplateFixture(sandbox, 'latest.tmpl', NEW);
+
+    const exit = run(['--baseline', baseline, '--latest', latest], {
+      cwd: sandbox.root,
+    });
+    expect(exit).toBe(0);
+    expect(stdio.out.join('')).toContain('audit workflow: clean');
   });
 });

--- a/.gaia/cli/src/setup-ci/check-audit-drift.ts
+++ b/.gaia/cli/src/setup-ci/check-audit-drift.ts
@@ -1,12 +1,14 @@
 /**
- * `gaia setup-ci check-audit-drift [--workflows-dir <path>] [--json]` handler.
+ * `gaia setup-ci check-audit-drift [--workflows-dir <path>]
+ *  [--baseline <path> [--latest <path>]] [--json]` handler.
  *
- * Byte-compares the installed `.github/workflows/code-review-audit.yml`
- * against the canonical template. The `/setup-gaia-ci` slash command's
- * Step 2 drift probe calls this alongside `check-drift` to detect whether
- * the audit workflow is present and up-to-date.
+ * Two modes, both read-only.
  *
- * JSON shape (canonical contract):
+ * **2-way (default).** Byte-compares the installed
+ * `.github/workflows/code-review-audit.yml` against the canonical bundled
+ * template. The `/setup-gaia-ci` slash command's Step 2 drift probe calls
+ * this alongside `check-drift` to detect whether the audit workflow is
+ * present and up-to-date.
  *
  *   { "state": "in_sync" | "drifted" | "missing" }
  *
@@ -14,7 +16,25 @@
  * - `drifted` : installed file exists but bytes differ from the template.
  * - `missing` : the file is absent (audit not yet installed or excluded).
  *
- * This is a read-only query command; it always exits 0.
+ * **3-way (with `--baseline`).** Classifies the installed file against the
+ * baseline template (what the prior release shipped) and the latest
+ * template (what this release ships) so `/update-gaia` Step 12 can refresh
+ * a stale audit workflow without clobbering adopter customizations. The
+ * audit template is static (no render), so this is a pure text 3-way.
+ * `--latest` defaults to the bundled template when omitted.
+ *
+ *   { "state": "in_sync" | "clean" | "conflict" | "missing" }
+ *
+ * - `in_sync`  : installed equals latest, OR the release did not change the
+ *                template (baseline == latest) so there is nothing to apply.
+ * - `clean`    : installed equals baseline (stale but un-customized); safe to
+ *                overwrite with latest.
+ * - `conflict` : installed matches neither (adopter drift), or the baseline
+ *                template is unavailable so cleanliness cannot be proven.
+ *                The caller must NOT auto-write; surface a patch instead.
+ * - `missing`  : the installed file is absent.
+ *
+ * This is a read-only query command; it exits 0 on every classification.
  */
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
@@ -23,31 +43,65 @@ import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {resolveRepoRoot} from '../wiki/util/git.js';
 
-const HELP_TEXT = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>] [--json]
+const HELP_TEXT = `Usage: gaia setup-ci check-audit-drift [--workflows-dir <p>]
+                                       [--baseline <p> [--latest <p>]] [--json]
 
-  Compare installed audit workflow vs template.
+  Compare the installed audit workflow against the template(s).
 
-  Byte-compares <workflows-dir>/code-review-audit.yml against the canonical
-  template. Reports state: in_sync | drifted | missing.
+  Default (2-way): byte-compares <workflows-dir>/code-review-audit.yml
+  against the canonical bundled template. Reports state:
+  in_sync | drifted | missing.
+
+  With --baseline (3-way): classifies the installed file against the prior
+  release's template (--baseline) and this release's template (--latest,
+  defaulting to the bundled template). Reports state:
+  in_sync | clean | conflict | missing. Used by /update-gaia to refresh a
+  stale audit workflow without clobbering adopter edits.
 
   --workflows-dir <path>   Optional. Override of .github/workflows. Defaults
                            to <repoRoot>/.github/workflows.
+  --baseline <path>        Prior release's code-review-audit.yml.tmpl. Enables
+                           3-way mode.
+  --latest <path>          This release's code-review-audit.yml.tmpl. Defaults
+                           to the bundled template. Requires --baseline.
   --json                   Emit machine-readable JSON instead of a human
                            report.
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
-type AuditDriftState = 'drifted' | 'in_sync' | 'missing';
+type AuditDriftState =
+  | 'clean'
+  | 'conflict'
+  | 'drifted'
+  | 'in_sync'
+  | 'missing';
 
 type ParsedArgs = {
+  baseline?: string;
   json: boolean;
+  latest?: string;
   workflowsDir?: string;
 };
 
 const parseArgs = (argv: readonly string[]): ParsedArgs | {error: string} => {
   let json = false;
   let workflowsDir: string | undefined;
+  let baseline: string | undefined;
+  let latest: string | undefined;
+
+  const takePath = (
+    flag: string,
+    index: number
+  ): {value: string} | {error: string} => {
+    const next = argv[index + 1];
+
+    if (next === undefined || next.startsWith('--')) {
+      return {error: `${flag} requires a path argument`};
+    }
+
+    return {value: next};
+  };
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index] as string;
@@ -58,13 +112,19 @@ const parseArgs = (argv: readonly string[]): ParsedArgs | {error: string} => {
       continue;
     }
 
-    if (token === '--workflows-dir') {
-      const next = argv[index + 1];
+    if (token === '--workflows-dir' || token === '--baseline' || token === '--latest') {
+      const taken = takePath(token, index);
 
-      if (next === undefined || next.startsWith('--')) {
-        return {error: '--workflows-dir requires a path argument'};
+      if ('error' in taken) {
+        return {error: taken.error};
       }
-      workflowsDir = next;
+      if (token === '--workflows-dir') {
+        workflowsDir = taken.value;
+      } else if (token === '--baseline') {
+        baseline = taken.value;
+      } else {
+        latest = taken.value;
+      }
       index += 1;
 
       continue;
@@ -73,7 +133,11 @@ const parseArgs = (argv: readonly string[]): ParsedArgs | {error: string} => {
     return {error: `unknown flag: ${token}`};
   }
 
-  return {json, workflowsDir};
+  if (latest !== undefined && baseline === undefined) {
+    return {error: '--latest requires --baseline'};
+  }
+
+  return {baseline, json, latest, workflowsDir};
 };
 
 const safeReadFile = (filePath: string): string | null => {
@@ -131,15 +195,11 @@ export const run = (
   const installedPath = path.join(workflowsDir, 'code-review-audit.yml');
   const onDisk = safeReadFile(installedPath);
 
-  let state: AuditDriftState;
-
-  if (onDisk === null) {
-    state = 'missing';
-  } else {
-    let template: string;
-
+  const readTemplateOrFail = (
+    templatePath: string
+  ): {content: string} | {exitCode: number} => {
     try {
-      template = readFileSync(workflowAuditTemplatePath(), 'utf8');
+      return {content: readFileSync(templatePath, 'utf8')};
     } catch (error) {
       structuredError({
         code: 'template_unreadable',
@@ -147,10 +207,43 @@ export const run = (
         subcommand: 'setup-ci check-audit-drift',
       });
 
-      return EXIT_CODES.STORAGE_INACCESSIBLE;
+      return {exitCode: EXIT_CODES.STORAGE_INACCESSIBLE};
     }
+  };
 
-    state = onDisk === template ? 'in_sync' : 'drifted';
+  let state: AuditDriftState;
+
+  if (onDisk === null) {
+    state = 'missing';
+  } else if (parsed.baseline === undefined) {
+    // 2-way mode: installed vs the bundled template.
+    const template = readTemplateOrFail(workflowAuditTemplatePath());
+
+    if ('exitCode' in template) {
+      return template.exitCode;
+    }
+    state = onDisk === template.content ? 'in_sync' : 'drifted';
+  } else {
+    // 3-way mode: installed vs baseline (prior release) and latest (this
+    // release). The latest template is required; the baseline may be
+    // unavailable (an older pre-template release), which collapses to
+    // conflict so the caller never auto-writes on an unprovable comparison.
+    const latest = readTemplateOrFail(parsed.latest ?? workflowAuditTemplatePath());
+
+    if ('exitCode' in latest) {
+      return latest.exitCode;
+    }
+    const baseline = safeReadFile(parsed.baseline);
+
+    if (onDisk === latest.content || baseline === latest.content) {
+      // Installed already at latest, OR the release did not touch the
+      // template (baseline == latest) so there is nothing to apply.
+      state = 'in_sync';
+    } else if (baseline !== null && onDisk === baseline) {
+      state = 'clean';
+    } else {
+      state = 'conflict';
+    }
   }
 
   if (parsed.json) {

--- a/.gaia/cli/src/setup-ci/index.ts
+++ b/.gaia/cli/src/setup-ci/index.ts
@@ -32,8 +32,9 @@ const HELP_TEXT = `Usage: gaia setup-ci <subcommand> [args]
   status [--json]                          Print Phase B configuration status.
   check-drift [--workflows-dir <p>] [--json]
                                            Compare rendered workflows vs template render.
-  check-audit-drift [--workflows-dir <p>] [--json]
-                                           Compare installed audit workflow vs template.
+  check-audit-drift [--workflows-dir <p>] [--baseline <p> [--latest <p>]] [--json]
+                                           Compare installed audit workflow vs template
+                                           (2-way), or 3-way classify vs baseline+latest.
   detect-remote [--json]                   Read git remote get-url origin.
   warn-existing-tools [--json]             Detect Dependabot / Renovate configs.
   check-admin --owner <o> --repo <r> [--json]

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-08
-updated: 2026-06-11
+updated: 2026-06-12
 tags: [concept, ci, audit, claude]
 ---
 
@@ -50,6 +50,14 @@ The `Check for source-code changes` step diffs only the **un-audited delta**: `<
 On this skip path the `Write GAIA-Audit commit status (out-of-scope skip)` step stamps a `GAIA-Audit` commit status (`<version> <tree>`) on HEAD, mirroring the full-audit path's status. An out-of-scope PR (CLI-only, docs-only, wiki-only, `.claude`-only) therefore satisfies the [[PR Merge Workflow]] merge hook with no local audit run; the agent would find nothing in scope to review. The description carries HEAD's own tree, since the hook checks tree equality against the content being merged.
 
 The stamp fires on the out-of-scope reason only. The already-audited reason (the `GAIA-Audit:` trailer already matches, so a status is redundant) and the workflow-self-modification reason (auto-approving a change to the audit gate itself would be a security hole) do not stamp. The `has_source == 'false'` condition structurally enforces this: both other reasons require `has_source == 'true'`. A self-modifying PR (including one editing `code-review-audit.yml`) gets no auto-stamp and still needs a local marker to merge.
+
+## Workflow refresh on /update-gaia
+
+The installed `code-review-audit.yml` is not synced by `/update-gaia`'s manifest walk; it tracks its own template. When an update finds the installed workflow stale, `/update-gaia` refreshes it **inside the update PR** via a 3-way classify (`gaia setup-ci check-audit-drift --baseline <prior-template> --latest <new-template>`), overwriting only when the installed file is an un-customized copy of the prior release's template. Adopter customizations classify as `conflict` and are never clobbered; the workflow is adopter-tunable (see [[Update Workflow]] for the full verdict table).
+
+The refresh is deliberately self-modifying, and that is the point. A GAIA-update PR whose payload changes auditable files (a dependency or config bump making `has_source=true`) would otherwise run a **full** audit under the **stale** workflow, which cannot earn a clean stamp, then need a separate manual `/setup-gaia-ci` commit. Landing the refresh in the same PR collapses both into one expected self-mod-skip: the `Check workflow self-modification` step trips on the changed `code-review-audit.yml`, the agent never runs, and the terminal `Status: skipped (workflow self-modification)` step reports green.
+
+This is a UX/ordering cleanup, not a clean-stamp path. The self-mod-skip stamps no `GAIA-Audit` status (auto-approving a change to the audit gate would be a security hole), so the update PR merges on the local audit marker / `GAIA-Audit:` trailer or the out-of-scope bypass, see [[PR Merge Workflow]]. Earning a CI stamp would require landing the workflow refresh on `main` in a separate PR merged before the payload, which is not worth it for a tooling-only update.
 
 ## Clean audit, no push
 

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Update Workflow
 status: active
 created: 2026-04-22
-updated: 2026-06-11
+updated: 2026-06-12
 tags: [release, claude, adopter, drift]
 ---
 
@@ -39,7 +39,7 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 1. Read `.gaia/VERSION`. Missing → tell user to run `/gaia-init` on a fresh `create-gaia` scaffold.
 2. Resolve latest release via `gh release list --repo gaia-react/gaia` (or GitHub API fallback).
 3. Compare to baseline. Same or older → exit, unless `.gaia/VERSION` has been bumped but not committed (an interrupted prior run), in which case surface the residual state so the adopter can commit or discard. Never downgrade.
-4. Show the adopter the release notes and **confirm** before touching anything. If on `main`/`master`, create the feature branch only after this confirmation — not before — so an early exit leaves no orphan branch.
+4. Show the adopter the release notes and **confirm** before touching anything. If on `main`/`master`, create the feature branch only after this confirmation, not before, so an early exit leaves no orphan branch.
 5. Download baseline + latest tarballs to `.gaia/cache/`. Stop on any download or extraction failure; do not proceed with a partial cache.
 6. Walk the latest manifest. For each file, apply the decision table below.
 7. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.
@@ -86,6 +86,23 @@ Per managed entry key `k`:
 | GAIA removed `k` (baseline only)                  | No-op: if adopter still has it, leave it.                        |
 
 The load-bearing guarantee: a dependency the adopter removed is **never re-added** unless GAIA changed it this release _and_ the adopter opts in, the JSON-key analog of the file-level "respect adopter deletions" rule. Clean applies are written surgically (the changed line only, preserving the adopter's formatting). Re-pin conflicts and dep suggestions go to `.gaia-merge/package.json.notes`. A version-only release touches nothing and emits no notes.
+
+## CI audit workflow refresh
+
+`.github/workflows/code-review-audit.yml` is not a manifest-class file, so the merge walk never touches it; it tracks its own template at `.gaia/cli/templates/workflows/code-review-audit.yml.tmpl`. After the PR opens, `/update-gaia` refreshes a stale copy in place so the update PR carries the current workflow instead of auditing itself under a frozen one.
+
+The refresh is a **3-way text classify** (the audit template is static, so there is no render): installed `A`, the baseline release's template `L_old`, and the latest release's template `L_new`, both pulled from the `.gaia/cache/` tarballs. `gaia setup-ci check-audit-drift --baseline <L_old> --latest <L_new>` returns the verdict:
+
+| Verdict    | Meaning                                             | Action                                                        |
+| ---------- | --------------------------------------------------- | ------------------------------------------------------------- |
+| `missing`  | CI not installed (audit is opt-in)                  | Silent no-op.                                                 |
+| `in_sync`  | Installed already current, or release left it alone | No-op.                                                        |
+| `clean`    | `A == L_old`: stale but un-customized               | Overwrite with `L_new`, commit, and push into the update PR.  |
+| `conflict` | `A` matches neither, or baseline unavailable        | Write `.gaia-merge/code-review-audit.yml.patch`; never write. |
+
+The audit workflow is **adopter-tunable**: `conflict` never clobbers adopter edits (self-hosted runners, extra secrets wiring, concurrency, extra steps), it emits a sidecar patch and defers to a manual `/setup-gaia-ci` refresh, mirroring the `shared` drift rule. The scheduled `gaia-ci-*` workflows stay disposable (regenerated wholesale on `/setup-gaia-ci --reconfigure`); only the audit workflow gets the 3-way.
+
+Re-rendering the workflow makes the update PR self-modifying, so [[Code Review Audit CI]]'s `claude-code-action` refuses to audit it and the run self-mod-skips. This is a UX/ordering cleanup: it replaces a wasted full audit under the stale workflow plus a manual refresh step with one expected skip. It does **not** earn a clean CI `GAIA-Audit` stamp; the merge proceeds on a local audit marker / trailer or the out-of-scope bypass (see [[PR Merge Workflow]]).
 
 ## Safety invariants
 


### PR DESCRIPTION
Implements the sequenced pair **#371** (posture decision) and **#372** (auto-render).

## #371 — posture decision (resolved: adopter-tunable / 3-way)

The rendered `code-review-audit.yml` carries **no** disposable provenance header. Per the maintainer's call, it is treated as **adopter-tunable**: it is the workflow most likely to be customized (self-hosted runners, secrets wiring, concurrency, extra steps), so drift is reconciled via a 3-way that honors adopter edits. The scheduled `gaia-ci-*` siblings stay disposable. Decision recorded on #371.

## #372 — auto-render in `/update-gaia` Step 12

`/update-gaia` Step 12 now **refreshes** a stale installed audit workflow inside the update PR instead of only nudging the operator to run `/setup-gaia-ci`.

**CLI primitive (`gaia setup-ci check-audit-drift`).** Extended with an optional 3-way classify (`--baseline <p> [--latest <p>]`), returning `missing | in_sync | clean | conflict`. The audit template is static (no render), so this is a pure text 3-way. The 2-way default mode (consumed by `/setup-gaia-ci`) is unchanged and fully backward compatible.

**Step 12 acts on the verdict:**

| Verdict | Action |
|---|---|
| `missing` | Silent no-op (GAIA CI is opt-in) |
| `in_sync` | No-op |
| `clean` (`A == prior template`) | Overwrite with the new template, commit, push into the update PR |
| `conflict` (adopter drift, or baseline unavailable) | Emit `.gaia-merge/code-review-audit.yml.patch`, defer to the manual nudge, never auto-write |

## Expectation set (not a clean-stamp path)

Re-rendering makes the update PR self-modifying, so `claude-code-action` still refuses to run the agent on it. This is a **UX/ordering cleanup**: it collapses "wasted full audit under the stale workflow + a separate manual `/setup-gaia-ci` commit" into a single expected self-mod-skip. It does **not** earn a clean CI `GAIA-Audit` stamp; the merge still rides the local marker/trailer or the out-of-scope bypass. The Step 12 prose and run summary say so explicitly.

## Tests / gate

- 10 new vitest cases for the 3-way classify (in_sync / clean / conflict / no-upstream-change / baseline-unavailable / missing / latest-default / arg-error / unreadable-latest / human output). CLI suite green (1346 passed, 1 skipped); `pnpm --dir .gaia/cli typecheck` clean.
- Bundled `.gaia/cli/gaia` rebuilt and committed (CI requires the maintainer to commit it).
- Lint/pw/build/dev-smoke gate steps N/A: changes are `.gaia/**` (eslint-ignored CLI) + markdown; no `app/` source.
- Wiki updated in wiki-style: `Update Workflow.md`, `Code Review Audit CI.md`.

## Deferred follow-up

The optional merge-gate change (teach `.claude/hooks/pr-merge-audit-check.sh` to recognize a self-mod-only update PR as a verbatim template re-render) is **deferred to its own PR**. It widens a fail-closed, security-sensitive merge gate and deserves a focused review + audit; the core #372 value lands without it (the local re-audit at merge still works, just slightly heavier UX).

Closes #371, closes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)