### PR TITLE
fix(release): allowlist audit-workflow path constant in runtime-deps

### DIFF
--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20118,7 +20118,8 @@ var RUNTIME_MARKERS = /* @__PURE__ */ new Set([
 ]);
 var PATH_PREFIXES = [".gaia/", ".claude/", ".specify/", ".github/"];
 var PROSE_PATH_ALLOWLIST = /* @__PURE__ */ new Set([
-  ".github/workflows"
+  ".github/workflows",
+  ".github/workflows/code-review-audit.yml"
 ]);
 var PATH_BODY_CHAR = /[a-zA-Z0-9._/-]/;
 var stripCommentSuffix = (line) => {

--- a/.gaia/cli/src/release/runtime-deps.test.ts
+++ b/.gaia/cli/src/release/runtime-deps.test.ts
@@ -158,6 +158,20 @@ describe('extractPathRefs', () => {
     );
     expect(refs.map((r) => r.path)).toContain('.github/workflows/deploy.yml');
   });
+
+  test('skips the allowlisted audit-workflow path constant', () => {
+    // pr-merge-audit-check.sh's check_self_mod_only_update_pr() assigns the
+    // audit workflow path to compare against the PR diff and template blob; it
+    // never sources or executes the file. The path is release-excluded, so the
+    // exact full-path token is allowlisted as a non-dependency.
+    const refs = extractPathRefs(
+      '.claude/hooks/pr-merge-audit-check.sh',
+      'audit_wf=".github/workflows/code-review-audit.yml"\n'
+    );
+    expect(refs.map((r) => r.path)).not.toContain(
+      '.github/workflows/code-review-audit.yml'
+    );
+  });
 });
 
 describe('release runtime-deps CLI', () => {

--- a/.gaia/cli/src/release/runtime-deps.ts
+++ b/.gaia/cli/src/release/runtime-deps.ts
@@ -102,17 +102,19 @@ const RUNTIME_MARKERS: ReadonlySet<string> = new Set([
 const PATH_PREFIXES = ['.gaia/', '.claude/', '.specify/', '.github/'] as const;
 
 /**
- * Bare-directory tokens that surface only as prose inside shipped scripts,
- * user-facing error text and help strings that name an in-scope directory as
- * an example path. They are descriptive, never sourced or invoked, so they
- * are not runtime dependencies and must not be reported as leaks.
+ * Path tokens referenced inside shipped scripts that are NOT runtime
+ * dependencies, so they must not be reported as leaks. Two categories:
+ * descriptive prose (an in-scope directory named as an example in
+ * operator-facing error/help text), and path constants the script feeds to
+ * git plumbing (`git diff`, `git cat-file`) rather than sourcing or invoking,
+ * which resolve to a benign "absent" branch when the file is not installed.
  *
  * Entries are exact, fully-qualified tokens (the trimmed output of
  * `extractPathRefs`). Exact-match is deliberate: allowlisting
  * `.github/workflows` does NOT suppress a genuine leak to a file under it,
  * `.github/workflows/foo.yml` is a distinct, longer token that still flags.
- * This is the documented channel for prose false-positives, add the exact
- * token plus a justification rather than reword the operator-facing prose.
+ * This is the documented channel for false-positives, add the exact token
+ * plus a justification rather than reword the reference.
  *
  *   - `.github/workflows`: named in `.claude/hooks/pr-merge-audit-check.sh`'s
  *     merge-gate error message as an example in-scope path, alongside `app/`,
@@ -120,9 +122,17 @@ const PATH_PREFIXES = ['.gaia/', '.claude/', '.specify/', '.github/'] as const;
  *     descriptive, not an invocation. An inline-ignore comment cannot annotate
  *     the occurrence because it lives inside a multi-line quoted `reason="..."`
  *     string that renders to the operator, hence this central allowlist.
+ *   - `.github/workflows/code-review-audit.yml`: the workflow path constant in
+ *     the same hook's `check_self_mod_only_update_pr()` bypass. It is compared
+ *     against the PR's changed-file list and against the bundled template's
+ *     git blob; it is never sourced or executed. The file is release-excluded
+ *     (installed on demand by `/setup-gaia-ci`), and when absent on an adopter
+ *     clone the path simply never appears in the diff, so the bypass returns
+ *     the normal deny. A path constant, not a runtime dependency.
  */
 const PROSE_PATH_ALLOWLIST: ReadonlySet<string> = new Set([
   '.github/workflows',
+  '.github/workflows/code-review-audit.yml',
 ]);
 
 const PATH_BODY_CHAR = /[a-zA-Z0-9._/-]/;


### PR DESCRIPTION
## Problem

`release.yml` for v1.6.1 failed at the **Verify runtime dependencies** gate:

```
runtime-dependency leaks (1):
  .claude/hooks/pr-merge-audit-check.sh:294  .github/workflows/code-review-audit.yml
```

The `check_self_mod_only_update_pr()` bypass added this release cycle assigns the audit-workflow path to a variable for `git diff` / blob comparisons. That workflow path is release-excluded, so the leak-checker flagged the string constant.

## Why it is safe

The path is fed to git plumbing, never sourced or executed. When the workflow is absent on an adopter clone, the path simply never appears in the PR diff and the bypass returns the normal deny. It is a path constant, not a runtime dependency.

## Fix

Add the exact full-path token to `PROSE_PATH_ALLOWLIST` in `runtime-deps.ts` (the checker's documented channel for non-dependency references), with justification, plus a regression test. Rebuild the maintainer binary so `release.yml` (which runs the committed binary) sees the fix.

Verified locally: CLI typecheck clean, 20/20 runtime-deps tests pass, `release runtime-deps` reports no leaks. Scope is `.gaia/cli/` only; the adopter tarball is unaffected (the maintainer binary is release-excluded).

This unblocks the v1.6.1 `release.yml` re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)