### PR TITLE
fix(telemetry): accept --abandoned as a valued boolean flag

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -24831,6 +24831,14 @@ var ArgParseError = class extends Error {
   arg;
 };
 var parseValueByKind = {
+  boolean: (token, valueToken) => {
+    if (valueToken === "true") return true;
+    if (valueToken === "false") return false;
+    throw new ArgParseError(
+      `flag ${token} expects true or false; got ${valueToken}`,
+      token
+    );
+  },
   json: (token, valueToken) => {
     try {
       return JSON.parse(valueToken);
@@ -24871,18 +24879,13 @@ var parseArgs6 = (argv) => {
     if (definition === void 0) {
       throw new ArgParseError(`unknown flag: ${token}`, token);
     }
-    if (definition.kind === "boolean") {
-      flags[definition.target] = true;
-      index += 1;
-    } else {
-      const valueToken = rest[index + 1];
-      if (valueToken === void 0 || valueToken.startsWith("--")) {
-        throw new ArgParseError(`flag ${token} expects a value`, token);
-      }
-      const parser = parseValueByKind[definition.kind];
-      flags[definition.target] = parser(token, valueToken);
-      index += 2;
+    const valueToken = rest[index + 1];
+    if (valueToken === void 0 || valueToken.startsWith("--")) {
+      throw new ArgParseError(`flag ${token} expects a value`, token);
     }
+    const parser = parseValueByKind[definition.kind];
+    flags[definition.target] = parser(token, valueToken);
+    index += 2;
   }
   return { eventType, flags };
 };
@@ -28469,8 +28472,7 @@ var GROUP_RULES = [
       "@react-router/node",
       "@react-router/remix-routes-option-adapter",
       "@react-router/serve",
-      "react-router",
-      "react-router-dom"
+      "react-router"
     ],
     group: "react-router"
   },

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -26591,6 +26591,14 @@ var ArgParseError = class extends Error {
   arg;
 };
 var parseValueByKind = {
+  boolean: (token, valueToken) => {
+    if (valueToken === "true") return true;
+    if (valueToken === "false") return false;
+    throw new ArgParseError(
+      `flag ${token} expects true or false; got ${valueToken}`,
+      token
+    );
+  },
   json: (token, valueToken) => {
     try {
       return JSON.parse(valueToken);
@@ -26631,18 +26639,13 @@ var parseArgs4 = (argv) => {
     if (definition === void 0) {
       throw new ArgParseError(`unknown flag: ${token}`, token);
     }
-    if (definition.kind === "boolean") {
-      flags[definition.target] = true;
-      index += 1;
-    } else {
-      const valueToken = rest[index + 1];
-      if (valueToken === void 0 || valueToken.startsWith("--")) {
-        throw new ArgParseError(`flag ${token} expects a value`, token);
-      }
-      const parser = parseValueByKind[definition.kind];
-      flags[definition.target] = parser(token, valueToken);
-      index += 2;
+    const valueToken = rest[index + 1];
+    if (valueToken === void 0 || valueToken.startsWith("--")) {
+      throw new ArgParseError(`flag ${token} expects a value`, token);
     }
+    const parser = parseValueByKind[definition.kind];
+    flags[definition.target] = parser(token, valueToken);
+    index += 2;
   }
   return { eventType, flags };
 };
@@ -27865,8 +27868,7 @@ var GROUP_RULES = [
       "@react-router/node",
       "@react-router/remix-routes-option-adapter",
       "@react-router/serve",
-      "react-router",
-      "react-router-dom"
+      "react-router"
     ],
     group: "react-router"
   },

--- a/.gaia/cli/src/telemetry/__tests__/emit.test.ts
+++ b/.gaia/cli/src/telemetry/__tests__/emit.test.ts
@@ -87,6 +87,20 @@ const goodUatPassArgv = [
   'a'.repeat(32),
 ];
 
+const timeToResolvedArgv = (abandoned: string): string[] => [
+  'time_to_resolved_spec',
+  '--spec-id',
+  'SPEC-014',
+  '--question-count',
+  '10',
+  '--duration-seconds',
+  '1800',
+  '--area-tags',
+  'visual',
+  '--abandoned',
+  abandoned,
+];
+
 describe('handleEmit', () => {
   let sandbox: Sandbox;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -140,6 +154,45 @@ describe('handleEmit', () => {
     expect(cloudLine.event_type).toBe('uat_pass');
     expect(cloudLine._local).toBeUndefined();
     expect(mentorshipLine.schema_version).toBe(1);
+  });
+
+  test('--abandoned false emits abandoned: false (success path)', async () => {
+    await enableMentorship(sandbox.roots);
+
+    const exit = await handleEmit(timeToResolvedArgv('false'), {
+      roots: sandbox.roots,
+    });
+
+    expect(exit).toBe(EXIT_CODES.OK);
+    const cloudLine = JSON.parse(
+      readLines(todayJsonl(sandbox.roots.cloudDir))[0] ?? '{}'
+    ) as {payload?: Record<string, unknown>};
+    expect(cloudLine.payload?.abandoned).toBe(false);
+  });
+
+  test('--abandoned true emits abandoned: true (abandoned-exit path)', async () => {
+    await enableMentorship(sandbox.roots);
+
+    const exit = await handleEmit(timeToResolvedArgv('true'), {
+      roots: sandbox.roots,
+    });
+
+    expect(exit).toBe(EXIT_CODES.OK);
+    const cloudLine = JSON.parse(
+      readLines(todayJsonl(sandbox.roots.cloudDir))[0] ?? '{}'
+    ) as {payload?: Record<string, unknown>};
+    expect(cloudLine.payload?.abandoned).toBe(true);
+  });
+
+  test('--abandoned rejects a non-boolean value, no writes', async () => {
+    await enableMentorship(sandbox.roots);
+
+    const exit = await handleEmit(timeToResolvedArgv('nope'), {
+      roots: sandbox.roots,
+    });
+
+    expect(exit).toBe(EXIT_CODES.PAYLOAD_VALIDATION_FAILED);
+    expect(existsSync(todayJsonl(sandbox.roots.cloudDir))).toBe(false);
   });
 
   test('UAT-009: writes only cloud when mentorship is disabled', async () => {

--- a/.gaia/cli/src/telemetry/emit.ts
+++ b/.gaia/cli/src/telemetry/emit.ts
@@ -48,11 +48,9 @@ const isCloudOnlyEventType = (
   (CLOUD_ONLY_EVENT_TYPES as readonly string[]).includes(eventType);
 
 type FlagDefinition = {
-  kind: FlagKind;
+  kind: ValueKind;
   target: string;
 };
-
-type FlagKind = 'boolean' | ValueKind;
 
 type ParsedArgs = {
   eventType: string;
@@ -122,7 +120,7 @@ const FLAG_DEFINITIONS: Readonly<Partial<Record<string, FlagDefinition>>> = {
   '--uat-id': {kind: 'string', target: 'uatId'},
 };
 
-type ValueKind = 'json' | 'list' | 'number' | 'string';
+type ValueKind = 'boolean' | 'json' | 'list' | 'number' | 'string';
 
 class ArgParseError extends Error {
   constructor(
@@ -137,6 +135,15 @@ class ArgParseError extends Error {
 const parseValueByKind: Readonly<
   Record<ValueKind, (token: string, valueToken: string) => unknown>
 > = {
+  boolean: (token, valueToken) => {
+    if (valueToken === 'true') return true;
+    if (valueToken === 'false') return false;
+
+    throw new ArgParseError(
+      `flag ${token} expects true or false; got ${valueToken}`,
+      token
+    );
+  },
   json: (token, valueToken) => {
     try {
       return JSON.parse(valueToken) as object;
@@ -193,19 +200,14 @@ const parseArgs = (argv: readonly string[]): ParsedArgs => {
       throw new ArgParseError(`unknown flag: ${token}`, token);
     }
 
-    if (definition.kind === 'boolean') {
-      flags[definition.target] = true;
-      index += 1;
-    } else {
-      const valueToken = rest[index + 1] as string | undefined;
+    const valueToken = rest[index + 1] as string | undefined;
 
-      if (valueToken === undefined || valueToken.startsWith('--')) {
-        throw new ArgParseError(`flag ${token} expects a value`, token);
-      }
-      const parser = parseValueByKind[definition.kind];
-      flags[definition.target] = parser(token, valueToken);
-      index += 2;
+    if (valueToken === undefined || valueToken.startsWith('--')) {
+      throw new ArgParseError(`flag ${token} expects a value`, token);
     }
+    const parser = parseValueByKind[definition.kind];
+    flags[definition.target] = parser(token, valueToken);
+    index += 2;
   }
 
   return {eventType, flags};


### PR DESCRIPTION
## What

Makes the `gaia telemetry emit` `--abandoned` flag a **valued** boolean (`--abandoned true|false`) instead of presence-only.

## Why

`--abandoned` was declared `kind: 'boolean'` (presence-only), but `time_to_resolved_spec` requires `abandoned: z.boolean()` and every call site passes a value. The result:

- `--abandoned false` → parser set `abandoned=true`, then choked on the stray `false` (`unknown flag: false`).
- omitting the flag → required field absent → schema validation failed.

So **`abandoned: false` was impossible to emit**. The success-path `time_to_resolved_spec` mentorship signal — emitted with `--abandoned false` at `/gaia-spec` finalize — has been silently failing under its `|| true` guard, so completed-spec timing never recorded (only the abandoned-exit path, which passes `--abandoned true`, would have surfaced the stray-token error too).

## How

`--abandoned` becomes a valued boolean parsed as `true`/`false` (anything else is a clean `arg_parse_error`). It was the only `boolean`-kind flag, so no other flag is affected, and the skill reference already passes a value — no `/gaia-spec` changes needed.

## Verification

- TDD: added 3 tests, confirmed **RED** on the old parser (`--abandoned false|true` → exit 11), then **GREEN** after the fix.
- CLI `typecheck` clean; full CLI suite **1428 passed / 1 skipped**.
- Rebuilt both bundles; e2e on the real binary: `--abandoned false`→0, `--abandoned true`→0, `--abandoned nope`→11 (`flag --abandoned expects true or false`).

## Note

The rebuilt bundles also re-sync a pre-existing drift: #419 removed `react-router-dom` from `src/update-deps/groups.ts` but never re-bundled, so that one-line removal rides along here. It is correct (the committed bundle should match src) and unrelated to the telemetry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
