### PR TITLE
docs(typescript): point Zod work at official LLM docs over stale memory

### DIFF
--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -77,4 +77,4 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 
 - **`z.literal([...])` not `z.enum()`** for string unions, sort values alphanumerically
 
-Read `references/zod.md` for the full Zod 3 → Zod 4 migration map (`z.strictObject`, top-level string formats, `z.record` arity, function and error shapes).
+Read `references/zod.md` for the full Zod 3 → Zod 4 migration map (`z.strictObject`, top-level string formats, `z.record` arity, function and error shapes). It opens with a standing directive to verify uncertain or suspect Zod forms against the official docs (WebFetched, auto-discovered from `node_modules/zod/package.json`) rather than trusting v3-era memory.

--- a/.claude/skills/typescript/references/zod.md
+++ b/.claude/skills/typescript/references/zod.md
@@ -1,5 +1,22 @@
 # Zod 4, Zod 3 → Zod 4 Migration Map
 
+## Authoritative source, consult before judging a schema
+
+Zod 4 reworked the API heavily from v3, and most v3 forms still type-check, so training memory is an unreliable guide here: it is easy to "correct" valid v4 code back into deprecated v3 code, or to reject a valid form as invalid. The array union `z.literal(['a', 'b'])` in the migration map below is real Zod 4, not a mistake. So before writing a schema you are unsure of, and especially before flagging or rewriting an existing Zod form as wrong, verify it against the installed Zod's official docs and treat them as authoritative over memory.
+
+The docs are hosted, and the package advertises their URLs through the `package.json` auto-discovery convention. Read the URL from the installed package rather than hardcoding it:
+
+```bash
+node -p "require('./node_modules/zod/package.json').llmsFull"  # https://zod.dev/llms-full.txt, full concatenated docs
+node -p "require('./node_modules/zod/package.json').llms"      # https://zod.dev/llms.txt, curated index
+```
+
+WebFetch that URL with a specific question instead of reading it into context. The full doc is ~65k tokens, but WebFetch distills it through a side model and returns only the answer, so context pays for the answer, not the doc. Ask for the exact signature and request a verbatim quote (e.g. "quote the exact `z.literal` signature for multiple values"). When the topic is unclear, WebFetch the smaller index first to find the right page. If the fields are absent, fall back to `https://zod.dev/llms-full.txt`.
+
+Version caveat: these hosted docs track the latest published Zod, not the installed one, so confirm the installed major matches before trusting them with `node -p "require('./node_modules/zod/package.json').version"`. If the project is ever pinned behind what zod.dev serves, the docs run ahead of the installed API and the memory-versus-reality problem returns.
+
+## Migration map
+
 This project uses Zod 4. Several Zod 3 forms still type-check and lint clean, so nothing flags them until runtime or a `react-doctor` scan. Default to the Zod 4 form in every schema.
 
 | Zod 3, avoid                             | Zod 4, use                            |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ## [Unreleased]
 
+### Added
+
+- point Zod schema work at Zod's official LLM docs, auto-discovered from `node_modules/zod/package.json` (`llmsFull`/`llms`), and treat them as authoritative over training memory so valid Zod 4 forms are not rejected from stale v3 recollection
+
 ### Fixed
 
 - `/update-deps` override audit re-resolves with `pnpm dedupe` instead of `pnpm install` (which short-circuits "Already up to date" on an overrides-only change and could leave a security-floor override unapplied), and asserts the lockfile `overrides` block matches `pnpm-workspace.yaml` before finishing (#388)


### PR DESCRIPTION
## Why

Zod 4 reworked the API heavily from v3, and most v3 forms still type-check, so training memory is an unreliable guide: a session will confidently "correct" valid v4 code back into deprecated v3, or reject a valid form as invalid (the original trigger: insisting the v4 `z.literal(['a', 'b'])` array union is wrong because it remembers v3 `z.enum`).

## What

A standing directive at the top of the typescript skill's Zod reference (`references/zod.md`), with a one-line pointer from `SKILL.md`:

- **Targets the failure mode, not every schema.** Fires at the dangerous moment, before flagging or rewriting a Zod form as wrong, or when unsure of v4 syntax, rather than a blanket "every schema."
- **Auto-discovery, not a hardcoded URL.** Reads the docs URL from `node_modules/zod/package.json` (`llmsFull`/`llms`), so it tracks the installed package rather than rotting in prose.
- **WebFetch, not a local cache.** A targeted WebFetch distills the ~65k-token doc through a side model and returns only the answer, so the main context pays for the answer, not the doc. (We considered downloading + version-syncing the docs locally and rejected it: reading a local copy wholesale costs the full 65k tokens every consult, and zod.dev only ever serves the latest published version, so a local cache can't be pinned to an older installed major.)
- **Version caveat retained.** Hosted docs track the latest published Zod, not the installed one; confirm the installed major matches before trusting them.

## Where it lives, and why a skill not a rule

GAIA scopes **rules** by path glob (the React Router docs rule works because RR code lives in bounded paths). Zod schemas have no clean path boundary (forms, env parsing, services, API edges), so a `paths:` rule would over- or under-match. The `typescript` skill already triggers on "using Zod schemas" and already routes to `references/zod.md`, so the reference is the activation path already wired for Zod work.

## Verification

- `node_modules/zod/package.json` exposes `llms`/`llmsFull`; installed `4.4.3` (major 4).
- `https://zod.dev/llms-full.txt` resolves, is Zod 4, and shows the `z.literal([...])` array form.
- Auto-discovery command runs as written from the project root.
- Markdown-only change: instruction-files path audit clean (repo-relative paths), no em dashes, Quality Gate has nothing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)