### PR TITLE
feat(remix-utils): awareness map + hydration dogfood (SPEC-007)

### DIFF
--- a/.claude/rules/react-router-docs.md
+++ b/.claude/rules/react-router-docs.md
@@ -3,6 +3,7 @@ paths:
   - 'app/routes/**/*'
   - 'app/pages/**/*'
   - 'app/root.tsx'
+  - 'app/middleware/**/*'
   - 'react-router.config.ts'
 ---
 
@@ -15,5 +16,7 @@ ls node_modules/react-router/docs   # explanation/ how-to/ start/ upgrading/ ind
 ```
 
 Reach for the online docs (`reactrouter.com/docs`) only when the local copy is absent (older React Router) or a topic is missing.
+
+When a loader, action, or middleware tempts a hand-rolled server-side primitive (csrf, honeypot, safe-redirect), check the remix-utils decision map at `wiki/dependencies/remix-utils.md` before reinventing; remix-utils ships these as audited utilities.
 
 This rule covers React Router's **own API**. GAIA's route/page structure conventions (thin routes, group folders, page-dir layout, loader meta) are governed separately by the Route & Page Conventions rule and `wiki/decisions/Thin Routes.md`.

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -13,7 +13,7 @@ Before installing a package or hand-rolling a primitive, walk this ladder and st
 
 1. **Existing GAIA code**, a component, hook, or util already covers it (form inputs → Gate 2).
 2. **Web platform**, a browser API or native element does the job: `Intl` (dates, numbers, lists, plurals), `URL` / `URLSearchParams`, `crypto.randomUUID()`, `structuredClone()`, `AbortController`, native `Array` / `Object` methods, `<dialog>`, modern CSS (`:has()`, container queries).
-3. **Already-installed dependency**, check `package.json` before adding a sibling that does the same job.
+3. **Already-installed dependency**, check `package.json` before adding a sibling that does the same job. For component/hook traps Claude often hand-rolls (client-only/useHydrated, sse, debounce-fetcher), see the remix-utils decision map at `wiki/dependencies/remix-utils.md` before reinventing.
 4. **New dependency**, only when 1-3 genuinely fall short; the added weight has to earn its place.
 5. **Custom code**, last resort, kept minimal.
 

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -491,6 +491,7 @@
     "wiki/dependencies/remix-flat-routes.md": "wiki-owned",
     "wiki/dependencies/remix-i18next.md": "wiki-owned",
     "wiki/dependencies/remix-toast.md": "wiki-owned",
+    "wiki/dependencies/remix-utils.md": "wiki-owned",
     "wiki/dependencies/Serena.md": "wiki-owned",
     "wiki/dependencies/spec-kit.md": "wiki-owned",
     "wiki/dependencies/Storybook.md": "wiki-owned",

--- a/app/components/Document/MetaHydrated/index.tsx
+++ b/app/components/Document/MetaHydrated/index.tsx
@@ -1,14 +1,10 @@
 import type {FC} from 'react';
-import {useEffect, useState} from 'react';
+import {useHydrated} from 'remix-utils/use-hydrated';
 
 // For Playwright
 // Adds meta tag to document when JavaScript is hydrated
 const MetaHydrated: FC = () => {
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  useEffect(() => {
-    queueMicrotask(() => setIsHydrated(true));
-  }, []);
+  const isHydrated = useHydrated();
 
   if (isHydrated) {
     return <meta content="true" name="hydrated" />;

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -30,7 +30,6 @@ export default {
     'lru-cache',
     'msw-storybook-addon',
     'nanoid',
-    'remix-utils',
     'stylelint-config-clean-order',
     'stylelint-config-standard',
     'stylelint-config-tailwindcss',

--- a/wiki/dependencies/remix-utils.md
+++ b/wiki/dependencies/remix-utils.md
@@ -11,7 +11,7 @@ tags: [dependency, claude, decision-map]
 
 # remix-utils
 
-A curated utility belt bundled for React Router 7 apps. This page is a Claude-targeted decision map: it decides *when* to reach for a bundled utility instead of hand-rolling a primitive that is redundant, or subtly wrong. It does not document *how*. The living source of truth for how each utility works is the library's own shipped reference, `node_modules/remix-utils/README.md`, cited below by section title. The export subpath is the durable key (the README is version-pinned at 9.3.1); this page copies no API prose.
+A decision map for the bundled `remix-utils` belt: *when* to reach for a utility instead of hand-rolling a primitive that is redundant or subtly wrong. For *how* each one works, see `node_modules/remix-utils/README.md`, cited below by section title.
 
 ## Decision map
 

--- a/wiki/dependencies/remix-utils.md
+++ b/wiki/dependencies/remix-utils.md
@@ -1,0 +1,51 @@
+---
+type: dependency
+status: active
+package: remix-utils
+version: 9.3.1
+role: utility-belt
+created: 2026-06-25
+updated: 2026-06-25
+tags: [dependency, claude, decision-map]
+---
+
+# remix-utils
+
+A curated utility belt bundled for React Router 7 apps. This page is a Claude-targeted decision map: it decides *when* to reach for a bundled utility instead of hand-rolling a primitive that is redundant, or subtly wrong. It does not document *how*. The living source of truth for how each utility works is the library's own shipped reference, `node_modules/remix-utils/README.md`, cited below by section title. The export subpath is the durable key (the README is version-pinned at 9.3.1); this page copies no API prose.
+
+## Decision map
+
+Risk-sorted, footguns first. Each row pairs a trap to hand-roll with the resolvable subpath that solves it safely and the README section that documents it.
+
+| DIY trap | Reach for | Why safer | README section |
+|---|---|---|---|
+| Hand-rolled client-only / hydration guard (`useState` + `useEffect` flag) | `remix-utils/use-hydrated` (component-wrapper sibling: `remix-utils/client-only`) | `useSyncExternalStore`-based, no provider, avoids hydration mismatch; in-repo usage: `app/components/Document/MetaHydrated/index.tsx` | `### useHydrated` (and `### ClientOnly`) |
+| Hand-rolled SSE hook / `EventSource` wiring | `remix-utils/sse/react` (server emitter: `remix-utils/sse/server`) | Manages the connection lifecycle and cleanup; a hand-rolled hook leaks connections | `### Server-Sent Events` |
+| Hand-rolled CSRF token + verification | `remix-utils/middleware/csrf` (classic split `remix-utils/csrf/server` + `remix-utils/csrf/react` for non-middleware routes) | Battle-tested token generation and verification; rolling your own is a security footgun | `#### CSRF Middleware` (classic: `### CSRF`) |
+| Hand-rolled bot/spam honeypot field | `remix-utils/middleware/honeypot` (classic split `remix-utils/honeypot/server` + `remix-utils/honeypot/react` for non-middleware routes) | Correct hidden-field plus timing checks; ad-hoc honeypots miss the timing trap | `#### Honeypot Middleware` (classic: `### Form Honeypot`) |
+| Hand-rolled open-redirect / safe-redirect check | `remix-utils/safe-redirect` | Blocks `//` and `/\` protocol-relative escapes; naive checks miss them. In GAIA code, see the redirect divergence below: use `isLocalRedirect` | `### Safe Redirects` |
+| Hand-rolled fetcher debounce (timeout wrapping `fetcher.submit`) | `remix-utils/use-debounce-fetcher` | Correct debounced `fetcher.submit`; distinct from a value debounce | `### Debounced Fetcher and Submit` |
+
+**Surface choice (CSRF and honeypot).** GAIA runs a middleware stack (`app/middleware/i18next.ts`), so each of those rows points at the v7.9 middleware subpath as the canonical surface for new code, with the classic split named in parentheses for routes that do not run through middleware. They are a different mechanism, not a fallback: middleware wires the check into the request pipeline; the classic split is the per-route hook plus server helper.
+
+## Considered but excluded
+
+Second-tier candidates weighed against the risk axis (likelihood-of-hand-rolling times cost-of-getting-it-wrong) and cut, so the curation is transparent rather than a silent cap:
+
+- `cache-assets` (`remix-utils/cache-assets`): lower-stakes perf convenience.
+- `preload-route-assets` (`remix-utils/preload-route-assets`): lower-stakes perf convenience.
+- `use-global-navigation-state` (`remix-utils/use-global-navigation-state`): lower-stakes convenience reinvention.
+
+## Deliberate divergences
+
+Where GAIA intentionally does not reach for remix-utils, with the reason, so the choice is not re-litigated:
+
+- **locale** → GAIA uses `remix-i18next` (full i18next: namespaces, SSR `Accept-Language`), more robust than remix-utils locales. See [[remix-i18next]].
+- **redirect** → GAIA uses a Zod `.refine()` `isLocalRedirect` guard (`app/utils/http.ts`). Validate-and-reject fits GAIA's Conform/Zod architecture better than safe-redirect's sanitize-and-fallback, and the safety is equivalent (both block `//` and `/\`). This is the in-GAIA position for the safe-redirect core row above: know the open-redirect trap, and in GAIA code guard with `isLocalRedirect`.
+- **responses** → GAIA uses native React Router 7 `data()`, the modern idiom over remix-utils `responses`.
+- **cookie** → GAIA uses native `createCookie`; locale is a known string, so a typed-cookie wrapper is low value.
+- **value-debounce** → GAIA's `useDebounce` is a *value* debounce, which is **not** remix-utils' fetcher-debounce (`use-debounce-fetcher`). No overlap, so both coexist.
+
+## Where each layer lives
+
+`node_modules/remix-utils/README.md` is the how, this map is the when, and the two trigger surfaces (the `react-code` skill's platform-first ladder and the `react-router-docs` path-scoped rule) are the awareness that points here.


### PR DESCRIPTION
## Summary

One PR, two deliverables.

**A — Awareness map.** New `wiki/dependencies/remix-utils.md`: a curated, Claude-targeted decision map (six risk-sorted core rows: hydration-safe client render, SSE, CSRF, honeypot, safe-redirect, debounced fetcher) reachable from the two surfaces Claude already loads when deciding whether to hand-roll a primitive:
- the `react-code` skill's "Reach for the Platform First" ladder, step 3 (component/hook traps);
- the `react-router-docs` path-scoped rule, now also scoped to `app/middleware/**` (server-side traps).

The map cites `node_modules/remix-utils/README.md` by section title as the source of truth and copies no API prose. It also records the considered-but-excluded second tier and GAIA's deliberate non-adoptions.

**B — Hydration dogfood.** `MetaHydrated` now derives its hydration signal from remix-utils' `useHydrated()`, keeping the `<meta name="hydrated" content="true">` tag byte-identical. The `remix-utils` entry is dropped from `knip.config.ts` `ignoreDependencies` (now a genuine import), and the new wiki page is classified `wiki-owned` in `.gaia/manifest.json`.

## Verification
- Per-phase gate: `pnpm typecheck` + `pnpm lint` clean (zero warnings).
- Phase-2 acceptance gate (build, knip, Playwright warm + cold) runs after this PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)