### PR TITLE
wiki: advance consolidate state through 152597a

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -2,6 +2,6 @@
   "version": 1,
   "last_evaluated_sha": "152597ad8b6013988d8d33158604f4958cac634c",
   "last_evaluated_at": "2026-06-30T19:05:49Z",
-  "last_consolidated_sha": "20611f530b690c9a5cffb2e3abe439a03e11ad4a",
-  "last_consolidated_at": "2026-06-24T05:36:18Z"
+  "last_consolidated_sha": "15ddaf9676b4fca22031e441e6d70b3c1df1d2a5",
+  "last_consolidated_at": "2026-06-30T19:19:44Z"
 }


### PR DESCRIPTION
Follow-up to #473. The standalone `/gaia-wiki sync` opened and auto-merged #473 (squash) before the manual `/gaia-wiki consolidate` ran, so the consolidate run's state advance never reached `main`.

This lands the missing advance: `last_consolidated_sha` → `15ddaf9` (main HEAD), recording the 0-finding consolidate pass so the sync Step 9 gate baseline stays current. `last_evaluated_sha` is preserved.

- Consolidate: 0 findings (no supersessions, reversed decisions, near-collisions, or subject-orphans).
- Lint: low drift, no actionable findings (report already in `main`).
- No CHANGELOG entry: internal wiki-state housekeeping, not adopter-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)