### PR TITLE
refactor(rules): shrink dep-audit.md to a wiki pointer

### DIFF
--- a/.claude/rules/dep-audit.md
+++ b/.claude/rules/dep-audit.md
@@ -1,22 +1,5 @@
 # Dependency-CVE Advisory, pnpm audit
 
-`pnpm audit --json` is the deterministic oracle for "known vulnerable dependencies." It runs pre-merge inside the `code-review-audit` agent (parallel with `react-doctor` and `knip`) as an ADVISORY surface, it reads the live advisory DB, reports high/critical findings so the operator can decide, and never blocks the audit marker or `gh pr merge`.
+Policy, noise-scoping filters, baseline allowlist, and acting-on-output: `wiki/dependencies/pnpm-audit.md`.
 
-This local check is **read-only and distinct from the blocking CI path.** GAIA CI's automation runs its own `pnpm audit` cron that opens review-required security PRs and issues for high/critical advisories, that is the blocking placement, on the network side. The local check duplicates none of that: it opens no PR, files no issue, bumps no package. It only informs one review.
-
-## Noise scoping
-
-Two filters keep the same unfixable transitive advisory from spamming every review:
-
-1. **Severity threshold**: only `high` and `critical` advisories are candidates (matches the CI floor; drops low/moderate transitive noise).
-2. **Baseline allowlist**: `.gaia/local/dep-audit-baseline.json` (machine-local, gitignored). Acknowledge an unfixable advisory by its ID and it is suppressed (count-only) on later reviews:
-
-   ```jsonc
-   {"acknowledged": [{"id": 1098765, "module": "tough-cookie", "note": "why"}]}
-   ```
-
-   The audit only READS this file, acknowledging is an explicit operator action, never something the audit writes (that would turn an advisory into a self-managed suppression gate). Missing file ⇒ empty baseline ⇒ every high/critical surfaces.
-
-## Reference
-
-Extraction recipe + bucket format + acting-on-output: `.claude/agents/code-review-audit.md` (Dependency-CVE advisory). Blocking CI path: the `gaia-ci-pnpm-audit` workflow at `.github/workflows/gaia-ci-pnpm-audit.yml` (wired up by `/setup-gaia-ci`).
+Extraction recipe + bucket format used by the audit agent: `.claude/agents/code-review-audit.md` (Dependency-CVE advisory section).


### PR DESCRIPTION
## What

`/gaia-audit` flagged `.claude/rules/dep-audit.md` as the sole action: it carries 22 lines of prose with no `paths:` frontmatter glob. Per the Rules-vs-wiki policy, a non-path-scoped rule must point to the canonical wiki page rather than duplicate it.

## Change

Replace the body with a 3-line pointer to `wiki/dependencies/pnpm-audit.md` (which already covers the policy, noise-scoping filters, baseline allowlist, and acting-on-output at higher fidelity). The unique cross-link to `.claude/agents/code-review-audit.md` is preserved.

Net: 2 insertions, 19 deletions.

## Audit

Entire diff is within `.claude/` (out of audit scope) — the PR Merge Workflow's out-of-scope bypass applies; no audit marker required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)