### PR TITLE
chore(entry): drop stale Remix scaffolding comments

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,9 +1,3 @@
-/**
- * By default, Remix will handle hydrating your app on the client for you.
- * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/file-conventions/entry.client
- */
-
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 import {I18nextProvider, initReactI18next} from 'react-i18next';

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,10 +1,4 @@
 /* eslint-disable max-params, no-console */
-/**
- * By default, Remix will handle generating the HTTP Response for you.
- * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
- * For more information, see https://remix.run/file-conventions/entry.server
- */
-
 import type {RenderToPipeableStreamOptions} from 'react-dom/server';
 import type {EntryContext, RouterContextProvider} from 'react-router';
 import {renderToPipeableStream} from 'react-dom/server';


### PR DESCRIPTION
## What

Remove the Remix-era header comment block from `app/entry.client.tsx` and `app/entry.server.tsx`.

## Why

Both files carried a comment block left over from Remix v2 scaffolding:

```
/**
 * By default, Remix will handle hydrating your app on the client for you.
 * You are free to delete this file ... run `npx remix reveal` ✨
 * For more information, see https://remix.run/file-conventions/entry.client
 */
```

These are stale and misleading:

- **`npx remix reveal` does not exist in this project.** It's a React Router v7 app; the CLI is `react-router`, there is no `remix` binary.
- **The URLs point at remix.run docs** for a framework this app no longer is.

I checked what React Router v7.18.0 (the installed version) actually scaffolds today: **no file-level header comment at all** — both `entry.client.tsx` and `entry.server.node.tsx` start straight with imports, carrying only inline explanatory comments. So removal both deletes wrong information and realigns us with current upstream defaults.

Nothing in the block aids comprehension (the code is self-evident), so no replacement comment was added.

## Notes

- The functional `/* eslint-disable max-params, no-console */` directive on line 1 of `entry.server.tsx` is **retained** — it is not a Remix comment.
- Comment-only change: 12 deletions, no logic touched. Local `pnpm typecheck` and `pnpm lint` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)