### PR TITLE
docs(wiki): wrap remaining maintainer-repo references in maintainer-only markers

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -11,7 +11,9 @@ tags: [meta, schema]
 Mode: B (Codebase) + E (Research)
 Plugin baseline: claude-obsidian v1.9.2 (DragonScale features intentionally not adopted, see [[DragonScale Opt-Out]])
 Purpose: Persistent knowledge base for the GAIA React workflow: architecture, conventions, decisions, Claude integration.
+<!-- gaia:maintainer-only:start -->
 Owner: Steven Sacks
+<!-- gaia:maintainer-only:end -->
 Created: 2026-04-20
 
 ## Structure

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -73,7 +73,7 @@ This is the audit's instance of the cross-workflow mechanism in [[Incremental CI
 
 ## Progress breadcrumbs
 
-The agent's own SDK output is not surfaced in the public Actions log: `claude-code-action` does not echo tool results unless explicitly enabled, and the workflow leaves that off (it passes only `--max-turns`, `--allowedTools`, and `--verbose` in `claude_args`). This is deliberate: `gaia-react/gaia` is a public repo and full output would expose tool results that may contain secrets.
+The agent's own SDK output is not surfaced in the public Actions log: `claude-code-action` does not echo tool results unless explicitly enabled, and the workflow leaves that off (it passes only `--max-turns`, `--allowedTools`, and `--verbose` in `claude_args`). This is deliberate: on a public repo the Actions log is world-readable, so echoing tool results that may contain secrets is unsafe.
 
 To provide a public-safe, post-hoc view of audit progress, the agent writes a curated per-phase breadcrumb line to `.gaia/local/audit/progress.log` (runner-local, gitignored; the same directory as the `<sha>.ok` clean marker) via its `Write`/`Edit` tool. Each line is a phase label plus integer counts only: no code, no file contents, no raw tool output, no secrets. These writes are best-effort: a write failure never blocks or fails the audit.
 

--- a/wiki/concepts/Incremental CI Skipping.md
+++ b/wiki/concepts/Incremental CI Skipping.md
@@ -17,11 +17,14 @@ suite on a tree it has already cleared.
 
 ## Scope
 
+<!-- gaia:maintainer-only:start -->
 `main`'s ruleset requires three checks: `Run Chromatic`, `Vitest and
-Playwright`, and `code-review-audit`. All three are **job-level** checks; the
-required context equals the job `name:`. A job that runs but gates its
-expensive steps off still completes and posts a green check under that name, so
-the ruleset stays satisfied with no external check stamping.
+Playwright`, and `code-review-audit`.
+<!-- gaia:maintainer-only:end -->
+GAIA's expensive required checks are **job-level**: the required context equals
+the job `name:`. A job that runs but gates its expensive steps off still
+completes and posts a green check under that name, so a required-check rule
+stays satisfied with no external check stamping.
 
 Incremental skipping applies to the two expensive checks:
 


### PR DESCRIPTION
## What

Repo-wide sweep (follow-up to #488) for statements specific to the maintainer repo that leak into adopter bundles. Cross-checked every candidate against existing `gaia:maintainer-only` marker ranges **and** `.gaia/release-exclude` (many hits live in files stripped wholesale, so they need no wrapping).

Three genuine leaks handled:

1. **`wiki/concepts/Code Review Audit CI.md`** — reworded the "`gaia-react/gaia` is a public repo" secrets rationale to a general public-repo conditional. Drops the this-repo-is-public claim; keeps the adopter-useful reason visible. No wrap needed.
2. **`wiki/concepts/Incremental CI Skipping.md`** — wrapped the sentence naming `main`'s ruleset and its three required checks (`Run Chromatic`, `Vitest and Playwright`, `code-review-audit`). Reworded the follow-on so the general job-level-check mechanism stays adopter-visible.
3. **`wiki/README.md`** — wrapped the `Owner: Steven Sacks` attribution line (consistent with the file's existing markers around `entities/`/`meta/`).

## Not flagged (correctly)

All `gaia-react/gaia` references that are legitimate upstream interactions on an adopter clone: filing bug reports (forensics skill), pulling releases/CHANGELOG (`/update-gaia`, Update Workflow), release URLs.

## Separate hygiene note (not in this PR)

`.specify/extensions/gaia/test/v2-validation.md` hardcodes `/Users/stevensacks/...` absolute paths, but that file is release-excluded wholesale, so it never reaches an adopter tarball. Source-repo hygiene only; left for a separate call.

## Scope

Wiki docs only, out of audit scope. No behavior change. Marker pairs balanced in all touched files.