### PR TITLE
wiki: sync through d67753f

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d6cc88fa44d60e9abd751228aa14dd736c9af061",
-  "last_evaluated_at": "2026-06-24T18:42:50Z",
+  "last_evaluated_sha": "d67753f31d38c7821e7c70fb56729edb72a4a3c2",
+  "last_evaluated_at": "2026-06-25T09:26:41Z",
   "last_consolidated_sha": "20611f530b690c9a5cffb2e3abe439a03e11ad4a",
   "last_consolidated_at": "2026-06-24T05:36:18Z"
 }

--- a/wiki/dependencies/gaia-lint.md
+++ b/wiki/dependencies/gaia-lint.md
@@ -2,10 +2,10 @@
 type: dependency
 status: active
 package: '@gaia-react/lint'
-version: 1.5.1
+version: 1.6.0
 role: lint-config
 created: 2026-04-27
-updated: 2026-06-24
+updated: 2026-06-25
 tags: [dependency, lint, eslint]
 ---
 
@@ -55,6 +55,20 @@ export default defineConfig([
   },
 ]);
 ```
+
+## Active rule groups
+
+| Group | Key rules | Notes |
+|---|---|---|
+| `base` | Standard TS/JS hygiene | — |
+| `react` | React-specific rules | — |
+| `testing` | D-8 test-honesty: `vitest/prefer-called-with`, `no-restricted-imports` (blocks `*.server` / internals from consumer tests) | Added in 1.6.0 |
+| `guardrails` | `no-enum`, `no-switch`, `no-jsx-iife` custom plugins | — |
+| `styleHygiene` | `import-x/no-restricted-paths` with carve-outs: `resources+/` and `actions+/` routes are exempt for UI layers | Carve-out added in 1.6.0 |
+| `betterTailwind` | Tailwind class ordering and hygiene | — |
+| `prettier` | Formatting via Prettier as an ESLint rule | — |
+
+The `resources+/` and `actions+/` carve-out means UI-layer files may import typed action/loader types from flat-file resource routes without an `eslint-disable` comment. Consumer tests must not import from `*.server` files or internal server surfaces; the `test/setup.ts` global Vitest setupFile is the single sanctioned place to start the MSW harness.
 
 ## When to edit
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,11 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-06-25 5c0afcf SKIP - wiki: maintenance chain commit (sync+lint run), not a source change
+- 2026-06-25 75ad7f3 SKIP - chore(release): release plumbing, no wiki-content change needed
+- 2026-06-25 c2c6d97 WORTHY - fix(checks): reconcile check definitions contradicting GAIA design → wiki pages updated in commit
+- 2026-06-25 5eed5a7 WORTHY - chore(lint): bump @gaia-react/lint 1.5.1→1.6.0; D-8 rules active → wiki/dependencies/gaia-lint.md
+- 2026-06-25 d67753f WORTHY - fix(release-scrub): derive excluded-slug set at scan time → wiki/decisions/Bundle-time Scrub.md updated in commit
 - 2026-06-24 d6cc88f WORTHY - docs(wiki): debloat + factual-drift audit across 24 pages; pages corrected directly in-commit
 - 2026-06-24 b3d7aff WORTHY - feat(remix-utils): new wiki/dependencies/remix-utils.md decision map created in-commit
 - 2026-06-24 e371947 WORTHY - feat(spec-ledger): auto-archive merged SPECs post-reconcile; wiki/concepts/GAIA Spec.md updated in-commit


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to d67753f.