### PR TITLE
chore(deps): remove vestigial react-router-dom dependency

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -93,7 +93,7 @@ update together**, so a group moves as one unit (and snoozes as one unit).
 
 | Group             | Members                                                                                                                                                                      |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `react-router`    | `react-router`, `react-router-dom`, `@react-router/dev`, `@react-router/node`, `@react-router/serve`, `@react-router/fs-routes`, `@react-router/remix-routes-option-adapter` |
+| `react-router`    | `react-router`, `@react-router/dev`, `@react-router/node`, `@react-router/serve`, `@react-router/fs-routes`, `@react-router/remix-routes-option-adapter`                     |
 | `react`           | `react`, `react-dom`, `@types/react`, `@types/react-dom`                                                                                                                     |
 | `tailwindcss`     | `tailwindcss`, `@tailwindcss/vite`, `@tailwindcss/forms`, `@tailwindcss/typography`, `prettier-plugin-tailwindcss`                                                           |
 | `storybook`       | `storybook`, `@storybook/*`, `eslint-plugin-storybook`, `msw-storybook-addon`, `storybook-react-i18next`, `@vueless/storybook-dark-mode`                                     |

--- a/.gaia/cli/src/update-deps/decline.test.ts
+++ b/.gaia/cli/src/update-deps/decline.test.ts
@@ -50,7 +50,7 @@ const SOURCE_PAYLOAD = {
           is_pinned: false,
           kind: 'major',
           latest: '7.0.0',
-          name: 'react-router-dom',
+          name: '@react-router/serve',
           wanted: '6.30.0',
         },
       ],
@@ -154,7 +154,7 @@ describe('update-deps decline', () => {
 
   test('skipping one member snoozes the whole companion group', () => {
     sandbox.writeSource('updates.json');
-    const exit = run(['--source', 'updates.json', '--skip', 'react-router-dom'], {
+    const exit = run(['--source', 'updates.json', '--skip', '@react-router/serve'], {
       cwd: sandbox.root,
       now: NOW,
     });
@@ -164,7 +164,7 @@ describe('update-deps decline', () => {
     expect(declined[0]?.group).toBe('react-router');
     expect(declined[0]?.targets).toEqual({
       'react-router': '7.0.0',
-      'react-router-dom': '7.0.0',
+      '@react-router/serve': '7.0.0',
     });
   });
 

--- a/.gaia/cli/src/update-deps/declines.test.ts
+++ b/.gaia/cli/src/update-deps/declines.test.ts
@@ -42,7 +42,7 @@ const payload: CountablePayload = {
       group: 'react-router',
       packages: [
         {current: '7.1.0', latest: '7.2.0', name: 'react-router'},
-        {current: '7.1.0', latest: '7.2.0', name: 'react-router-dom'},
+        {current: '7.1.0', latest: '7.2.0', name: '@react-router/serve'},
       ],
     },
   ],
@@ -50,7 +50,7 @@ const payload: CountablePayload = {
 
 const reactRouterTargets = {
   'react-router': '7.2.0',
-  'react-router-dom': '7.2.0',
+  '@react-router/serve': '7.2.0',
 };
 
 const now = new Date('2026-06-11T18:00:00.000Z');

--- a/.gaia/cli/src/update-deps/groups.ts
+++ b/.gaia/cli/src/update-deps/groups.ts
@@ -46,7 +46,6 @@ const GROUP_RULES: readonly GroupRule[] = [
       '@react-router/remix-routes-option-adapter',
       '@react-router/serve',
       'react-router',
-      'react-router-dom',
     ],
     group: 'react-router',
   },

--- a/.gaia/cli/src/update-deps/run.test.ts
+++ b/.gaia/cli/src/update-deps/run.test.ts
@@ -189,7 +189,6 @@ describe('update-deps run: version classification', () => {
 describe('update-deps run: group resolution', () => {
   test('react-router family maps to react-router group', () => {
     expect(resolveGroup('react-router')).toBe('react-router');
-    expect(resolveGroup('react-router-dom')).toBe('react-router');
     expect(resolveGroup('@react-router/dev')).toBe('react-router');
     expect(resolveGroup('@react-router/serve')).toBe('react-router');
   });
@@ -299,7 +298,7 @@ describe('update-deps run: computeUpdates', () => {
     sandbox.writePackageJson({
       dependencies: {
         'react-router': '^6.30.0',
-        'react-router-dom': '^6.30.0',
+        '@react-router/serve': '^6.30.0',
       },
     });
 
@@ -307,7 +306,7 @@ describe('update-deps run: computeUpdates', () => {
       cwd: sandbox.root,
       pnpmRunner: makePnpmRunner({
         'react-router': {current: '6.30.0', latest: '7.0.0', wanted: '6.30.0'},
-        'react-router-dom': {
+        '@react-router/serve': {
           current: '6.30.0',
           latest: '7.0.0',
           wanted: '6.30.0',
@@ -462,11 +461,11 @@ describe('update-deps run: computeUpdates', () => {
   });
 
   test('sibling expansion: non-outdated group member included in wave_a when trigger is minor', () => {
-    // react-router is minor bump, react-router-dom is current but present in pkg.json
+    // react-router is minor bump, @react-router/serve is current but present in pkg.json
     sandbox.writePackageJson({
       dependencies: {
         'react-router': '^7.0.0',
-        'react-router-dom': '^7.0.0',
+        '@react-router/serve': '^7.0.0',
       },
     });
 
@@ -477,13 +476,13 @@ describe('update-deps run: computeUpdates', () => {
           'react-router': {current: '7.0.0', latest: '7.1.0', wanted: '7.1.0'},
         },
         undefined,
-        {'react-router-dom': '7.1.0'}
+        {'@react-router/serve': '7.1.0'}
       ),
     });
 
     expect(result.wave_b).toEqual([]);
     expect(result.wave_a).toHaveLength(2);
-    const rrd = result.wave_a.find((e) => e.name === 'react-router-dom');
+    const rrd = result.wave_a.find((e) => e.name === '@react-router/serve');
     expect(rrd).toBeDefined();
     expect(rrd?.latest).toBe('7.1.0');
     expect(rrd?.current).toBe('7.0.0');
@@ -492,11 +491,11 @@ describe('update-deps run: computeUpdates', () => {
   });
 
   test('sibling expansion: up-to-date sibling (current === latest) still included', () => {
-    // react-router-dom is truly up-to-date after fetch; must still be included
+    // @react-router/serve is truly up-to-date after fetch; must still be included
     sandbox.writePackageJson({
       dependencies: {
         'react-router': '^7.1.0',
-        'react-router-dom': '^7.1.0',
+        '@react-router/serve': '^7.1.0',
       },
     });
 
@@ -507,23 +506,23 @@ describe('update-deps run: computeUpdates', () => {
           'react-router': {current: '7.1.0', latest: '7.2.0', wanted: '7.2.0'},
         },
         undefined,
-        {'react-router-dom': '7.2.0'}
+        {'@react-router/serve': '7.2.0'}
       ),
     });
 
     expect(result.wave_a).toHaveLength(2);
-    const rrd = result.wave_a.find((e) => e.name === 'react-router-dom');
+    const rrd = result.wave_a.find((e) => e.name === '@react-router/serve');
     expect(rrd).toBeDefined();
     // current 7.1.0 vs latest 7.2.0 → minor
     expect(rrd?.kind).toBe('minor');
   });
 
   test('sibling expansion: up-to-date sibling where current === latest gets kind: "patch"', () => {
-    // react-router-dom is exactly on latest after fetch → no-op, kind: "patch"
+    // @react-router/serve is exactly on latest after fetch → no-op, kind: "patch"
     sandbox.writePackageJson({
       dependencies: {
         'react-router': '^7.1.0',
-        'react-router-dom': '^7.2.0',
+        '@react-router/serve': '^7.2.0',
       },
     });
 
@@ -534,12 +533,12 @@ describe('update-deps run: computeUpdates', () => {
           'react-router': {current: '7.1.0', latest: '7.2.0', wanted: '7.2.0'},
         },
         undefined,
-        {'react-router-dom': '7.2.0'}
+        {'@react-router/serve': '7.2.0'}
       ),
     });
 
     expect(result.wave_a).toHaveLength(2);
-    const rrd = result.wave_a.find((e) => e.name === 'react-router-dom');
+    const rrd = result.wave_a.find((e) => e.name === '@react-router/serve');
     expect(rrd).toBeDefined();
     // current 7.2.0 vs latest 7.2.0 → equal, kind: "patch" as no-op default
     expect(rrd?.kind).toBe('patch');
@@ -981,7 +980,7 @@ describe('update-deps run: release-age cooldown', () => {
 
   test('caps a sibling-expanded version too', () => {
     sandbox.writePackageJson({
-      dependencies: {'react-router': '^7.0.0', 'react-router-dom': '^7.0.0'},
+      dependencies: {'react-router': '^7.0.0', '@react-router/serve': '^7.0.0'},
     });
     writeWorkspace(sandbox.root, 10080);
 
@@ -991,10 +990,10 @@ describe('update-deps run: release-age cooldown', () => {
       pnpmRunner: makePnpmRunner(
         {'react-router': {current: '7.0.0', latest: '7.2.0', wanted: '7.2.0'}},
         undefined,
-        {'react-router-dom': '7.3.0'},
+        {'@react-router/serve': '7.3.0'},
         {
           'react-router': {'7.0.0': ANCIENT, '7.2.0': AGED},
-          'react-router-dom': {
+          '@react-router/serve': {
             '7.0.0': ANCIENT,
             '7.2.0': AGED,
             '7.3.0': TOO_YOUNG,
@@ -1005,14 +1004,14 @@ describe('update-deps run: release-age cooldown', () => {
 
     expect(result.skipped).toEqual([]);
     expect(result.wave_a).toHaveLength(2);
-    const rrd = result.wave_a.find((e) => e.name === 'react-router-dom');
+    const rrd = result.wave_a.find((e) => e.name === '@react-router/serve');
     expect(rrd?.latest).toBe('7.2.0');
     expect(rrd?.kind).toBe('minor');
   });
 
   test('an up-to-date sibling (current === latest) is still included', () => {
     sandbox.writePackageJson({
-      dependencies: {'react-router': '^7.1.0', 'react-router-dom': '^7.2.0'},
+      dependencies: {'react-router': '^7.1.0', '@react-router/serve': '^7.2.0'},
     });
     writeWorkspace(sandbox.root, 10080);
 
@@ -1022,8 +1021,8 @@ describe('update-deps run: release-age cooldown', () => {
       pnpmRunner: makePnpmRunner(
         {'react-router': {current: '7.1.0', latest: '7.2.0', wanted: '7.2.0'}},
         undefined,
-        {'react-router-dom': '7.2.0'},
-        // No time table for react-router-dom: it is up to date, so the
+        {'@react-router/serve': '7.2.0'},
+        // No time table for @react-router/serve: it is up to date, so the
         // cooldown must not attempt a lookup for it.
         {'react-router': {'7.1.0': ANCIENT, '7.2.0': AGED}}
       ),
@@ -1031,7 +1030,7 @@ describe('update-deps run: release-age cooldown', () => {
 
     expect(result.skipped).toEqual([]);
     expect(result.wave_a).toHaveLength(2);
-    const rrd = result.wave_a.find((e) => e.name === 'react-router-dom');
+    const rrd = result.wave_a.find((e) => e.name === '@react-router/serve');
     expect(rrd).toBeDefined();
     expect(rrd?.kind).toBe('patch');
     expect(rrd?.latest).toBe('7.2.0');
@@ -1104,14 +1103,14 @@ describe('update-deps run: preview payload fields', () => {
       dependencies: {
         foo: '^1.2.3',
         'react-router': '^7.1.0',
-        'react-router-dom': '^7.1.0',
+        '@react-router/serve': '^7.1.0',
       },
     });
     saveDeclines(sandbox.root, [
       {
         declined_at: NOW().toISOString(),
         group: 'react-router',
-        targets: {'react-router': '7.2.0', 'react-router-dom': '7.2.0'},
+        targets: {'react-router': '7.2.0', '@react-router/serve': '7.2.0'},
       },
     ]);
 
@@ -1121,7 +1120,7 @@ describe('update-deps run: preview payload fields', () => {
       pnpmRunner: makePnpmRunner({
         foo: {current: '1.2.3', latest: '1.3.0', wanted: '1.3.0'},
         'react-router': {current: '7.1.0', latest: '7.2.0', wanted: '7.2.0'},
-        'react-router-dom': {
+        '@react-router/serve': {
           current: '7.1.0',
           latest: '7.2.0',
           wanted: '7.2.0',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the
 - `/gaia-harden` weighs an efficacy lens (Axis 3) before recommending a form: a recurring finding proves the problem, not the fix, so when the recommended form is prose and no cheap before/after evidence shows it would change behavior, that surfaces as a defer/decline signal for the human, never an auto-decline
 - point Zod schema work at Zod's official LLM docs, auto-discovered from `node_modules/zod/package.json` (`llmsFull`/`llms`), and treat them as authoritative over training memory so valid Zod 4 forms are not rejected from stale v3 recollection
 
+### Removed
+
+- the vestigial `react-router-dom` dependency, a v6/v7 re-export shim that React Router 8 drops entirely; GAIA runs framework mode and imports everything from `react-router` (`HydratedRouter` comes from `react-router/dom`), so it was already dead weight on v7. `/update-gaia` leaves an existing `react-router-dom` in your `package.json` by design (adopter-owned dependencies are never auto-removed), so run `pnpm remove react-router-dom` to drop it; `pnpm knip` also flags it as unused after this release (#419)
+
 ### Fixed
 
 - `/update-deps` override audit re-resolves with `pnpm dedupe` instead of `pnpm install` (which short-circuits "Already up to date" on an overrides-only change and could leave a security-floor override unapplied), and asserts the lockfile `overrides` block matches `pnpm-workspace.yaml` before finishing (#388)

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -30,7 +30,6 @@ export default {
     'lru-cache',
     'msw-storybook-addon',
     'nanoid',
-    'react-router-dom',
     'remix-utils',
     'stylelint-config-clean-order',
     'stylelint-config-standard',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "react-i18next": "17.0.8",
     "react-icons": "5.6.0",
     "react-router": "7.18.0",
-    "react-router-dom": "7.18.0",
     "remix-i18next": "7.5.0",
     "remix-toast": "4.0.0",
     "remix-utils": "9.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       react-router:
         specifier: 7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: 7.18.0
-        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       remix-i18next:
         specifier: 7.5.0
         version: 7.5.0(i18next@26.3.1(typescript@6.0.3))(react-i18next@17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -113,7 +110,7 @@ importers:
         version: 10.4.0
       '@gaia-react/lint':
         specifier: 1.5.1
-        version: 1.5.1(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)
+        version: 1.5.1(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)
       '@msw/data':
         specifier: 1.1.6
         version: 1.1.6
@@ -4632,13 +4629,6 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.18.0:
-    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
   react-router@7.18.0:
     resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
     engines: {node: '>=20.0.0'}
@@ -6182,7 +6172,7 @@ snapshots:
 
   '@faker-js/faker@10.4.0': {}
 
-  '@gaia-react/lint@1.5.1(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)':
+  '@gaia-react/lint@1.5.1(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@9.39.4(jiti@2.7.0))
       '@eslint/config-helpers': 0.6.0
@@ -6192,7 +6182,7 @@ snapshots:
       eslint-config-airbnb-extended: 3.1.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-better-tailwindcss: 4.5.0(eslint@9.39.4(jiti@2.7.0))(tailwindcss@4.3.1)(typescript@6.0.3)
-      eslint-plugin-canonical: 5.1.3(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      eslint-plugin-canonical: 5.1.3(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-check-file: 3.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jest-dom: 5.5.0(@testing-library/dom@10.4.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-no-relative-import-paths: 1.6.1
@@ -8169,7 +8159,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.7.0))
       confusing-browser-globals: 1.0.11
       eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
@@ -8205,7 +8195,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8221,7 +8211,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
@@ -8237,14 +8227,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8255,7 +8245,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8276,14 +8266,14 @@ snapshots:
       - '@eslint/css'
       - typescript
 
-  eslint-plugin-canonical@5.1.3(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
+  eslint-plugin-canonical@5.1.3(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       array-includes: 3.1.9
       debug: 4.4.3
       doctrine: 3.0.0
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       is-get-set-prop: 1.0.0
       is-js-type: 2.0.0
       is-obj-prop: 1.0.0
@@ -9937,12 +9927,6 @@ snapshots:
   react-is@17.0.2: {}
 
   react-refresh@0.14.2: {}
-
-  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/wiki/dependencies/React Router 7.md
+++ b/wiki/dependencies/React Router 7.md
@@ -20,7 +20,6 @@ The full-stack web framework GAIA is built on. Provides SSR, file-based routing,
 - `@react-router/dev`
 - `@react-router/fs-routes`
 - `@react-router/remix-routes-option-adapter`
-- `react-router-dom`
 
 The `/update-deps` command upgrades all of these together when react-router is selected.
 


### PR DESCRIPTION
## What

Removes the `react-router-dom` dependency. It is a v6/v7-era re-export shim that React Router v8 drops entirely (no 8.x on npm; the latest dist-tag is stuck at 7.18.0). GAIA runs framework mode (`@react-router/dev`) and imports everything from `react-router` — `HydratedRouter` comes from `react-router/dom`, part of the `react-router` package — so the shim was already dead weight on v7.

## Why

Pure dead-weight removal, and a prerequisite for the upcoming RR8 bump. No runtime behavior changes: nothing in the app ever imported `react-router-dom`.

## Changes

- **`package.json` + `pnpm-lock.yaml`** — drop the dependency (`pnpm remove`, −6 packages).
- **`knip.config.ts`** — remove the now-unneeded `ignoreDependencies` entry.
- **`.gaia/cli/src/update-deps/groups.ts` + `.claude/skills/update-deps/SKILL.md`** — drop `react-router-dom` from the `react-router` companion-group table (the CLI table and its skill doc must agree). The package is gone from GAIA and dropped from the RR ecosystem in v8.
- **update-deps tests** (`run.test.ts`, `declines.test.ts`, `decline.test.ts`) — the `react-router` group's lockstep/snooze coverage used `react-router-dom` as its canonical sibling fixture; swapped to `@react-router/serve` (a real, surviving react-router companion) so coverage is preserved unchanged.
- **`wiki/dependencies/React Router 7.md`** — remove the stale companion-package bullet.

## Verification

- Repo-wide grep (excluding `node_modules`, lockfile, generated `build/`) → zero `react-router-dom` references.
- App Quality Gate: typecheck ✅ · lint ✅ · unit tests ✅ (120) · Playwright E2E ✅ · dev smoke HTTP 200 ✅ · build ✅.
- CLI package: typecheck ✅ · test suite ✅ (1425 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)