### PR TITLE
wiki: sync through 35e1d7e

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "05304c69fddd6e503cdd6af3ae41456a52d9d463",
-  "last_evaluated_at": "2026-06-12T12:18:40Z",
+  "last_evaluated_sha": "35e1d7ebde45dae16d8fb78087fe6c8b5c922b47",
+  "last_evaluated_at": "2026-06-12T12:33:26Z",
   "last_consolidated_sha": "3e090b14c0bdc9b6bcdce738833dde2d4e765e9d",
   "last_consolidated_at": "2026-06-10T18:23:05Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [v1.6.0] 2026-06-11 | Released
 
+- 2026-06-12 35e1d7e SKIP - wiki: self-referential (squash-merge of maintenance chain PR #381)
 - 2026-06-12 e76dcea SKIP - wiki: self-referential sync result commit
 - 2026-06-12 6b6c146 SKIP - wiki: self-referential sync+lint result commit
 - 2026-06-12 5633b5e WORTHY - feat(gaia-wiki): adds gaia wiki chain begin|commit|finish CLI subcommand; documented in wiki/decisions/Wiki Management.md and wiki/concepts/Wiki Sync.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 35e1d7e.