### PR TITLE
feat(update-gaia): prune prior-run artifacts at the start of a confirmed update

### DIFF
--- a/.claude/skills/update-gaia/SKILL.md
+++ b/.claude/skills/update-gaia/SKILL.md
@@ -125,6 +125,41 @@ git checkout -b chore/update-gaia-$(date +%Y-%m-%d-%H-%M)
 
 Otherwise stay on the current branch.
 
+## Step 4b: Prune prior-run artifacts
+
+Three gitignored directories accumulate across updates: `.gaia-backup/`, `.gaia/cache/`, and `.gaia-merge/`. Prune the prior runs' leftovers here, at the start of a confirmed update and **before this run creates any of its own artifacts** (Step 5 populates the cache, Step 7 creates `$BACKUP_DIR`), so the current run's fresh safety net is never touched. This runs only after the Step 4 `Proceed`, so an abort, an already-up-to-date exit, and the interrupted-prior-run case Step 3 surfaces (whose backups and patches are still in flight) never reach it.
+
+```bash
+# .gaia-backup/: prior runs' pre-overwrite copies. Once an update is committed,
+# git history is the durable recovery, so prior backups are redundant. This run
+# creates its own $BACKUP_DIR in Step 7.
+rm -rf .gaia-backup
+
+# .gaia/cache/: keep the baseline tarball (v$BASELINE is this run's baseline,
+# reused by Step 5 instead of re-downloading) and update-check.json (the
+# SessionStart hook reads it). Delete every other cached tag dir.
+if [ -d .gaia/cache ]; then
+  for d in .gaia/cache/*/; do
+    [ -d "$d" ] || continue
+    [ "$(basename "$d")" = "v$BASELINE" ] && continue
+    rm -rf "$d"
+  done
+fi
+
+# .gaia-merge/: conflict patches + .notes the operator resolves by hand (Step
+# 11). Remove only when empty; a populated dir holds unresolved action items, so
+# never delete it, warn and name the leftovers instead.
+if [ -d .gaia-merge ]; then
+  if [ -n "$(ls -A .gaia-merge 2>/dev/null)" ]; then
+    echo "Heads up: .gaia-merge/ still holds unresolved patches from a prior run, NOT deleted:"
+    ls -A .gaia-merge
+    echo "Resolve or delete them by hand, then re-run /update-gaia."
+  else
+    rmdir .gaia-merge
+  fi
+fi
+```
+
 ## Model selection
 
 After the user confirms, determine the model for the execution agent:

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -17,9 +17,9 @@ How `/update-gaia` pulls a newer GAIA release into an initialized project withou
 | --------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `.gaia/VERSION`       | Adopter's current baseline: which GAIA version `my-app/` was scaffolded from (or last `/update-gaia`d to).          |
 | `.gaia/manifest.json` | Ships with every release. Maps each file in the release to a class.                                                 |
-| `.gaia/cache/`        | Gitignored. Holds downloaded baseline + latest tarballs for the 3-way comparison.                                   |
-| `.gaia-merge/`        | Gitignored. Sidecar `.patch` files emitted for files the update can't safely auto-merge. Adopter resolves manually. |
-| `.gaia-backup/`       | Gitignored. Per-timestamp backups of any file the adopter agreed to overwrite.                                      |
+| `.gaia/cache/`        | Gitignored. Holds downloaded baseline + latest tarballs for the 3-way comparison. Pruned to the baseline tarball (plus `update-check.json`) at the start of each confirmed update; other cached tag dirs are removed. |
+| `.gaia-merge/`        | Gitignored. Sidecar `.patch` files emitted for files the update can't safely auto-merge. Adopter resolves manually. Removed at the start of an update only when empty; a populated dir is kept and its leftover patches flagged. |
+| `.gaia-backup/`       | Gitignored. Per-timestamp backups of any file the adopter agreed to overwrite. Prior runs' backups are pruned at the start of each confirmed update; once an update is committed git history is the durable recovery. |
 
 ## File classes
 
@@ -40,7 +40,7 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 2. Resolve latest release via `gh release list --repo gaia-react/gaia` (or GitHub API fallback).
 3. Compare to baseline. Same or older → exit, unless `.gaia/VERSION` has been bumped but not committed (an interrupted prior run), in which case surface the residual state so the adopter can commit or discard. Never downgrade.
 4. Show the adopter the release notes and **confirm** before touching anything. If on `main`/`master`, create the feature branch only after this confirmation, not before, so an early exit leaves no orphan branch.
-5. Download baseline + latest tarballs to `.gaia/cache/`. Stop on any download or extraction failure; do not proceed with a partial cache.
+5. Prune prior runs' leftover artifacts before this run creates its own: drop stale `.gaia-backup/` copies and stale `.gaia/cache/` tag dirs (keeping the baseline tarball), and remove `.gaia-merge/` only when empty. Then download baseline + latest tarballs to `.gaia/cache/`. Stop on any download or extraction failure; do not proceed with a partial cache.
 6. Walk the latest manifest. For each file, apply the decision table below.
 7. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.
 8. Bump `.gaia/VERSION` and replace `.gaia/manifest.json` with the latest version's copy. This happens after the summary prints so that if the walk was aborted mid-way the version stays at baseline and a re-run resumes cleanly.


### PR DESCRIPTION
## What

Adds a **Step 4b: Prune prior-run artifacts** to the `/update-gaia` skill so three gitignored local artifacts stop accumulating across updates. Local-disk hygiene only; nothing reaches the repo or a PR.

Per artifact, at the start of a confirmed update:

- **`.gaia-backup/`** — remove prior runs' pre-overwrite copies. Once an update is committed, git history is the durable recovery, so prior backups are redundant. This run creates its own `$BACKUP_DIR` in Step 7.
- **`.gaia/cache/`** — keep the baseline tarball (`v$BASELINE`, reused by Step 5 instead of re-downloading) and `update-check.json` (the SessionStart hook reads it); delete every other cached tag dir.
- **`.gaia-merge/`** — remove **only when empty**. A populated dir holds unresolved conflict patches/notes (action items the operator resolves by hand), so it is kept and its leftovers named in a warning.

## Placement

A new `## Step 4b` in the orchestrator, after the Step 4 `Proceed`/branch creation and before Model selection. This sits past Step 3's interrupted-prior-run exit (whose backups/patches are still in flight) and before Step 5 (fetch) and Step 7 (`$BACKUP_DIR`), so **this run's fresh safety net is never touched** and an interrupted prior run is never reached. Uses the doc's existing `Nb` sub-step convention (cf. Step 8b) — zero renumbering churn.

## Inline vs extracted CLI

Implemented as **inline bash**, not an extracted `.gaia/cli` primitive. The existing `update merge-workspace` / `setup-ci check-audit-drift` extractions are pure verdict *oracles* (parse → structured JSON, no side effects); this is filesystem hygiene with no verdict to return, matching the runbook's existing inline `rm -rf` cleanups. Avoids committing a regenerated ~1MB binary into a disk-hygiene change.

## Verification

- Sandbox-tested all three branches: populated `.gaia-merge/` kept + warned; empty `.gaia-merge/` removed; backups cleared; cache pruned to baseline tarball + `update-check.json`; no-dirs case is a clean no-op.
- `instruction-files` audit (no absolute paths in `.claude/`): clean.
- `wiki-style` audit (no historical phrasing / UAT / SPEC refs in the touched wiki page): clean.
- Quality Gate skips (markdown + `.claude/**` + `wiki/**` only, no staged source).
- Wiki `Update Workflow.md` updated in present-tense wiki-style (Primitives rows + Flow step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)