### PR TITLE
docs(react-code): trigger the skill on dependency-vs-platform decisions

### DIFF
--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-code
-description: Patterns and conventions for writing and editing React code, including components and hooks. Use this skill whenever writing or reviewing React components, hooks (useEffect, useCallback, useState), event handlers, or component extraction decisions. Also trigger when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues.
+description: Patterns and conventions for writing and editing React code, including components and hooks. Use this skill whenever writing or reviewing React components, hooks (useEffect, useCallback, useState), event handlers, or component extraction decisions. Also trigger when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues, or when deciding whether to add a dependency, reach for a web-platform API (Intl, URL, crypto.randomUUID), or hand-roll a primitive.
 ---
 
 # React Code


### PR DESCRIPTION
Follow-up to #405. That PR added the **"Reach for the Platform First"** section to the `react-code` skill, but the skill's `description:` only triggers on authoring/reviewing components and hooks. So the new ladder would load when someone is *writing* React code, not when the actual decision, "should I add this dependency or use the platform?", is on the table.

This extends the description with that trigger: deciding whether to add a dependency, reach for a web-platform API (`Intl`, `URL`, `crypto.randomUUID`), or hand-roll a primitive. Single-line frontmatter change, matching the existing parenthetical style (no backticks in the description, same as the existing `(useEffect, useCallback, useState)`).

## Notes

- Frontmatter/markdown only; the Quality Gate has nothing to check and skips.
- No CHANGELOG entry: this tunes when already-shipped guidance loads, below the adopter-notable threshold (the platform-first ladder itself is already noted under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)