### PR TITLE
feat(wiki): restore hot cache after compaction via GAIA-owned hooks

### DIFF
--- a/.claude/hooks/wiki-recompact-inject.sh
+++ b/.claude/hooks/wiki-recompact-inject.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# GAIA-owned wiki hook. Pairs with wiki-recompact-sentinel.sh (PostCompact).
+#
+# On the first UserPromptSubmit after a context compaction, re-inject
+# wiki/hot.md into context (a UserPromptSubmit hook's stdout is added to the
+# model's context, the same mechanism wiki-drift-check.sh relies on) and clear
+# the sentinel so it fires exactly once per compaction.
+#
+# Why: compaction drops hook-injected context, including the SessionStart hot
+# cache. This restores it deterministically, replacing the upstream prompt-type
+# PostCompact hook that some Claude Code builds reject. A no-op on every prompt
+# where no compaction has occurred (sentinel absent).
+
+set -euo pipefail
+
+# Best-effort: any internal failure exits 0. Never block prompt submission.
+trap 'exit 0' ERR
+
+sentinel=".claude/wiki-recompact-pending"
+[ -f "$sentinel" ] || exit 0
+
+# Consume the sentinel first: a single failed injection must not loop forever.
+rm -f "$sentinel"
+
+[ -f wiki/hot.md ] || exit 0
+
+printf '# Restored wiki hot cache after context compaction:\n\n'
+cat wiki/hot.md
+
+exit 0

--- a/.claude/hooks/wiki-recompact-sentinel.sh
+++ b/.claude/hooks/wiki-recompact-sentinel.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# GAIA-owned wiki hook. Upstream contract: claude-obsidian/hooks/hooks.json::PostCompact
+# (a prompt-type hook asking the model to silently re-read wiki/hot.md).
+#
+# Why GAIA overrides: prompt-type hooks are rejected on some Claude Code builds,
+# and even where valid they depend on the model choosing to act. This
+# command-type hook drops a sentinel instead; wiki-recompact-inject.sh
+# (UserPromptSubmit) re-injects hot.md deterministically on the next turn.
+#
+# Hook-injected context does not survive compaction, so the hot cache must be
+# restored afterward. PostCompact command hooks cannot inject their stdout into
+# context, hence the sentinel handoff to UserPromptSubmit. Pairs with
+# wiki-recompact-inject.sh; neither does anything without the other.
+
+set -euo pipefail
+
+# Best-effort: any internal failure exits 0. Never disrupt the compaction event.
+trap 'exit 0' ERR
+
+# Nothing to restore if there is no hot cache.
+[ -f wiki/hot.md ] || exit 0
+
+mkdir -p .claude
+: > .claude/wiki-recompact-pending
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,21 @@
           {
             "type": "command",
             "command": ".claude/hooks/wiki-drift-check.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/wiki-recompact-inject.sh"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/wiki-recompact-sentinel.sh"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage
 .claude/wiki-drift-checked
 .claude/wiki-safety-checked
 .claude/i18n-strings-checked
+.claude/wiki-recompact-pending
 
 # GAIA release/update working directories
 .gaia/cache

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -15,4 +15,4 @@ tags: [meta, cache]
 
 ## Active Threads
 
-- None.
+- claude-obsidian PostCompact hot-cache restore is now handled by GAIA's own hooks (`wiki-recompact-{sentinel,inject}.sh`, registered in `.claude/settings.json`), so it no longer depends on the plugin's prompt hook. Optional cleanup: `jq 'del(.hooks.PostCompact)'` on the plugin cache silences a cosmetic "prompt-type hooks not supported" error if one ever shows up.


### PR DESCRIPTION
## Summary

Makes the wiki hot cache survive context compaction with GAIA-owned hooks, independent of claude-obsidian's prompt-type `PostCompact` hook (which some Claude Code builds reject).

- `.claude/hooks/wiki-recompact-sentinel.sh` (PostCompact): drops a sentinel marker.
- `.claude/hooks/wiki-recompact-inject.sh` (UserPromptSubmit): re-injects `wiki/hot.md` on the next turn, then clears the sentinel so it fires exactly once per compaction.
- Registers both in `.claude/settings.json`; gitignores the runtime marker `.claude/wiki-recompact-pending`.

The upstream plugin's `PostCompact` hook is left in place; this replaces dependence on it, not the hook itself. Restoration now works regardless of whether that prompt hook is valid on a given Claude Code build.

## Testing

No source files touched, so the Quality Gate skips. Verified the pair end-to-end:
- no-op on normal prompts (sentinel absent),
- sentinel hook drops the marker on compaction,
- inject hook restores the hot cache on the next prompt and clears the marker,
- second prompt is a no-op (fires once per compaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)