### PR TITLE
docs(gaia-plan): re-tense non-interactive triggers after SPEC-012

### DIFF
--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -34,7 +34,7 @@ If no SPEC reference is detected, `SPEC_SLUG_SEED` and `SPEC_PATH` are unset; st
 The deep synthesis runs in the planner spawned at step 4, and the planner's model is pinned at spawn time, so it can be Opus even when this orchestration runs on Sonnet. Decide the planner's model:
 
 - If you are on Opus, the planner inherits Opus; skip to step 3.
-- If you are running non-interactively (no user to prompt, e.g. dispatched by `/gaia-spec auto`), default the planner to Opus: spawn it with `model: opus` at step 4. Skip to step 3.
+- If you are running non-interactively (a headless or automation context with no interactive user to prompt), default the planner to Opus: spawn it with `model: opus` at step 4. Skip to step 3.
 - Otherwise call `AskUserQuestion` with:
   - question: `"You're on [model name]. Use Opus for planning?"`
   - header: `"Model"`
@@ -269,7 +269,7 @@ Present (recommended option FIRST, carrying the `(Recommended)` tag):
 
 `Skip` is never the recommended option for a non-trivial plan. On **Skip**, proceed to step 4.7.
 
-**Auto-mode.** No prompt fires. When `/gaia-plan` runs non-interactively (dispatched by `/gaia-spec auto`), gauge the plan, run the audit if it is non-trivial, and apply its dispositions non-interactively.
+**Auto-mode.** No prompt fires. When `/gaia-plan` runs non-interactively (a headless or automation context with no interactive user), gauge the plan, run the audit if it is non-trivial, and apply its dispositions non-interactively.
 
 **Fallback (never block).** If the parallel `general-purpose` Agent fan-out is unavailable (a restricted context that cannot spawn subagents), do NOT block the handoff: note the skip (`decomposition audit unavailable`) and proceed to step 4.7. The orchestrator's per-phase quality gates and the non-skippable pre-merge `code-review-audit` remain the safety net.
 


### PR DESCRIPTION
## What

Fixes two stale references in `.claude/skills/gaia/references/plan.md` left behind by SPEC-012 (#484), which removed the inline `/gaia-spec` → `/gaia-plan` chain. `/gaia-plan` is no longer "dispatched by `/gaia-spec auto`", so that example was false.

- **Step 2 (Check model), line ~37** — the non-interactive branch that defaults the planner to Opus.
- **Step 4.6 (Auto-mode), line ~272** — the auto-mode audit branch.

## Why keep both branches

The non-interactive path still exists independently of the removed chain. It is a **runtime property**, not something `/gaia-spec auto` uniquely created: a headless `claude -p` / CI / scheduled-agent run has no interactive user to answer `AskUserQuestion`. The file already treats headless/auto as first-class elsewhere — the audit "works headless and in auto mode" (step 4.6) and has a "restricted context that cannot spawn subagents" fallback (step 4.6, Fallback). So both branches are re-tensed to the true trigger (a headless or automation context with no interactive user) and the stale `/gaia-spec auto` example is dropped.

## Scope

Surgical: only the two stale parentheticals. No adjacent logic, model-choice flow, or audit flow touched.

## Gates

- `grep -nE "/gaia-spec auto|dispatched (by|from) /gaia-spec" .claude/skills/gaia/references/plan.md` → no matches.
- `git diff main -- .claude/ | grep -E '^\+' | grep -E '/Users/|/home/'` → empty (no absolute paths).
- `pnpm typecheck && pnpm lint` → clean (no TS/JS/CSS touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
