### PR TITLE
wiki: sync through d44678a

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "0624cabca0f9ef457bf4dda56d4cd1c78eb689f4",
-  "last_evaluated_at": "2026-06-25T11:48:07Z",
+  "last_evaluated_sha": "d44678a1231ee262709df75362807579e8171aae",
+  "last_evaluated_at": "2026-06-27T09:12:34Z",
   "last_consolidated_sha": "20611f530b690c9a5cffb2e3abe439a03e11ad4a",
   "last_consolidated_at": "2026-06-24T05:36:18Z"
 }

--- a/wiki/dependencies/gaia-lint.md
+++ b/wiki/dependencies/gaia-lint.md
@@ -2,10 +2,10 @@
 type: dependency
 status: active
 package: '@gaia-react/lint'
-version: 1.6.0
+version: 1.7.0
 role: lint-config
 created: 2026-04-27
-updated: 2026-06-25
+updated: 2026-06-27
 tags: [dependency, lint, eslint]
 ---
 
@@ -63,7 +63,7 @@ export default defineConfig([
 | `base` | Standard TS/JS hygiene | — |
 | `react` | React-specific rules | — |
 | `testing` | D-8 test-honesty: `vitest/prefer-called-with`, `no-restricted-imports` (blocks `*.server` / internals from consumer tests) | Added in 1.6.0 |
-| `guardrails` | `no-enum`, `no-switch`, `no-jsx-iife` custom plugins | — |
+| `guardrails` | `no-enum`, `no-switch`, `no-jsx-iife` custom plugins; `gaia/no-restricted-syntax` selectors ban `cond ? <JSX/> : null` and `cond ? null : <JSX/>` (flag-only, no autofix) | — |
 | `styleHygiene` | `import-x/no-restricted-paths` with carve-outs: `resources+/` and `actions+/` routes are exempt for UI layers | Carve-out added in 1.6.0 |
 | `betterTailwind` | Tailwind class ordering and hygiene | — |
 | `prettier` | Formatting via Prettier as an ESLint rule | — |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,21 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-06-27 fbe229e WORTHY - wiki: note minimumReleaseAgeExclude lifecycle → wiki/decisions/pnpm.md updated + sync/lint committed in-commit
+- 2026-06-27 db582f6 SKIP - docs(changelog): backfill CHANGELOG entries only; no architecture change
+- 2026-06-27 d5ad285 WORTHY - docs(spec-close): correct spec-close manual handle → wiki/concepts/GAIA Spec.md updated in-commit
+- 2026-06-27 5cf87d3 SKIP - fix(gaia-init): CI configure block corrected to skill file only; wiki/concepts/GAIA Init Workflow.md subcommand abstractions remain accurate
+- 2026-06-27 69404a1 SKIP - docs(changelog): backfill CHANGELOG entries only; no architecture change
+- 2026-06-27 d7b1174 WORTHY - feat(react-code): React 19 idioms + @gaia-react/lint 1.7.0 (gaia/no-restricted-syntax) → wiki/dependencies/gaia-lint.md updated
+- 2026-06-27 a28d02e WORTHY - feat(react-perf): /gaia-react-perf diagnostic → wiki/concepts/React Perf Diagnostic.md created in-commit
+- 2026-06-27 5d93d2a SKIP - chore(release): release plumbing; manifest + wiki-style rule maintainer-only marker, no new wiki content
+- 2026-06-27 06e2532 SKIP - chore(entry): removes stale Remix scaffolding comments from entry files; no wiki surface needed
+- 2026-06-27 0c14af3 SKIP - docs(changelog): backfill CHANGELOG entries only; no architecture change
+- 2026-06-27 0a4af7b WORTHY - docs(pr-merge): CHANGELOG gate added to PR merge workflow → wiki/concepts/PR Merge Workflow.md updated in-commit
+- 2026-06-27 b213e19 SKIP - fix(gaia-wiki): adds mkdir -p wiki/meta/ to tooling scripts; no wiki content change
+- 2026-06-27 8ce8258 WORTHY - feat(handoff): delete-on-done lifecycle → wiki/concepts/GAIA Handoff.md + wiki/concepts/GAIA Pickup.md rewritten in-commit
+- 2026-06-27 97bb16d SKIP - docs(readme): README + CHANGELOG only; no wiki content change
+- 2026-06-27 d44678a WORTHY - chore(deps): upgrade to React Router 8; wiki/dependencies/React Router.md + 11 other wiki pages updated in-commit
 - 2026-06-25 0624cab SKIP - docs(wiki): minimumReleaseAgeExclude lifecycle already noted directly in wiki/decisions/pnpm.md in-commit
 - 2026-06-25 167dac7 SKIP - wiki sync chain commit (state + gaia-lint.md already updated in-commit, no new source changes)
 - 2026-06-25 5c0afcf SKIP - wiki: maintenance chain commit (sync+lint run), not a source change


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to d44678a.