### PR TITLE
feat(gaia-wiki): land the full chain on one branch and one PR

### DIFF
--- a/.claude/skills/gaia/references/wiki.md
+++ b/.claude/skills/gaia/references/wiki.md
@@ -77,6 +77,8 @@ When the subagent returns, relay its final summary verbatim. Do not redo the wor
 
 If invoked as `/gaia-wiki sync` (sub-arg form): stop after relaying the summary. Do **not** chain into consolidate or lint, that's only the no-arg form's job. The sub-arg form `/gaia-wiki sync --force` is also valid; the same defer / force logic from "GAIA CI deferral check" applies.
 
+Standalone, sync's Step 7 lands on its own: from `main` it cuts a `wiki-sync/<date>-<sha>` branch and opens its own PR; from a feature branch it commits in place. In the no-arg full chain the parent pre-cuts the branch via `chain begin`, so the same Step 7 commits in place on the chain branch and the chain opens a single PR at the end (see "Full chain").
+
 ## Consolidate
 
 Two-stage. **Detection (Steps 1–3) runs in a Sonnet subagent** so the heavy page-index walk and frontmatter reads stay out of the parent. **Apply, state, and report (Steps 4–6) run in the parent** because Step 4 calls `AskUserQuestion` per finding, and `AskUserQuestion` is unavailable inside dispatched subagents.
@@ -137,14 +139,21 @@ When the subagent returns, relay its summary verbatim. If the drift severity is 
 
 ## Full chain (no sub-arg)
 
-Run sync first, then branch on its `CONSOLIDATE_TRIGGERED` line, then run lint.
+The whole chain lands on **one branch and one PR**, not one PR per stage. The parent (the agent reading this file) owns the branch lifecycle through `gaia wiki chain`; each stage still runs as its own subagent. The `chain` calls are the only parent-side git/branch/PR actions, the playbook bans inlining any other branch logic, manual `gh pr` calls, or push narrative.
 
-1. **Sync.** Run the "Sync" section above. Capture the final summary.
-2. **Inspect last line of summary.** Step 9 of sync emits `CONSOLIDATE_TRIGGERED: <true|false>` as the summary's last line on normal sync paths (including drift=0). The line is **absent** on the re-anchor path (Step 1 rebase recovery) and on partial-sync interruptions (Step 7 failure mode), both leave the wiki in a known-incomplete state. Branch on its presence:
-   - **Line absent**: skip both consolidate and lint. The maintainer needs to address the exceptional state first.
-   - **`CONSOLIDATE_TRIGGERED: true`**: run consolidate, then run lint.
-   - **`CONSOLIDATE_TRIGGERED: false`**: skip consolidate, run lint.
+1. **Begin the chain.** Run `.gaia/cli/gaia wiki chain begin --branch-aware`. On `main`/`master` it cuts a `wiki-sync/<date>-<sha>` branch so every stage commits there instead of landing separately; on a feature branch it is a no-op and the chain commits in place. Proceed regardless of which.
 
-3. **Lint runs last** because consolidate may move, rename, or archive pages, and lint's orphan/dead-link/drift checks need the true post-state.
+2. **Sync.** Run the "Sync" section above. Capture the final summary. The chain branch is already checked out, so sync's Step 7 (`gaia wiki sync land --branch-aware`) commits in place on the chain branch rather than opening its own PR.
 
-Each sub-section dispatches its own subagent, never run their playbooks yourself in this conversation.
+3. **Inspect last line of summary.** Step 9 of sync emits `CONSOLIDATE_TRIGGERED: <true|false>` as the summary's last line on normal sync paths (including drift=0). The line is **absent** on the re-anchor path (Step 1 rebase recovery) and on partial-sync interruptions (Step 7 failure mode), both leave the wiki in a known-incomplete state. Branch on its presence:
+   - **Line absent**: skip consolidate and lint, then go straight to step 6 (finish) and surface the exceptional state. `chain finish` lands a lone re-anchor commit, removes the branch if sync committed nothing, or leaves an aborted (uncommitted) tree in place for the maintainer.
+   - **`CONSOLIDATE_TRIGGERED: true`**: run consolidate (step 4), then lint (step 5), then finish (step 6).
+   - **`CONSOLIDATE_TRIGGERED: false`**: skip consolidate, run lint (step 5), then finish (step 6).
+
+4. **Consolidate.** Run the "Consolidate" section above. After its apply loop completes, commit the staged edits: `.gaia/cli/gaia wiki chain commit --label "wiki: consolidate through <head-sha>"` (the short HEAD sha sync reported in `State advanced to {head_sha}`). The command is a no-op when nothing was applied.
+
+5. **Lint.** Run the "Lint" section above. Lint runs after consolidate because consolidate may move, rename, or archive pages and lint's orphan/dead-link/drift checks need the true post-state. After the lint subagent returns, commit its report: `.gaia/cli/gaia wiki chain commit --label "wiki: lint through <head-sha>"`.
+
+6. **Finish the chain.** Run `.gaia/cli/gaia wiki chain finish --branch-aware`. On the chain branch it pushes, opens ONE PR carrying every stage's commit, enables auto-merge, and returns to the base branch (deleting the branch if no stage produced a commit). On a feature-branch (in-place) run it is a no-op and the commits remain on the current branch. Relay its summary / the resulting PR to the user.
+
+Each stage still dispatches its own subagent; never run their playbooks yourself in this conversation.

--- a/.claude/skills/gaia/references/wiki/sync.md
+++ b/.claude/skills/gaia/references/wiki/sync.md
@@ -176,6 +176,8 @@ Exit codes:
 
 Do NOT inline branch logic, manual `gh pr` calls, or any push narrative. The CLI is authoritative.
 
+The command is branch-aware: on `main`/`master` it cuts a branch and opens its own PR; on any feature branch it commits in place. The no-arg `/gaia-wiki` full chain pre-cuts a `wiki-sync/<date>-<sha>` branch before sync runs, so this same step commits in place there and the chain opens one PR for all stages at the end. No change to this step is needed for either path.
+
 ## Step 8: Report
 
 Print a brief summary:

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -23067,8 +23067,8 @@ var run54 = async (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const defaultBranch = parseDefaultBranch(repoViewResult.stdout);
-  if (defaultBranch === null) {
+  const defaultBranch2 = parseDefaultBranch(repoViewResult.stdout);
+  if (defaultBranch2 === null) {
     structuredError({
       code: "default_branch_lookup_failed",
       message: "could not resolve defaultBranchRef from gh repo view output",
@@ -23078,7 +23078,7 @@ var run54 = async (argv, options = {}) => {
   }
   const triggerTime = Date.now();
   const triggerResult = await runGh2({
-    args: ["workflow", "run", workflowFile, "--ref", defaultBranch],
+    args: ["workflow", "run", workflowFile, "--ref", defaultBranch2],
     cwd
   });
   if (!triggerResult.ok) {
@@ -29100,13 +29100,368 @@ var run63 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
+// src/wiki/util/branch.ts
+import { spawnSync as spawnSync4 } from "node:child_process";
+var defaultRunner = (command, args, options) => spawnSync4(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var PROTECTED_BRANCHES = /* @__PURE__ */ new Set(["main", "master"]);
+var expectSuccess = (result, command, args) => {
+  if (result.error !== void 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed: ${result.error.message}`
+    );
+  }
+  if ((result.status ?? -1) !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
+    );
+  }
+  return result.stdout ?? "";
+};
+var currentBranch = (cwd, runner = defaultRunner) => {
+  const args = ["rev-parse", "--abbrev-ref", "HEAD"];
+  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
+  return out.trim();
+};
+var isProtectedBranch = (branch) => PROTECTED_BRANCHES.has(branch);
+var defaultBranch = (cwd, runner = defaultRunner) => {
+  const args = ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"];
+  const result = runner("git", args, { cwd });
+  if (result.error !== void 0 || (result.status ?? -1) !== 0) return "main";
+  const ref = (result.stdout ?? "").trim();
+  const stripped = ref.startsWith("origin/") ? ref.slice("origin/".length) : ref;
+  return stripped.length > 0 ? stripped : "main";
+};
+var inspectWorkingTree = (cwd, runner = defaultRunner) => {
+  const args = ["status", "--porcelain=v1", "-uall"];
+  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
+  const paths = [];
+  for (const rawLine of out.split("\n")) {
+    const line = rawLine.replace(/\r$/u, "");
+    if (line.length === 0) continue;
+    const rawPayload = line.slice(3);
+    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
+    const renameSplit = payload.indexOf(" -> ");
+    if (renameSplit === -1) {
+      paths.push(payload);
+    } else {
+      paths.push(payload.slice(0, renameSplit));
+      paths.push(payload.slice(renameSplit + 4));
+    }
+  }
+  let hasWikiChanges = false;
+  let hasNonWikiChanges = false;
+  for (const candidate of paths) {
+    if (candidate.startsWith("wiki/")) {
+      hasWikiChanges = true;
+    } else {
+      hasNonWikiChanges = true;
+    }
+  }
+  return { hasNonWikiChanges, hasWikiChanges, paths };
+};
+
+// src/wiki/util/land.ts
+var UNEXPECTED_EXIT9 = 2;
+var todayUtc = (now = /* @__PURE__ */ new Date()) => {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+var refuse = (message) => {
+  process.stderr.write(`${message}
+`);
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+var commandSucceeded = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var passthroughFailure = (prefix, result, command, args) => {
+  const stderr = (result.stderr ?? "").trim();
+  const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
+  const status = result.status ?? -1;
+  process.stderr.write(
+    `${prefix}: ${command} ${args.join(" ")} exited ${status}${errorPart}
+`
+  );
+  if (stderr.length > 0) process.stderr.write(`${stderr}
+`);
+  return UNEXPECTED_EXIT9;
+};
+
+// src/wiki/chain.ts
+var WIKI_CHAIN_BRANCH_PREFIX = "wiki-sync/";
+var passthroughFailure2 = (result, command, args) => passthroughFailure("chain", result, command, args);
+var stepOk = commandSucceeded;
+var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TEXT51 = `Usage: gaia wiki chain <begin|commit|finish> [args]
+
+  begin [--branch-aware]       On main/master: cut wiki-sync/<date>-<sha> so the
+                               whole chain lands on one branch + PR. On a feature
+                               branch: no-op (the chain commits in place).
+  commit --label "<subject>"   In-place commit of this stage's wiki/ changes.
+                               No-op when nothing changed; refuses non-wiki changes.
+  finish [--branch-aware]      Push the chain branch, open one PR, enable
+                               auto-merge, return to the base branch. Removes an
+                               empty chain branch; no-op for in-place runs.
+
+  Exit codes:
+    0  success
+    1  user-correctable refusal (on main without --branch-aware, missing --label, ...)
+    2  unexpected (git/gh failure)
+`;
+var resolveRoot3 = (cwdOption, action) => {
+  try {
+    return resolveRepoRoot2(cwdOption);
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia wiki chain must run inside a git repository",
+      subcommand: `wiki chain ${action}`
+    });
+    return null;
+  }
+};
+var resolveShortHead = (runner, cwd) => {
+  const result = runner("git", ["rev-parse", "HEAD"], { cwd });
+  if (!stepOk(result)) return null;
+  return shortSha((result.stdout ?? "").trim(), cwd);
+};
+var parseBranchAware = (argv) => {
+  let branchAware = false;
+  for (const token of argv) {
+    if (token === "--branch-aware") {
+      branchAware = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { branchAware, ok: true };
+};
+var parseCommitFlags = (argv) => {
+  let label;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--label") {
+      const value = argv[index + 1];
+      if (value === void 0) return { message: "--label requires a value", ok: false };
+      label = value;
+      index += 1;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  if (label === void 0 || label.length === 0)
+    return { message: "--label is required", ok: false };
+  return { label, ok: true };
+};
+var begin = (argv, options) => {
+  const parsed = parseBranchAware(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain begin"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot2 = resolveRoot3(cwd, "begin");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let branch;
+  try {
+    branch = currentBranch(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT9;
+  }
+  if (!isProtectedBranch(branch)) {
+    process.stdout.write(`chain begin: in-place on ${branch}
+`);
+    return EXIT_CODES.OK;
+  }
+  if (!parsed.branchAware) {
+    return refuse(
+      "chain begin: refusing to start a wiki chain on main; pass --branch-aware or check out a feature branch"
+    );
+  }
+  const shortHead = resolveShortHead(runner, repoRoot2);
+  if (shortHead === null) {
+    process.stderr.write("chain: could not resolve HEAD\n");
+    return UNEXPECTED_EXIT9;
+  }
+  const branchName = `${WIKI_CHAIN_BRANCH_PREFIX}${options.today ?? todayUtc()}-${shortHead}`;
+  const args = ["checkout", "-b", branchName];
+  const result = runner("git", args, { cwd: repoRoot2 });
+  if (!stepOk(result)) return passthroughFailure2(result, "git", args);
+  process.stdout.write(`chain begin: started ${branchName}
+`);
+  return EXIT_CODES.OK;
+};
+var commit = (argv, options) => {
+  const parsed = parseCommitFlags(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain commit"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot2 = resolveRoot3(cwd, "commit");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let workingTree;
+  try {
+    workingTree = inspectWorkingTree(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT9;
+  }
+  if (workingTree.hasNonWikiChanges) {
+    return refuse("chain commit: working tree has non-wiki changes; aborting");
+  }
+  if (!workingTree.hasWikiChanges) {
+    process.stdout.write("chain commit: nothing to commit\n");
+    return EXIT_CODES.OK;
+  }
+  const addArgs = ["add", "wiki"];
+  const addResult = runner("git", addArgs, { cwd: repoRoot2 });
+  if (!stepOk(addResult)) return passthroughFailure2(addResult, "git", addArgs);
+  const commitArgs = ["commit", "-m", parsed.label];
+  const commitResult = runner("git", commitArgs, { cwd: repoRoot2 });
+  if (!stepOk(commitResult)) {
+    runner("git", ["reset", "HEAD", "--", "wiki"], { cwd: repoRoot2 });
+    return passthroughFailure2(commitResult, "git", commitArgs);
+  }
+  process.stdout.write(`chain commit: ${parsed.label}
+`);
+  return EXIT_CODES.OK;
+};
+var finish = (argv, options) => {
+  const parsed = parseBranchAware(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain finish"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot2 = resolveRoot3(cwd, "finish");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let branch;
+  try {
+    branch = currentBranch(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT9;
+  }
+  if (!branch.startsWith(WIKI_CHAIN_BRANCH_PREFIX)) {
+    process.stdout.write(
+      `chain finish: in-place commits remain on ${branch}; no PR opened
+`
+    );
+    return EXIT_CODES.OK;
+  }
+  const base = defaultBranch(repoRoot2, runner);
+  const countArgs = ["rev-list", "--count", `${base}..HEAD`];
+  const countResult = runner("git", countArgs, { cwd: repoRoot2 });
+  if (!stepOk(countResult)) return passthroughFailure2(countResult, "git", countArgs);
+  const ahead = Number.parseInt((countResult.stdout ?? "").trim(), 10);
+  if (!Number.isNaN(ahead) && ahead === 0) {
+    let dirty = true;
+    try {
+      const tree = inspectWorkingTree(repoRoot2, runner);
+      dirty = tree.hasWikiChanges || tree.hasNonWikiChanges;
+    } catch {
+      dirty = true;
+    }
+    if (dirty) {
+      process.stdout.write(
+        `chain finish: ${branch} has uncommitted changes and no commits; left in place for review
+`
+      );
+      return EXIT_CODES.OK;
+    }
+    const checkoutArgs = ["checkout", base];
+    const checkoutResult = runner("git", checkoutArgs, { cwd: repoRoot2 });
+    if (!stepOk(checkoutResult))
+      return passthroughFailure2(checkoutResult, "git", checkoutArgs);
+    runner("git", ["branch", "-D", branch], { cwd: repoRoot2 });
+    process.stdout.write(
+      `chain finish: nothing to land; removed empty branch ${branch}
+`
+    );
+    return EXIT_CODES.OK;
+  }
+  const shortHead = resolveShortHead(runner, repoRoot2) ?? branch;
+  const prTitle = `wiki: maintenance chain through ${shortHead}`;
+  const prBody = `Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via \`gaia wiki chain finish\`.`;
+  const remoteSequence = [
+    { args: ["push", "-u", "origin", branch], command: "git" },
+    {
+      args: ["pr", "create", "--title", prTitle, "--body", prBody],
+      command: "gh"
+    },
+    { args: ["pr", "merge", "--squash", "--auto"], command: "gh" }
+  ];
+  for (const step of remoteSequence) {
+    const result = runner(step.command, step.args, { cwd: repoRoot2 });
+    if (!stepOk(result)) return passthroughFailure2(result, step.command, step.args);
+  }
+  runner("git", ["checkout", base], { cwd: repoRoot2 });
+  process.stdout.write(
+    `chain finish: opened PR for ${branch} and enabled auto-merge
+`
+  );
+  return EXIT_CODES.OK;
+};
+var ACTIONS = {
+  begin,
+  commit,
+  finish
+};
+var run64 = (argv, options = {}) => {
+  const action = argv[0];
+  const rest = argv.slice(1);
+  if (action === void 0 || HELP_TOKENS49.has(action)) {
+    process.stdout.write(HELP_TEXT51);
+    return EXIT_CODES.OK;
+  }
+  const handler = ACTIONS[action];
+  if (handler !== void 0) return handler(rest, options);
+  structuredError({
+    code: "unknown_subcommand",
+    message: `unknown wiki chain action: ${action}`,
+    subcommand: `wiki chain ${action}`
+  });
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
 // src/wiki/commit-classify.ts
-var HELP_TEXT51 = `Usage: gaia wiki commit-classify --since <sha> [--json]
+var HELP_TEXT52 = `Usage: gaia wiki commit-classify --since <sha> [--json]
 
   Emit a deterministic WORTHY/SKIP suggestion for every commit in
   <sha>..HEAD. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var takeValue9 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0)
@@ -29159,10 +29514,10 @@ var APP_INVENTORY_PREFIXES = [
 var touchesAny = (files, prefixes) => files.some((file2) => prefixes.some((prefix) => file2.startsWith(prefix)));
 var touchesAppNonTest = (files) => files.some((file2) => file2.startsWith("app/") && !file2.includes(".test."));
 var touchesOnlyTests = (files) => files.length > 0 && files.every((file2) => file2.includes(".test."));
-var classify = (commit) => {
-  const subject = commit.subject;
-  const body = commit.body;
-  const files = commit.files;
+var classify = (commit2) => {
+  const subject = commit2.subject;
+  const body = commit2.body;
+  const files = commit2.files;
   if (subject.startsWith("Merge pull request")) {
     return { reason: "merge commit", suggestion: "SKIP" };
   }
@@ -29262,21 +29617,21 @@ var printHuman10 = (classification) => {
     return;
   }
   const lines = [`Classified ${classification.commits.length} commit(s):`, ""];
-  for (const commit of classification.commits) {
+  for (const commit2 of classification.commits) {
     lines.push(
-      `  ${commit.sha.slice(0, 7)}  ${commit.suggestion.padEnd(7)}  ${commit.subject}`
+      `  ${commit2.sha.slice(0, 7)}  ${commit2.suggestion.padEnd(7)}  ${commit2.subject}`
     );
-    lines.push(`            reason: ${commit.suggestion_reason}`);
+    lines.push(`            reason: ${commit2.suggestion_reason}`);
     lines.push(
-      `            ${commit.files_changed} files, +${commit.insertions} -${commit.deletions}`
+      `            ${commit2.files_changed} files, +${commit2.insertions} -${commit2.deletions}`
     );
   }
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run64 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS49.has(argv[0])) {
-    process.stdout.write(HELP_TEXT51);
+var run65 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS50.has(argv[0])) {
+    process.stdout.write(HELP_TEXT52);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const parsed = parseFlags13(argv);
@@ -29337,7 +29692,7 @@ var run64 = (argv, options = {}) => {
 // src/wiki/dead-paths.ts
 import { readdirSync as readdirSync6, readFileSync as readFileSync34, statSync as statSync4 } from "node:fs";
 import path45 from "node:path";
-var HELP_TEXT52 = `Usage: gaia wiki dead-paths [--json]
+var HELP_TEXT53 = `Usage: gaia wiki dead-paths [--json]
 
   Scan wiki/**/*.md for backticked repo-relative paths under .claude/, .gaia/,
   app/, test/, wiki/ that no longer exist on disk, plus any reference to
@@ -29346,7 +29701,7 @@ var HELP_TEXT52 = `Usage: gaia wiki dead-paths [--json]
   and wiki/meta/** (audit artifacts that legitimately reference historical
   paths).
 `;
-var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TRACKED_PREFIXES = [
   ".claude/",
   ".gaia/",
@@ -29427,11 +29782,11 @@ var findDeadPaths = (cwd) => {
   }
   return dead;
 };
-var run65 = (argv, options = {}) => {
+var run66 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS50.has(token)) {
-      process.stdout.write(HELP_TEXT52);
+    if (HELP_TOKENS51.has(token)) {
+      process.stdout.write(HELP_TEXT53);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29470,7 +29825,7 @@ var run65 = (argv, options = {}) => {
 
 // src/wiki/diff-size.ts
 import { execFileSync as execFileSync5 } from "node:child_process";
-var HELP_TEXT53 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
+var HELP_TEXT54 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
 
   Compute wiki/** lines-changed (added + removed) between <base> (default
   HEAD~1) and HEAD as a percentage of the base tree's wiki line count.
@@ -29482,7 +29837,7 @@ var HELP_TEXT53 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>]
                       changed_lines, threshold_pct } instead of the bare
                       keyword.
 `;
-var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var WIKI_PREFIX = "wiki/";
 var git = (cwd, args) => execFileSync5("git", ["-C", cwd, ...args], {
   encoding: "utf8",
@@ -29624,10 +29979,10 @@ var emitJson = (result) => {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}
 `);
 };
-var run66 = (argv, options = {}) => {
+var run67 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS51.has(token)) {
-      process.stdout.write(HELP_TEXT53);
+    if (HELP_TOKENS52.has(token)) {
+      process.stdout.write(HELP_TEXT54);
       return EXIT_CODES.OK;
     }
   }
@@ -29728,7 +30083,7 @@ var parseFrontmatter = (raw) => {
 };
 
 // src/wiki/empty-sections.ts
-var HELP_TEXT54 = `Usage: gaia wiki empty-sections [--json]
+var HELP_TEXT55 = `Usage: gaia wiki empty-sections [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
   LEAF headings with no body, no child heading and no non-blank, non-heading
@@ -29737,7 +30092,7 @@ var HELP_TEXT54 = `Usage: gaia wiki empty-sections [--json]
   Without --json, prints one "path:line  heading" line per finding. With
   --json, emits { "empty": [ { path, line, heading } ] }.
 `;
-var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SKIP_PATH_FRAGMENTS2 = ["wiki/meta/"];
 var SKIP_PATHS = /* @__PURE__ */ new Set(["wiki/hot.md", "wiki/log.md"]);
 var ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
@@ -29823,11 +30178,11 @@ var findEmptySections = (cwd) => {
   }
   return empty;
 };
-var run67 = (argv, options = {}) => {
+var run68 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS52.has(token)) {
-      process.stdout.write(HELP_TEXT54);
+    if (HELP_TOKENS53.has(token)) {
+      process.stdout.write(HELP_TEXT55);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29872,14 +30227,14 @@ var run67 = (argv, options = {}) => {
 // src/wiki/frontmatter.ts
 import { readdirSync as readdirSync8, readFileSync as readFileSync36, statSync as statSync6 } from "node:fs";
 import path47 from "node:path";
-var HELP_TEXT55 = `Usage: gaia wiki frontmatter [--json]
+var HELP_TEXT56 = `Usage: gaia wiki frontmatter [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
   frontmatter. Required floor is type and status. Without --json, prints one
   "path: missing a, b" line per gap. With --json, emits
   { "gaps": [ { path, missing } ] }.
 `;
-var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var REQUIRED_FIELDS = ["type", "status"];
 var SKIP_PATH_FRAGMENTS3 = ["wiki/meta/"];
 var shouldSkipFile3 = (relPath) => SKIP_PATH_FRAGMENTS3.some((fragment) => relPath.startsWith(fragment));
@@ -29921,11 +30276,11 @@ var findFrontmatterGaps = (cwd) => {
   }
   return gaps;
 };
-var run68 = (argv, options = {}) => {
+var run69 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS53.has(token)) {
-      process.stdout.write(HELP_TEXT55);
+    if (HELP_TOKENS54.has(token)) {
+      process.stdout.write(HELP_TEXT56);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29970,11 +30325,11 @@ var run68 = (argv, options = {}) => {
 // src/wiki/log-prepend.ts
 import { existsSync as existsSync33, readFileSync as readFileSync37, renameSync as renameSync10, writeFileSync as writeFileSync15 } from "node:fs";
 import path48 from "node:path";
-var HELP_TEXT56 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+var HELP_TEXT57 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
 var FRONTMATTER_FENCE2 = "---";
 var takeValue10 = (argv, index, flag) => {
@@ -30025,7 +30380,7 @@ var parseFlags14 = (argv) => {
   }
   return { flags: { decision, reason, sha }, ok: true };
 };
-var todayUtc = () => {
+var todayUtc2 = () => {
   const now = /* @__PURE__ */ new Date();
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, "0");
@@ -30055,14 +30410,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run69 = (argv, options = {}) => {
+var run70 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT56);
+    process.stdout.write(HELP_TEXT57);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS54.has(first)) {
-    process.stdout.write(HELP_TEXT56);
+  if (HELP_TOKENS55.has(first)) {
+    process.stdout.write(HELP_TEXT57);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags14(argv);
@@ -30105,7 +30460,7 @@ var run69 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const date5 = options.today ?? todayUtc();
+  const date5 = options.today ?? todayUtc2();
   const newLine = `- ${date5} ${parsed.flags.sha} ${parsed.flags.decision} - ${parsed.flags.reason}`;
   const insertionIndex = findInsertionIndex(lines, scan.endLineIndex);
   const next = [
@@ -30122,12 +30477,12 @@ var run69 = (argv, options = {}) => {
 // src/wiki/near-collisions.ts
 import { existsSync as existsSync34, readdirSync as readdirSync9, statSync as statSync7 } from "node:fs";
 import path49 from "node:path";
-var HELP_TEXT57 = `Usage: gaia wiki near-collisions [--max-distance 3]
+var HELP_TEXT58 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS = [
   "components",
@@ -30236,9 +30591,9 @@ var parseFlags15 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run70 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS55.has(argv[0])) {
-    process.stdout.write(HELP_TEXT57);
+var run71 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS56.has(argv[0])) {
+    process.stdout.write(HELP_TEXT58);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags15(argv);
@@ -30295,12 +30650,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT58 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT59 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS56 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS2 = [
   "components",
   "concepts",
@@ -30430,11 +30785,11 @@ var computePageIndex = (cwd) => {
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run71 = (argv, options = {}) => {
+var run72 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS56.has(token)) {
-      process.stdout.write(HELP_TEXT58);
+    if (HELP_TOKENS57.has(token)) {
+      process.stdout.write(HELP_TEXT59);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -30473,19 +30828,19 @@ var run71 = (argv, options = {}) => {
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT59 = `Usage: gaia wiki orphans [--json]
+var HELP_TEXT60 = `Usage: gaia wiki orphans [--json]
 
   List wiki pages with zero inbound wikilinks. Without --json, prints one
   repo-relative path per line. With --json, emits { "orphans": [ { path,
   title, domain } ] }.
 `;
-var HELP_TOKENS57 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var isMaintainerOnly = (path54) => path54.startsWith("wiki/meta/") || path54.startsWith("wiki/entities/");
-var run72 = (argv, options = {}) => {
+var run73 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS57.has(token)) {
-      process.stdout.write(HELP_TEXT59);
+    if (HELP_TOKENS58.has(token)) {
+      process.stdout.write(HELP_TEXT60);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -30538,9 +30893,9 @@ var run72 = (argv, options = {}) => {
 // src/wiki/state.ts
 import { existsSync as existsSync36, readdirSync as readdirSync11, readFileSync as readFileSync39, statSync as statSync9 } from "node:fs";
 import path51 from "node:path";
-var HELP_TEXT60 = `Usage: gaia wiki state [--json]
+var HELP_TEXT61 = `Usage: gaia wiki state [--json]
 `;
-var HELP_TOKENS58 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var classifySeverity = (commitCount) => {
   if (commitCount <= 0) return "none";
   if (commitCount <= 5) return "low";
@@ -30599,8 +30954,8 @@ var printHuman12 = (state, write) => {
   }
   if (state.recent_commits.length > 0) {
     lines.push("  Recent unsynced:");
-    for (const commit of state.recent_commits) {
-      lines.push(`    - ${commit.sha} ${commit.subject}`);
+    for (const commit2 of state.recent_commits) {
+      lines.push(`    - ${commit2.sha} ${commit2.subject}`);
     }
   }
   lines.push("  Per-domain pages:");
@@ -30610,14 +30965,14 @@ var printHuman12 = (state, write) => {
   write(`${lines.join("\n")}
 `);
 };
-var run73 = (argv, options = {}) => {
+var run74 = (argv, options = {}) => {
   const write = options.write ?? ((chunk) => {
     process.stdout.write(chunk);
   });
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS58.has(token)) {
-      write(HELP_TEXT60);
+    if (HELP_TOKENS59.has(token)) {
+      write(HELP_TEXT61);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -30679,13 +31034,13 @@ var run73 = (argv, options = {}) => {
 // src/wiki/state-bump.ts
 import { existsSync as existsSync37, readFileSync as readFileSync40 } from "node:fs";
 import path52 from "node:path";
-var HELP_TEXT61 = `Usage: gaia wiki state-bump <field> <value>
+var HELP_TEXT62 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS59 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson = (raw) => {
   try {
     return JSON.parse(raw);
@@ -30707,13 +31062,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run74 = (argv, options = {}) => {
+var run75 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT61);
+    process.stdout.write(HELP_TEXT62);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS59.has(argv[0])) {
-    process.stdout.write(HELP_TEXT61);
+  if (HELP_TOKENS60.has(argv[0])) {
+    process.stdout.write(HELP_TEXT62);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30789,7 +31144,7 @@ var run74 = (argv, options = {}) => {
 import { execFileSync as execFileSync6 } from "node:child_process";
 import { existsSync as existsSync38, mkdirSync as mkdirSync21 } from "node:fs";
 import path53 from "node:path";
-var HELP_TEXT62 = `Usage: gaia wiki state-init <sha>
+var HELP_TEXT63 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -30797,7 +31152,7 @@ var HELP_TEXT62 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag); it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS60 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha = (ref, cwd) => {
   try {
     const out = execFileSync6(
@@ -30814,13 +31169,13 @@ var resolveFullSha = (ref, cwd) => {
     return null;
   }
 };
-var run75 = (argv, options = {}) => {
+var run76 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT62);
+    process.stdout.write(HELP_TEXT63);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS60.has(argv[0])) {
-    process.stdout.write(HELP_TEXT62);
+  if (HELP_TOKENS61.has(argv[0])) {
+    process.stdout.write(HELP_TEXT63);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30888,65 +31243,8 @@ var run75 = (argv, options = {}) => {
   return EXIT_CODES.OK;
 };
 
-// src/wiki/util/branch.ts
-import { spawnSync as spawnSync4 } from "node:child_process";
-var defaultRunner = (command, args, options) => spawnSync4(command, args, {
-  cwd: options.cwd,
-  encoding: "utf8",
-  stdio: ["ignore", "pipe", "pipe"]
-});
-var PROTECTED_BRANCHES = /* @__PURE__ */ new Set(["main", "master"]);
-var expectSuccess = (result, command, args) => {
-  if (result.error !== void 0) {
-    throw new Error(
-      `${command} ${args.join(" ")} failed: ${result.error.message}`
-    );
-  }
-  if ((result.status ?? -1) !== 0) {
-    const stderr = (result.stderr ?? "").trim();
-    throw new Error(
-      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
-    );
-  }
-  return result.stdout ?? "";
-};
-var currentBranch = (cwd, runner = defaultRunner) => {
-  const args = ["rev-parse", "--abbrev-ref", "HEAD"];
-  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
-  return out.trim();
-};
-var isProtectedBranch = (branch) => PROTECTED_BRANCHES.has(branch);
-var inspectWorkingTree = (cwd, runner = defaultRunner) => {
-  const args = ["status", "--porcelain=v1", "-uall"];
-  const out = expectSuccess(runner("git", args, { cwd }), "git", args);
-  const paths = [];
-  for (const rawLine of out.split("\n")) {
-    const line = rawLine.replace(/\r$/u, "");
-    if (line.length === 0) continue;
-    const rawPayload = line.slice(3);
-    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
-    const renameSplit = payload.indexOf(" -> ");
-    if (renameSplit === -1) {
-      paths.push(payload);
-    } else {
-      paths.push(payload.slice(0, renameSplit));
-      paths.push(payload.slice(renameSplit + 4));
-    }
-  }
-  let hasWikiChanges = false;
-  let hasNonWikiChanges = false;
-  for (const candidate of paths) {
-    if (candidate.startsWith("wiki/")) {
-      hasWikiChanges = true;
-    } else {
-      hasNonWikiChanges = true;
-    }
-  }
-  return { hasNonWikiChanges, hasWikiChanges, paths };
-};
-
 // src/wiki/sync-land.ts
-var HELP_TEXT63 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT64 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -30957,8 +31255,7 @@ var HELP_TEXT63 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS61 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var UNEXPECTED_EXIT9 = 2;
+var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseFlags16 = (argv) => {
   let branchAware = false;
   for (const token of argv) {
@@ -30970,27 +31267,9 @@ var parseFlags16 = (argv) => {
   }
   return { flags: { branchAware }, ok: true };
 };
-var refuse = (message) => {
-  process.stderr.write(`${message}
-`);
-  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-};
 var runStep = (runner, step, cwd) => runner(step.command, step.args, { cwd });
-var passthroughFailure = (result, step) => {
-  const stderr = (result.stderr ?? "").trim();
-  const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
-  const status = result.status ?? -1;
-  process.stderr.write(
-    `sync-land: ${step.command} ${step.args.join(" ")} exited ${status}${errorPart}
-`
-  );
-  if (stderr.length > 0) {
-    process.stderr.write(`${stderr}
-`);
-  }
-  return UNEXPECTED_EXIT9;
-};
-var stepSucceeded = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var passthroughFailure3 = (result, step) => passthroughFailure("sync-land", result, step.command, step.args);
+var stepSucceeded = commandSucceeded;
 var inPlaceLanding = (ctx) => {
   const message = `wiki: sync through ${ctx.shortHead}`;
   const sequence = [
@@ -31008,7 +31287,7 @@ var inPlaceLanding = (ctx) => {
           ctx.cwd
         );
       }
-      return passthroughFailure(result, step);
+      return passthroughFailure3(result, step);
     }
     if (step.marks === "staged") staged = true;
   }
@@ -31017,12 +31296,6 @@ var inPlaceLanding = (ctx) => {
 `
   );
   return EXIT_CODES.OK;
-};
-var todayUtc2 = (now = /* @__PURE__ */ new Date()) => {
-  const year = now.getUTCFullYear();
-  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(now.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
 };
 var rollbackLocalLanding = (ctx, branchName, onSyncBranch) => {
   if (!onSyncBranch) return;
@@ -31069,13 +31342,13 @@ var protectedBranchLanding = (ctx, options) => {
     const result = runStep(ctx.runner, step, ctx.cwd);
     if (!stepSucceeded(result)) {
       rollbackLocalLanding(ctx, branchName, onSyncBranch);
-      return passthroughFailure(result, step);
+      return passthroughFailure3(result, step);
     }
     if (step.marks === "onSyncBranch") onSyncBranch = true;
   }
   for (const step of remoteSequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
-    if (!stepSucceeded(result)) return passthroughFailure(result, step);
+    if (!stepSucceeded(result)) return passthroughFailure3(result, step);
   }
   process.stdout.write(
     `sync-land: landed via branch-and-PR commit ${ctx.shortHead}
@@ -31083,9 +31356,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run76 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS61.has(argv[0])) {
-    process.stdout.write(HELP_TEXT63);
+var run77 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS62.has(argv[0])) {
+    process.stdout.write(HELP_TEXT64);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags16(argv);
@@ -31151,7 +31424,7 @@ var run76 = (argv, options = {}) => {
     shortHead
   };
   if (isProtectedBranch(branch)) {
-    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc2() });
+    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc() });
   }
   return inPlaceLanding(ctx);
 };
@@ -31170,7 +31443,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT64 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT65 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -31187,22 +31460,24 @@ var HELP_TEXT64 = `Usage: gaia wiki <subcommand> [args]
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
+  chain <begin|commit|finish>                 One-branch / one-PR orchestration of the
+                                              full /gaia-wiki chain.
 `;
 var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
 
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS62 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS63 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS62.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS63.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run76(rest);
+    return run77(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -31212,25 +31487,26 @@ var runSync = async (args) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 var SUBCOMMAND_HANDLERS8 = {
-  "commit-classify": run64,
-  "dead-paths": run65,
-  "diff-size": run66,
-  "empty-sections": run67,
-  frontmatter: run68,
-  "log-prepend": run69,
-  "near-collisions": run70,
-  orphans: run72,
-  "page-index": run71,
-  state: run73,
-  "state-bump": run74,
-  "state-init": run75,
+  chain: run64,
+  "commit-classify": run65,
+  "dead-paths": run66,
+  "diff-size": run67,
+  "empty-sections": run68,
+  frontmatter: run69,
+  "log-prepend": run70,
+  "near-collisions": run71,
+  orphans: run73,
+  "page-index": run72,
+  state: run74,
+  "state-bump": run75,
+  "state-init": run76,
   sync: runSync
 };
-var run77 = async (argv) => {
+var run78 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS62.has(subcommand)) {
-    process.stdout.write(HELP_TEXT64);
+  if (subcommand === void 0 || HELP_TOKENS63.has(subcommand)) {
+    process.stdout.write(HELP_TEXT65);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS8[subcommand];
@@ -31247,7 +31523,7 @@ var run77 = async (argv) => {
 };
 
 // src/index.ts
-var HELP_TEXT65 = `Usage: gaia <subcommand> [args]
+var HELP_TEXT66 = `Usage: gaia <subcommand> [args]
 
   telemetry emit <event_type> [--field value ...]
   telemetry compute-profile
@@ -31268,9 +31544,9 @@ var HELP_TEXT65 = `Usage: gaia <subcommand> [args]
   setup-ci status|detect-remote|warn-existing-tools|check-admin|dismiss-personal|opt-out-team|enable-delete-branch|set-secret|verify-run|finalize|write-tool-mode
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT65);
+  process.stdout.write(HELP_TEXT66);
 };
-var HELP_TOKENS63 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS64 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS9 = {
   automation: run6,
   "ci-revert": run8,
@@ -31286,12 +31562,12 @@ var SUBCOMMAND_HANDLERS9 = {
   telemetry: run58,
   update: run60,
   "update-deps": run63,
-  wiki: run77
+  wiki: run78
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS63.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS64.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -18627,9 +18627,9 @@ var PATCH_TYPES = /* @__PURE__ */ new Set([
   "test"
 ]);
 var CONVENTIONAL_HEADER_REGEX = /^(?<type>[a-z]+)(?:\([^)]*\))?(?<bang>!?):/u;
-var classifyCommit = (commit) => {
-  const subject = commit.subject.trim();
-  const body = commit.body;
+var classifyCommit = (commit2) => {
+  const subject = commit2.subject.trim();
+  const body = commit2.body;
   if (/(^|\n)BREAKING CHANGE: /u.test(body)) return "major";
   const match = CONVENTIONAL_HEADER_REGEX.exec(subject);
   if (match === null) return null;
@@ -18643,8 +18643,8 @@ var classifyCommit = (commit) => {
 var RANK = { major: 3, minor: 2, patch: 1 };
 var aggregateBump = (commits) => {
   let highest = null;
-  for (const commit of commits) {
-    const classified = classifyCommit(commit);
+  for (const commit2 of commits) {
+    const classified = classifyCommit(commit2);
     if (classified === null) continue;
     if (highest === null || RANK[classified] > RANK[highest]) {
       highest = classified;
@@ -18893,8 +18893,8 @@ var TYPE_TO_SECTION = {
 var CONVENTIONAL_HEADER_REGEX2 = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?!?:\s*(?<rest>.*)$/u;
 var groupCommits = (commits) => {
   const sections = { Added: [], Changed: [], Fixed: [] };
-  for (const commit of commits) {
-    const subject = commit.subject.trim();
+  for (const commit2 of commits) {
+    const subject = commit2.subject.trim();
     const match = CONVENTIONAL_HEADER_REGEX2.exec(subject);
     if (match === null) continue;
     const groups = match.groups ?? {};
@@ -19796,8 +19796,8 @@ var printHuman = (state, write) => {
   }
   if (state.recent_commits.length > 0) {
     lines.push("  Recent unsynced:");
-    for (const commit of state.recent_commits) {
-      lines.push(`    - ${commit.sha} ${commit.subject}`);
+    for (const commit2 of state.recent_commits) {
+      lines.push(`    - ${commit2.sha} ${commit2.subject}`);
     }
   }
   lines.push("  Per-domain pages:");
@@ -28495,13 +28495,368 @@ var run54 = async (argv) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
+// src/wiki/util/branch.ts
+import { spawnSync as spawnSync6 } from "node:child_process";
+var defaultRunner5 = (command, args, options) => spawnSync6(command, args, {
+  cwd: options.cwd,
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"]
+});
+var PROTECTED_BRANCHES = /* @__PURE__ */ new Set(["main", "master"]);
+var expectSuccess3 = (result, command, args) => {
+  if (result.error !== void 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed: ${result.error.message}`
+    );
+  }
+  if ((result.status ?? -1) !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(
+      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
+    );
+  }
+  return result.stdout ?? "";
+};
+var currentBranch = (cwd, runner = defaultRunner5) => {
+  const args = ["rev-parse", "--abbrev-ref", "HEAD"];
+  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
+  return out.trim();
+};
+var isProtectedBranch = (branch) => PROTECTED_BRANCHES.has(branch);
+var defaultBranch = (cwd, runner = defaultRunner5) => {
+  const args = ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"];
+  const result = runner("git", args, { cwd });
+  if (result.error !== void 0 || (result.status ?? -1) !== 0) return "main";
+  const ref = (result.stdout ?? "").trim();
+  const stripped = ref.startsWith("origin/") ? ref.slice("origin/".length) : ref;
+  return stripped.length > 0 ? stripped : "main";
+};
+var inspectWorkingTree = (cwd, runner = defaultRunner5) => {
+  const args = ["status", "--porcelain=v1", "-uall"];
+  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
+  const paths = [];
+  for (const rawLine of out.split("\n")) {
+    const line = rawLine.replace(/\r$/u, "");
+    if (line.length === 0) continue;
+    const rawPayload = line.slice(3);
+    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
+    const renameSplit = payload.indexOf(" -> ");
+    if (renameSplit === -1) {
+      paths.push(payload);
+    } else {
+      paths.push(payload.slice(0, renameSplit));
+      paths.push(payload.slice(renameSplit + 4));
+    }
+  }
+  let hasWikiChanges = false;
+  let hasNonWikiChanges = false;
+  for (const candidate of paths) {
+    if (candidate.startsWith("wiki/")) {
+      hasWikiChanges = true;
+    } else {
+      hasNonWikiChanges = true;
+    }
+  }
+  return { hasNonWikiChanges, hasWikiChanges, paths };
+};
+
+// src/wiki/util/land.ts
+var UNEXPECTED_EXIT17 = 2;
+var todayUtc3 = (now = /* @__PURE__ */ new Date()) => {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+var refuse2 = (message) => {
+  process.stderr.write(`${message}
+`);
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+var commandSucceeded = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var passthroughFailure2 = (prefix, result, command, args) => {
+  const stderr = (result.stderr ?? "").trim();
+  const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
+  const status = result.status ?? -1;
+  process.stderr.write(
+    `${prefix}: ${command} ${args.join(" ")} exited ${status}${errorPart}
+`
+  );
+  if (stderr.length > 0) process.stderr.write(`${stderr}
+`);
+  return UNEXPECTED_EXIT17;
+};
+
+// src/wiki/chain.ts
+var WIKI_CHAIN_BRANCH_PREFIX = "wiki-sync/";
+var passthroughFailure3 = (result, command, args) => passthroughFailure2("chain", result, command, args);
+var stepOk = commandSucceeded;
+var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TEXT43 = `Usage: gaia wiki chain <begin|commit|finish> [args]
+
+  begin [--branch-aware]       On main/master: cut wiki-sync/<date>-<sha> so the
+                               whole chain lands on one branch + PR. On a feature
+                               branch: no-op (the chain commits in place).
+  commit --label "<subject>"   In-place commit of this stage's wiki/ changes.
+                               No-op when nothing changed; refuses non-wiki changes.
+  finish [--branch-aware]      Push the chain branch, open one PR, enable
+                               auto-merge, return to the base branch. Removes an
+                               empty chain branch; no-op for in-place runs.
+
+  Exit codes:
+    0  success
+    1  user-correctable refusal (on main without --branch-aware, missing --label, ...)
+    2  unexpected (git/gh failure)
+`;
+var resolveRoot = (cwdOption, action) => {
+  try {
+    return resolveRepoRoot2(cwdOption);
+  } catch {
+    structuredError({
+      code: "not_a_git_repo",
+      message: "gaia wiki chain must run inside a git repository",
+      subcommand: `wiki chain ${action}`
+    });
+    return null;
+  }
+};
+var resolveShortHead = (runner, cwd) => {
+  const result = runner("git", ["rev-parse", "HEAD"], { cwd });
+  if (!stepOk(result)) return null;
+  return shortSha((result.stdout ?? "").trim(), cwd);
+};
+var parseBranchAware = (argv) => {
+  let branchAware = false;
+  for (const token of argv) {
+    if (token === "--branch-aware") {
+      branchAware = true;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  return { branchAware, ok: true };
+};
+var parseCommitFlags = (argv) => {
+  let label;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--label") {
+      const value = argv[index + 1];
+      if (value === void 0) return { message: "--label requires a value", ok: false };
+      label = value;
+      index += 1;
+      continue;
+    }
+    return { message: `unknown flag: ${token}`, ok: false };
+  }
+  if (label === void 0 || label.length === 0)
+    return { message: "--label is required", ok: false };
+  return { label, ok: true };
+};
+var begin = (argv, options) => {
+  const parsed = parseBranchAware(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain begin"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner5;
+  const repoRoot2 = resolveRoot(cwd, "begin");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let branch;
+  try {
+    branch = currentBranch(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT17;
+  }
+  if (!isProtectedBranch(branch)) {
+    process.stdout.write(`chain begin: in-place on ${branch}
+`);
+    return EXIT_CODES.OK;
+  }
+  if (!parsed.branchAware) {
+    return refuse2(
+      "chain begin: refusing to start a wiki chain on main; pass --branch-aware or check out a feature branch"
+    );
+  }
+  const shortHead = resolveShortHead(runner, repoRoot2);
+  if (shortHead === null) {
+    process.stderr.write("chain: could not resolve HEAD\n");
+    return UNEXPECTED_EXIT17;
+  }
+  const branchName = `${WIKI_CHAIN_BRANCH_PREFIX}${options.today ?? todayUtc3()}-${shortHead}`;
+  const args = ["checkout", "-b", branchName];
+  const result = runner("git", args, { cwd: repoRoot2 });
+  if (!stepOk(result)) return passthroughFailure3(result, "git", args);
+  process.stdout.write(`chain begin: started ${branchName}
+`);
+  return EXIT_CODES.OK;
+};
+var commit = (argv, options) => {
+  const parsed = parseCommitFlags(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain commit"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner5;
+  const repoRoot2 = resolveRoot(cwd, "commit");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let workingTree;
+  try {
+    workingTree = inspectWorkingTree(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT17;
+  }
+  if (workingTree.hasNonWikiChanges) {
+    return refuse2("chain commit: working tree has non-wiki changes; aborting");
+  }
+  if (!workingTree.hasWikiChanges) {
+    process.stdout.write("chain commit: nothing to commit\n");
+    return EXIT_CODES.OK;
+  }
+  const addArgs = ["add", "wiki"];
+  const addResult = runner("git", addArgs, { cwd: repoRoot2 });
+  if (!stepOk(addResult)) return passthroughFailure3(addResult, "git", addArgs);
+  const commitArgs = ["commit", "-m", parsed.label];
+  const commitResult = runner("git", commitArgs, { cwd: repoRoot2 });
+  if (!stepOk(commitResult)) {
+    runner("git", ["reset", "HEAD", "--", "wiki"], { cwd: repoRoot2 });
+    return passthroughFailure3(commitResult, "git", commitArgs);
+  }
+  process.stdout.write(`chain commit: ${parsed.label}
+`);
+  return EXIT_CODES.OK;
+};
+var finish = (argv, options) => {
+  const parsed = parseBranchAware(argv);
+  if (!parsed.ok) {
+    structuredError({
+      code: "invalid_arguments",
+      message: parsed.message,
+      subcommand: "wiki chain finish"
+    });
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner5;
+  const repoRoot2 = resolveRoot(cwd, "finish");
+  if (repoRoot2 === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  let branch;
+  try {
+    branch = currentBranch(repoRoot2, runner);
+  } catch (error51) {
+    process.stderr.write(
+      `chain: ${error51 instanceof Error ? error51.message : String(error51)}
+`
+    );
+    return UNEXPECTED_EXIT17;
+  }
+  if (!branch.startsWith(WIKI_CHAIN_BRANCH_PREFIX)) {
+    process.stdout.write(
+      `chain finish: in-place commits remain on ${branch}; no PR opened
+`
+    );
+    return EXIT_CODES.OK;
+  }
+  const base = defaultBranch(repoRoot2, runner);
+  const countArgs = ["rev-list", "--count", `${base}..HEAD`];
+  const countResult = runner("git", countArgs, { cwd: repoRoot2 });
+  if (!stepOk(countResult)) return passthroughFailure3(countResult, "git", countArgs);
+  const ahead = Number.parseInt((countResult.stdout ?? "").trim(), 10);
+  if (!Number.isNaN(ahead) && ahead === 0) {
+    let dirty = true;
+    try {
+      const tree = inspectWorkingTree(repoRoot2, runner);
+      dirty = tree.hasWikiChanges || tree.hasNonWikiChanges;
+    } catch {
+      dirty = true;
+    }
+    if (dirty) {
+      process.stdout.write(
+        `chain finish: ${branch} has uncommitted changes and no commits; left in place for review
+`
+      );
+      return EXIT_CODES.OK;
+    }
+    const checkoutArgs = ["checkout", base];
+    const checkoutResult = runner("git", checkoutArgs, { cwd: repoRoot2 });
+    if (!stepOk(checkoutResult))
+      return passthroughFailure3(checkoutResult, "git", checkoutArgs);
+    runner("git", ["branch", "-D", branch], { cwd: repoRoot2 });
+    process.stdout.write(
+      `chain finish: nothing to land; removed empty branch ${branch}
+`
+    );
+    return EXIT_CODES.OK;
+  }
+  const shortHead = resolveShortHead(runner, repoRoot2) ?? branch;
+  const prTitle = `wiki: maintenance chain through ${shortHead}`;
+  const prBody = `Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via \`gaia wiki chain finish\`.`;
+  const remoteSequence = [
+    { args: ["push", "-u", "origin", branch], command: "git" },
+    {
+      args: ["pr", "create", "--title", prTitle, "--body", prBody],
+      command: "gh"
+    },
+    { args: ["pr", "merge", "--squash", "--auto"], command: "gh" }
+  ];
+  for (const step of remoteSequence) {
+    const result = runner(step.command, step.args, { cwd: repoRoot2 });
+    if (!stepOk(result)) return passthroughFailure3(result, step.command, step.args);
+  }
+  runner("git", ["checkout", base], { cwd: repoRoot2 });
+  process.stdout.write(
+    `chain finish: opened PR for ${branch} and enabled auto-merge
+`
+  );
+  return EXIT_CODES.OK;
+};
+var ACTIONS = {
+  begin,
+  commit,
+  finish
+};
+var run55 = (argv, options = {}) => {
+  const action = argv[0];
+  const rest = argv.slice(1);
+  if (action === void 0 || HELP_TOKENS41.has(action)) {
+    process.stdout.write(HELP_TEXT43);
+    return EXIT_CODES.OK;
+  }
+  const handler = ACTIONS[action];
+  if (handler !== void 0) return handler(rest, options);
+  structuredError({
+    code: "unknown_subcommand",
+    message: `unknown wiki chain action: ${action}`,
+    subcommand: `wiki chain ${action}`
+  });
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
 // src/wiki/commit-classify.ts
-var HELP_TEXT43 = `Usage: gaia wiki commit-classify --since <sha> [--json]
+var HELP_TEXT44 = `Usage: gaia wiki commit-classify --since <sha> [--json]
 
   Emit a deterministic WORTHY/SKIP suggestion for every commit in
   <sha>..HEAD. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS41 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var takeValue15 = (argv, index, flag) => {
   const value = argv[index];
   if (value === void 0)
@@ -28554,10 +28909,10 @@ var APP_INVENTORY_PREFIXES = [
 var touchesAny = (files, prefixes) => files.some((file2) => prefixes.some((prefix) => file2.startsWith(prefix)));
 var touchesAppNonTest = (files) => files.some((file2) => file2.startsWith("app/") && !file2.includes(".test."));
 var touchesOnlyTests = (files) => files.length > 0 && files.every((file2) => file2.includes(".test."));
-var classify = (commit) => {
-  const subject = commit.subject;
-  const body = commit.body;
-  const files = commit.files;
+var classify = (commit2) => {
+  const subject = commit2.subject;
+  const body = commit2.body;
+  const files = commit2.files;
   if (subject.startsWith("Merge pull request")) {
     return { reason: "merge commit", suggestion: "SKIP" };
   }
@@ -28657,21 +29012,21 @@ var printHuman5 = (classification) => {
     return;
   }
   const lines = [`Classified ${classification.commits.length} commit(s):`, ""];
-  for (const commit of classification.commits) {
+  for (const commit2 of classification.commits) {
     lines.push(
-      `  ${commit.sha.slice(0, 7)}  ${commit.suggestion.padEnd(7)}  ${commit.subject}`
+      `  ${commit2.sha.slice(0, 7)}  ${commit2.suggestion.padEnd(7)}  ${commit2.subject}`
     );
-    lines.push(`            reason: ${commit.suggestion_reason}`);
+    lines.push(`            reason: ${commit2.suggestion_reason}`);
     lines.push(
-      `            ${commit.files_changed} files, +${commit.insertions} -${commit.deletions}`
+      `            ${commit2.files_changed} files, +${commit2.insertions} -${commit2.deletions}`
     );
   }
   process.stdout.write(`${lines.join("\n")}
 `);
 };
-var run55 = (argv, options = {}) => {
-  if (argv.length === 0 || HELP_TOKENS41.has(argv[0])) {
-    process.stdout.write(HELP_TEXT43);
+var run56 = (argv, options = {}) => {
+  if (argv.length === 0 || HELP_TOKENS42.has(argv[0])) {
+    process.stdout.write(HELP_TEXT44);
     return argv.length === 0 ? EXIT_CODES.UNKNOWN_SUBCOMMAND : EXIT_CODES.OK;
   }
   const parsed = parseFlags21(argv);
@@ -28732,7 +29087,7 @@ var run55 = (argv, options = {}) => {
 // src/wiki/dead-paths.ts
 import { readdirSync as readdirSync8, readFileSync as readFileSync36, statSync as statSync6 } from "node:fs";
 import path44 from "node:path";
-var HELP_TEXT44 = `Usage: gaia wiki dead-paths [--json]
+var HELP_TEXT45 = `Usage: gaia wiki dead-paths [--json]
 
   Scan wiki/**/*.md for backticked repo-relative paths under .claude/, .gaia/,
   app/, test/, wiki/ that no longer exist on disk, plus any reference to
@@ -28741,7 +29096,7 @@ var HELP_TEXT44 = `Usage: gaia wiki dead-paths [--json]
   and wiki/meta/** (audit artifacts that legitimately reference historical
   paths).
 `;
-var HELP_TOKENS42 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS43 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var TRACKED_PREFIXES = [
   ".claude/",
   ".gaia/",
@@ -28822,11 +29177,11 @@ var findDeadPaths = (cwd) => {
   }
   return dead;
 };
-var run56 = (argv, options = {}) => {
+var run57 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS42.has(token)) {
-      process.stdout.write(HELP_TEXT44);
+    if (HELP_TOKENS43.has(token)) {
+      process.stdout.write(HELP_TEXT45);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -28865,7 +29220,7 @@ var run56 = (argv, options = {}) => {
 
 // src/wiki/diff-size.ts
 import { execFileSync as execFileSync5 } from "node:child_process";
-var HELP_TEXT45 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
+var HELP_TEXT46 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>] [--json]
 
   Compute wiki/** lines-changed (added + removed) between <base> (default
   HEAD~1) and HEAD as a percentage of the base tree's wiki line count.
@@ -28877,7 +29232,7 @@ var HELP_TEXT45 = `Usage: gaia wiki diff-size --threshold-pct <N> [--base <ref>]
                       changed_lines, threshold_pct } instead of the bare
                       keyword.
 `;
-var HELP_TOKENS43 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS44 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var WIKI_PREFIX = "wiki/";
 var git = (cwd, args) => execFileSync5("git", ["-C", cwd, ...args], {
   encoding: "utf8",
@@ -29019,10 +29374,10 @@ var emitJson = (result) => {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}
 `);
 };
-var run57 = (argv, options = {}) => {
+var run58 = (argv, options = {}) => {
   for (const token of argv) {
-    if (HELP_TOKENS43.has(token)) {
-      process.stdout.write(HELP_TEXT45);
+    if (HELP_TOKENS44.has(token)) {
+      process.stdout.write(HELP_TEXT46);
       return EXIT_CODES.OK;
     }
   }
@@ -29123,7 +29478,7 @@ var parseFrontmatter = (raw) => {
 };
 
 // src/wiki/empty-sections.ts
-var HELP_TEXT46 = `Usage: gaia wiki empty-sections [--json]
+var HELP_TEXT47 = `Usage: gaia wiki empty-sections [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**, wiki/hot.md, wiki/log.md) for
   LEAF headings with no body, no child heading and no non-blank, non-heading
@@ -29132,7 +29487,7 @@ var HELP_TEXT46 = `Usage: gaia wiki empty-sections [--json]
   Without --json, prints one "path:line  heading" line per finding. With
   --json, emits { "empty": [ { path, line, heading } ] }.
 `;
-var HELP_TOKENS44 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS45 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SKIP_PATH_FRAGMENTS2 = ["wiki/meta/"];
 var SKIP_PATHS = /* @__PURE__ */ new Set(["wiki/hot.md", "wiki/log.md"]);
 var ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})(?:\s|$)/u;
@@ -29218,11 +29573,11 @@ var findEmptySections = (cwd) => {
   }
   return empty;
 };
-var run58 = (argv, options = {}) => {
+var run59 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS44.has(token)) {
-      process.stdout.write(HELP_TEXT46);
+    if (HELP_TOKENS45.has(token)) {
+      process.stdout.write(HELP_TEXT47);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29267,14 +29622,14 @@ var run58 = (argv, options = {}) => {
 // src/wiki/frontmatter.ts
 import { readdirSync as readdirSync10, readFileSync as readFileSync38, statSync as statSync8 } from "node:fs";
 import path46 from "node:path";
-var HELP_TEXT47 = `Usage: gaia wiki frontmatter [--json]
+var HELP_TEXT48 = `Usage: gaia wiki frontmatter [--json]
 
   Scan wiki/**/*.md (excluding wiki/meta/**) for pages missing required
   frontmatter. Required floor is type and status. Without --json, prints one
   "path: missing a, b" line per gap. With --json, emits
   { "gaps": [ { path, missing } ] }.
 `;
-var HELP_TOKENS45 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS46 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var REQUIRED_FIELDS = ["type", "status"];
 var SKIP_PATH_FRAGMENTS3 = ["wiki/meta/"];
 var shouldSkipFile3 = (relPath) => SKIP_PATH_FRAGMENTS3.some((fragment) => relPath.startsWith(fragment));
@@ -29316,11 +29671,11 @@ var findFrontmatterGaps = (cwd) => {
   }
   return gaps;
 };
-var run59 = (argv, options = {}) => {
+var run60 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS45.has(token)) {
-      process.stdout.write(HELP_TEXT47);
+    if (HELP_TOKENS46.has(token)) {
+      process.stdout.write(HELP_TEXT48);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29365,11 +29720,11 @@ var run59 = (argv, options = {}) => {
 // src/wiki/log-prepend.ts
 import { existsSync as existsSync35, readFileSync as readFileSync39, renameSync as renameSync8, writeFileSync as writeFileSync13 } from "node:fs";
 import path47 from "node:path";
-var HELP_TEXT48 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
+var HELP_TEXT49 = `Usage: gaia wiki log-prepend --sha <h> --decision <WORTHY|SKIP|RE_ANCHOR> --reason "..."
 
   Prepends one canonical line to wiki/log.md after the frontmatter.
 `;
-var HELP_TOKENS46 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var VALID_DECISIONS = /* @__PURE__ */ new Set(["RE_ANCHOR", "SKIP", "WORTHY"]);
 var FRONTMATTER_FENCE2 = "---";
 var takeValue16 = (argv, index, flag) => {
@@ -29420,7 +29775,7 @@ var parseFlags22 = (argv) => {
   }
   return { flags: { decision, reason, sha }, ok: true };
 };
-var todayUtc3 = () => {
+var todayUtc4 = () => {
   const now = /* @__PURE__ */ new Date();
   const year = now.getUTCFullYear();
   const month = String(now.getUTCMonth() + 1).padStart(2, "0");
@@ -29450,14 +29805,14 @@ var findInsertionIndex = (lines, endFenceIndex) => {
   }
   return endFenceIndex + 1;
 };
-var run60 = (argv, options = {}) => {
+var run61 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT48);
+    process.stdout.write(HELP_TEXT49);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
   const first = argv[0];
-  if (HELP_TOKENS46.has(first)) {
-    process.stdout.write(HELP_TEXT48);
+  if (HELP_TOKENS47.has(first)) {
+    process.stdout.write(HELP_TEXT49);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags22(argv);
@@ -29500,7 +29855,7 @@ var run60 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const date5 = options.today ?? todayUtc3();
+  const date5 = options.today ?? todayUtc4();
   const newLine = `- ${date5} ${parsed.flags.sha} ${parsed.flags.decision} - ${parsed.flags.reason}`;
   const insertionIndex = findInsertionIndex(lines, scan.endLineIndex);
   const next = [
@@ -29517,12 +29872,12 @@ var run60 = (argv, options = {}) => {
 // src/wiki/near-collisions.ts
 import { existsSync as existsSync36, readdirSync as readdirSync11, statSync as statSync9 } from "node:fs";
 import path48 from "node:path";
-var HELP_TEXT49 = `Usage: gaia wiki near-collisions [--max-distance 3]
+var HELP_TEXT50 = `Usage: gaia wiki near-collisions [--max-distance 3]
 
   Per-domain Levenshtein over slugs. Emits tab-separated rows:
   <domain>  <slugA>  <slugB>  <distance>
 `;
-var HELP_TOKENS47 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DEFAULT_MAX_DISTANCE = 3;
 var DOMAIN_DIRS2 = [
   "components",
@@ -29631,9 +29986,9 @@ var parseFlags23 = (argv) => {
   }
   return { flags: { maxDistance }, ok: true };
 };
-var run61 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS47.has(argv[0])) {
-    process.stdout.write(HELP_TEXT49);
+var run62 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS48.has(argv[0])) {
+    process.stdout.write(HELP_TEXT50);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags23(argv);
@@ -29690,12 +30045,12 @@ var extractWikilinks = (body) => {
 };
 
 // src/wiki/page-index.ts
-var HELP_TEXT50 = `Usage: gaia wiki page-index [--json]
+var HELP_TEXT51 = `Usage: gaia wiki page-index [--json]
 
   Walk wiki/<domain>/*.md, parse frontmatter, and count inbound/outbound
   wikilinks. Without --json, prints a tabular summary.
 `;
-var HELP_TOKENS48 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var DOMAIN_DIRS3 = [
   "components",
   "concepts",
@@ -29825,11 +30180,11 @@ var computePageIndex = (cwd) => {
   const rootSources = collectRootLinkSources(wikiRoot);
   return buildIndex(pages, rootSources);
 };
-var run62 = (argv, options = {}) => {
+var run63 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS48.has(token)) {
-      process.stdout.write(HELP_TEXT50);
+    if (HELP_TOKENS49.has(token)) {
+      process.stdout.write(HELP_TEXT51);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29868,19 +30223,19 @@ var run62 = (argv, options = {}) => {
 };
 
 // src/wiki/orphans.ts
-var HELP_TEXT51 = `Usage: gaia wiki orphans [--json]
+var HELP_TEXT52 = `Usage: gaia wiki orphans [--json]
 
   List wiki pages with zero inbound wikilinks. Without --json, prints one
   repo-relative path per line. With --json, emits { "orphans": [ { path,
   title, domain } ] }.
 `;
-var HELP_TOKENS49 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var isMaintainerOnly = (path52) => path52.startsWith("wiki/meta/") || path52.startsWith("wiki/entities/");
-var run63 = (argv, options = {}) => {
+var run64 = (argv, options = {}) => {
   let json3 = false;
   for (const token of argv) {
-    if (HELP_TOKENS49.has(token)) {
-      process.stdout.write(HELP_TEXT51);
+    if (HELP_TOKENS50.has(token)) {
+      process.stdout.write(HELP_TEXT52);
       return EXIT_CODES.OK;
     }
     if (token === "--json") {
@@ -29933,13 +30288,13 @@ var run63 = (argv, options = {}) => {
 // src/wiki/state-bump.ts
 import { existsSync as existsSync38, readFileSync as readFileSync41 } from "node:fs";
 import path50 from "node:path";
-var HELP_TEXT52 = `Usage: gaia wiki state-bump <field> <value>
+var HELP_TEXT53 = `Usage: gaia wiki state-bump <field> <value>
 
   Updates a single field in wiki/.state.json. Sibling fields and key order
   are preserved. <value> is parsed as JSON when it parses (numbers,
   booleans, null, arrays, objects); otherwise treated as a string.
 `;
-var HELP_TOKENS50 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var tryParseJson = (raw) => {
   try {
     return JSON.parse(raw);
@@ -29961,13 +30316,13 @@ var reorderObject = (source, field, newValue) => {
   next[field] = newValue;
   return next;
 };
-var run64 = (argv, options = {}) => {
+var run65 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT52);
+    process.stdout.write(HELP_TEXT53);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS50.has(argv[0])) {
-    process.stdout.write(HELP_TEXT52);
+  if (HELP_TOKENS51.has(argv[0])) {
+    process.stdout.write(HELP_TEXT53);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30043,7 +30398,7 @@ var run64 = (argv, options = {}) => {
 import { execFileSync as execFileSync6 } from "node:child_process";
 import { existsSync as existsSync39, mkdirSync as mkdirSync19 } from "node:fs";
 import path51 from "node:path";
-var HELP_TEXT53 = `Usage: gaia wiki state-init <sha>
+var HELP_TEXT54 = `Usage: gaia wiki state-init <sha>
 
   Create wiki/.state.json with {version: 1, last_evaluated_sha,
   last_evaluated_at}. Refuses if the file already exists.
@@ -30051,7 +30406,7 @@ var HELP_TEXT53 = `Usage: gaia wiki state-init <sha>
   <sha> may be any ref (full sha, short sha, branch, tag); it is
   resolved to a full 40-char sha via \`git rev-parse\`.
 `;
-var HELP_TOKENS51 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var resolveFullSha = (ref, cwd) => {
   try {
     const out = execFileSync6(
@@ -30068,13 +30423,13 @@ var resolveFullSha = (ref, cwd) => {
     return null;
   }
 };
-var run65 = (argv, options = {}) => {
+var run66 = (argv, options = {}) => {
   if (argv.length === 0) {
-    process.stdout.write(HELP_TEXT53);
+    process.stdout.write(HELP_TEXT54);
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  if (HELP_TOKENS51.has(argv[0])) {
-    process.stdout.write(HELP_TEXT53);
+  if (HELP_TOKENS52.has(argv[0])) {
+    process.stdout.write(HELP_TEXT54);
     return EXIT_CODES.OK;
   }
   const positional = [];
@@ -30142,65 +30497,8 @@ var run65 = (argv, options = {}) => {
   return EXIT_CODES.OK;
 };
 
-// src/wiki/util/branch.ts
-import { spawnSync as spawnSync6 } from "node:child_process";
-var defaultRunner5 = (command, args, options) => spawnSync6(command, args, {
-  cwd: options.cwd,
-  encoding: "utf8",
-  stdio: ["ignore", "pipe", "pipe"]
-});
-var PROTECTED_BRANCHES = /* @__PURE__ */ new Set(["main", "master"]);
-var expectSuccess3 = (result, command, args) => {
-  if (result.error !== void 0) {
-    throw new Error(
-      `${command} ${args.join(" ")} failed: ${result.error.message}`
-    );
-  }
-  if ((result.status ?? -1) !== 0) {
-    const stderr = (result.stderr ?? "").trim();
-    throw new Error(
-      `${command} ${args.join(" ")} exited ${result.status ?? -1}: ${stderr}`
-    );
-  }
-  return result.stdout ?? "";
-};
-var currentBranch = (cwd, runner = defaultRunner5) => {
-  const args = ["rev-parse", "--abbrev-ref", "HEAD"];
-  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
-  return out.trim();
-};
-var isProtectedBranch = (branch) => PROTECTED_BRANCHES.has(branch);
-var inspectWorkingTree = (cwd, runner = defaultRunner5) => {
-  const args = ["status", "--porcelain=v1", "-uall"];
-  const out = expectSuccess3(runner("git", args, { cwd }), "git", args);
-  const paths = [];
-  for (const rawLine of out.split("\n")) {
-    const line = rawLine.replace(/\r$/u, "");
-    if (line.length === 0) continue;
-    const rawPayload = line.slice(3);
-    const payload = rawPayload.startsWith('"') && rawPayload.endsWith('"') ? rawPayload.slice(1, -1) : rawPayload;
-    const renameSplit = payload.indexOf(" -> ");
-    if (renameSplit === -1) {
-      paths.push(payload);
-    } else {
-      paths.push(payload.slice(0, renameSplit));
-      paths.push(payload.slice(renameSplit + 4));
-    }
-  }
-  let hasWikiChanges = false;
-  let hasNonWikiChanges = false;
-  for (const candidate of paths) {
-    if (candidate.startsWith("wiki/")) {
-      hasWikiChanges = true;
-    } else {
-      hasNonWikiChanges = true;
-    }
-  }
-  return { hasNonWikiChanges, hasWikiChanges, paths };
-};
-
 // src/wiki/sync-land.ts
-var HELP_TEXT54 = `Usage: gaia wiki sync land [--branch-aware]
+var HELP_TEXT55 = `Usage: gaia wiki sync land [--branch-aware]
 
   Land staged wiki changes via the correct branch strategy:
     - on main/master: refuses unless --branch-aware (then branch + PR + auto-merge)
@@ -30211,8 +30509,7 @@ var HELP_TEXT54 = `Usage: gaia wiki sync land [--branch-aware]
     1  user-correctable refusal (dirty tree, missing flag, ...)
     2  unexpected (git/gh failure)
 `;
-var HELP_TOKENS52 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
-var UNEXPECTED_EXIT17 = 2;
+var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseFlags24 = (argv) => {
   let branchAware = false;
   for (const token of argv) {
@@ -30224,27 +30521,9 @@ var parseFlags24 = (argv) => {
   }
   return { flags: { branchAware }, ok: true };
 };
-var refuse2 = (message) => {
-  process.stderr.write(`${message}
-`);
-  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-};
 var runStep = (runner, step, cwd) => runner(step.command, step.args, { cwd });
-var passthroughFailure2 = (result, step) => {
-  const stderr = (result.stderr ?? "").trim();
-  const errorPart = result.error !== void 0 ? ` (${result.error.message})` : "";
-  const status = result.status ?? -1;
-  process.stderr.write(
-    `sync-land: ${step.command} ${step.args.join(" ")} exited ${status}${errorPart}
-`
-  );
-  if (stderr.length > 0) {
-    process.stderr.write(`${stderr}
-`);
-  }
-  return UNEXPECTED_EXIT17;
-};
-var stepSucceeded2 = (result) => result.error === void 0 && (result.status ?? -1) === 0;
+var passthroughFailure4 = (result, step) => passthroughFailure2("sync-land", result, step.command, step.args);
+var stepSucceeded2 = commandSucceeded;
 var inPlaceLanding = (ctx) => {
   const message = `wiki: sync through ${ctx.shortHead}`;
   const sequence = [
@@ -30262,7 +30541,7 @@ var inPlaceLanding = (ctx) => {
           ctx.cwd
         );
       }
-      return passthroughFailure2(result, step);
+      return passthroughFailure4(result, step);
     }
     if (step.marks === "staged") staged = true;
   }
@@ -30271,12 +30550,6 @@ var inPlaceLanding = (ctx) => {
 `
   );
   return EXIT_CODES.OK;
-};
-var todayUtc4 = (now = /* @__PURE__ */ new Date()) => {
-  const year = now.getUTCFullYear();
-  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(now.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
 };
 var rollbackLocalLanding = (ctx, branchName, onSyncBranch) => {
   if (!onSyncBranch) return;
@@ -30323,13 +30596,13 @@ var protectedBranchLanding = (ctx, options) => {
     const result = runStep(ctx.runner, step, ctx.cwd);
     if (!stepSucceeded2(result)) {
       rollbackLocalLanding(ctx, branchName, onSyncBranch);
-      return passthroughFailure2(result, step);
+      return passthroughFailure4(result, step);
     }
     if (step.marks === "onSyncBranch") onSyncBranch = true;
   }
   for (const step of remoteSequence) {
     const result = runStep(ctx.runner, step, ctx.cwd);
-    if (!stepSucceeded2(result)) return passthroughFailure2(result, step);
+    if (!stepSucceeded2(result)) return passthroughFailure4(result, step);
   }
   process.stdout.write(
     `sync-land: landed via branch-and-PR commit ${ctx.shortHead}
@@ -30337,9 +30610,9 @@ var protectedBranchLanding = (ctx, options) => {
   );
   return EXIT_CODES.OK;
 };
-var run66 = (argv, options = {}) => {
-  if (argv.length > 0 && HELP_TOKENS52.has(argv[0])) {
-    process.stdout.write(HELP_TEXT54);
+var run67 = (argv, options = {}) => {
+  if (argv.length > 0 && HELP_TOKENS53.has(argv[0])) {
+    process.stdout.write(HELP_TEXT55);
     return EXIT_CODES.OK;
   }
   const parsed = parseFlags24(argv);
@@ -30405,7 +30678,7 @@ var run66 = (argv, options = {}) => {
     shortHead
   };
   if (isProtectedBranch(branch)) {
-    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc4() });
+    return protectedBranchLanding(ctx, { today: options.today ?? todayUtc3() });
   }
   return inPlaceLanding(ctx);
 };
@@ -30424,7 +30697,7 @@ var spawnHead = (runner, cwd) => {
 };
 
 // src/wiki/index.ts
-var HELP_TEXT55 = `Usage: gaia wiki <subcommand> [args]
+var HELP_TEXT56 = `Usage: gaia wiki <subcommand> [args]
 
   state [--json]                              Drift report.
   commit-classify --since <sha> [--json]      Per-commit WORTHY/SKIP.
@@ -30441,22 +30714,24 @@ var HELP_TEXT55 = `Usage: gaia wiki <subcommand> [args]
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
+  chain <begin|commit|finish>                 One-branch / one-PR orchestration of the
+                                              full /gaia-wiki chain.
 `;
 var SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
 
   land [--branch-aware]                       Land staged wiki changes via the correct
                                               branch strategy.
 `;
-var HELP_TOKENS53 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var runSync = async (args) => {
   const subcommand = args[0];
   const rest = args.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS53.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
     process.stdout.write(SYNC_HELP_TEXT);
     return EXIT_CODES.OK;
   }
   if (subcommand === "land") {
-    return run66(rest);
+    return run67(rest);
   }
   structuredError({
     code: "unknown_subcommand",
@@ -30466,25 +30741,26 @@ var runSync = async (args) => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 var SUBCOMMAND_HANDLERS8 = {
-  "commit-classify": run55,
-  "dead-paths": run56,
-  "diff-size": run57,
-  "empty-sections": run58,
-  frontmatter: run59,
-  "log-prepend": run60,
-  "near-collisions": run61,
-  orphans: run63,
-  "page-index": run62,
+  chain: run55,
+  "commit-classify": run56,
+  "dead-paths": run57,
+  "diff-size": run58,
+  "empty-sections": run59,
+  frontmatter: run60,
+  "log-prepend": run61,
+  "near-collisions": run62,
+  orphans: run64,
+  "page-index": run63,
   state: run33,
-  "state-bump": run64,
-  "state-init": run65,
+  "state-bump": run65,
+  "state-init": run66,
   sync: runSync
 };
-var run67 = async (argv) => {
+var run68 = async (argv) => {
   const subcommand = argv[0];
   const rest = argv.slice(1);
-  if (subcommand === void 0 || HELP_TOKENS53.has(subcommand)) {
-    process.stdout.write(HELP_TEXT55);
+  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
+    process.stdout.write(HELP_TEXT56);
     return EXIT_CODES.OK;
   }
   const handler = SUBCOMMAND_HANDLERS8[subcommand];
@@ -30501,7 +30777,7 @@ var run67 = async (argv) => {
 };
 
 // src/index.maintainer.ts
-var HELP_TEXT56 = `Usage: gaia-maintainer <subcommand> [args]
+var HELP_TEXT57 = `Usage: gaia-maintainer <subcommand> [args]
 
 Maintainer-only binary. Adopters use 'gaia' (no release namespace).
 
@@ -30520,9 +30796,9 @@ Maintainer-only binary. Adopters use 'gaia' (no release namespace).
   setup status|mark-step|finalize|link-worktree
 `;
 var printHelp2 = () => {
-  process.stdout.write(HELP_TEXT56);
+  process.stdout.write(HELP_TEXT57);
 };
-var HELP_TOKENS54 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
+var HELP_TOKENS55 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var SUBCOMMAND_HANDLERS9 = {
   automation: run6,
   fitness: run8,
@@ -30534,12 +30810,12 @@ var SUBCOMMAND_HANDLERS9 = {
   telemetry: run49,
   update: run51,
   "update-deps": run54,
-  wiki: run67
+  wiki: run68
 };
 var main = async () => {
   const subcommand = process.argv[2];
   const rest = process.argv.slice(3);
-  if (subcommand === void 0 || HELP_TOKENS54.has(subcommand)) {
+  if (subcommand === void 0 || HELP_TOKENS55.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }

--- a/.gaia/cli/src/wiki/chain.test.ts
+++ b/.gaia/cli/src/wiki/chain.test.ts
@@ -1,0 +1,554 @@
+/**
+ * Tests for `gaia wiki chain <begin|commit|finish>`.
+ *
+ * Strategy mirrors `sync-land.test.ts`: stand up a real (empty) git repo so
+ * `git rev-parse --show-toplevel` resolves the sandbox root, then inject a
+ * fake `CommandRunner` that returns canned `SpawnSyncReturns<string>` values
+ * keyed off argv. Each test asserts the handler's exit code and the exact
+ * sequence of git/gh invocations the fake observed.
+ */
+import {execFileSync, type SpawnSyncReturns} from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {run} from './chain.js';
+import type {CommandRunner} from './util/branch.js';
+
+type Sandbox = {
+  cleanup: () => void;
+  root: string;
+};
+
+const setupSandbox = (): Sandbox => {
+  const root = mkdtempSync(path.join(tmpdir(), 'gaia-wiki-chain-'));
+  execFileSync('git', ['init', '-q'], {cwd: root});
+  mkdirSync(path.join(root, 'wiki'), {recursive: true});
+  writeFileSync(path.join(root, 'wiki', 'log.md'), '---\n---\n', 'utf8');
+
+  return {
+    cleanup: () => {
+      rmSync(root, {force: true, recursive: true});
+    },
+    root,
+  };
+};
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+type RecordedCall = {
+  args: string[];
+  command: string;
+};
+
+const okResult = (stdout = ''): SpawnSyncReturns<string> => ({
+  output: ['', stdout, ''] as never,
+  pid: 0,
+  signal: null,
+  status: 0,
+  stderr: '',
+  stdout,
+});
+
+const failResult = (
+  status: number,
+  stderr: string
+): SpawnSyncReturns<string> => ({
+  output: ['', '', stderr] as never,
+  pid: 0,
+  signal: null,
+  status,
+  stderr,
+  stdout: '',
+});
+
+const matches = (
+  argv: readonly string[],
+  command: string,
+  observed: readonly string[]
+): boolean => {
+  const target = [command, ...argv];
+  const seen = [command, ...observed];
+
+  return (
+    target.length === seen.length &&
+    target.every((token, index) => token === seen[index])
+  );
+};
+
+const buildRunner =
+  (
+    scripted: Array<{
+      argv: readonly string[];
+      result: SpawnSyncReturns<string>;
+    }>,
+    recorded: RecordedCall[]
+  ): CommandRunner =>
+  (command, args) => {
+    recorded.push({args: [...args], command});
+    const match = scripted.find((entry) =>
+      matches(entry.argv, command, args)
+    );
+
+    if (match !== undefined) return match.result;
+
+    return okResult('');
+  };
+
+const gitCalls = (recorded: RecordedCall[]): RecordedCall[] =>
+  recorded.filter((entry) => entry.command === 'git');
+
+const ghCalls = (recorded: RecordedCall[]): RecordedCall[] =>
+  recorded.filter((entry) => entry.command === 'gh');
+
+describe('wiki chain', () => {
+  let sandbox: Sandbox;
+  let stdio: ReturnType<typeof captureStdio>;
+
+  beforeEach(() => {
+    stdio = captureStdio();
+  });
+
+  afterEach(() => {
+    stdio.restore();
+    sandbox.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('begin', () => {
+    test('on a feature branch: no-op, exit 0, no branch cut', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('feature/x\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['begin'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('chain begin: in-place on feature/x');
+      expect(recorded.find((c) => c.args[0] === 'checkout')).toBeUndefined();
+    });
+
+    test('on main without --branch-aware: exit 1, no branch cut', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('main\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['begin'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('refusing to start a wiki chain on main');
+      expect(recorded.find((c) => c.args[0] === 'checkout')).toBeUndefined();
+    });
+
+    test('on main with --branch-aware: cuts wiki-sync/<date>-<sha>, exit 0', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('main\n'),
+          },
+          {
+            argv: ['rev-parse', 'HEAD'],
+            result: okResult('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['begin', '--branch-aware'], {
+        cwd: sandbox.root,
+        runner,
+        today: '2026-05-07',
+      });
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain(
+        'chain begin: started wiki-sync/2026-05-07-bbbbbbb'
+      );
+      expect(gitCalls(recorded).at(-1)).toMatchObject({
+        args: ['checkout', '-b', 'wiki-sync/2026-05-07-bbbbbbb'],
+        command: 'git',
+      });
+    });
+
+    test('treats master like main', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('master\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['begin'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('refusing to start a wiki chain on main');
+    });
+
+    test('rejects unknown flag', () => {
+      sandbox = setupSandbox();
+      const exit = run(['begin', '--bogus'], {cwd: sandbox.root});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('unknown flag');
+    });
+  });
+
+  describe('commit', () => {
+    test('with only wiki changes: add + commit, exit 0', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['status', '--porcelain=v1', '-uall'],
+            result: okResult(' M wiki/log.md\n?? wiki/meta/lint-report.md\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['commit', '--label', 'wiki: lint through abc1234'], {
+        cwd: sandbox.root,
+        runner,
+      });
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('chain commit: wiki: lint through abc1234');
+      const verbs = gitCalls(recorded);
+      expect(verbs.at(-2)).toMatchObject({args: ['add', 'wiki'], command: 'git'});
+      expect(verbs.at(-1)).toMatchObject({
+        args: ['commit', '-m', 'wiki: lint through abc1234'],
+        command: 'git',
+      });
+      expect(ghCalls(recorded)).toHaveLength(0);
+    });
+
+    test('with no wiki changes: graceful no-op, exit 0', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['status', '--porcelain=v1', '-uall'],
+            result: okResult(''),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['commit', '--label', 'wiki: consolidate'], {
+        cwd: sandbox.root,
+        runner,
+      });
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('chain commit: nothing to commit');
+      expect(recorded.find((c) => c.args[0] === 'commit')).toBeUndefined();
+    });
+
+    test('with non-wiki changes: exit 1, no commit', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['status', '--porcelain=v1', '-uall'],
+            result: okResult(' M app/foo.ts\n M wiki/log.md\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['commit', '--label', 'wiki: x'], {
+        cwd: sandbox.root,
+        runner,
+      });
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('non-wiki changes');
+      expect(recorded.find((c) => c.args[0] === 'commit')).toBeUndefined();
+    });
+
+    test('missing --label: exit 1', () => {
+      sandbox = setupSandbox();
+      const exit = run(['commit'], {cwd: sandbox.root});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('--label is required');
+    });
+
+    test('commit failure unstages wiki and exits 2', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['status', '--porcelain=v1', '-uall'],
+            result: okResult(' M wiki/log.md\n'),
+          },
+          {argv: ['add', 'wiki'], result: okResult('')},
+          {
+            argv: ['commit', '-m', 'wiki: x'],
+            result: failResult(1, 'nothing to commit'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['commit', '--label', 'wiki: x'], {
+        cwd: sandbox.root,
+        runner,
+      });
+      expect(exit).toBe(2);
+      expect(gitCalls(recorded)).toContainEqual({
+        args: ['reset', 'HEAD', '--', 'wiki'],
+        command: 'git',
+      });
+    });
+  });
+
+  describe('finish', () => {
+    test('on a non-chain branch: no-op, exit 0, no PR', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('feature/x\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['finish'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('chain finish: in-place commits remain on feature/x');
+      expect(ghCalls(recorded)).toHaveLength(0);
+      expect(recorded.find((c) => c.args[0] === 'push')).toBeUndefined();
+    });
+
+    test('on a chain branch with commits: push + PR + auto-merge + checkout base', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('wiki-sync/2026-05-07-bbbbbbb\n'),
+          },
+          {
+            argv: ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            result: okResult('origin/main\n'),
+          },
+          {
+            argv: ['rev-list', '--count', 'main..HEAD'],
+            result: okResult('3\n'),
+          },
+          {
+            argv: ['rev-parse', 'HEAD'],
+            result: okResult('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['finish', '--branch-aware'], {
+        cwd: sandbox.root,
+        runner,
+      });
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('opened PR for wiki-sync/2026-05-07-bbbbbbb');
+
+      const ordered = recorded.map((c) => [c.command, ...c.args].join(' '));
+      const pushIndex = ordered.findIndex((c) =>
+        c.startsWith('git push -u origin wiki-sync/2026-05-07-bbbbbbb')
+      );
+      const prCreateIndex = ordered.findIndex((c) => c.startsWith('gh pr create'));
+      const prMergeIndex = ordered.findIndex((c) =>
+        c.startsWith('gh pr merge --squash --auto')
+      );
+      const checkoutBaseIndex = ordered.findIndex((c) => c === 'git checkout main');
+      expect(pushIndex).toBeGreaterThanOrEqual(0);
+      expect(prCreateIndex).toBeGreaterThan(pushIndex);
+      expect(prMergeIndex).toBeGreaterThan(prCreateIndex);
+      expect(checkoutBaseIndex).toBeGreaterThan(prMergeIndex);
+    });
+
+    test('on a chain branch with no commits ahead: drop empty branch, no PR', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('wiki-sync/2026-05-07-ccccccc\n'),
+          },
+          {
+            argv: ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            result: okResult('origin/main\n'),
+          },
+          {
+            argv: ['rev-list', '--count', 'main..HEAD'],
+            result: okResult('0\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['finish'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('removed empty branch wiki-sync/2026-05-07-ccccccc');
+      expect(gitCalls(recorded)).toContainEqual({
+        args: ['checkout', 'main'],
+        command: 'git',
+      });
+      expect(gitCalls(recorded)).toContainEqual({
+        args: ['branch', '-D', 'wiki-sync/2026-05-07-ccccccc'],
+        command: 'git',
+      });
+      expect(ghCalls(recorded)).toHaveLength(0);
+    });
+
+    test('empty chain branch with a dirty tree: left in place, no delete', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('wiki-sync/2026-05-07-eeeeeee\n'),
+          },
+          {
+            argv: ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            result: okResult('origin/main\n'),
+          },
+          {
+            argv: ['rev-list', '--count', 'main..HEAD'],
+            result: okResult('0\n'),
+          },
+          {
+            argv: ['status', '--porcelain=v1', '-uall'],
+            result: okResult(' M wiki/log.md\n'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['finish'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('has uncommitted changes and no commits');
+      expect(recorded.find((c) => c.args[0] === 'checkout')).toBeUndefined();
+      expect(recorded.find((c) => c.args[0] === 'branch')).toBeUndefined();
+      expect(ghCalls(recorded)).toHaveLength(0);
+    });
+
+    test('push failure short-circuits before any gh call, exit 2', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner(
+        [
+          {
+            argv: ['rev-parse', '--abbrev-ref', 'HEAD'],
+            result: okResult('wiki-sync/2026-05-07-ddddddd\n'),
+          },
+          {
+            argv: ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            result: okResult('origin/main\n'),
+          },
+          {
+            argv: ['rev-list', '--count', 'main..HEAD'],
+            result: okResult('2\n'),
+          },
+          {
+            argv: ['rev-parse', 'HEAD'],
+            result: okResult('dddddddddddddddddddddddddddddddddddddddd\n'),
+          },
+          {
+            argv: ['push', '-u', 'origin', 'wiki-sync/2026-05-07-ddddddd'],
+            result: failResult(128, 'remote: rejected'),
+          },
+        ],
+        recorded
+      );
+
+      const exit = run(['finish'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(2);
+      expect(stdio.errors.join('')).toContain('remote: rejected');
+      expect(ghCalls(recorded)).toHaveLength(0);
+      expect(recorded.find((c) => c.args[0] === 'checkout')).toBeUndefined();
+    });
+
+    test('rejects unknown flag', () => {
+      sandbox = setupSandbox();
+      const exit = run(['finish', '--bogus'], {cwd: sandbox.root});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('unknown flag');
+    });
+  });
+
+  describe('dispatch', () => {
+    test('--help prints usage without invoking git', () => {
+      sandbox = setupSandbox();
+      const recorded: RecordedCall[] = [];
+      const runner = buildRunner([], recorded);
+
+      const exit = run(['--help'], {cwd: sandbox.root, runner});
+      expect(exit).toBe(0);
+      expect(stdio.outputs.join('')).toContain('Usage:');
+      expect(recorded).toHaveLength(0);
+    });
+
+    test('unknown action: exit 1', () => {
+      sandbox = setupSandbox();
+      const exit = run(['bogus'], {cwd: sandbox.root});
+      expect(exit).toBe(1);
+      expect(stdio.errors.join('')).toContain('unknown wiki chain action');
+    });
+  });
+});

--- a/.gaia/cli/src/wiki/chain.ts
+++ b/.gaia/cli/src/wiki/chain.ts
@@ -1,0 +1,420 @@
+/**
+ * `gaia wiki chain <begin|commit|finish>` handler.
+ *
+ * Orchestrates the `/gaia-wiki` full chain (sync → consolidate → lint) so it
+ * lands on ONE branch and ONE PR instead of each stage landing independently.
+ * The router (`references/wiki.md`) calls:
+ *   begin   once, before sync         → cut `wiki-sync/<date>-<sha>` on main
+ *   commit  after consolidate & lint   → in-place commit of that stage's edits
+ *   finish  once, after lint           → push + PR + auto-merge, return to base
+ *
+ * `begin` runs BEFORE sync on purpose: sync's own Step 7 (`gaia wiki sync land
+ * --branch-aware`) then sees a feature branch and commits in place rather than
+ * opening its own premature PR. On a feature branch every action degrades to a
+ * no-op or a plain in-place commit, so a full chain run from a feature branch
+ * leaves its commits there for the developer to land their own way.
+ *
+ * Determinism contract mirrors `sync-land.ts`: no prose narration on stdout
+ * (one-line summaries only), every git/gh call routes through an injectable
+ * `runner`, and exit codes are 0 (ok) / 1 (user-correctable refusal) /
+ * 2 (unexpected git/gh process failure, stderr piped through).
+ */
+import {EXIT_CODES} from '../exit.js';
+import {structuredError} from '../stderr.js';
+import {
+  currentBranch,
+  defaultBranch,
+  defaultRunner,
+  inspectWorkingTree,
+  isProtectedBranch,
+  type CommandRunner,
+} from './util/branch.js';
+import {resolveRepoRoot, shortSha} from './util/git.js';
+import {
+  UNEXPECTED_EXIT,
+  commandSucceeded,
+  passthroughFailure as passthroughFailureWithPrefix,
+  refuse,
+  todayUtc,
+} from './util/land.js';
+
+const WIKI_CHAIN_BRANCH_PREFIX = 'wiki-sync/';
+
+const passthroughFailure = (
+  result: Parameters<typeof passthroughFailureWithPrefix>[1],
+  command: string,
+  args: readonly string[]
+): number => passthroughFailureWithPrefix('chain', result, command, args);
+
+const stepOk = commandSucceeded;
+
+const HELP_TOKENS = new Set(['--help', '-h', 'help']);
+
+const HELP_TEXT = `Usage: gaia wiki chain <begin|commit|finish> [args]
+
+  begin [--branch-aware]       On main/master: cut wiki-sync/<date>-<sha> so the
+                               whole chain lands on one branch + PR. On a feature
+                               branch: no-op (the chain commits in place).
+  commit --label "<subject>"   In-place commit of this stage's wiki/ changes.
+                               No-op when nothing changed; refuses non-wiki changes.
+  finish [--branch-aware]      Push the chain branch, open one PR, enable
+                               auto-merge, return to the base branch. Removes an
+                               empty chain branch; no-op for in-place runs.
+
+  Exit codes:
+    0  success
+    1  user-correctable refusal (on main without --branch-aware, missing --label, ...)
+    2  unexpected (git/gh failure)
+`;
+
+type RunOptions = {
+  cwd?: string;
+  runner?: CommandRunner;
+  /** Override "today" for deterministic tests. ISO-8601 date string. */
+  today?: string;
+};
+
+const resolveRoot = (cwdOption: string, action: string): string | null => {
+  try {
+    return resolveRepoRoot(cwdOption);
+  } catch {
+    structuredError({
+      code: 'not_a_git_repo',
+      message: 'gaia wiki chain must run inside a git repository',
+      subcommand: `wiki chain ${action}`,
+    });
+
+    return null;
+  }
+};
+
+const resolveShortHead = (runner: CommandRunner, cwd: string): string | null => {
+  const result = runner('git', ['rev-parse', 'HEAD'], {cwd});
+
+  if (!stepOk(result)) return null;
+
+  return shortSha((result.stdout ?? '').trim(), cwd);
+};
+
+type BranchAwareParse =
+  | {branchAware: boolean; ok: true}
+  | {message: string; ok: false};
+
+const parseBranchAware = (argv: readonly string[]): BranchAwareParse => {
+  let branchAware = false;
+
+  for (const token of argv) {
+    if (token === '--branch-aware') {
+      branchAware = true;
+      continue;
+    }
+
+    return {message: `unknown flag: ${token}`, ok: false};
+  }
+
+  return {branchAware, ok: true};
+};
+
+type CommitParse = {label: string; ok: true} | {message: string; ok: false};
+
+const parseCommitFlags = (argv: readonly string[]): CommitParse => {
+  let label: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--label') {
+      const value = argv[index + 1];
+
+      if (value === undefined) return {message: '--label requires a value', ok: false};
+      label = value;
+      index += 1;
+      continue;
+    }
+
+    return {message: `unknown flag: ${token}`, ok: false};
+  }
+
+  if (label === undefined || label.length === 0)
+    return {message: '--label is required', ok: false};
+
+  return {label, ok: true};
+};
+
+const begin = (argv: readonly string[], options: RunOptions): number => {
+  const parsed = parseBranchAware(argv);
+
+  if (!parsed.ok) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed.message,
+      subcommand: 'wiki chain begin',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot = resolveRoot(cwd, 'begin');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  let branch: string;
+
+  try {
+    branch = currentBranch(repoRoot, runner);
+  } catch (error) {
+    process.stderr.write(
+      `chain: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+
+    return UNEXPECTED_EXIT;
+  }
+
+  if (!isProtectedBranch(branch)) {
+    process.stdout.write(`chain begin: in-place on ${branch}\n`);
+
+    return EXIT_CODES.OK;
+  }
+
+  if (!parsed.branchAware) {
+    return refuse(
+      'chain begin: refusing to start a wiki chain on main; pass --branch-aware or check out a feature branch'
+    );
+  }
+
+  const shortHead = resolveShortHead(runner, repoRoot);
+
+  if (shortHead === null) {
+    process.stderr.write('chain: could not resolve HEAD\n');
+
+    return UNEXPECTED_EXIT;
+  }
+
+  const branchName = `${WIKI_CHAIN_BRANCH_PREFIX}${options.today ?? todayUtc()}-${shortHead}`;
+  const args = ['checkout', '-b', branchName];
+  const result = runner('git', args, {cwd: repoRoot});
+
+  if (!stepOk(result)) return passthroughFailure(result, 'git', args);
+
+  process.stdout.write(`chain begin: started ${branchName}\n`);
+
+  return EXIT_CODES.OK;
+};
+
+const commit = (argv: readonly string[], options: RunOptions): number => {
+  const parsed = parseCommitFlags(argv);
+
+  if (!parsed.ok) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed.message,
+      subcommand: 'wiki chain commit',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot = resolveRoot(cwd, 'commit');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  let workingTree: ReturnType<typeof inspectWorkingTree>;
+
+  try {
+    workingTree = inspectWorkingTree(repoRoot, runner);
+  } catch (error) {
+    process.stderr.write(
+      `chain: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+
+    return UNEXPECTED_EXIT;
+  }
+
+  if (workingTree.hasNonWikiChanges) {
+    return refuse('chain commit: working tree has non-wiki changes; aborting');
+  }
+
+  if (!workingTree.hasWikiChanges) {
+    // A skipped stage (e.g. consolidate gated off) leaves nothing to commit.
+    // Graceful no-op so the chain does not abort.
+    process.stdout.write('chain commit: nothing to commit\n');
+
+    return EXIT_CODES.OK;
+  }
+
+  const addArgs = ['add', 'wiki'];
+  const addResult = runner('git', addArgs, {cwd: repoRoot});
+
+  if (!stepOk(addResult)) return passthroughFailure(addResult, 'git', addArgs);
+
+  const commitArgs = ['commit', '-m', parsed.label];
+  const commitResult = runner('git', commitArgs, {cwd: repoRoot});
+
+  if (!stepOk(commitResult)) {
+    // Unstage `wiki` so a failed commit leaves a clean index behind.
+    runner('git', ['reset', 'HEAD', '--', 'wiki'], {cwd: repoRoot});
+
+    return passthroughFailure(commitResult, 'git', commitArgs);
+  }
+
+  process.stdout.write(`chain commit: ${parsed.label}\n`);
+
+  return EXIT_CODES.OK;
+};
+
+const finish = (argv: readonly string[], options: RunOptions): number => {
+  const parsed = parseBranchAware(argv);
+
+  if (!parsed.ok) {
+    structuredError({
+      code: 'invalid_arguments',
+      message: parsed.message,
+      subcommand: 'wiki chain finish',
+    });
+
+    return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultRunner;
+  const repoRoot = resolveRoot(cwd, 'finish');
+
+  if (repoRoot === null) return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+
+  let branch: string;
+
+  try {
+    branch = currentBranch(repoRoot, runner);
+  } catch (error) {
+    process.stderr.write(
+      `chain: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+
+    return UNEXPECTED_EXIT;
+  }
+
+  if (!branch.startsWith(WIKI_CHAIN_BRANCH_PREFIX)) {
+    // In-place run (begin was a no-op on a feature branch). The stage commits
+    // already live on the developer's branch; opening a PR is their call.
+    process.stdout.write(
+      `chain finish: in-place commits remain on ${branch}; no PR opened\n`
+    );
+
+    return EXIT_CODES.OK;
+  }
+
+  const base = defaultBranch(repoRoot, runner);
+  const countArgs = ['rev-list', '--count', `${base}..HEAD`];
+  const countResult = runner('git', countArgs, {cwd: repoRoot});
+
+  if (!stepOk(countResult)) return passthroughFailure(countResult, 'git', countArgs);
+
+  const ahead = Number.parseInt((countResult.stdout ?? '').trim(), 10);
+
+  if (!Number.isNaN(ahead) && ahead === 0) {
+    // No commits to land. A clean tree means every stage was a no-op: drop
+    // the empty branch and return to base rather than open an empty PR. A
+    // dirty tree means sync aborted mid-write (the Step 5b fabrication guard
+    // leaves the tree untouched without committing); leave the branch and
+    // changes in place for the maintainer to resolve.
+    let dirty = true;
+
+    try {
+      const tree = inspectWorkingTree(repoRoot, runner);
+      dirty = tree.hasWikiChanges || tree.hasNonWikiChanges;
+    } catch {
+      dirty = true;
+    }
+
+    if (dirty) {
+      process.stdout.write(
+        `chain finish: ${branch} has uncommitted changes and no commits; left in place for review\n`
+      );
+
+      return EXIT_CODES.OK;
+    }
+
+    const checkoutArgs = ['checkout', base];
+    const checkoutResult = runner('git', checkoutArgs, {cwd: repoRoot});
+
+    if (!stepOk(checkoutResult))
+      return passthroughFailure(checkoutResult, 'git', checkoutArgs);
+
+    runner('git', ['branch', '-D', branch], {cwd: repoRoot});
+    process.stdout.write(
+      `chain finish: nothing to land; removed empty branch ${branch}\n`
+    );
+
+    return EXIT_CODES.OK;
+  }
+
+  const shortHead = resolveShortHead(runner, repoRoot) ?? branch;
+  const prTitle = `wiki: maintenance chain through ${shortHead}`;
+  const prBody = `Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via \`gaia wiki chain finish\`.`;
+
+  // Remote steps run while still on the chain branch so `gh pr merge` targets
+  // its PR. Once `push` succeeds the branch exists on the remote and is left
+  // for the maintainer to resolve rather than force-reverted.
+  const remoteSequence: Array<{args: string[]; command: string}> = [
+    {args: ['push', '-u', 'origin', branch], command: 'git'},
+    {
+      args: ['pr', 'create', '--title', prTitle, '--body', prBody],
+      command: 'gh',
+    },
+    {args: ['pr', 'merge', '--squash', '--auto'], command: 'gh'},
+  ];
+
+  for (const step of remoteSequence) {
+    const result = runner(step.command, step.args, {cwd: repoRoot});
+
+    if (!stepOk(result)) return passthroughFailure(result, step.command, step.args);
+  }
+
+  // Best-effort return to base. The tree is clean (every stage committed), so
+  // the checkout cannot strand uncommitted work; a failure here does not undo
+  // the queued merge.
+  runner('git', ['checkout', base], {cwd: repoRoot});
+  process.stdout.write(
+    `chain finish: opened PR for ${branch} and enabled auto-merge\n`
+  );
+
+  return EXIT_CODES.OK;
+};
+
+const ACTIONS: Readonly<
+  Partial<Record<string, (argv: readonly string[], options: RunOptions) => number>>
+> = {
+  begin,
+  commit,
+  finish,
+};
+
+export const run = (
+  argv: readonly string[],
+  options: RunOptions = {}
+): number => {
+  const action = argv[0] as string | undefined;
+  const rest = argv.slice(1);
+
+  if (action === undefined || HELP_TOKENS.has(action)) {
+    process.stdout.write(HELP_TEXT);
+
+    return EXIT_CODES.OK;
+  }
+
+  const handler = ACTIONS[action];
+
+  if (handler !== undefined) return handler(rest, options);
+
+  structuredError({
+    code: 'unknown_subcommand',
+    message: `unknown wiki chain action: ${action}`,
+    subcommand: `wiki chain ${action}`,
+  });
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};

--- a/.gaia/cli/src/wiki/index.ts
+++ b/.gaia/cli/src/wiki/index.ts
@@ -10,6 +10,7 @@
  */
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
+import {run as runChain} from './chain.js';
 import {run as runCommitClassify} from './commit-classify.js';
 import {run as runDeadPaths} from './dead-paths.js';
 import {run as runDiffSize} from './diff-size.js';
@@ -41,6 +42,8 @@ const HELP_TEXT = `Usage: gaia wiki <subcommand> [args]
   diff-size --threshold-pct N [--base <ref>] [--json]
                                               Gate auto-merge on wiki byte-delta vs base.
   sync land [--branch-aware]                  Branch-aware landing of staged wiki changes.
+  chain <begin|commit|finish>                 One-branch / one-PR orchestration of the
+                                              full /gaia-wiki chain.
 `;
 
 const SYNC_HELP_TEXT = `Usage: gaia wiki sync <subcommand> [args]
@@ -81,6 +84,7 @@ const runSync: SubcommandHandler = async (
 const SUBCOMMAND_HANDLERS: Readonly<
   Partial<Record<string, SubcommandHandler>>
 > = {
+  chain: runChain,
   'commit-classify': runCommitClassify,
   'dead-paths': runDeadPaths,
   'diff-size': runDiffSize,

--- a/.gaia/cli/src/wiki/sync-land.ts
+++ b/.gaia/cli/src/wiki/sync-land.ts
@@ -32,6 +32,13 @@ import {
   type CommandRunner,
 } from './util/branch.js';
 import {resolveRepoRoot, shortSha} from './util/git.js';
+import {
+  UNEXPECTED_EXIT,
+  commandSucceeded,
+  passthroughFailure as passthroughFailureWithPrefix,
+  refuse,
+  todayUtc,
+} from './util/land.js';
 
 const HELP_TEXT = `Usage: gaia wiki sync land [--branch-aware]
 
@@ -46,7 +53,6 @@ const HELP_TEXT = `Usage: gaia wiki sync land [--branch-aware]
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
-const UNEXPECTED_EXIT = 2;
 
 type ParsedFlags = {
   branchAware: boolean;
@@ -79,12 +85,6 @@ const parseFlags = (argv: readonly string[]): FlagParseResult => {
   return {flags: {branchAware}, ok: true};
 };
 
-const refuse = (message: string): number => {
-  process.stderr.write(`${message}\n`);
-
-  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
-};
-
 type RunStep = {
   args: readonly string[];
   command: string;
@@ -106,26 +106,10 @@ const runStep = (
 const passthroughFailure = (
   result: SpawnSyncReturns<string>,
   step: RunStep
-): number => {
-  // Surface the failing command + its stderr so the caller has enough
-  // context to diagnose without re-running. The CLI itself adds nothing.
-  const stderr = (result.stderr ?? '').trim();
-  const errorPart =
-    result.error !== undefined ? ` (${result.error.message})` : '';
-  const status = result.status ?? -1;
-  process.stderr.write(
-    `sync-land: ${step.command} ${step.args.join(' ')} exited ${status}${errorPart}\n`
-  );
+): number =>
+  passthroughFailureWithPrefix('sync-land', result, step.command, step.args);
 
-  if (stderr.length > 0) {
-    process.stderr.write(`${stderr}\n`);
-  }
-
-  return UNEXPECTED_EXIT;
-};
-
-const stepSucceeded = (result: SpawnSyncReturns<string>): boolean =>
-  result.error === undefined && (result.status ?? -1) === 0;
+const stepSucceeded = commandSucceeded;
 
 type LandingContext = {
   cwd: string;
@@ -167,14 +151,6 @@ const inPlaceLanding = (ctx: LandingContext): number => {
   );
 
   return EXIT_CODES.OK;
-};
-
-const todayUtc = (now: Date = new Date()): string => {
-  const year = now.getUTCFullYear();
-  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(now.getUTCDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
 };
 
 /**

--- a/.gaia/cli/src/wiki/util/branch.ts
+++ b/.gaia/cli/src/wiki/util/branch.ts
@@ -67,6 +67,27 @@ export const currentBranch = (
 export const isProtectedBranch = (branch: string): boolean =>
   PROTECTED_BRANCHES.has(branch);
 
+/**
+ * Resolve the repository's default branch (the base a chain PR targets and
+ * the branch `chain finish` returns to). Reads `origin/HEAD`; falls back to
+ * `main` when the symbolic ref is unset (e.g. a freshly-cloned sandbox or a
+ * repo whose remote HEAD was never resolved).
+ */
+export const defaultBranch = (
+  cwd: string,
+  runner: CommandRunner = defaultRunner
+): string => {
+  const args = ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'];
+  const result = runner('git', args, {cwd});
+
+  if (result.error !== undefined || (result.status ?? -1) !== 0) return 'main';
+
+  const ref = (result.stdout ?? '').trim();
+  const stripped = ref.startsWith('origin/') ? ref.slice('origin/'.length) : ref;
+
+  return stripped.length > 0 ? stripped : 'main';
+};
+
 export type WorkingTreeStatus = {
   hasNonWikiChanges: boolean;
   hasWikiChanges: boolean;

--- a/.gaia/cli/src/wiki/util/land.ts
+++ b/.gaia/cli/src/wiki/util/land.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared landing primitives for the wiki `sync land` and `chain` commands.
+ *
+ * Both commands shell out through an injected `CommandRunner` and translate
+ * git/gh outcomes into the CLI's exit-code contract: 0 (ok) / 1 (refusal) /
+ * 2 (unexpected). These leaf helpers keep that translation identical across
+ * the two surfaces.
+ */
+import {type SpawnSyncReturns} from 'node:child_process';
+import {EXIT_CODES} from '../../exit.js';
+
+/** Exit code for an unexpected git/gh process failure. */
+export const UNEXPECTED_EXIT = 2;
+
+/** UTC `YYYY-MM-DD`; the date component of a `wiki-sync/<date>-<sha>` branch. */
+export const todayUtc = (now: Date = new Date()): string => {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(now.getUTCDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+/** Print a user-correctable refusal to stderr and return exit code 1. */
+export const refuse = (message: string): number => {
+  process.stderr.write(`${message}\n`);
+
+  return EXIT_CODES.UNKNOWN_SUBCOMMAND;
+};
+
+/** A git/gh step succeeded: no spawn error and a zero exit status. */
+export const commandSucceeded = (result: SpawnSyncReturns<string>): boolean =>
+  result.error === undefined && (result.status ?? -1) === 0;
+
+/**
+ * Surface a failing git/gh step (command + argv + its stderr) under `prefix`
+ * and return exit code 2. The caller gets enough context to diagnose without
+ * re-running; the CLI adds nothing beyond that.
+ */
+export const passthroughFailure = (
+  prefix: string,
+  result: SpawnSyncReturns<string>,
+  command: string,
+  args: readonly string[]
+): number => {
+  const stderr = (result.stderr ?? '').trim();
+  const errorPart =
+    result.error !== undefined ? ` (${result.error.message})` : '';
+  const status = result.status ?? -1;
+  process.stderr.write(
+    `${prefix}: ${command} ${args.join(' ')} exited ${status}${errorPart}\n`
+  );
+
+  if (stderr.length > 0) process.stderr.write(`${stderr}\n`);
+
+  return UNEXPECTED_EXIT;
+};


### PR DESCRIPTION
## Problem

Running `/gaia-wiki` (no sub-arg) from `main` produced **two PRs**:

1. Sync self-landed its own `wiki-sync/<date>-<sha>` PR — Step 7 (`gaia wiki sync land --branch-aware`) opens branch + PR + auto-merge on a protected branch, *before* consolidate/lint run.
2. The lint report had no in-chain landing step, so it became a second, operator-made PR.

## Fix

New `gaia wiki chain <begin|commit|finish>` so the `/gaia-wiki` router owns the branch lifecycle and every stage lands on **one branch → one PR**:

- **begin** (before sync): cuts `wiki-sync/<date>-<sha>` on `main`/`master`; no-op on a feature branch (chain then commits in place).
- **commit** (per stage): in-place commit of that stage's `wiki/` changes; graceful no-op when nothing changed; refuses non-wiki changes.
- **finish** (after lint): pushes, opens ONE PR for all stage commits, enables auto-merge, returns to base; drops an empty branch; leaves an aborted (dirty, uncommitted) tree in place for review; no-op for in-place runs.

Because `begin` pre-cuts the branch, sync's **unchanged** Step 7 commits in place instead of opening its own PR.

## Scope / safety

- Standalone `/gaia-wiki sync|consolidate|lint` are **unchanged**.
- The CI wiki workflow uses sub-arg commands + its own auto-merge partial → **unaffected**.
- Shared git/gh landing leaf helpers (`todayUtc`, `refuse`, `commandSucceeded`, `passthroughFailure`) extracted to `util/land.ts`; `sync-land.ts` refactored to use them (behavior identical, full sync-land test suite green).
- `references/wiki.md` "Full chain" rewired; `sync.md` Step 7 notes the branch-aware interaction. CLI bundle regenerated.

## Tests

- 19 new `chain.test.ts` cases (begin/commit/finish across protected/feature/empty/dirty/failure paths).
- Full `.gaia/cli` suite green (1365 passing); `sync-land` regression intact; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)