### PR TITLE
wiki: sync through 283683e

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "c510ea51706bb76964c362a3e3f058624275d06f",
-  "last_evaluated_at": "2026-06-11T16:48:34.432Z",
+  "last_evaluated_sha": "283683e9678c6b762891029d7438ec1f527b536a",
+  "last_evaluated_at": "2026-06-12T07:54:00Z",
   "last_consolidated_sha": "3e090b14c0bdc9b6bcdce738833dde2d4e765e9d",
   "last_consolidated_at": "2026-06-10T18:23:05Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,4 +11,11 @@ tags: [meta, log]
 
 ## [v1.6.0] 2026-06-11 | Released
 
+- 2026-06-12 4045c41 SKIP - wiki: self-referential
+- 2026-06-12 9daa0d6 SKIP - chore: generic chore
+- 2026-06-12 3602248 SKIP - fix(audit): hooks-only change; no wiki page covers the audit-stamp dirty-check implementation
+- 2026-06-12 9cf26ca SKIP - docs(wiki): wiki/decisions/pnpm.md already updated inline by the commit
+- 2026-06-12 e6b9335 SKIP - feat(update-gaia): wiki/concepts/Update Workflow.md and Code Review Audit CI.md already updated inline by the commit
+- 2026-06-12 bac2306 SKIP - feat(merge-gate): wiki/concepts/PR Merge Workflow.md and Code Review Audit CI.md already updated inline by the commit
+- 2026-06-12 283683e SKIP - feat(update-gaia): wiki/concepts/Update Workflow.md already updated inline by the commit
 See CHANGELOG.md for details.


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 283683e.