### PR TITLE
wiki: note minimumReleaseAgeExclude lifecycle in pnpm decision

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d67753f31d38c7821e7c70fb56729edb72a4a3c2",
-  "last_evaluated_at": "2026-06-25T09:26:41Z",
+  "last_evaluated_sha": "0624cabca0f9ef457bf4dda56d4cd1c78eb689f4",
+  "last_evaluated_at": "2026-06-25T11:48:07Z",
   "last_consolidated_sha": "20611f530b690c9a5cffb2e3abe439a03e11ad4a",
   "last_consolidated_at": "2026-06-24T05:36:18Z"
 }

--- a/wiki/decisions/pnpm.md
+++ b/wiki/decisions/pnpm.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-04-26
 created: 2026-04-26
-updated: 2026-06-24
+updated: 2026-06-25
 tags: [decision, tooling, package-manager, security]
 ---
 
@@ -16,7 +16,7 @@ GAIA uses **pnpm** for installs and dependency resolution. The `packageManager` 
 
 - **Speed**: content-addressed store with hard-linking installs significantly faster than npm.
 - **Strict isolation**: flat `node_modules/` is gone. A package can only `require` what it declared. Phantom deps fail loud.
-- **Built-in supply-chain protection**: `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days), blocking installs of versions less than a week old, plus `trustPolicy: no-downgrade`, which fails the install when a package's trust level drops versus prior releases (possible takeover). The release-age delay catches the bulk of compromised-package incidents in the window between publish and detection. pnpm enforces both policies against the entire lockfile on every install, including `--frozen-lockfile` runs in CI, so a latent pre-provenance transitive surfaces at install time rather than only on re-resolution. `trustPolicyExclude` acknowledges the few old, pre-provenance final-major releases that trip `no-downgrade` because a newer major later added npm provenance; each entry is scoped to an exact version and names its requiring dependent.
+- **Built-in supply-chain protection**: `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days), blocking installs of versions less than a week old, plus `trustPolicy: no-downgrade`, which fails the install when a package's trust level drops versus prior releases (possible takeover). The release-age delay catches the bulk of compromised-package incidents in the window between publish and detection. pnpm enforces both policies against the entire lockfile on every install, including `--frozen-lockfile` runs in CI, so a latent pre-provenance transitive surfaces at install time rather than only on re-resolution. `trustPolicyExclude` acknowledges the few old, pre-provenance final-major releases that trip `no-downgrade` because a newer major later added npm provenance; each entry is scoped to an exact version and names its requiring dependent. `minimumReleaseAgeExclude` is the parallel escape hatch for the release-age delay: it exempts first-party packages whose third-party-vetting rationale does not apply, and is also how a third-party version ships before it clears the window. Because enforcement runs against the whole lockfile on every install (CI `--frozen-lockfile` included), such an entry stays committed until that version ages past the window; removing it earlier fails both local and CI installs with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, so it is not an add-install-then-revert step.
 - **Reproducible installs**: `pnpm-lock.yaml` + CI `--frozen-lockfile` guarantees the lockfile is the only source of truth.
 
 ## How

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,8 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-06-25 0624cab SKIP - docs(wiki): minimumReleaseAgeExclude lifecycle already noted directly in wiki/decisions/pnpm.md in-commit
+- 2026-06-25 167dac7 SKIP - wiki sync chain commit (state + gaia-lint.md already updated in-commit, no new source changes)
 - 2026-06-25 5c0afcf SKIP - wiki: maintenance chain commit (sync+lint run), not a source change
 - 2026-06-25 75ad7f3 SKIP - chore(release): release plumbing, no wiki-content change needed
 - 2026-06-25 c2c6d97 WORTHY - fix(checks): reconcile check definitions contradicting GAIA design → wiki pages updated in commit

--- a/wiki/meta/lint-report-2026-06-25.md
+++ b/wiki/meta/lint-report-2026-06-25.md
@@ -11,14 +11,11 @@ status: developing
 
 ## #11: Wiki drift check
 
-ℹ 1 commits behind HEAD. Run /gaia-wiki sync at next opportunity.
+ℹ 1 commit behind HEAD. Run /gaia-wiki sync at next opportunity.
 
 ## #12: Dead repo-relative paths
 
-⚠ 2 dead path reference(s) in wiki/, files no longer exist on disk:
-
-- `wiki/concepts/GAIA Init Workflow.md:25` → `.gaia/automation.json`
-- `wiki/concepts/Wiki Sync.md:25` → `.gaia/automation.json`
+✓ No dead repo-relative paths detected in wiki body prose.
 
 ## #13: UAT/SPEC narrative-ref drift
 


### PR DESCRIPTION
## Summary

Documents the `minimumReleaseAgeExclude` lifecycle in the pnpm decision page, plus the `/gaia-wiki` chain housekeeping that rode along.

- `wiki/decisions/pnpm.md` — note the `minimumReleaseAgeExclude` lifecycle
- `wiki/.state.json`, `wiki/log.md` — sync stage advanced wiki state to `0624cab`
- `wiki/meta/lint-report-2026-06-25.md` — lint report (drift: low, all structural checks passed)

## Notes

Wiki-only change. Sync evaluated `d67753f..0624cab` with 0 worthy diffs (the doc commit carried its own in-tree edit); consolidate skipped (threshold not met); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
