### PR TITLE
feat(scaffold): support comma-bearing prop types in scaffold component --props

### DIFF
--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -19,7 +19,7 @@ Trigger: user asks to create a component, scaffold a card, etc.
 
 - `--no-story`, skip Storybook story
 - `--parent <dir>`, non-default parent dir (e.g. `app/components/Form`)
-- `--props "a:string,b:number"`, typed props rendered as a Props alias and destructured in the signature. Commas separate props, so comma-bearing types (`Record<K, V>`, `(a, b) => void`, tuples) are not supported; pass one `--props` flag per prop.
+- `--props "a:string,b:number"`, typed props rendered as a Props alias and destructured in the signature. Only top-level commas separate props, so comma-bearing types (`Record<K, V>`, `(a, b) => void`, tuples) are supported within a single entry.
 
 ## Accessibility assertion
 

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -20029,26 +20029,21 @@ var splitTopLevelCommas = (raw) => {
   const segments = [];
   let depth = 0;
   let current = "";
-  let hasNestedComma = false;
   for (const char of raw) {
     if (char in BRACKET_PAIRS) {
       depth += 1;
     } else if (CLOSERS.has(char) && depth > 0) {
       depth -= 1;
     }
-    if (char === ",") {
-      if (depth > 0) {
-        hasNestedComma = true;
-      } else {
-        segments.push(current);
-        current = "";
-        continue;
-      }
+    if (char === "," && depth === 0) {
+      segments.push(current);
+      current = "";
+      continue;
     }
     current += char;
   }
   segments.push(current);
-  return { hasNestedComma, segments };
+  return segments;
 };
 var HELP_TEXT22 = `Usage: gaia scaffold component <Name> [flags]
 
@@ -20057,18 +20052,12 @@ var HELP_TEXT22 = `Usage: gaia scaffold component <Name> [flags]
   --props "a:string,b:number"
                       Typed props rendered as a Props type alias.
                       Comma-bearing types (Record<K, V>, (a, b) => void,
-                      tuples) are not supported; pass one --props flag per prop.
+                      tuples) are supported; only top-level commas split props.
   --json              Emit ScaffoldResult JSON on stdout
 `;
 var HELP_TOKENS22 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseProps = (raw) => {
-  const { hasNestedComma, segments } = splitTopLevelCommas(raw);
-  if (hasNestedComma) {
-    return {
-      message: `--props value contains a comma-bearing type (got: "${raw}"); comma-bearing types (Record<K, V>, (a, b) => void, tuples) are not supported. Pass one --props flag per prop, or split the type out.`,
-      ok: false
-    };
-  }
+  const segments = splitTopLevelCommas(raw);
   const entries = segments.flatMap((entry) => {
     const trimmed = entry.trim();
     return trimmed.length > 0 ? [trimmed] : [];

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -23571,26 +23571,21 @@ var splitTopLevelCommas = (raw) => {
   const segments = [];
   let depth = 0;
   let current = "";
-  let hasNestedComma = false;
   for (const char of raw) {
     if (char in BRACKET_PAIRS) {
       depth += 1;
     } else if (CLOSERS.has(char) && depth > 0) {
       depth -= 1;
     }
-    if (char === ",") {
-      if (depth > 0) {
-        hasNestedComma = true;
-      } else {
-        segments.push(current);
-        current = "";
-        continue;
-      }
+    if (char === "," && depth === 0) {
+      segments.push(current);
+      current = "";
+      continue;
     }
     current += char;
   }
   segments.push(current);
-  return { hasNestedComma, segments };
+  return segments;
 };
 var HELP_TEXT28 = `Usage: gaia scaffold component <Name> [flags]
 
@@ -23599,18 +23594,12 @@ var HELP_TEXT28 = `Usage: gaia scaffold component <Name> [flags]
   --props "a:string,b:number"
                       Typed props rendered as a Props type alias.
                       Comma-bearing types (Record<K, V>, (a, b) => void,
-                      tuples) are not supported; pass one --props flag per prop.
+                      tuples) are supported; only top-level commas split props.
   --json              Emit ScaffoldResult JSON on stdout
 `;
 var HELP_TOKENS28 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var parseProps = (raw) => {
-  const { hasNestedComma, segments } = splitTopLevelCommas(raw);
-  if (hasNestedComma) {
-    return {
-      message: `--props value contains a comma-bearing type (got: "${raw}"); comma-bearing types (Record<K, V>, (a, b) => void, tuples) are not supported. Pass one --props flag per prop, or split the type out.`,
-      ok: false
-    };
-  }
+  const segments = splitTopLevelCommas(raw);
   const entries = segments.flatMap((entry) => {
     const trimmed = entry.trim();
     return trimmed.length > 0 ? [trimmed] : [];

--- a/.gaia/cli/src/scaffold/component.test.ts
+++ b/.gaia/cli/src/scaffold/component.test.ts
@@ -361,7 +361,7 @@ describe('scaffold component', () => {
     expect(stdio.errors.join('')).toContain('--props entry must be name:type');
   });
 
-  test('comma-bearing object type exits 1 and writes no file', () => {
+  test('comma-bearing Record type scaffolds a single prop with the full type', () => {
     const exit = run(
       [
         'Widget',
@@ -373,15 +373,62 @@ describe('scaffold component', () => {
       {cwd: sandbox.root}
     );
 
-    expect(exit).toBe(1);
-    expect(stdio.errors.join('')).toContain('comma-bearing');
-    expect(stdio.errors.join('')).toContain('one --props flag per prop');
-    expect(() =>
-      read(path.join(sandbox.parent, 'Widget', 'index.tsx'))
-    ).toThrow();
+    expect(exit).toBe(0);
+
+    const indexContents = read(
+      path.join(sandbox.parent, 'Widget', 'index.tsx')
+    );
+    expect(indexContents).toContain('type WidgetProps = {');
+    expect(indexContents).toContain('  meta: Record<string, unknown>;');
+    expect(indexContents).toContain(
+      'const Widget: FC<WidgetProps> = ({meta}) => ('
+    );
   });
 
-  test('comma-bearing function type exits 1 and writes no file (no silent garbage)', () => {
+  test('comma-bearing tuple type scaffolds a single prop with the full type', () => {
+    const exit = run(
+      [
+        'Pair',
+        '--parent',
+        'app/components',
+        '--props',
+        'pair:[string, number]',
+      ],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).toBe(0);
+
+    const indexContents = read(path.join(sandbox.parent, 'Pair', 'index.tsx'));
+    expect(indexContents).toContain('  pair: [string, number];');
+    expect(indexContents).toContain(
+      'const Pair: FC<PairProps> = ({pair}) => ('
+    );
+  });
+
+  test('a plain prop and a comma-bearing prop separate into two props', () => {
+    const exit = run(
+      [
+        'Card',
+        '--parent',
+        'app/components',
+        '--props',
+        'title:string,meta:Record<string, unknown>',
+      ],
+      {cwd: sandbox.root}
+    );
+
+    expect(exit).toBe(0);
+
+    const indexContents = read(path.join(sandbox.parent, 'Card', 'index.tsx'));
+    expect(indexContents).toContain('  title: string;');
+    expect(indexContents).toContain('  meta: Record<string, unknown>;');
+    expect(indexContents).toContain(
+      'const Card: FC<CardProps> = ({title, meta}) => ('
+    );
+  });
+
+  test('multi-arg function prop scaffolds one prop with a callable no-op fallback', () => {
     const exit = run(
       [
         'Picker',
@@ -389,15 +436,32 @@ describe('scaffold component', () => {
         'app/components',
         '--props',
         'onSelect:(id: string, ev: Event) => void',
+        '--no-story',
       ],
       {cwd: sandbox.root}
     );
 
-    expect(exit).toBe(1);
-    expect(stdio.errors.join('')).toContain('comma-bearing');
-    expect(() =>
-      read(path.join(sandbox.parent, 'Picker', 'index.tsx'))
-    ).toThrow();
+    expect(exit).toBe(0);
+
+    const indexContents = read(
+      path.join(sandbox.parent, 'Picker', 'index.tsx')
+    );
+    expect(indexContents).toContain(
+      '  onSelect: (id: string, ev: Event) => void;'
+    );
+    expect(indexContents).toContain(
+      'const Picker: FC<PickerProps> = ({onSelect}) => ('
+    );
+
+    const testContents = read(
+      path.join(sandbox.parent, 'Picker', 'tests', 'index.test.tsx')
+    );
+    // The render attribute must be a CALLABLE no-op cast, so wiring the prop
+    // into the render body survives being invoked with arguments.
+    expect(testContents).toContain(
+      'onSelect={(() => undefined) as (id: string, ev: Event) => void}'
+    );
+    expect(testContents).not.toContain('onSelect={{} as');
   });
 
   test('single-arg function prop scaffolds with a callable no-op fallback (not {} as)', () => {

--- a/.gaia/cli/src/scaffold/component.ts
+++ b/.gaia/cli/src/scaffold/component.ts
@@ -18,9 +18,9 @@
  * The `--props "name:type,name:type"` flag turns the bare `FC` signature
  * into a typed `FC<NameProps>` and emits a Props type alias plus a
  * destructured signature. Each entry must be `name:type`; empty entries
- * and malformed pairs are rejected with exit 1. Commas separate props, so
- * comma-bearing types (`Record<K, V>`, `(a, b) => void`, tuples) are not
- * supported and are rejected with exit 1; pass one `--props` flag per prop.
+ * and malformed pairs are rejected with exit 1. Only depth-0 commas separate
+ * props, so comma-bearing types (`Record<K, V>`, `(a, b) => void`, tuples) are
+ * supported within a single entry.
  *
  * The handler uses the shared scaffold utilities (`writeFileIfAbsent`,
  * `loadTemplate`, `renderTemplate`) so behavior matches the other
@@ -47,19 +47,13 @@ const CLOSERS = new Set(Object.values(BRACKET_PAIRS));
  * Split a `--props` value on prop-separating commas only. A comma at bracket
  * depth 0 separates props; a comma inside a bracket pair (`<>`, `()`, `[]`,
  * `{}`) belongs to a comma-bearing type (`Record<string, unknown>`,
- * `(id: string, ev: Event) => void`, a tuple `[string, number]`).
- *
- * `hasNestedComma` is true when any depth>0 comma is present. The honest-reject
- * path uses that flag today; the segment list it returns is the seam a future
- * change would use to split on depth-0 commas instead of rejecting.
+ * `(id: string, ev: Event) => void`, a tuple `[string, number]`) and is kept
+ * intact inside its segment.
  */
-const splitTopLevelCommas = (
-  raw: string
-): {hasNestedComma: boolean; segments: string[]} => {
+const splitTopLevelCommas = (raw: string): string[] => {
   const segments: string[] = [];
   let depth = 0;
   let current = '';
-  let hasNestedComma = false;
 
   for (const char of raw) {
     if (char in BRACKET_PAIRS) {
@@ -68,14 +62,10 @@ const splitTopLevelCommas = (
       depth -= 1;
     }
 
-    if (char === ',') {
-      if (depth > 0) {
-        hasNestedComma = true;
-      } else {
-        segments.push(current);
-        current = '';
-        continue;
-      }
+    if (char === ',' && depth === 0) {
+      segments.push(current);
+      current = '';
+      continue;
     }
 
     current += char;
@@ -83,7 +73,7 @@ const splitTopLevelCommas = (
 
   segments.push(current);
 
-  return {hasNestedComma, segments};
+  return segments;
 };
 
 type ParsedFlags = {
@@ -118,21 +108,14 @@ const HELP_TEXT = `Usage: gaia scaffold component <Name> [flags]
   --props "a:string,b:number"
                       Typed props rendered as a Props type alias.
                       Comma-bearing types (Record<K, V>, (a, b) => void,
-                      tuples) are not supported; pass one --props flag per prop.
+                      tuples) are supported; only top-level commas split props.
   --json              Emit ScaffoldResult JSON on stdout
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
 const parseProps = (raw: string): FlagParseResult => {
-  const {hasNestedComma, segments} = splitTopLevelCommas(raw);
-
-  if (hasNestedComma) {
-    return {
-      message: `--props value contains a comma-bearing type (got: "${raw}"); comma-bearing types (Record<K, V>, (a, b) => void, tuples) are not supported. Pass one --props flag per prop, or split the type out.`,
-      ok: false,
-    };
-  }
+  const segments = splitTopLevelCommas(raw);
 
   const entries = segments.flatMap((entry) => {
     const trimmed = entry.trim();


### PR DESCRIPTION
Closes #409.

## What
`gaia scaffold component --props` now supports comma-bearing prop **types** within a single `--props` value:
- `Record<string, unknown>`
- multi-arg function props: `(id: string, ev: Event) => void`
- tuples: `[string, number]`
- and mixes: `title:string,meta:Record<string, unknown>` → two props

## How
Previously these exited 1 (the previously-shipped honest-reject stopgap) because `--props` split naively on every comma. The seam (`splitTopLevelCommas`, depth-aware over `<> () [] {}`) already existed; this drops the reject branch and consumes the depth-0 `segments` directly, simplifying it to return `string[]`. Function-typed props keep the callable no-op cast `(() => undefined) as <T>` so the placeholder survives being invoked in render.

## TDD
RED first: 4 failing tests (Record, multi-arg fn, tuple, mixed) → GREEN by removing the reject branch. Existing comma-free `--props` tests stay green.

## Verification
- `.gaia/cli` typecheck clean; full `.gaia/cli` vitest suite green (1425 tests; one unrelated scaffold-service flake cleared on re-run); 19/19 scaffold-component tests deterministic.
- Main `pnpm lint` clean.
- End-to-end with the rebundled `gaia` binary: one `--props` with all four shapes splits into four correct props; generated `{} as` / callable-no-op casts typecheck under `--strict`.
- Rebundled `gaia` + `gaia-maintainer`; verified no artifact drift vs a fresh `pnpm bundle`.
- **Pre-merge code-review-audit: PASS** (no Critical/Important/Suggestions; edge cases — nested generics, empty-middle `a:string,,b:number`, trailing comma, unbalanced brackets — all degrade to a loud reject, never silent garbage).

## Acceptance (#409) — all met
- [x] `meta:Record<string, unknown>` → one prop
- [x] `onSelect:(id: string, ev: Event) => void` → fn prop with callable no-op default
- [x] `pair:[string, number]` → tuple prop
- [x] `title:string,meta:Record<string, unknown>` → two props
- [x] Regression tests for each; comma-free tests stay green

## Files
- `.gaia/cli/src/scaffold/component.ts`, `component.test.ts`
- `.claude/skills/new-component/SKILL.md`
- Rebundled `.gaia/cli/gaia`, `.gaia/cli/gaia-maintainer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
