### PR TITLE
wiki: maintenance chain through a3ba6b1

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "9191a32aa09789e46b20a391732384148446cc05",
-  "last_evaluated_at": "2026-06-24T09:10:19Z",
+  "last_evaluated_sha": "d6cc88fa44d60e9abd751228aa14dd736c9af061",
+  "last_evaluated_at": "2026-06-24T18:42:50Z",
   "last_consolidated_sha": "20611f530b690c9a5cffb2e3abe439a03e11ad4a",
   "last_consolidated_at": "2026-06-24T05:36:18Z"
 }

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Update Workflow
 status: active
 created: 2026-04-22
-updated: 2026-06-24
+updated: 2026-06-25
 tags: [release, claude, adopter, drift]
 ---
 
@@ -39,7 +39,7 @@ Sentinel paths (always adopter-owned regardless of what GAIA ships): `wiki/hot.m
 1. Read `.gaia/VERSION`. Missing → tell user to run `/gaia-init` on a fresh `create-gaia` scaffold.
 2. Resolve latest release via `gh release list --repo gaia-react/gaia` (or GitHub API fallback).
 3. Compare to baseline. Same or older → exit, unless `.gaia/VERSION` has been bumped but not committed (an interrupted prior run), in which case surface the residual state so the adopter can commit or discard. Never downgrade.
-4. Show the adopter the release notes and **confirm** before touching anything. If on `main`/`master`, create the feature branch only after this confirmation, not before, so an early exit leaves no orphan branch.
+4. Show the adopter the **full baseline-to-latest CHANGELOG range** (every versioned section newer than `$BASELINE`, fetched no-auth from the release tarball) and **confirm** before touching anything. An adopter several versions behind sees every intervening entry, not just the latest tag's body. Step 9 cross-references the Step 7a removal no-op and deletion sweep against `**Action required:**`-anchored entries in the displayed range and surfaces a documented, opt-in cleanup suggestion for any convention-marked entry the merge walk left in place. Never auto-removes a dependency or deletes a file. If on `main`/`master`, create the feature branch only after this confirmation, not before, so an early exit leaves no orphan branch.
 5. Prune prior runs' leftover artifacts before this run creates its own: drop stale `.gaia-backup/` copies and stale `.gaia/cache/` tag dirs (keeping the baseline tarball), and remove `.gaia-merge/` only when empty. Then download baseline + latest tarballs to `.gaia/cache/`. Stop on any download or extraction failure; do not proceed with a partial cache.
 6. Walk the latest manifest. For each file, apply the decision table below.
 7. Report summary: overwritten / added / removed / skipped / conflicts / deleted / backed up.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,17 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-06-24 d6cc88f WORTHY - docs(wiki): debloat + factual-drift audit across 24 pages; pages corrected directly in-commit
+- 2026-06-24 b3d7aff WORTHY - feat(remix-utils): new wiki/dependencies/remix-utils.md decision map created in-commit
+- 2026-06-24 e371947 WORTHY - feat(spec-ledger): auto-archive merged SPECs post-reconcile; wiki/concepts/GAIA Spec.md updated in-commit
+- 2026-06-24 3f3f0a4 WORTHY - feat(spec-ledger): canonical status vocab + auto-heal; wiki/concepts/GAIA Spec.md updated in-commit
+- 2026-06-24 a2e1337 WORTHY - feat(plan): adversarial decomposition audit step 4.6; wiki/concepts/GAIA Plan.md updated in-commit
+- 2026-06-24 a49f3da WORTHY - feat(spec): adversarial SPEC-audit + lifecycle ledger; wiki/concepts/GAIA Spec.md updated in-commit
+- 2026-06-24 7df81c3 SKIP - fix(telemetry): CLI bug fix for --abandoned flag; internal, no wiki page needed
+- 2026-06-24 bbe006f SKIP - docs(changelog): backfill CHANGELOG entries only, no architecture change
+- 2026-06-24 67e903d WORTHY - feat(changelog): adopter-action convention + full-range CHANGELOG display in /update-gaia Step 4 → wiki/concepts/Update Workflow.md updated
+- 2026-06-24 c1c6121 WORTHY - chore(deps): remove react-router-dom; wiki/dependencies/React Router 7.md already updated in-commit
+- 2026-06-24 bdc0781 WORTHY - wiki: stale-claims + gap-fill across 86 pages; pages corrected directly in this commit
 - 2026-06-24 e645404 SKIP - wiki: maintenance chain commit (sync + consolidate + lint), self-referential
 - 2026-06-24 0ccc199 SKIP - chore(deps): Wave A version bumps + obsolete override pruning, no behavior change
 - 2026-06-24 0a07a8f WORTHY - fix(gaia-audit): 0-action auto-apply + statusline cache-bust; wiki/concepts/GAIA Audit.md already reflects this via 9191a32

--- a/wiki/meta/lint-report-2026-06-25.md
+++ b/wiki/meta/lint-report-2026-06-25.md
@@ -1,0 +1,37 @@
+---
+type: meta
+title: 'Lint Report 2026-06-25'
+created: 2026-06-25
+updated: 2026-06-25
+tags: [meta, lint]
+status: developing
+---
+
+# Lint Report: 2026-06-25
+
+## #11: Wiki drift check
+
+ℹ 1 commits behind HEAD. Run /gaia-wiki sync at next opportunity.
+
+## #12: Dead repo-relative paths
+
+⚠ 2 dead path reference(s) in wiki/, files no longer exist on disk:
+
+- `wiki/concepts/GAIA Init Workflow.md:25` → `.gaia/automation.json`
+- `wiki/concepts/Wiki Sync.md:25` → `.gaia/automation.json`
+
+## #13: UAT/SPEC narrative-ref drift
+
+✓ No narrative `UAT-NNN` or concrete maintainer `SPEC-NNN` references detected outside the structural exemptions in `.claude/rules/wiki-style.md`.
+
+## #14: Orphan pages
+
+✓ No orphan pages (every page has at least one inbound wikilink).
+
+## #15: Frontmatter gaps
+
+✓ All wiki pages carry the required frontmatter (type, status).
+
+## #16: Empty sections
+
+✓ No empty sections detected.


### PR DESCRIPTION
Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via `gaia wiki chain finish`.