### PR TITLE
docs(wiki): record vite 8.1.x Storybook __commonJS ceiling

### DIFF
--- a/wiki/dependencies/Storybook.md
+++ b/wiki/dependencies/Storybook.md
@@ -5,7 +5,7 @@ package: storybook
 version: 10.4.6
 role: component-development-and-visual-testing
 created: 2026-04-20
-updated: 2026-06-24
+updated: 2026-07-01
 tags: [dependency, storybook]
 ---
 
@@ -18,3 +18,7 @@ Component-Driven Development environment. v10 with `@storybook/react-vite`.
 `@storybook/react-vite`, `@storybook/addon-docs`, `@storybook/addon-links`, `@vueless/storybook-dark-mode`, `storybook-react-i18next`, `chromatic`. `msw-storybook-addon` is in `package.json` but deliberately unused (stories seed from `@msw/data`). Storybook lint rules ship through the `@gaia-react/lint` config (spread as `...lint.storybook` in `eslint.config.mjs`), which supplies `eslint-plugin-storybook` transitively rather than as a direct `package.json` dependency.
 
 See [[Storybook Stories]] module page.
+
+## Vite version ceiling
+
+Vite is held at 8.0.16. Vite 8.1.x (Rolldown 1.1.2 and up) builds a Storybook iframe bundle that calls the `__commonJS` interop helper without ever defining it, so the published Storybook throws `__commonJS is not defined` and Chromatic cannot extract stories. The app build (`react-router build`) is unaffected, so the local quality gate passes clean; only the Storybook build surfaces the fault, which makes [[Chromatic]] the gate that catches a `vite` 8.1.x bump. The contrast is sharp: an 8.0.16 Storybook bundle carries zero `__commonJS` references, every 8.1.x bundle (verified through 8.1.2) emits the call sites with no definition. The `vite` companion group stays pinned to 8.0.16 until an upstream Rolldown release fixes the helper emission.


### PR DESCRIPTION
Records the vite version ceiling on the Storybook dependency page.

Follow-up to #470, where vite was held at 8.0.16 because vite 8.1.x
(Rolldown 1.1.2+) builds a Storybook iframe bundle that calls the
`__commonJS` interop helper without defining it → `__commonJS is not defined`,
which breaks the published Storybook and Chromatic. Verified through 8.1.2
(Rolldown 1.1.3) by bypassing the install cooldown locally: 8.0.16 emits zero
`__commonJS` references, every 8.1.x bundle emits the call sites with no
definition. The gotcha was meant to ride along with #470 but that PR
auto-merged first, so it lands here.

The page note tells the next person who sees vite 8.1.x offered by
`/update-deps` to hold until an upstream Rolldown release fixes the emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
