### PR TITLE
fix(update-deps): re-resolve override toggles with pnpm dedupe

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -205,7 +205,7 @@ Each `.advisories` key is one advisory ID; this file is the set of advisories th
 Then, for each override key, one at a time, leaving every other `pnpm-workspace.yaml` setting untouched:
 
 1. Temporarily remove that single key from the `overrides:` map.
-2. Run `pnpm install`. If it exits non-zero, restore the key, note as **retained (install error)**, and move to the next key, do not diagnose the failure or run the tests below for this key.
+2. Run `pnpm dedupe`. A bare `pnpm install`, even `pnpm install --force`, short-circuits with "Already up to date" when only the `overrides:` map changed and leaves the lockfile untouched, so the toggle would not re-resolve and the test below would read the stale tree; `pnpm dedupe` performs a full install that re-resolves and applies the override change. See `wiki/dependencies/pnpm-overrides.md`. If it exits non-zero, restore the key, note as **retained (install error)**, and move to the next key, do not diagnose the failure or run the tests below for this key.
 3. **Peer-dep test:** run `pnpm ls 2>&1` and scan for peer-dep errors.
 4. **Security-floor test:** run `pnpm audit --json` and extract its advisory IDs the same way. Any ID present now but absent from `/tmp/audit-baseline.txt` means removing this override reintroduced a known vulnerability.
 
@@ -218,7 +218,9 @@ Then, for each override key, one at a time, leaving every other `pnpm-workspace.
    - Peer-dep errors **or** any newly introduced advisory → the override is load-bearing. Restore the key. Note as **retained** (record which test failed, and the advisory ID + package if it was the security-floor test).
    - Neither regressed → the override is obsolete. Leave it removed. Note as **removed**.
 
-Always `pnpm install` after each toggle. The security-floor test is **severity-agnostic on purpose**: an override is a deliberate maintainer artifact, so any advisory it was silencing, at any severity, is reason to keep it. This is intentionally stricter than the high/critical surfacing floor in `.claude/rules/dep-audit.md`: deciding whether to *delete a maintainer's pin* warrants more caution than deciding whether to *surface* an advisory for review. A maintainer who wants a pin gone removes it by hand.
+Always `pnpm dedupe` after each toggle, never a bare `pnpm install`, which cannot apply an overrides-only change. The security-floor test is **severity-agnostic on purpose**: an override is a deliberate maintainer artifact, so any advisory it was silencing, at any severity, is reason to keep it. This is intentionally stricter than the high/critical surfacing floor in `.claude/rules/dep-audit.md`: deciding whether to *delete a maintainer's pin* warrants more caution than deciding whether to *surface* an advisory for review. A maintainer who wants a pin gone removes it by hand.
+
+**After the toggle loop, assert the lockfile matches config.** Once every retained key is restored, the lockfile's top-level `overrides:` block must list exactly the keys present in the `overrides:` map in `pnpm-workspace.yaml`. Compare the two; on any drift (a config key missing from the lockfile block, or vice versa) the floor is unapplied, so run `pnpm dedupe` once more and re-run the quality gate. This assertion is the guarantee that the audit never leaves a stale, silently-disabled security floor. Note the tradeoff: `pnpm dedupe` re-optimizes the whole tree, so a single toggle can yield a wider lockfile diff than the one key it touched (it may also drop now-redundant transitives). That broader diff is expected, and correct, the alternative is an unapplied override.
 
 ### Wave A input
 
@@ -235,7 +237,7 @@ any, are handled by the orchestrator).
 1. Build install args. For each entry: if `is_pinned` use the exact target, else use `^<latest>`. Example: `pnpm add foo@1.2.3 bar@^4.5.0 ...`.
 2. Run the single `pnpm add` command.
 3. Run `pnpm ls 2>&1`. Scan for peer-dep errors.
-4. On error: try one targeted fix in the `overrides:` map in `pnpm-workspace.yaml` (e.g. add a `parent>child` pin), then `pnpm install` again.
+4. On error: try one targeted fix in the `overrides:` map in `pnpm-workspace.yaml` (e.g. add a `parent>child` pin), then `pnpm dedupe` to apply it, a bare `pnpm install` won't re-resolve an overrides-only change.
 5. If still failing: revert the offending packages (`pnpm add <pkg>@<previous>`) and log them as **skipped** with the reason.
 6. Run the quality gate (below). If it fails, revert the entire Wave A batch.
 
@@ -305,7 +307,7 @@ You are upgrading the `{GROUP}` dependency group from `{FROM}` to `{TO}`.
 2. **Install** the group, **from project root only**:
    - `storybook` group: run `pnpm dlx storybook@latest upgrade` (Storybook's own upgrade tool migrates config alongside the version bump).
    - All others: `pnpm add <pkg1>@<latest> <pkg2>@<latest> ...` for every group member present in root `package.json`.
-3. **Conflict check**: `pnpm ls 2>&1`. On peer-dep error, attempt one `overrides:` fix in `pnpm-workspace.yaml`. If still failing, revert the group and skip with reason.
+3. **Conflict check**: `pnpm ls 2>&1`. On peer-dep error, attempt one `overrides:` fix in `pnpm-workspace.yaml`, then `pnpm dedupe` to apply it, a bare `pnpm install` won't re-resolve an overrides-only change. If still failing, revert the group and skip with reason.
 4. **Apply breaking changes** within root scope: from the migration guide, identify code-affecting changes (renamed APIs, removed exports, config schema changes). Grep `app/`, `test/`, and root config files for affected patterns. Edit only files inside root scope.
 5. **Verify root `package.json` moved**: read root `package.json` and confirm every group member you bumped now shows the new version. If `pnpm add` did not change root's spec (e.g. the dep is declared in a sibling project's `package.json` and not actually consumed by root code), revert the install and report the package as **skipped, not a root dep**. The skill does not resolve cross-project declarations; the maintainer must clean up manually. If the dep is in root `package.json` but has zero call sites in root scope, that's a phantom declaration: bump it anyway so the version stays current, and add a one-line note `phantom: no call sites in root` to the breaking-changes report so the maintainer can investigate.
 6. **Quality gate**:
@@ -339,7 +341,7 @@ Report back: updated packages, breaking changes applied, any skipped reason, qua
 
 ## Phase 6: Post-update override audit
 
-For every override that was **retained** in Phase 0, repeat the full Phase 0 toggle test (both the peer-dep and the security-floor check, re-capturing a fresh advisory baseline against the now-updated tree) now that surrounding packages have moved. A version that landed in Wave A or Wave B may have resolved the original peer-dep conflict or carried the patched transitive dependency that made a security-floor pin obsolete. Run this as a **Haiku agent**.
+For every override that was **retained** in Phase 0, repeat the full Phase 0 toggle test (both the peer-dep and the security-floor check, re-capturing a fresh advisory baseline against the now-updated tree) now that surrounding packages have moved. A version that landed in Wave A or Wave B may have resolved the original peer-dep conflict or carried the patched transitive dependency that made a security-floor pin obsolete. The toggle test re-resolves with `pnpm dedupe`, never a bare `pnpm install`, exactly as in Phase 0. This is the last phase that mutates the `overrides:` map, so the lockfile settles here: close it with the same assertion Phase 0 runs, the lockfile's `overrides:` block must list exactly the keys in `pnpm-workspace.yaml`, repairing any drift with `pnpm dedupe` and re-running the quality gate. Run this as a **Haiku agent**.
 
 ## Phase 7: Final report
 

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -484,6 +484,7 @@
     "wiki/dependencies/MSW.md": "wiki-owned",
     "wiki/dependencies/Playwright.md": "wiki-owned",
     "wiki/dependencies/pnpm-audit.md": "wiki-owned",
+    "wiki/dependencies/pnpm-overrides.md": "wiki-owned",
     "wiki/dependencies/React Router 7.md": "wiki-owned",
     "wiki/dependencies/React Testing Library.md": "wiki-owned",
     "wiki/dependencies/react-icons.md": "wiki-owned",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Fixed
+
+- `/update-deps` override audit re-resolves with `pnpm dedupe` instead of `pnpm install` (which short-circuits "Already up to date" on an overrides-only change and could leave a security-floor override unapplied), and asserts the lockfile `overrides` block matches `pnpm-workspace.yaml` before finishing (#388)
+
 ## [1.6.1] - 2026-06-12
 
 ### Added

--- a/wiki/decisions/pnpm.md
+++ b/wiki/decisions/pnpm.md
@@ -39,7 +39,7 @@ Caret ranges (`^x.y.z`) are kept in `package.json`. The lockfile is the authorit
 
 ## Override audit
 
-Overrides drift. The `update-deps` skill's Phase 0 toggles each `overrides` key out, runs `pnpm install`, scans `pnpm ls` for peer-dep errors, and removes any override that is no longer needed. Phase 6 re-checks retained overrides after a wave updates surrounding packages.
+Overrides drift. The `update-deps` skill's Phase 0 toggles each `overrides` key out, re-resolves with `pnpm dedupe`, then runs two tests, `pnpm ls` for peer-dep errors and `pnpm audit` for reintroduced advisories, and removes only an override that regresses neither. Phase 6 re-checks retained overrides after a wave updates surrounding packages. The re-resolution primitive is `pnpm dedupe`, not `pnpm install`: an overrides-only change does not re-resolve under `pnpm install`, which short-circuits with "Already up to date" and leaves the floor unapplied. See [[pnpm-overrides]].
 
 ## Release-age-aware version selection
 

--- a/wiki/dependencies/pnpm-audit.md
+++ b/wiki/dependencies/pnpm-audit.md
@@ -40,7 +40,7 @@ This local check is read-only. GAIA CI's automation runs its own `pnpm audit` cr
 High/critical advisories surface in the audit's advisory bucket, never in Critical/Important/Suggestions (those are blocking tiers). They are **advisory, not blocking**, like knip's and react-doctor's; they never block the audit marker or [[PR Merge Workflow]]. Per surfaced advisory, the fix path is one of:
 
 1. **Bump**: a `patched_versions` range exists; update the dependency to a patched version.
-2. **Override**: no patched range and the advisory is transitive; pin a safe version via a `pnpm.overrides` entry.
+2. **Override**: no patched range and the advisory is transitive; pin a safe version via an `overrides` entry in `pnpm-workspace.yaml`. Apply it with `pnpm dedupe`, not `pnpm install`, which does not re-resolve an overrides-only change; see [[pnpm-overrides]].
 3. **Acknowledge**: unfixable for now; add the advisory `id` to `.gaia/local/dep-audit-baseline.json` so it is suppressed (count-only) on later reviews.
 
-See [[Code Review Audit Agent]], [[PR Merge Workflow]], [[Quality Gate]].
+See [[Code Review Audit Agent]], [[PR Merge Workflow]], [[Quality Gate]], [[pnpm-overrides]].

--- a/wiki/dependencies/pnpm-overrides.md
+++ b/wiki/dependencies/pnpm-overrides.md
@@ -1,0 +1,48 @@
+---
+type: dependency
+status: active
+package: pnpm
+role: override-application-gotcha
+created: 2026-06-22
+updated: 2026-06-22
+tags: [dependency, pnpm, overrides, security, lockfile]
+---
+
+# pnpm-overrides
+
+The `overrides:` map in `pnpm-workspace.yaml` pins transitive dependency versions, most often to enforce a **security floor**: hold a transitive at or above a patched version to clear a known advisory. A change to that map only takes effect once it reaches `pnpm-lock.yaml` as a top-level `overrides:` block. The gotcha is which command writes it.
+
+## The gotcha
+
+`pnpm install` does **not** re-resolve when only the `overrides:` map changed. It short-circuits with `Already up to date` and leaves the lockfile byte-for-byte unchanged. `pnpm install --force` behaves the same: it re-links `node_modules` but still does not re-resolve an overrides-only edit. The result is silent: the config declares a floor, the lockfile carries no `overrides:` block, and the vulnerable transitive resolves anyway.
+
+`pnpm dedupe` is the reliable primitive. It performs a full install that re-resolves the graph, writes the `overrides:` block into the lockfile, applies the pin, and drops any now-redundant duplicate that the override made unreachable. Regenerating the lockfile from scratch (delete `pnpm-lock.yaml`, then `pnpm install`) also re-resolves, but `pnpm dedupe` is the targeted, non-destructive choice.
+
+## Verify a floor is applied
+
+A floor is applied only when both hold:
+
+1. The lockfile's top-level `overrides:` block lists every key from the `overrides:` map in `pnpm-workspace.yaml`.
+
+   ```bash
+   # the block must exist and match config
+   grep -A20 '^overrides:' pnpm-lock.yaml
+   ```
+
+2. No version below the floor survives in the tree.
+
+   ```bash
+   pnpm why qs        # every path resolves to the pinned floor, no older copy
+   ```
+
+If the config declares a key the lockfile block omits, or `pnpm why` shows a version under the floor, the floor is unapplied: run `pnpm dedupe` and re-run the quality gate.
+
+## Tradeoff
+
+`pnpm dedupe` re-optimizes the entire tree, so applying one override can produce a wider lockfile diff than the single key warrants (it also removes transitives that deduplicate away). That broader diff is expected and correct, the alternative is an unapplied floor.
+
+## Where this bites
+
+The `update-deps` skill's override audit (Phase 0 and Phase 6) toggles each override key out, re-resolves, and tests whether removal regresses a peer dependency or reintroduces an advisory. If the toggle re-resolves with `pnpm install` instead of `pnpm dedupe`, the tree never moves: the audit reads a stale graph, its keep/remove decisions are unreliable, and a restored key can be left unapplied, silently disabling the floor it was meant to enforce. The audit re-resolves with `pnpm dedupe` for exactly this reason, and asserts the lockfile `overrides:` block matches config before it finishes.
+
+See [[pnpm]], [[pnpm-audit]].

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -81,6 +81,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[gaia-lint]]
 - [[knip]]
 - [[pnpm-audit]]: dependency-CVE advisory oracle (`pnpm audit --json`); read-only, advisory, baseline-scoped.
+- [[pnpm-overrides]]: applying `overrides`/security-floor changes needs `pnpm dedupe`; `pnpm install` short-circuits "Already up to date".
 - [[Vitest]]
 - [[React Testing Library]]
 - [[Playwright]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -9,6 +9,10 @@ tags: [meta, log]
 
 # Log
 
+## [Unreleased]
+
+- `/update-deps` override audit re-resolves with `pnpm dedupe`, not `pnpm install` (which short-circuits "Already up to date" on an overrides-only change and leaves a security floor unapplied), and now asserts the lockfile `overrides:` block matches `pnpm-workspace.yaml` before finishing. New page [[pnpm-overrides]] documents the gotcha; [[pnpm-audit]] and [[pnpm]] cross-link it.
+
 ## [v1.6.1] 2026-06-12 | Released
 
 See CHANGELOG.md for details.


### PR DESCRIPTION
## The bug

The `/update-deps` override audit edits the `overrides:` map in `pnpm-workspace.yaml` and then re-resolves with a bare `pnpm install` to apply and test each toggle (Phase 0, Phase 6, and the Wave A/B targeted override fixes). But a plain `pnpm install`, even `pnpm install --force`, does **not** re-resolve when only the overrides map changed. It short-circuits with `Already up to date` and leaves the lockfile byte-for-byte unchanged.

Net effect: after the audit toggles and restores an override key, the lockfile can be left with **no** `overrides:` block, so the override never applies, silently disabling a security floor. Worse, because the toggle never re-resolves, the audit's keep/remove **decisions** read a stale tree: a load-bearing override could be marked obsolete, or a dead one retained.

## Root cause (confirmed, pnpm 11.5.2, this repo)

Reproduced against the live repo state, where `pnpm-workspace.yaml` declares the `'qs': '>=6.15.2'` security floor (express pulls a vulnerable `qs` via GHSA-q8mj-m7cp-5q26, a DoS) but the lockfile carried no `overrides:` block:

- The lockfile had both `qs@6.14.2` (vulnerable) and `qs@6.15.2`. A global `qs` floor makes the lower copy impossible, proving the floor was unapplied.
- `pnpm install` -> `Already up to date` in ~200ms, **zero** lockfile change.
- `pnpm install --force` -> same, `Already up to date`, **zero** change.
- `pnpm dedupe` -> re-resolved, wrote `overrides:` with `qs: '>=6.15.2'` into the lockfile, removed `qs@6.14.2`, kept `qs@6.15.2`.

Doc citation: pnpm's docs describe `pnpm dedupe` as a command that "performs an install, removing older dependencies in the lockfile if a newer version can be used" (`https://pnpm.io/cli/dedupe`). It is the re-resolution primitive; a bare `install` is not.

## The fix

- Replace the override-toggle re-resolution command with `pnpm dedupe` in **Phase 0**, **Phase 6**, and the **Wave A / Wave B** targeted override fixes. The audit's two-test logic (peer-dep test + security-floor advisory-diff test) is unchanged; only the re-resolution command moves.
- Add a closing assertion: after the audit restores all retained overrides, the lockfile's `overrides:` block must list exactly the keys in `pnpm-workspace.yaml`; on drift, repair with `pnpm dedupe` and re-run the quality gate. This guarantees the skill never leaves a stale, unapplied floor.
- Document the `pnpm dedupe` side effect (it re-optimizes the whole tree, so the diff can be broader than the one key) in the skill text and the wiki page.

## The wiki note

New page `wiki/dependencies/pnpm-overrides.md`: the install-vs-dedupe override-application gotcha, how to verify a floor is applied (lockfile `overrides:` block matches config; `pnpm why <pkg>`), and that the `/update-deps` audit depends on this. Added to `wiki/index.md`, cross-linked from `pnpm-audit.md`, and the stale primitive named in the `pnpm` decision page prose is corrected to point here. `wiki/log.md` and `CHANGELOG.md` (Unreleased / Fixed) updated; `.gaia/manifest.json` records the new page as `wiki-owned`.

## How I verified

- Live reproduction above (install + `--force` no-op; `pnpm dedupe` applies the floor and removes the vulnerable copy).
- The reproduction's lockfile mutation was reverted; this branch carries **only** the skill + wiki changes (no lockfile change).
- Wiki-style audit (no UAT/SPEC refs, no historical phrasing) and the absolute-path audit both clean.
- Quality Gate correctly skips: no staged `.ts/.tsx/.js/.jsx/.css` or gate-affecting config.

## Out of scope (flagged for follow-up)

The live lockfile in this repo currently has the `qs` floor **unapplied** (the very symptom this fix prevents going forward). Repairing it is a one-line re-resolution (`pnpm dedupe`) that produces a real lockfile/deps diff, so it belongs in its own deps PR rather than this docs/skill change. Recommend running `pnpm dedupe` (or letting the fixed `/update-deps` audit do it) to restore the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
