### PR TITLE
docs(skills): add harden efficacy lens (Axis 3) and react-code platform-first ladder

### DIFF
--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -76,6 +76,14 @@ Inspect the `finding_class` prefix and the pattern's nature:
 
 When a pattern is mechanizable, the recommendation is the deterministic check, not a skill and not a prose rule.
 
+### Axis 3, will it earn its weight (efficacy lens)
+
+A recurring finding proves the problem is real, the cost of NOT acting. It does not prove the chosen guidance will fix it. Before presenting, ask one question: **what cheap evidence would show this form actually changes behavior, and can I get it?**
+
+Prose is the weakest form on this axis: it advises rather than enforces, a capable agent may already honor it or may rationalize past it, and it costs context on every matching task. A deterministic check enforces. So the efficacy lens reinforces Axis 2: when the pattern is mechanizable, prefer the check.
+
+The evidence bar is deliberately low, a couple of before/after task replays or a single reproduction of the agent ignoring vs following the guidance, never a benchmark. If the recommended form is prose and you cannot name even that cheap evidence (because it restates a principle a strong agent already honors, or the anti-pattern is judgment-laden and easy to talk past), say so in the rationale and surface **weak efficacy evidence, consider defer until it recurs again, or decline** in the action framing. Never auto-decline, the human owns the call; the lens sharpens the recommendation and the rationale, nothing more.
+
 ### Present and act
 
 For each candidate, present: the finding_class, its distinct-PR count and the PRs it recurred on, the recommended form, and the one-line rationale. Then offer the action set: **approve / decline / defer / redirect**.
@@ -174,4 +182,5 @@ Run `harden-tally`, find the candidate whose `finding_class` matches the argumen
 - A decline is machine-local only (gitignored ledger); it never vetoes the candidate for a teammate.
 - A defer persists nothing.
 - Recommend exactly one form per candidate, with rationale; check edit-vs-new first; bias to the lowest-context-weight form. Never reflexively author a prose rule.
+- Factor the efficacy lens (Axis 3) into the recommendation and rationale: a recurring finding proves the problem, not the fix. When the recommended form is prose and no cheap evidence shows it would change behavior, surface that as a defer/decline signal for the human, never as an auto-decline.
 - Do not read the privacy-sealed mentorship event store to make any of these decisions; this loop keys only on `finding_class` recurrence from the PR window.

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -7,6 +7,18 @@ description: Patterns and conventions for writing and editing React code, includ
 
 Write and edit React components, pages, routes, hooks, and forms following project conventions.
 
+## Reach for the Platform First
+
+Before installing a package or hand-rolling a primitive, walk this ladder and stop at the first hit:
+
+1. **Existing GAIA code**, a component, hook, or util already covers it (form inputs → Gate 2).
+2. **Web platform**, a browser API or native element does the job: `Intl` (dates, numbers, lists, plurals), `URL` / `URLSearchParams`, `crypto.randomUUID()`, `structuredClone()`, `AbortController`, native `Array` / `Object` methods, `<dialog>`, modern CSS (`:has()`, container queries).
+3. **Already-installed dependency**, check `package.json` before adding a sibling that does the same job.
+4. **New dependency**, only when 1-3 genuinely fall short; the added weight has to earn its place.
+5. **Custom code**, last resort, kept minimal.
+
+The largest real savings come from `Intl` over date/number-formatting libraries and native collection methods over `lodash`/`underscore` (already enforced by `you-dont-need-lodash-underscore`). Reaching for the platform replaces a needless dependency or bespoke widget; it never overrides accessibility, input validation, or an existing GAIA component (a wrapper exists for a reason).
+
 ## Pre-Flight Gates
 
 Most hook bugs come from misidentifying the type of problem being solved. Before writing or editing hooks, run through these gate, it only applies when the relevant pattern is present in your changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 
 ### Added
 
+- `react-code` skill leads with a platform-first ladder (existing GAIA code → web platform like `Intl`/`URL`/`crypto.randomUUID` → already-installed dep → new dep → custom code) to walk before adding a dependency or hand-rolling a primitive
+- `/gaia-harden` weighs an efficacy lens (Axis 3) before recommending a form: a recurring finding proves the problem, not the fix, so when the recommended form is prose and no cheap before/after evidence shows it would change behavior, that surfaces as a defer/decline signal for the human, never an auto-decline
 - point Zod schema work at Zod's official LLM docs, auto-discovered from `node_modules/zod/package.json` (`llmsFull`/`llms`), and treat them as authoritative over training memory so valid Zod 4 forms are not rejected from stale v3 recollection
 
 ### Fixed


### PR DESCRIPTION
Two skill-doc guidance additions, landed together (both are skill-doc guidance, unrelated in topic but same category).

## `.claude/skills/gaia/references/harden.md`

Adds an **"Axis 3, will it earn its weight (efficacy lens)"** section to the `/gaia-harden` reference. A recurring finding proves the problem is real (the cost of not acting) but not that the chosen form will fix it. Before presenting a candidate, ask what cheap evidence (a couple of before/after task replays) would show the form changes behavior. Prose is the weakest form on this axis: it advises rather than enforces, so the lens reinforces Axis 2 (mechanizable → deterministic check). When the recommended form is prose and no such evidence exists, surface "weak efficacy evidence, consider defer/decline" for the human, never an auto-decline. A matching bullet is added to the closing rules list.

## `.claude/skills/react-code/SKILL.md`

Adds a **"Reach for the Platform First"** section: a five-rung ladder to walk before adding a dependency or hand-rolling a primitive (existing GAIA code → web platform like `Intl`/`URL`/`crypto.randomUUID`/`structuredClone`/`AbortController` → already-installed dep → new dep → custom code). The biggest wins are `Intl` over date/number libraries and native collection methods over `lodash`/`underscore` (already enforced by `you-dont-need-lodash-underscore`). Reaching for the platform never overrides accessibility, input validation, or an existing GAIA component.

## Notes

- Markdown only; the Quality Gate has nothing to check (no staged `.ts/.tsx/.js/.css` or gate-affecting config) and skips.
- Repo-relative paths only, present-tense prose (harden.md is a reference doc), no em dashes.
- Two `## [Unreleased] → ### Added` CHANGELOG bullets, following the existing skill-doc-guidance precedent in that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)