### PR TITLE
chore(release): register gaia-react-perf in manifest + wiki maintainer-only-roadmap rule

### DIFF
--- a/.claude/rules/wiki-style.md
+++ b/.claude/rules/wiki-style.md
@@ -23,6 +23,10 @@ Body prose and code comments describe **what is** in present tense. The historic
 - **Present tense only.** Do not write "was changed from X to Y", "previously did A, now does B", "moved from a to b". State the current behavior directly.
 - **No UAT or SPEC references in prose or comments.** `UAT-NNN` identifies entries inside SPECs; `SPEC-NNN` identifies the SPECs themselves. Both are working documents, they get superseded, renumbered, or deleted. A reader querying the wiki about a feature gets no value from "implements UAT-012" or "from SPEC-005". Drop the reference; describe what the feature does and why.
 - **No inline PR / commit / date-of-change references in body prose.** Don't write "added in PR #97", "commit abc123 introduced …", "as of 2026-05-07 …". The git log answers those questions and stays accurate when prose drifts.
+- **No unreleased or speculative roadmap as current behavior.** Body prose describes what ships today. Do not document a planned, deferred, or not-yet-built feature as if it already exists, a reader cannot tell aspiration from shipped fact. State current behavior; keep forward-looking notes out of the page, or label them plainly as deferred and not yet built.
+  <!-- gaia:maintainer-only:start -->
+  GAIA maintainers: roadmap or forward-looking content that must live in the source repo but not reach adopter scaffolds goes inside the HTML-comment maintainer-only markers, the same pair wrapping this note. The bundle-time scrub strips marker-delimited blocks from markdown under `wiki/`, `.claude/`, and `.specify/extensions/gaia/` before tar, so the source repo stays a superset of the adopter bundle; unbalanced markers fail the release build. See [[Bundle-time Scrub]].
+  <!-- gaia:maintainer-only:end -->
 
 ## Why
 

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -70,6 +70,8 @@
     ".claude/skills/eslint-fixes/SKILL.md": "owned",
     ".claude/skills/gaia-handoff/SKILL.md": "owned",
     ".claude/skills/gaia-pickup/SKILL.md": "owned",
+    ".claude/skills/gaia-react-perf/references/measure-only.md": "owned",
+    ".claude/skills/gaia-react-perf/SKILL.md": "owned",
     ".claude/skills/gaia-wiki/SKILL.md": "owned",
     ".claude/skills/gaia/references/audit.md": "owned",
     ".claude/skills/gaia/references/fitness.md": "owned",
@@ -193,6 +195,9 @@
     ".playwright/e2e/language-switch-a11y.spec.ts": "owned",
     ".playwright/fixtures.ts": "owned",
     ".playwright/global-setup.ts": "owned",
+    ".playwright/react-perf/capture.ts": "owned",
+    ".playwright/react-perf/harness-entry.ts": "owned",
+    ".playwright/react-perf/types.ts": "owned",
     ".playwright/utils.ts": "owned",
     ".prettierignore": "owned",
     ".specify/extensions/gaia/commands/constitution-check.md": "owned",
@@ -455,6 +460,7 @@
     "wiki/concepts/Policy-Memory Loop.md": "wiki-owned",
     "wiki/concepts/PR Merge Workflow.md": "wiki-owned",
     "wiki/concepts/Pre-commit Hooks.md": "wiki-owned",
+    "wiki/concepts/React Perf Diagnostic.md": "wiki-owned",
     "wiki/concepts/Serena Integration.md": "wiki-owned",
     "wiki/concepts/Task Orchestration.md": "wiki-owned",
     "wiki/concepts/Telemetry.md": "wiki-owned",
@@ -531,6 +537,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-06-25T01:28:45.406Z",
+  "generated": "2026-06-26T05:05:22.765Z",
   "version": "1.6.1"
 }


### PR DESCRIPTION
Two release-prep follow-ups from the `/gaia-react-perf` diagnostic PR (#442), so the upcoming GAIA release ships the feature to adopters cleanly.

## 1. Manifest registration
Regenerates `.gaia/manifest.json` via `gaia-maintainer release manifest`. The diagnostic added six tracked paths now absent from the committed manifest:

| Path | Class |
|---|---|
| `.claude/skills/gaia-react-perf/SKILL.md` | owned |
| `.claude/skills/gaia-react-perf/references/measure-only.md` | owned |
| `.playwright/react-perf/capture.ts` | owned |
| `.playwright/react-perf/harness-entry.ts` | owned |
| `.playwright/react-perf/types.ts` | owned |
| `wiki/concepts/React Perf Diagnostic.md` | wiki-owned |

`/update-gaia` ships these to adopters once registered. The smoke-spec canary (`.playwright/e2e/react-perf-smoke.spec.ts`) and CLI maintainer source stay release-excluded by design. `release manifest --check` is clean; this clears the stale-manifest gate wired into `release.yml`.

## 2. Wiki-style rule: no unreleased roadmap as current behavior
Adds a `.claude/rules/wiki-style.md` rule: body prose describes shipped behavior, not unreleased or speculative roadmap. The GAIA-specific escape hatch (wrap source-only roadmap in the `<!-- gaia:maintainer-only -->` markers the bundle-time scrub strips) is itself wrapped in those markers, so adopters receive the generic guidance while the maintainer mechanism and its `[[Bundle-time Scrub]]` link are stripped from the adopter bundle.

Verified against the real scrub: one balanced block stripped, leaks none, adopter view retains only the generic bullet.

## Scope
Entire diff is `.gaia/` + `.claude/`, out of audit scope (out-of-scope merge-gate bypass applies; no code-review-audit marker required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)