### PR TITLE
docs(spec-close): correct manual-invocation handle to /speckit-gaia-spec-close

### DIFF
--- a/.specify/extensions/gaia/commands/spec-close.md
+++ b/.specify/extensions/gaia/commands/spec-close.md
@@ -10,7 +10,7 @@ Closes a SPEC after its implementing PR has merged. Two responsibilities:
 1. **Drain a deferred wiki-promote**, if `/speckit-implement` saw the PR unmerged and cached a defer flag.
 2. **Prompt for SPEC artifact disposition**, archive, delete, or keep in place, once the wiki side is settled.
 
-Auto-triggered from `wiki-promote` Step 8 on the immediate-merge path. Also invokable manually as `/gaia-spec close [SPEC-NNN]` for the deferred path or for retroactive disposition.
+Auto-triggered from `wiki-promote` Step 8 on the immediate-merge path. Also invokable manually as `/speckit-gaia-spec-close [SPEC-NNN]` for the deferred path or for retroactive disposition.
 
 ## Step 1: Resolve target SPEC
 
@@ -56,7 +56,7 @@ Surface via `AskUserQuestion`:
 - Options:
   - `{ label: "Archive (Recommended)", description: "Move the SPEC folder to .gaia/local/specs/archived/ with status=archived. Preserves the SPEC artifact and its siblings for posterity. Wiki content was already promoted at implement time; no re-summarization." }`
   - `{ label: "Delete", description: "Remove the SPEC folder. Local-only (.gaia/local/ is gitignored), so the SPEC is not recoverable from git history." }`
-  - `{ label: "Keep in place", description: "Leave the folder at .gaia/local/specs/<spec_id>/ unchanged. Choose if undecided; re-run /gaia-spec close <spec_id> later to revisit." }`
+  - `{ label: "Keep in place", description: "Leave the folder at .gaia/local/specs/<spec_id>/ unchanged. Choose if undecided; re-run /speckit-gaia-spec-close <spec_id> later to revisit." }`
 
 ## Step 4: Apply disposition
 

--- a/.specify/extensions/gaia/commands/wiki-promote.md
+++ b/.specify/extensions/gaia/commands/wiki-promote.md
@@ -60,7 +60,7 @@ If `$pr_json` is `[]` (no merged PR for this branch):
 
    (Cache directory creation: `mkdir -p .gaia/local/cache/wiki-promote/`. The `.gaia/local/` line in `.gitignore` covers this path.)
 
-2. Exit with: `wiki-promote: SPEC-NNN deferred, awaiting PR merge for branch <current_branch>. Drain via /gaia-spec close SPEC-NNN after merge.`
+2. Exit with: `wiki-promote: SPEC-NNN deferred, awaiting PR merge for branch <current_branch>. Drain via /speckit-gaia-spec-close SPEC-NNN after merge.`
 
 If `$pr_json` contains a merged PR:
 
@@ -314,7 +314,7 @@ Wiki promote complete for SPEC-NNN.
 
 If any pages were skipped due to hand-edit detection, include a one-line note:
 
-`Hand-edited skips can be resolved by re-running /gaia-spec close SPEC-NNN --force (TBD; for now resolve manually).`
+`Hand-edited skips can be resolved by re-running /speckit-gaia-spec-close SPEC-NNN --force (TBD; for now resolve manually).`
 
 ## Step 8 - Chain to spec-close (immediate-merge path only)
 
@@ -328,4 +328,4 @@ Otherwise, invoke `/speckit-gaia-spec-close` directly by calling the Skill tool 
 
 This presents the user with the archive / delete / keep prompt for the local SPEC artifact. The wiki content is already committed (Step 6's wiki-sync handoff); the disposition only affects `.gaia/local/specs/<spec_id>/`.
 
-If `/speckit-gaia-spec-close` fails or refuses, exit with the warning `wiki-promote: pages staged and committed; spec-close chain failed. Run /gaia-spec close <spec_id> manually to dispose of the SPEC artifact.` Do NOT retry the chain, the wiki side is already settled.
+If `/speckit-gaia-spec-close` fails or refuses, exit with the warning `wiki-promote: pages staged and committed; spec-close chain failed. Run /speckit-gaia-spec-close <spec_id> manually to dispose of the SPEC artifact.` Do NOT retry the chain, the wiki side is already settled.

--- a/.specify/extensions/gaia/rules/smoke.md
+++ b/.specify/extensions/gaia/rules/smoke.md
@@ -27,4 +27,4 @@ GAIA's verification artifacts split across two trees: `.specify/extensions/gaia/
 
 ## Enforcement
 
-Maintainer rule + good-faith review. No CI lint, no `/gaia-spec close` audit hook. When authoring a new verification artifact, classify it by shape against the decision table and place it in the matching tree; when reviewing, flag misclassification and migrate. If repeated violations surface post-launch, escalate to a `/gaia-spec close` audit step, never CI lint.
+Maintainer rule + good-faith review. No CI lint, no `/speckit-gaia-spec-close` audit hook. When authoring a new verification artifact, classify it by shape against the decision table and place it in the matching tree; when reviewing, flag misclassification and migrate. If repeated violations surface post-launch, escalate to a `/speckit-gaia-spec-close` audit step, never CI lint.

--- a/wiki/concepts/GAIA Spec.md
+++ b/wiki/concepts/GAIA Spec.md
@@ -62,7 +62,7 @@ Archiving moves a SPEC folder to `.gaia/local/specs/archived/<id>/` and stamps `
 
 Two paths reach the archive:
 
-- **Explicit disposition.** `/gaia-spec close` prompts Archive / Delete / Keep in place once the implementing PR has merged (and after any deferred wiki-promote drain). Archive is the recommended default.
+- **Explicit disposition.** `/speckit-gaia-spec-close` prompts Archive / Delete / Keep in place once the implementing PR has merged (and after any deferred wiki-promote drain). Archive is the recommended default.
 - **Auto-sweep.** `lib/spec-archive-merged.sh` runs on every `/gaia-spec`, right after `spec-reconcile.sh`. It archives any folder whose ledger row reads `merged` and that has no pending wiki-promote drain cache at `.gaia/local/cache/wiki-promote/<id>.json` (a pending cache means the wiki content has not promoted yet, so the close flow still owns it). A merged row with no active folder is skipped, and an id that already has an `archived/` folder is left in place rather than overwritten. This is the safety net for a PR merged out-of-band (the GitHub button, another session) or a `Keep in place` disposition that left the folder active. The sweep is silent-but-logged: one stdout line (`Archived N merged SPEC(s): …`) and a `spec_closed` telemetry event (`disposition: archive`) per folder moved.
 
 `Keep in place` persists no marker, so the sweep cannot tell it apart from a SPEC that was never closed and will archive both. This is acceptable because archiving is reversible: move the folder back out of `archived/` to undo it.


### PR DESCRIPTION
## What

Six sites documented the spec-close manual entry point as `/gaia-spec close [SPEC-NNN]` — an invocation the router does not implement. The command is registered as `name: speckit-gaia-spec-close`, and `/gaia-spec`'s argument parser only special-cases `auto` (its `argument-hint` is `[auto] [description]`). There is no `close` dispatch branch, so `/gaia-spec close SPEC-001` starts a brand-new spec titled "close SPEC-001" rather than closing one.

This corrects all references to the real registered handle, `/speckit-gaia-spec-close`. No router branch was added.

## Why this resolution (Option A, docs-only)

Verified against the actual wiring rather than either file's prose:

- **Registration:** `spec-close.md` frontmatter → `name: speckit-gaia-spec-close`.
- **Router:** `spec.md` argument parsing tokenizes only `auto`; everything else is the feature description.
- **Command hint:** `gaia-spec.md` advertises `[auto] [description]`.

Closing a SPEC is already automatic for the normal path — wiki-promote Step 8 chains to `/speckit-gaia-spec-close` on immediate merge, and `spec-reconcile.sh` + `spec-archive-merged.sh` sweep merged folders into `archived/` on every `/gaia-spec` run. The manual command survives only as the backstop for the deferred-drain path (which the sweep deliberately skips while a `wiki-promote/<id>.json` cache is pending) and retroactive disposition override. So no `close` subcommand is warranted; only the name was wrong.

## Sites corrected

- `.specify/extensions/gaia/commands/spec-close.md` (lines 13, 59)
- `.specify/extensions/gaia/commands/wiki-promote.md` (lines 63, 317, 331)
- `.specify/extensions/gaia/rules/smoke.md` (line 30, two refs)
- `wiki/concepts/GAIA Spec.md` (line 65)

Repo grep for `/gaia-spec close` is now clean. Docs-only; no behavior change. The website docs page already shows the `/speckit-gaia-spec-close [SPEC-NNN]` form, so it stays consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)