### PR TITLE
feat(spec-ledger): enforce canonical status vocabulary + auto-heal misnamed statuses

### DIFF
--- a/.gaia/specs.json
+++ b/.gaia/specs.json
@@ -5,29 +5,33 @@
       "id": "SPEC-001",
       "allocated_at": "2026-05-05T23:25:51Z",
       "source": "backfilled",
-      "status": "shipped",
-      "intent": "GAIA CI auto-maintenance system shipped to every adopter (smart cron, auto-merge, auto-revert)."
+      "status": "merged",
+      "intent": "GAIA CI auto-maintenance system shipped to every adopter (smart cron, auto-merge, auto-revert).",
+      "merged_at": "2026-05-09T08:22:10Z"
     },
     {
       "id": "SPEC-002",
       "allocated_at": "2026-05-12T07:49:29Z",
       "source": "allocated",
-      "status": "shipped",
-      "intent": "/gaia-fitness: adopter-facing Claude-integration health check + auto-heal; /health-audit refactored to compose it."
+      "status": "merged",
+      "intent": "/gaia-fitness: adopter-facing Claude-integration health check + auto-heal; /health-audit refactored to compose it.",
+      "merged_at": "2026-05-12T10:10:36Z"
     },
     {
       "id": "SPEC-003",
       "allocated_at": "2026-06-04T09:35:37Z",
       "source": "allocated",
-      "status": "shipped",
-      "intent": "GAIA's test-driven workflow already instructs the agent to write a failing"
+      "status": "merged",
+      "intent": "GAIA's test-driven workflow already instructs the agent to write a failing",
+      "merged_at": "2026-06-04T12:53:33Z"
     },
     {
       "id": "SPEC-004",
       "allocated_at": "2026-06-05T08:44:29Z",
       "source": "allocated",
-      "status": "shipped",
-      "intent": "GAIA's code-review-audit flags anti-patterns review after review, but each"
+      "status": "merged",
+      "intent": "GAIA's code-review-audit flags anti-patterns review after review, but each",
+      "merged_at": "2026-06-05T13:28:30Z"
     },
     {
       "id": "SPEC-005",

--- a/.gaia/tests/lib/helpers/tmp-spec-repo.sh
+++ b/.gaia/tests/lib/helpers/tmp-spec-repo.sh
@@ -55,7 +55,7 @@ printf '{\n  "version": 1,\n  "specs": []\n}\n' > .gaia/specs.json
 # Copy (not symlink) so the scripts' ${BASH_SOURCE[0]}-relative source of
 # with-ledger-lock.sh resolves to this tmp lib dir.
 for s in spec-allocator.sh ledger-update.sh with-ledger-lock.sh \
-         spec-folderize.sh spec-renumber.sh; do
+         spec-folderize.sh spec-renumber.sh spec-reconcile.sh; do
   cp "${real_lib}/${s}" ".specify/extensions/gaia/lib/${s}"
   chmod +x ".specify/extensions/gaia/lib/${s}"
 done

--- a/.gaia/tests/lib/spec-allocator-concurrency.bats
+++ b/.gaia/tests/lib/spec-allocator-concurrency.bats
@@ -105,12 +105,16 @@ _run_parallel_next() {
   [ "$output" = "SPEC-007" ]
 }
 
-@test "11: in_progress fallback; canonical folder file, no ledger row" {
+@test "11: in_progress no fallback; folder file without a ledger row is not surfaced" {
+  # The SPEC-file frontmatter fallback is intentionally gone: in_progress
+  # sources the ledger only. A foldered SPEC.md with no ledger row must NOT be
+  # surfaced as in-flight, otherwise finalized work re-flags as resumable
+  # forever (the defect-2 staleness this design removes; see test 10).
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-013)"
   cd "$REPO"
   run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
   [ "$status" -eq 0 ]
-  [ "$output" = "SPEC-013" ]
+  [ "$output" = "none" ]
 }
 
 @test "12: in_progress none; empty ledger, no files" {

--- a/.gaia/tests/lib/spec-folder-layout.bats
+++ b/.gaia/tests/lib/spec-folder-layout.bats
@@ -173,22 +173,23 @@ _snapshot() {
   [ "$(jq -r '.specs[-1].id' "$REPO/.gaia/specs.json")" = "SPEC-005" ]
 }
 
-@test "7b: in_progress ledger-first wins over a foldered fallback artifact" {
-  # Ledger has an in-progress row for SPEC-009; a foldered SPEC-013/SPEC.md
-  # is also status:in-progress. Ledger order wins per Contract C3.
-  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-inprogress SPEC-009 --seed-folder SPEC-013)"
+@test "7b: in_progress sources the ledger; a foldered artifact is not a fallback" {
+  # A draft ledger row (SPEC-009) is the resume source; a foldered
+  # SPEC-013/SPEC.md with no ledger row is NOT surfaced. Ledger-only per
+  # Contract C3 (the SPEC-file frontmatter fallback is intentionally gone).
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-009 --seed-folder SPEC-013)"
   cd "$REPO"
   run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
   [ "$status" -eq 0 ]
   [ "$output" = "SPEC-009" ]
 }
 
-@test "7c: in_progress fallback reads a foldered status:in-progress artifact" {
+@test "7c: in_progress no fallback; a foldered artifact without a ledger row yields none" {
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-folder SPEC-013)"
   cd "$REPO"
   run bash -c "bash '$REPO/$ALLOC' in_progress '$REPO'"
   [ "$status" -eq 0 ]
-  [ "$output" = "SPEC-013" ]
+  [ "$output" = "none" ]
 }
 
 # --- 8: renumber folder ------------------------------------------------------

--- a/.gaia/tests/lib/spec-ledger-status.bats
+++ b/.gaia/tests/lib/spec-ledger-status.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Canonical-status-vocabulary tests for the SPEC ledger.
+#
+# Three concerns:
+#   1. Behavioral guard: ledger-update.sh (the single chokepoint for ledger
+#      writes) accepts the four canonical statuses {draft, specified, merged,
+#      archived} plus the tolerated legacy in-progress, and rejects anything
+#      else with exit 6. This guard ships to adopters, so it protects every
+#      tool-path write on every clone.
+#   2. Auto-fix: spec-reconcile.sh renames a known-misnamed status (shipped ->
+#      merged) to canonical through that same chokepoint, and leaves an
+#      unrecognized status untouched (logging it). This repairs the hand-edit /
+#      backfill vector the guard cannot see (raw edits bypass the chokepoint),
+#      and it also ships to adopters (runs on every /gaia-spec).
+#   3. Data integrity: the real project .gaia/specs.json carries no
+#      off-vocabulary status row.
+#
+# Canonical vocabulary is documented in wiki/concepts/GAIA Spec.md
+# ("Ledger status vocabulary"). Keep WRITABLE below in sync with that section.
+#
+# Each behavioral test spins up its own tmp git repo via
+# helpers/tmp-spec-repo.sh and tears it down; hermetic, no reliance on the
+# real project ledger. The teardown uses the explicit-if form (the && idiom is
+# a bats teardown footgun: a falsy first clause makes teardown itself "fail").
+
+setup() {
+  HELPERS="$BATS_TEST_DIRNAME/helpers"
+  # Statuses ledger-update.sh accepts: the four canonical values plus the
+  # tolerated legacy in-progress.
+  WRITABLE="draft specified merged archived in-progress"
+}
+
+teardown() {
+  if [ -n "${REPO:-}" ]; then
+    rm -rf "$REPO"
+  fi
+}
+
+_ledger_update() {
+  bash "$REPO/.specify/extensions/gaia/lib/ledger-update.sh" "$@"
+}
+
+_reconcile() {
+  bash "$REPO/.specify/extensions/gaia/lib/spec-reconcile.sh" "$@"
+}
+
+# Raw-write a status onto a row, bypassing the guard. Used to plant a
+# pre-guard off-vocabulary row that the guard itself would refuse to create.
+_plant_status() {
+  local id="$1" status="$2" tmp
+  tmp="$(mktemp)"
+  jq --arg id "$id" --arg s "$status" \
+    '.specs |= map(if .id == $id then .status = $s else . end)' \
+    "$REPO/.gaia/specs.json" > "$tmp"
+  mv "$tmp" "$REPO/.gaia/specs.json"
+}
+
+@test "1: non-canonical status is rejected with exit 6" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  run _ledger_update "$REPO" SPEC-001 '{"status":"shipped"}'
+  [ "$status" -eq 6 ]
+  [[ "$output" == *"non-canonical status 'shipped'"* ]]
+}
+
+@test "2: a rejected patch leaves the ledger byte-for-byte unchanged" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  before="$(cat "$REPO/.gaia/specs.json")"
+  run _ledger_update "$REPO" SPEC-001 '{"status":"shipped"}'
+  [ "$status" -eq 6 ]
+  [ "$(cat "$REPO/.gaia/specs.json")" = "$before" ]
+}
+
+@test "3: every writable status (canonical + legacy in-progress) is accepted" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  for s in $WRITABLE; do
+    run _ledger_update "$REPO" SPEC-001 "{\"status\":\"$s\"}"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.specs[0].status' "$REPO/.gaia/specs.json")" = "$s" ]
+  done
+}
+
+@test "4: a status-less patch (merged_at only) passes the guard" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  run _ledger_update "$REPO" SPEC-001 '{"merged_at":"2026-01-02T00:00:00Z"}'
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.specs[0].merged_at' "$REPO/.gaia/specs.json")" = "2026-01-02T00:00:00Z" ]
+  [ "$(jq -r '.specs[0].status' "$REPO/.gaia/specs.json")" = "draft" ]
+}
+
+@test "5: spec-reconcile renames a planted 'shipped' row to 'merged'" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  _plant_status SPEC-001 shipped
+  run _reconcile "$REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"normalized SPEC-001: shipped -> merged"* ]]
+  [ "$(jq -r '.specs[0].status' "$REPO/.gaia/specs.json")" = "merged" ]
+}
+
+@test "6: spec-reconcile leaves an unrecognized status untouched and warns" {
+  REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
+  _plant_status SPEC-001 bogus-status
+  run _reconcile "$REPO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unrecognized status bogus-status"* ]]
+  [ "$(jq -r '.specs[0].status' "$REPO/.gaia/specs.json")" = "bogus-status" ]
+}
+
+@test "7: the real project ledger carries only writable statuses" {
+  root="$(git -C "$BATS_TEST_DIRNAME" rev-parse --show-toplevel)"
+  ledger="$root/.gaia/specs.json"
+  [ -f "$ledger" ] || skip "no project ledger at $ledger"
+  bad="$(jq -r --arg writable "$WRITABLE" '
+    ($writable | split(" ")) as $ok
+    | .specs[] | select(.status as $s | $ok | index($s) | not)
+    | .id + ":" + (.status // "null")
+  ' "$ledger")"
+  [ -z "$bad" ] || {
+    echo "off-vocabulary ledger rows: $bad" >&2
+    false
+  }
+}

--- a/.specify/extensions/gaia/lib/ledger-update.sh
+++ b/.specify/extensions/gaia/lib/ledger-update.sh
@@ -13,7 +13,8 @@
 # env knobs (GAIA_LEDGER_LOCK_*).
 #
 # Exit codes: 0 ok, 2 usage, 4 ledger or row missing OR lock-acquisition
-# timeout (could not safely apply the ledger write), 5 invalid patch JSON.
+# timeout (could not safely apply the ledger write), 5 invalid patch JSON,
+# 6 non-canonical status value in the patch.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -38,6 +39,27 @@ fi
 if ! jq -e --arg id "$spec_id" '.specs[] | select(.id == $id)' "$ledger_path" >/dev/null 2>&1; then
   echo "ledger-update: spec $spec_id not in ledger" >&2
   exit 4
+fi
+
+# Canonical status vocabulary guard. The ledger's status is one of the four
+# canonical values draft|specified|merged|archived, plus the tolerated legacy
+# value in-progress (wiki/concepts/GAIA Spec.md, "Ledger status vocabulary").
+# This is the single chokepoint for ledger writes, so rejecting an
+# off-vocabulary status here keeps every tool path (allocator finalize,
+# spec-reconcile, spec-close) from persisting a stray label. A patch that does
+# not set status (e.g. a merged_at-only stamp) passes untouched. An unparseable
+# patch falls through to apply_patch, which reports it as exit 5. Existing
+# off-vocabulary rows (e.g. a hand-edited "shipped") are repaired by
+# spec-reconcile.sh, which renames known aliases through this same chokepoint.
+patch_status="$(jq -r 'if type == "object" and has("status") then (.status | tostring) else empty end' <<<"$patch" 2>/dev/null || true)"
+if [ -n "$patch_status" ]; then
+  case "$patch_status" in
+    draft | specified | merged | archived | in-progress) ;;
+    *)
+      echo "ledger-update: non-canonical status '$patch_status' (allowed: draft, specified, merged, archived)" >&2
+      exit 6
+      ;;
+  esac
 fi
 
 apply_patch() {

--- a/.specify/extensions/gaia/lib/spec-reconcile.sh
+++ b/.specify/extensions/gaia/lib/spec-reconcile.sh
@@ -38,6 +38,46 @@ _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 command -v jq >/dev/null 2>&1 || exit 0
 git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
+# --- Normalize known-misnamed statuses to canonical (local, no network) ------
+# Pre-guard ledgers can carry an off-vocabulary status (a hand-edited or
+# backfilled "shipped", say). Rename known aliases to their canonical value
+# through the guarded ledger-update.sh chokepoint, so a stray label self-heals
+# on the next housekeeping pass. Runs before the network reconcile and is
+# independent of it. An unrecognized off-vocabulary status is logged, never
+# guessed (its lifecycle position is not safely inferable).
+canon_for_status() {
+  case "$1" in
+    shipped) printf 'merged' ;;
+    *) printf '' ;;
+  esac
+}
+
+offvocab_ids="$(jq -r '
+  .specs[]
+  | select((.status // "") as $s
+      | ["draft","specified","merged","archived","in-progress"] | index($s) | not)
+  | .id
+' "$ledger_path" 2>/dev/null || true)"
+
+if [ -n "$offvocab_ids" ]; then
+  while IFS= read -r ov_id; do
+    [ -n "$ov_id" ] || continue
+    ov_status="$(jq -r --arg id "$ov_id" \
+      '.specs[] | select(.id == $id) | .status // "null"' "$ledger_path" 2>/dev/null || true)"
+    canon="$(canon_for_status "$ov_status")"
+    if [ -n "$canon" ]; then
+      patch="$(jq -nc --arg s "$canon" '{status: $s}')"
+      if bash "${_lib_dir}/ledger-update.sh" "$repo_root" "$ov_id" "$patch" >/dev/null 2>&1; then
+        printf 'normalized %s: %s -> %s\n' "$ov_id" "$ov_status" "$canon"
+      fi
+    else
+      printf 'spec-reconcile: %s has unrecognized status %s; left as-is\n' "$ov_id" "$ov_status" >&2
+    fi
+  done <<EOF
+$offvocab_ids
+EOF
+fi
+
 # Candidate rows (local, cheap): finalized but not yet recorded as merged.
 candidates="$(jq -r '
   .specs[] | select(.status == "specified" or .status == "in-progress") | .id

--- a/wiki/concepts/GAIA Spec.md
+++ b/wiki/concepts/GAIA Spec.md
@@ -43,6 +43,19 @@ Auto-generated Playwright specs (written by the `before_implement` hook via `lib
 - **Cosmetic divergence** (selector text, button labels, copy, URL slugs, layout assertions): editable by the implementer without reopening the SPEC.
 - **Logical divergence** (user flow, success criteria, error branches, preconditions, post-state): forbidden. Implementer must raise the divergence; the SPEC is reopened and the UAT rewritten before re-running `/speckit-implement`.
 
+## Ledger status vocabulary
+
+`.gaia/specs.json` is a fast index over git; the `status` field on each row is exactly one of four canonical values:
+
+- `draft`: allocated, still being authored. The only status `lib/spec-allocator.sh in_progress` surfaces for the resume-vs-start prompt.
+- `specified`: artifact finalized and frozen. Downstream plan → implement → merge owns the feature from here.
+- `merged`: the implementing PR has landed; `merged_at` records when. `lib/spec-reconcile.sh` sets this from git ground truth.
+- `archived`: a finalized SPEC retired to `.gaia/local/specs/archived/`. The archive disposition is carried on the SPEC artifact frontmatter (`status: archived`, `archived_at`); the ledger row tracks lifecycle and reads `merged` for a SPEC that both merged and was archived.
+
+No other value is valid. `lib/ledger-update.sh` is the single chokepoint for ledger writes; it accepts the four canonical values plus the tolerated legacy `in-progress`, and rejects anything else (exit 6), so a stray label cannot reach the ledger through a tool path. `in-progress` is a deprecated legacy value that `spec-reconcile.sh` advances toward `merged` from git; new flows use `draft → specified`.
+
+A ledger that predates the chokepoint can still hold a misnamed status (a hand-edited or backfilled `shipped`, say). These self-heal: `spec-reconcile.sh` runs on every `/gaia-spec` and renames known aliases (`shipped → merged`) to canonical through the guarded chokepoint, logging any unrecognized status rather than guessing its lifecycle position.
+
 ## Pairs with
 
 - [[spec-kit Extension Strategy]]: the architectural decision that produced this workflow.


### PR DESCRIPTION
## Why

`.gaia/specs.json`'s `status` field had **no defined vocabulary and no enforcement**, so a non-canonical `shipped` label sat undetected on SPEC-001 through 004 (hand-set / backfilled). The canonical lifecycle is `draft → specified → merged`, plus `archived` (terminal disposition) and tolerated-legacy `in-progress`. Nothing guaranteed rows stayed in that set, and the gap reaches adopters too (they author their own SPECs through the same shipped tooling).

## What

A durable fix split across forward protection and backward repair, both reaching adopters via **shipped** surfaces:

- **`ledger-update.sh`** (the single ledger-write chokepoint, ships): rejects any patch whose `status` is off-vocabulary (`exit 6`). Every tool-path write (allocator finalize, reconcile, close) goes through here, so a stray label can no longer be written.
- **`spec-reconcile.sh`** (housekeeping pass on every `/gaia-spec`, ships): normalizes known-misnamed statuses to canonical through the guarded chokepoint (`shipped → merged`); logs an unrecognized status rather than guessing its lifecycle position. This repairs the hand-edit / backfill vector the guard itself cannot see.
- **`wiki/concepts/GAIA Spec.md`** (ships): documents the status vocabulary as the source of truth.
- **`.gaia/tests/lib/spec-ledger-status.bats`** (maintainer-only, not shipped): covers the guard (accept/reject), the auto-fix (rename + leave-and-warn), and our own ledger's integrity. `tmp-spec-repo.sh` now also copies `spec-reconcile.sh` so the test can drive it.
- **`.gaia/specs.json`**: the four `shipped` rows normalized to `merged`, with `merged_at` derived from each implementing PR (same algorithm `spec-reconcile.sh` uses).

## Stale-test cleanup (folded in)

Three tests asserted an allocator `in_progress` file-fallback that was deliberately removed (ledger-only source; the old fallback re-flagged finalized work as resumable forever, defect-2):

- `spec-allocator-concurrency.bats` 11 — folder file, no ledger row now yields `none`.
- `spec-folder-layout.bats` 7b — seed a draft ledger row (the resume source); assert the foldered artifact is not a fallback.
- `spec-folder-layout.bats` 7c — folder artifact without a ledger row now yields `none`.

These failed on `main` but were masked: `run-all.sh` uses `set -e`, so it bailed at the first failing file (11) before reaching 7b/7c. **Full suite now green (43/43).**

## Verification

- New suite (7 tests) green; full `.gaia/tests/lib/run-all.sh` green (43/43).
- `shellcheck` clean (exit 0) on all edited scripts.
- **Dogfooded on the real ledger**: flipped 001–004 back to `shipped` (raw write), confirmed the guard refuses a `shipped` write (`exit 6`), ran `spec-reconcile.sh`, and watched it emit `normalized SPEC-00N: shipped -> merged` for all four with `merged_at` preserved. SPEC-007 (`specified`, no merged PR) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)