### PR TITLE
fix(deps): pin nested vite to >=7.3.5 (GHSA-fx2h-pf6j-xcff)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   qs: '>=6.15.2'
   undici: '>=7.28.0 <8'
+  vite@>=7.0.0 <7.3.5: '>=7.3.5 <8'
 
 importers:
 
@@ -978,7 +979,7 @@ packages:
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1461,7 +1462,7 @@ packages:
       react-router: ^7.17.0
       react-server-dom-webpack: ^19.2.3
       typescript: ^5.1.0 || ^6.0.0
-      vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
       wrangler: ^3.28.2 || ^4.0.0
     peerDependenciesMeta:
       '@react-router/serve':
@@ -1806,7 +1807,7 @@ packages:
     resolution: {integrity: sha512-UFtMIojDT61OWhc2ti0wf6pUNlBRLYixyygXXTolaCxdACum6SOgJim+mEZE4S3VuTaZgjTRNyoc0WSJPqjQ2g==}
     peerDependencies:
       storybook: ^10.4.5
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
 
   '@storybook/csf-plugin@10.4.5':
     resolution: {integrity: sha512-OsSsSLulBmdKTz7MIKLgoWADZB8bjYaAjZZy/THdI50G/TTd6FVSXQMCM7GO7xQZ/EguRY1PmjOVCLbgcnXsDA==}
@@ -1814,7 +1815,7 @@ packages:
       esbuild: '*'
       rollup: '*'
       storybook: ^10.4.5
-      vite: '*'
+      vite: '>=7.3.5 <8'
       webpack: '*'
     peerDependenciesMeta:
       esbuild:
@@ -1855,7 +1856,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.4.5
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
 
   '@storybook/react@10.4.5':
     resolution: {integrity: sha512-VMEqdjplKJTf8KA5ER9kJp51dOJKlgvb9H0F45RL1pX42+briPmTe8VL0yJR3GyMBpicFbFpjZ7AC22DgZ6vNg==}
@@ -1982,7 +1983,7 @@ packages:
   '@tailwindcss/vite@4.3.1':
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7 || ^8
+      vite: '>=7.3.5 <8'
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2330,7 +2331,7 @@ packages:
     resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -5367,8 +5368,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5466,7 +5467,7 @@ packages:
       '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.5 <8'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -10779,7 +10780,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10794,7 +10795,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,12 @@ overrides:
   'qs': '>=6.15.2'
   # security floor for jsdom/vitest-transitive undici (TLS bypass / WebSocket DoS / cross-origin routing); test-toolchain only, never shipped.
   'undici': '>=7.28.0 <8'
+  # Security floor: @react-router/dev>vite-node pulls a vite 7.3.x copy below
+  # 7.3.5 (GHSA-fx2h-pf6j-xcff, dev-server server.fs.deny bypass on Windows
+  # alternate paths). vite-node accepts only vite ^5||^6||^7, so the nested copy
+  # cannot move to 8; pin the vulnerable 7.x line to the patched 7.x. The
+  # top-level vite@8 falls outside this selector and is untouched.
+  'vite@>=7.0.0 <7.3.5': '>=7.3.5 <8'
 
 # Build-script approval. pnpm 11 replaces the onlyBuiltDependencies allowlist
 # with the allowBuilds map (true = the package may run install/build scripts).


### PR DESCRIPTION
## What
Pins the nested `vite` copy (pulled by `@react-router/dev → vite-node`) to `>=7.3.5`, closing the high-severity dev-server advisory **GHSA-fx2h-pf6j-xcff** (`server.fs.deny` bypass on Windows alternate paths).

## Why
`pnpm audit` flagged a transitive `vite@7.3.2` (vulnerable range `>=7.0.0 <=7.3.4`) via `@react-router/dev@7.17.0 → vite-node@3.2.4`. The top-level `vite@8.0.16` is unaffected. `vite-node@3.2.4` only accepts `vite ^5||^6||^7`, so the nested copy cannot move to 8; bumping `@react-router/dev` to 8.x is a major routing change out of scope for a CVE patch.

## How
A scoped `overrides` selector in `pnpm-workspace.yaml` rewrites only the vulnerable 7.x line, applied with `pnpm dedupe`:

```yaml
'vite@>=7.0.0 <7.3.5': '>=7.3.5 <8'
```

## Result
- Nested `vite` now resolves to `7.3.5`; `vite@8.0.16` untouched.
- `pnpm audit`: **1 high + 2 moderate → 1 moderate + 2 low** (the high `fs.deny` bypass and the related `launch-editor` moderate both clear).

## Verification
Quality gate green: typecheck, lint, 120 unit tests, production build. App-side Playwright E2E + dev-smoke skipped as disproportionate for a transitive dev-tooling patch.

The remaining pre-existing advisories on `main` (js-yaml moderate, esbuild + @babel/core low) are outside this change's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
