### PR TITLE
feat(react-code): codify and enforce React 19 idioms

### DIFF
--- a/.claude/rules/state-pattern.md
+++ b/.claude/rules/state-pattern.md
@@ -38,14 +38,14 @@ Context holds `Maybe<T>`; hook asserts non-null and returns `T`.
 const ThingsContext = createContext<Maybe<Things>>(undefined);
 
 export const useThings = (): Things => {
-  const context = useContext(ThingsContext) as Maybe<Things>;
+  const context = use(ThingsContext) as Maybe<Things>;
   if (!context)
     throw new Error('useThings must be used within a ThingsProvider');
   return context;
 };
 
 export const ThingsProvider: FC<ThingsProviderProps> = ({children, things}) => (
-  <ThingsContext.Provider value={things}>{children}</ThingsContext.Provider>
+  <ThingsContext value={things}>{children}</ThingsContext>
 );
 ThingsProvider.displayName = 'ThingsProvider';
 ```
@@ -61,14 +61,14 @@ type XContextValue = [Maybe<number>, Dispatch<SetStateAction<Maybe<number>>>];
 const XContext = createContext<XContextValue>([undefined, noop]);
 
 export const useX = () => {
-  const context = useContext(XContext) as Maybe<XContextValue>;
+  const context = use(XContext) as Maybe<XContextValue>;
   if (!context) throw new Error('useX must be used within an XProvider');
   return context;
 };
 
 export const XProvider: FC<XProviderProps> = ({children, initialState}) => {
   const value = useState(initialState);
-  return <XContext.Provider value={value}>{children}</XContext.Provider>;
+  return <XContext value={value}>{children}</XContext>;
 };
 XProvider.displayName = 'XProvider';
 ```

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-code
-description: Patterns and conventions for writing and editing React code, including components and hooks. Use this skill whenever writing or reviewing React components, hooks (useEffect, useCallback, useState), event handlers, or component extraction decisions. Also trigger when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues, or when deciding whether to add a dependency, reach for a web-platform API (Intl, URL, crypto.randomUUID), or hand-roll a primitive.
+description: Patterns and conventions for writing and editing React code, including components and hooks. Use this skill whenever writing or reviewing React components, hooks (useEffect, useCallback, useState), event handlers, or component extraction decisions. Also trigger when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues, or when deciding whether to add a dependency, reach for a web-platform API (Intl, URL, crypto.randomUUID), or hand-roll a primitive. Also trigger when choosing a React 19 idiom, deciding between forwardRef and ref-as-prop, useContext and use(), or Context.Provider and the Context shorthand; when conditional rendering risks the && numeric-0 leak; or when tempted to reach for React's form Actions (useActionState, useFormStatus, useOptimistic) instead of React Router's form handling.
 ---
 
 # React Code
@@ -94,6 +94,58 @@ Every string a user can see or hear, labels, headings, placeholders, button text
 
 See `references/translation-patterns.md` for edge cases (keyPrefix, Trans component, dedup).
 
+### Gate 4: React 19 Idiom Check
+
+GAIA writes React 19 idioms. The work here is to not regress to pre-19 habits, and to not pull in React's framework-level form APIs that React Router already owns.
+
+**Before writing `forwardRef`: don't.** In React 19, `ref` is an ordinary prop on function components, so `forwardRef` is no longer needed (slated for deprecation in a future release). GAIA has zero `forwardRef`; every Form control destructures `ref` from props. Match that.
+
+```tsx
+// BAD, needless indirection
+const InputText = forwardRef<HTMLInputElement, Props>((props, ref) => <input ref={ref} {...props} />);
+// GOOD, ref is just a prop
+const InputText: FC<Props> = ({ref, ...rest}) => <input ref={ref} {...rest} />;
+```
+
+The ref _type_ (`Ref<T>`, or `ComponentProps<'input'>` already carrying `ref`) is the typescript skill's domain.
+
+**Before writing `&&` in JSX, make the left operand a real boolean.** `&&` returns its left operand when falsy. `false`/`null`/`undefined` render nothing, but a numeric **`0`** is a renderable value and leaks the literal "0" into the DOM. This is the most common React rendering bug, and **lint does not catch it.**
+
+```tsx
+// BAD, renders "0" when the list is empty
+{items.length && <List items={items} />}
+// GOOD, force a real boolean
+{items.length > 0 && <List items={items} />}
+```
+
+For render-or-nothing, a boolean-guarded `&&` is the idiom; it replaces the old `cond ? <X/> : null`. A ternary is only for a genuine either/or where both arms render, never `: null`.
+
+**Before writing `useContext` or `<Context.Provider>`, use the React 19 forms.** Read context with `use()` (unlike `useContext`, it may be called conditionally or after an early return); render the context object directly as the provider.
+
+```tsx
+const nonce = use(NonceContext); // not useContext(NonceContext)
+<NonceContext value={nonce}>{children}</NonceContext>; // not <NonceContext.Provider>
+```
+
+`<Context.Provider>`/`<Context.Consumer>` are legacy (deprecation planned). GAIA uses the `<Context>` shorthand and `use()` exclusively, never `.Provider`, `.Consumer`, or `useContext`. Convert any you find.
+
+**Stay in React Router's lane; don't reach for React's form Actions.** GAIA submits through React Router `<Form>` / `useFetcher` + route `action` exports, validates with Conform + Zod (Gate 2), and reads pending/optimistic state from React Router. React 19's framework-level form hooks duplicate and fight that surface. When tempted, redirect:
+
+| React 19 API (don't use here)          | Use instead                                                                                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `useActionState`, `<form action={fn}>` | route `action` + `useActionData`                                                              |
+| `useFormStatus`                        | `useNavigation().state` / `fetcher.state`                                                     |
+| `useOptimistic`                        | fetcher-based optimism (`useOptimisticThemeMode` in `useTheme.ts`)                            |
+| `use(promise)` for route data          | loader + `useLoaderData` (`use(promise)` only for non-route promises inside `<Suspense>`)     |
+
+Metadata is the mirror case: GAIA renders `<title>`/`<meta>` as JSX (React 19 hoisting), not a React Router route `meta`/`links` export. Keep it that way; adding a route `meta` export to a page that already renders `<title>` in JSX produces duplicate tags.
+
+When you do reach for React Router's API, read it from the version-matched docs shipped at `node_modules/react-router/docs`, not the web.
+
+**Render nothing with `undefined` or `false`, never `null`.** The pre-18 "a component must `return null`" rule is gone. A guard clause falls through to an implicit `undefined`, and `return false` / `return undefined` render nothing. GAIA never uses `null` to render nothing; rewrite every `return null` and `: null` render arm to the `undefined` / `false` / `&&` form, existing code included.
+
+For `useEffectEvent` (the sanctioned replacement for stale-deps / latest-ref hacks) and ref-callback cleanup functions, see `references/hook-patterns.md`.
+
 ## Component Structure
 
 - **FC typing:** `const MyComponent: FC<Props> = ({...}) => ...`
@@ -122,11 +174,10 @@ How: Create `ParentComponent/NewSection/index.tsx`, move exclusive types/state/h
 Thin shell only:
 
 - `loader` / `action` functions
-- `meta` export
 - Zod schemas for the action
 - One-line default export: `const MyRoute: FC = () => <MyPage />;`
 
-**No UI code, hooks, state, or sub-components in route files.**
+**No UI code, hooks, state, or sub-components in route files.** Metadata renders as JSX (`<title>`/`<meta>`) in the page, not a route `meta` export (Gate 4).
 
 ### Page components (`app/pages/`)
 

--- a/.claude/skills/react-code/SKILL.md
+++ b/.claude/skills/react-code/SKILL.md
@@ -44,7 +44,7 @@ Only use when the function is:
 
 If none apply, skip `useCallback`, it adds indirection without benefit.
 
-**`useState` type inference:** Omit explicit type when inferable from the default value. Only add types for `null` initial values, unions, or complex objects.
+**`useState` type inference:** Omit explicit type when inferable from the default value. Add types for unions or complex objects. For an absent initial value, prefer `undefined` over `null` (GAIA never-null): `useState<T>()` is already typed `T | undefined`.
 
 ### Gate 2: Form Element Check
 

--- a/.claude/skills/react-code/references/hook-patterns.md
+++ b/.claude/skills/react-code/references/hook-patterns.md
@@ -7,6 +7,8 @@
 - [Strict Mode & Cleanup](#strict-mode--cleanup)
 - [useCallback, When to Use](#usecallback--when-to-use)
 - [useMemo, When to Use](#usememo--when-to-use)
+- [useEffectEvent, Non-Reactive Effect Logic](#useeffectevent-non-reactive-effect-logic)
+- [Ref Callback Cleanup](#ref-callback-cleanup)
 
 ---
 
@@ -240,3 +242,47 @@ const label = `Hello, ${name}`;
 ```
 
 Missing or stale deps in `useMemo` introduce the same stale closure bugs as `useCallback`, the memoized value silently reads an old snapshot of whatever was omitted from the deps array.
+
+---
+
+## useEffectEvent, Non-Reactive Effect Logic
+
+`useEffectEvent` (stable in React 19.2) extracts a non-reactive read out of an Effect, so the Effect uses a current value without listing it as a dependency. It is the sanctioned replacement for "I had to omit X from the deps array" and for the latest-ref workaround (e.g. `TextArea` keeping `onAutoSizeRef.current = onAutoSize` behind an `eslint-disable react-hooks/refs`).
+
+```tsx
+// onVisit reads numItems, but the Effect should re-run only when url changes
+const onVisit = useEffectEvent((visitedUrl: string) => {
+  log(visitedUrl, numItems); // numItems is non-reactive here
+});
+
+useEffect(() => {
+  onVisit(url);
+}, [url]); // numItems intentionally absent, and lint won't demand it
+```
+
+Use sparingly, only for values that are genuinely non-reactive (the Effect should not re-run when they change). If the Effect should react to the value, keep it in the deps array.
+
+---
+
+## Ref Callback Cleanup
+
+A ref callback may return a cleanup function, run when the element leaves the DOM. When it returns a cleanup, React no longer calls the callback again with `null`.
+
+```tsx
+<div
+  ref={(node) => {
+    const observer = new ResizeObserver(() => {/* … */});
+    observer.observe(node);
+    return () => observer.disconnect(); // runs on unmount
+  }}
+/>;
+```
+
+**Strict-TS pitfall:** because a returned value is now read as a cleanup function, an arrow ref-callback with an implicit return of a non-`undefined` value flags. Use a block body so the callback returns `undefined`.
+
+```tsx
+// BAD, implicit return of the assignment is read as a cleanup
+<input ref={(node) => (ref.current = node)} />;
+// GOOD, block body returns undefined
+<input ref={(node) => { ref.current = node; }} />;
+```

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -71,6 +71,7 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 - JSX boolean props: always explicit `={true}`, makes props grep-able and avoids confusion when a prop is later refactored to a non-boolean type
 - Max 3 function parameters, use an options object beyond that; call sites with 4+ positional args are hard to read and argument order mistakes are common
 - Inline boolean coercion uses `!!x`, never `Boolean(x)`; reserve `Boolean` for point-free use (e.g. `array.filter(Boolean)`), and coerce per operand in a nullable `||` chain (`!!a || !!b`), since `!!(a || b)` trips `@typescript-eslint/prefer-nullish-coalescing`
+- Prefer `undefined` over `null` for GAIA-controlled absence (state, optional fields, internal sentinels); reserve `null` for external contracts that require it: DOM `useRef(null)`, ref-callback params, React Router `data(null)`, Zod `.nullable()`, and platform/library APIs that return `null`
 
 ## Zod
 

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -70,6 +70,7 @@ export const formatDate = (date: Date): string => format(date, 'yyyy-MM-dd');
 - No TypeScript enums, use `as const` objects with derived types; enums compile to runtime objects with surprising behavior and don't tree-shake well
 - JSX boolean props: always explicit `={true}`, makes props grep-able and avoids confusion when a prop is later refactored to a non-boolean type
 - Max 3 function parameters, use an options object beyond that; call sites with 4+ positional args are hard to read and argument order mistakes are common
+- Inline boolean coercion uses `!!x`, never `Boolean(x)`; reserve `Boolean` for point-free use (e.g. `array.filter(Boolean)`), and coerce per operand in a nullable `||` chain (`!!a || !!b`), since `!!(a || b)` trips `@typescript-eslint/prefer-nullish-coalescing`
 
 ## Zod
 

--- a/app/components/Button/index.tsx
+++ b/app/components/Button/index.tsx
@@ -95,10 +95,9 @@ const Button: FC<ButtonProps> = ({
   ...props
 }) => {
   const Icon = icon;
-  const iconComponent =
-    Icon ?
-      <Icon className={twJoin(children && 'flex-none', classNameIcon)} />
-    : null;
+  const iconComponent = Icon && (
+    <Icon className={twJoin(children && 'flex-none', classNameIcon)} />
+  );
 
   const innerClassName = twJoin(
     icon && 'flex items-center justify-center',

--- a/app/components/Document/MetaHydrated/index.tsx
+++ b/app/components/Document/MetaHydrated/index.tsx
@@ -10,7 +10,7 @@ const MetaHydrated: FC = () => {
     return <meta content="true" name="hydrated" />;
   }
 
-  return null;
+  return undefined;
 };
 
 export default MetaHydrated;

--- a/app/components/Document/index.tsx
+++ b/app/components/Document/index.tsx
@@ -30,7 +30,7 @@ const Document: FC<DocumentProps> = ({
   const nonce = useNonce();
   const theme = useOptionalTheme();
   const requestInfo = useOptionalRequestInfo();
-  const hasExplicitTheme = requestInfo?.userPrefs.theme != null;
+  const hasExplicitTheme = !!requestInfo?.userPrefs.theme;
 
   return (
     <html

--- a/app/components/Errors/ErrorStack/index.tsx
+++ b/app/components/Errors/ErrorStack/index.tsx
@@ -27,7 +27,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
     const statusDiv =
       status || statusText ?
         <div className="space-x-1 pt-px pr-1.5 pl-1 font-sans text-xs leading-none text-white">
-          {status && <span>{status}</span>}
+          {status !== undefined && <span>{status}</span>}
           {statusText && <span>{statusText}</span>}
         </div>
       : undefined;
@@ -62,7 +62,7 @@ const ErrorStack: FC<ErrorStackProps> = ({
     );
   }
 
-  return null;
+  return undefined;
 };
 
 export default ErrorStack;

--- a/app/components/Form/Checkbox/index.tsx
+++ b/app/components/Form/Checkbox/index.tsx
@@ -61,16 +61,15 @@ const Checkbox: FC<CheckboxProps> = ({
     />
   );
 
-  const status =
-    (description ?? error) ?
-      <FieldStatus
-        className={twMerge('mt-0', classNameDescription)}
-        description={description}
-        disabled={disabled}
-        error={error}
-        id={id}
-      />
-    : null;
+  const status = (description ?? error) && (
+    <FieldStatus
+      className={twMerge('mt-0', classNameDescription)}
+      description={description}
+      disabled={disabled}
+      error={error}
+      id={id}
+    />
+  );
 
   if (!label) {
     return (

--- a/app/components/Form/Checkbox/index.tsx
+++ b/app/components/Form/Checkbox/index.tsx
@@ -61,7 +61,7 @@ const Checkbox: FC<CheckboxProps> = ({
     />
   );
 
-  const status = (description ?? error) && (
+  const status = !!(description ?? error) && (
     <FieldStatus
       className={twMerge('mt-0', classNameDescription)}
       description={description}

--- a/app/components/Form/Field/FieldLabel/index.tsx
+++ b/app/components/Form/Field/FieldLabel/index.tsx
@@ -43,7 +43,7 @@ const FieldLabel: FC<FieldLabelProps> = ({
   const requiredExtra = (!!required || !!extra) && (
     <div>
       {required && <FieldRequiredText disabled={disabled} error={error} />}
-      {extra && <FieldExtra>{extra}</FieldExtra>}
+      {!!extra && <FieldExtra>{extra}</FieldExtra>}
     </div>
   );
 

--- a/app/components/Form/Field/FieldLabel/index.tsx
+++ b/app/components/Form/Field/FieldLabel/index.tsx
@@ -40,13 +40,12 @@ const FieldLabel: FC<FieldLabelProps> = ({
     </SpanOrLegend>
   );
 
-  const requiredExtra =
-    required || extra ?
-      <div>
-        {required && <FieldRequiredText disabled={disabled} error={error} />}
-        {extra && <FieldExtra>{extra}</FieldExtra>}
-      </div>
-    : null;
+  const requiredExtra = (!!required || !!extra) && (
+    <div>
+      {required && <FieldRequiredText disabled={disabled} error={error} />}
+      {extra && <FieldExtra>{extra}</FieldExtra>}
+    </div>
+  );
 
   const outerClassName = twJoin(
     'mb-1 ml-px flex items-center justify-between',

--- a/app/components/Form/Field/FieldStatus/index.tsx
+++ b/app/components/Form/Field/FieldStatus/index.tsx
@@ -33,10 +33,10 @@ const FieldStatus: FC<FieldStatusProps> = ({
         id={id}
         maxLength={maxLength}
       />
-    : null;
+    : undefined;
 
   const errorElement =
-    error && error !== true ? <FieldError error={error} /> : null;
+    error && error !== true ? <FieldError error={error} /> : undefined;
 
   return (
     <div className={twMerge('mt-1 ml-px', className)}>

--- a/app/components/Form/Field/index.tsx
+++ b/app/components/Form/Field/index.tsx
@@ -59,33 +59,31 @@ const Field: FC<FieldProps> = ({
   name,
   required,
 }) => {
-  const status =
-    description || error || maxLength ?
-      <FieldStatus
-        className={classNameDescription}
-        description={description}
-        disabled={disabled}
-        error={error}
-        hideMaxLength={hideMaxLength}
-        id={id ?? name}
-        length={length}
-        maxLength={maxLength}
-      />
-    : null;
+  const status = (!!description || !!error || !!maxLength) && (
+    <FieldStatus
+      className={classNameDescription}
+      description={description}
+      disabled={disabled}
+      error={error}
+      hideMaxLength={hideMaxLength}
+      id={id ?? name}
+      length={length}
+      maxLength={maxLength}
+    />
+  );
 
-  const fieldLabel =
-    label ?
-      <FieldLabel
-        className={classNameLabel}
-        disabled={disabled}
-        error={error}
-        extra={extra}
-        htmlFor={name ? (id ?? name) : undefined}
-        required={required}
-      >
-        {label}
-      </FieldLabel>
-    : null;
+  const fieldLabel = label && (
+    <FieldLabel
+      className={classNameLabel}
+      disabled={disabled}
+      error={error}
+      extra={extra}
+      htmlFor={name ? (id ?? name) : undefined}
+      required={required}
+    >
+      {label}
+    </FieldLabel>
+  );
 
   return (
     <div className={className} role="presentation">

--- a/app/components/Form/Field/index.tsx
+++ b/app/components/Form/Field/index.tsx
@@ -72,7 +72,7 @@ const Field: FC<FieldProps> = ({
     />
   );
 
-  const fieldLabel = label && (
+  const fieldLabel = !!label && (
     <FieldLabel
       className={classNameLabel}
       disabled={disabled}

--- a/app/components/Form/FormError/index.tsx
+++ b/app/components/Form/FormError/index.tsx
@@ -30,7 +30,7 @@ const FormError: FC<FormResultProps> = ({className, hide}) => {
   };
 
   if (!result) {
-    return null;
+    return undefined;
   }
 
   return (

--- a/app/components/LinkButton/index.tsx
+++ b/app/components/LinkButton/index.tsx
@@ -31,10 +31,9 @@ const LinkButton: FC<LinkButtonProps> = ({
   ...props
 }) => {
   const Icon = icon;
-  const iconComponent =
-    Icon ?
-      <Icon className={twJoin(children && 'flex-none', classNameIcon)} />
-    : null;
+  const iconComponent = Icon && (
+    <Icon className={twJoin(children && 'flex-none', classNameIcon)} />
+  );
 
   const innerSpan = (
     <span

--- a/app/components/ThemeSwitch/index.tsx
+++ b/app/components/ThemeSwitch/index.tsx
@@ -7,7 +7,7 @@ import type {action} from '~/routes/resources+/theme-switch';
 import type {Theme} from '~/utils/theme.server';
 
 export type ThemeSwitchProps = {
-  userPreference?: null | Theme;
+  userPreference?: Theme;
 };
 
 const NEXT_MODE: Record<

--- a/app/hooks/useComponentRect.ts
+++ b/app/hooks/useComponentRect.ts
@@ -18,7 +18,7 @@ export const useComponentRect = (
     y: 0,
   });
 
-  const timeoutRef = useRef<null | number>(null);
+  const timeoutRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
     if (ref.current) {

--- a/app/utils/nonce.ts
+++ b/app/utils/nonce.ts
@@ -2,6 +2,6 @@ import {createContext, use} from 'react';
 
 const NonceContext = createContext<string>('');
 
-export const NonceProvider = NonceContext.Provider;
+export const NonceProvider = NonceContext;
 
 export const useNonce = (): string => use(NonceContext);

--- a/app/utils/request-info.ts
+++ b/app/utils/request-info.ts
@@ -4,7 +4,7 @@ import type {Theme} from '~/utils/theme.server';
 export type RequestInfo = {
   origin: string;
   path: string;
-  userPrefs: {theme: null | Theme};
+  userPrefs: {theme?: Theme};
 };
 
 type RootLoaderShape = {requestInfo: RequestInfo};

--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -5,13 +5,13 @@ const COOKIE_NAME = '__theme';
 
 export type Theme = 'dark' | 'light';
 
-export const getTheme = (request: Request): null | Theme => {
+export const getTheme = (request: Request): Theme | undefined => {
   const cookieHeader = request.headers.get('Cookie');
-  if (!cookieHeader) return null;
+  if (!cookieHeader) return undefined;
   const parsed = cookie.parse(cookieHeader)[COOKIE_NAME];
   if (parsed === 'light' || parsed === 'dark') return parsed;
 
-  return null;
+  return undefined;
 };
 
 export const setTheme = (theme: 'system' | Theme): string => {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@axe-core/playwright": "4.11.3",
     "@faker-js/faker": "10.4.0",
-    "@gaia-react/lint": "1.6.0",
+    "@gaia-react/lint": "1.7.0",
     "@msw/data": "1.1.6",
     "@playwright-testing-library/test": "4.5.0",
     "@playwright/test": "1.61.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: 10.4.0
         version: 10.4.0
       '@gaia-react/lint':
-        specifier: 1.6.0
-        version: 1.6.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)
+        specifier: 1.7.0
+        version: 1.7.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)
       '@msw/data':
         specifier: 1.1.6
         version: 1.1.6
@@ -897,8 +897,8 @@ packages:
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
-  '@gaia-react/lint@1.6.0':
-    resolution: {integrity: sha512-YUGTpwoKDgmwZV+5lq1y4vlhUhSyt3dZlxHlZYDqO7UeCNDMIzwnsDQCR9UctOP2kjUqey2qJ10w0XvKC2sOfg==}
+  '@gaia-react/lint@1.7.0':
+    resolution: {integrity: sha512-DjHX1VVyRZEBW3qB+Dm9Ed9iRV+Xr/P/dqQPKNBiG/k9AtT5UMeJimiiPGtAq0XCOPi+SrR+VerbWjaNq5ojEA==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       eslint: ^9.0.0
@@ -6201,7 +6201,7 @@ snapshots:
 
   '@faker-js/faker@10.4.0': {}
 
-  '@gaia-react/lint@1.6.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)':
+  '@gaia-react/lint@1.7.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.13.0(typescript@6.0.3))(tailwindcss@4.3.1)(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@9.39.4(jiti@2.7.0))
       '@eslint/config-helpers': 0.6.0
@@ -6980,7 +6980,7 @@ snapshots:
   '@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/types': 8.61.1
       eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -7241,8 +7241,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7437,8 +7437,8 @@ snapshots:
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
@@ -8344,7 +8344,7 @@ snapshots:
 
   eslint-plugin-canonical@5.1.3(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       array-includes: 3.1.9
       debug: 4.4.3
       doctrine: 3.0.0
@@ -8385,7 +8385,7 @@ snapshots:
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@package-json/types': 0.0.12
-      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/types': 8.61.1
       comment-parser: 1.4.6
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
@@ -8490,8 +8490,8 @@ snapshots:
 
   eslint-plugin-prefer-arrow-functions@3.9.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -8557,7 +8557,7 @@ snapshots:
 
   eslint-plugin-storybook@10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
@@ -8566,8 +8566,8 @@ snapshots:
 
   eslint-plugin-testing-library@7.16.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Teaches and enforces React 19 idioms in GAIA: a new idiom gate in the `react-code` skill, hardened as invariants, plus the existing codebase brought into compliance.

## Skill and rules
- **react-code `SKILL.md`**: new **Gate 4: React 19 Idiom Check** — ref-as-prop over `forwardRef`, boolean-guarded `&&` over the numeric-`0` leak, `use()`/`<Context>` shorthand, never `null` in render, stay in React Router's lane for forms (no `useActionState`/`useFormStatus`/`useOptimistic`), and read the shipped React Router docs. Description updated to trigger on idiom questions.
- **`references/hook-patterns.md`**: `useEffectEvent`, ref-callback cleanup.
- **`state-pattern.md`**: Context examples modernized to `use()` / `<Context value>`.
- **typescript `SKILL.md`**: prefer `!!` over `Boolean()` for inline coercion.

## Code compliance (10 files)
- `return null` → `return undefined`
- `? : null` → boolean-guarded `&&` (or `: undefined` where the value feeds `??`)
- numeric-`0` `&&` leak fixed in `ErrorStack`
- `nonce.ts`: `NonceProvider = NonceContext` (drop legacy `.Provider`)

## Verification
typecheck, lint (0 errors / 0 warnings), 120 unit tests, and the production build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
