### PR TITLE
fix(audit-ci): stop self-heal from committing claude-code-action's PR-file restore

### DIFF
--- a/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/src/automation/templates/workflows/code-review-audit.yml.tmpl
@@ -376,6 +376,24 @@ jobs:
           git config user.name 'gaia-code-review-audit[bot]'
           git config user.email 'gaia-code-review-audit[bot]@users.noreply.github.com'
 
+          # Drop claude-code-action's untrusted-PR file restore before the tree
+          # is inspected or staged. The action restores a fixed set of sensitive
+          # config/hook paths from origin/main into the runner's working tree
+          # before the agent runs (it logs "Restoring ... from origin/main (PR
+          # head is untrusted)"). When this PR legitimately modifies one of them,
+          # that restore REVERTS the PR's change in the working tree; the
+          # `git add -u` below would then stage the revert and commit it as a
+          # bogus self-heal -- this is what stripped a .husky/pre-commit guard a
+          # PR had just added. The agent is never an allowed editor of these
+          # convention/hook surfaces, so any working-tree delta on them is either
+          # the action's restore or a forbidden edit; reset each to HEAD either
+          # way. Keep this list in sync with claude-code-action's restore set.
+          for restored_path in \
+            .husky .mcp.json .claude.json .gitmodules .ripgreprc \
+            CLAUDE.md CLAUDE.local.md; do
+            git checkout HEAD -- "$restored_path" 2>/dev/null || true
+          done
+
           # Surface untracked files for transparency. The agent or
           # claude-code-action may leave runtime artifacts (e.g. .claude-pr/)
           # behind; .gitignore should cover known cases. We never stage them.

--- a/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
+++ b/.gaia/cli/templates/workflows/code-review-audit.yml.tmpl
@@ -376,6 +376,24 @@ jobs:
           git config user.name 'gaia-code-review-audit[bot]'
           git config user.email 'gaia-code-review-audit[bot]@users.noreply.github.com'
 
+          # Drop claude-code-action's untrusted-PR file restore before the tree
+          # is inspected or staged. The action restores a fixed set of sensitive
+          # config/hook paths from origin/main into the runner's working tree
+          # before the agent runs (it logs "Restoring ... from origin/main (PR
+          # head is untrusted)"). When this PR legitimately modifies one of them,
+          # that restore REVERTS the PR's change in the working tree; the
+          # `git add -u` below would then stage the revert and commit it as a
+          # bogus self-heal -- this is what stripped a .husky/pre-commit guard a
+          # PR had just added. The agent is never an allowed editor of these
+          # convention/hook surfaces, so any working-tree delta on them is either
+          # the action's restore or a forbidden edit; reset each to HEAD either
+          # way. Keep this list in sync with claude-code-action's restore set.
+          for restored_path in \
+            .husky .mcp.json .claude.json .gitmodules .ripgreprc \
+            CLAUDE.md CLAUDE.local.md; do
+            git checkout HEAD -- "$restored_path" 2>/dev/null || true
+          done
+
           # Surface untracked files for transparency. The agent or
           # claude-code-action may leave runtime artifacts (e.g. .claude-pr/)
           # behind; .gitignore should cover known cases. We never stage them.

--- a/.github/workflows/code-review-audit.yml
+++ b/.github/workflows/code-review-audit.yml
@@ -376,6 +376,24 @@ jobs:
           git config user.name 'gaia-code-review-audit[bot]'
           git config user.email 'gaia-code-review-audit[bot]@users.noreply.github.com'
 
+          # Drop claude-code-action's untrusted-PR file restore before the tree
+          # is inspected or staged. The action restores a fixed set of sensitive
+          # config/hook paths from origin/main into the runner's working tree
+          # before the agent runs (it logs "Restoring ... from origin/main (PR
+          # head is untrusted)"). When this PR legitimately modifies one of them,
+          # that restore REVERTS the PR's change in the working tree; the
+          # `git add -u` below would then stage the revert and commit it as a
+          # bogus self-heal -- this is what stripped a .husky/pre-commit guard a
+          # PR had just added. The agent is never an allowed editor of these
+          # convention/hook surfaces, so any working-tree delta on them is either
+          # the action's restore or a forbidden edit; reset each to HEAD either
+          # way. Keep this list in sync with claude-code-action's restore set.
+          for restored_path in \
+            .husky .mcp.json .claude.json .gitmodules .ripgreprc \
+            CLAUDE.md CLAUDE.local.md; do
+            git checkout HEAD -- "$restored_path" 2>/dev/null || true
+          done
+
           # Surface untracked files for transparency. The agent or
           # claude-code-action may leave runtime artifacts (e.g. .claude-pr/)
           # behind; .gitignore should cover known cases. We never stage them.


### PR DESCRIPTION
## Root cause

The `code-review-audit` **Commit and push self-heal** step ran `git add -u` and committed *any* dirty tracked file as a self-heal, with no check on what dirtied the tree.

`claude-code-action`'s untrusted-PR hardening restores a fixed set of sensitive config/hook paths from `origin/main` into the runner's working tree **before the agent runs** (it logs `Restoring .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc, CLAUDE.md, CLAUDE.local.md, .husky from origin/main (PR head is untrusted)`). When a PR legitimately modifies one of those paths, the restore **reverts the PR's change in the working tree**, and the self-heal step then commits the revert.

### Concrete incident (PR #394)

- `4845cfa` added an 11-line duplicate-config guard to `.husky/pre-commit`.
- The audit on `4845cfa` reported **zero findings** and explicitly praised the guard.
- claude-code-action restored `.husky` from `origin/main` (which predates the guard), reverting `.husky/pre-commit` in the working tree.
- `git add -u` staged that revert; commit `4ce82eb` ("chore: code-review-audit self-heal") deleted the guard and pushed it.

### Why the prior fix (#159) didn't catch it

The #159 guard is **prompt-level only** — it tells the *agent* not to restore intentionally removed lines. Here the agent made no edit at all; the action's restore plus the workflow's blind `git add -u` did the damage, in the **opposite direction** (PR *added* lines, the working tree *lost* them). The `git add -u` staging path had no guard for that.

## Fix

Before the tree is inspected or staged, reset claude-code-action's restore set to HEAD. The agent is never an allowed editor of these convention/hook surfaces, so any working-tree delta on them is either the action's restore or a forbidden edit — resetting to HEAD is correct either way.

Applied to the live workflow and **both** template copies; the `audit-template-dogfood` drift-guard enforces byte-identity across all three.

## Verification

- `audit-template-dogfood` drift-guard: byte-identity across all 3 copies ✅
- Full CLI suite (`automation` + `setup-ci` + `runtime-deps`): 293 tests pass ✅
- YAML parse + shell-syntax of the inserted loop ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)