### PR TITLE
wiki: maintenance chain through 4568997

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "283683e9678c6b762891029d7438ec1f527b536a",
-  "last_evaluated_at": "2026-06-12T07:54:00Z",
+  "last_evaluated_sha": "05304c69fddd6e503cdd6af3ae41456a52d9d463",
+  "last_evaluated_at": "2026-06-12T12:18:40Z",
   "last_consolidated_sha": "3e090b14c0bdc9b6bcdce738833dde2d4e765e9d",
   "last_consolidated_at": "2026-06-10T18:23:05Z"
 }

--- a/wiki/concepts/Wiki Sync.md
+++ b/wiki/concepts/Wiki Sync.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-03
-updated: 2026-06-05
+updated: 2026-06-12
 tags: [concept, claude, workflow, wiki]
 ---
 
@@ -80,6 +80,8 @@ For each commit since `last_evaluated_sha`:
    3b. **Fabrication guard.** Before advancing state, asserts every WORTHY edit was actually written to disk: a per-path porcelain check confirms each claimed page shows as changed or created, and a broader content-change check confirms at least one wiki content file is modified when the WORTHY set is non-empty. Any failure aborts the run before state advances, leaving `last_evaluated_sha` unchanged so the next sync re-evaluates the same range.
 4. **Advance state** to current HEAD.
 5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`. The landing strategy is branch-aware: on `main` (push-protected), it creates `wiki/sync-YYYY-MM-DD`, pushes, opens a PR, and squash-merges; on any other branch (feature/fix/release/worktree), it commits in place so the maintainer's working state isn't fragmented.
+
+When invoked as part of the no-arg `/gaia-wiki` full chain, `gaia wiki chain begin` pre-cuts the branch before sync runs, so this same step commits in place rather than opening its own PR. `gaia wiki chain finish` opens one PR covering all stage commits (sync, consolidate, lint) at the end of the chain. Standalone `/gaia-wiki sync` is unaffected: it still self-lands via `sync land --branch-aware`.
 
 `sync land` uses `git status --porcelain=v1` to inspect the working tree. Git wraps paths containing spaces or special characters in double quotes; the CLI strips that quoting before classifying paths as wiki or non-wiki changes. Nearly every GAIA wiki page has a space in its filename, so this normalization is required for `sync land` to recognize wiki edits and proceed.
 

--- a/wiki/decisions/Wiki Management.md
+++ b/wiki/decisions/Wiki Management.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-05-07
 created: 2026-05-07
-updated: 2026-06-02
+updated: 2026-06-12
 tags: [decision, wiki, cli]
 ---
 
@@ -33,6 +33,14 @@ The wiki is critical infrastructure; it decays when drift between code and docum
 **`gaia wiki dead-paths`**: Lists backticked repo paths in `wiki/` body prose that don't exist on disk. Used by `/gaia-wiki lint` to catch zombie filename references after merges and renames.
 
 **`gaia wiki sync land`**: Branch-aware landing of staged wiki changes: commits in place on a feature branch; on `main`, stages a branch and opens a PR. Used by `/gaia-wiki sync` as the deterministic write step.
+
+**`gaia wiki chain <begin|commit|finish>`**: Manages the branch lifecycle for the `/gaia-wiki` full chain so all stages (sync, consolidate, lint) land in one PR rather than opening separate PRs.
+
+- `begin` (before sync): cuts a `wiki-sync/<date>-<sha>` branch from `main`; no-op on a feature branch, where stages commit in place.
+- `commit` (after each stage): commits that stage's `wiki/` changes in place; gracefully no-ops when nothing changed; refuses non-wiki changes.
+- `finish` (after lint): pushes the branch, opens one PR for all stage commits, enables auto-merge, then returns to base. Drops the branch if it is empty. Leaves an aborted dirty tree in place for review. No-op for in-place runs on a feature branch.
+
+Standalone `/gaia-wiki sync`, `/gaia-wiki consolidate`, and `/gaia-wiki lint` are unaffected; the chain commands are invoked only by the no-arg `/gaia-wiki` full-chain wrapper.
 
 ## State file
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,10 @@ tags: [meta, log]
 
 ## [v1.6.0] 2026-06-11 | Released
 
+- 2026-06-12 e76dcea SKIP - wiki: self-referential sync result commit
+- 2026-06-12 6b6c146 SKIP - wiki: self-referential sync+lint result commit
+- 2026-06-12 5633b5e WORTHY - feat(gaia-wiki): adds gaia wiki chain begin|commit|finish CLI subcommand; documented in wiki/decisions/Wiki Management.md and wiki/concepts/Wiki Sync.md
+- 2026-06-12 05304c6 SKIP - refactor(.claude/rules/dep-audit.md) to wiki pointer only; no new wiki content, canonical wiki/dependencies/pnpm-audit.md unchanged
 - 2026-06-12 4045c41 SKIP - wiki: self-referential
 - 2026-06-12 9daa0d6 SKIP - chore: generic chore
 - 2026-06-12 3602248 SKIP - fix(audit): hooks-only change; no wiki page covers the audit-stamp dirty-check implementation

--- a/wiki/meta/lint-report-2026-06-12.md
+++ b/wiki/meta/lint-report-2026-06-12.md
@@ -11,7 +11,7 @@ status: developing
 
 ## #11: Wiki drift check
 
-ℹ 1 commits behind HEAD. Run /gaia-wiki sync at next opportunity.
+ℹ 1 commit behind HEAD. Run /gaia-wiki sync at next opportunity.
 
 ## #12: Dead repo-relative paths
 


### PR DESCRIPTION
Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via `gaia wiki chain finish`.