### PR TITLE
Harden the /gaia-harden command (doc + CLI)

### DIFF
--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -14,7 +14,7 @@ The agent never runs `git add`, `git commit`, or `git push` anywhere in this flo
 
 Tokenize the first whitespace-separated word of `$ARGUMENTS`:
 
-- `review` (or empty `$ARGUMENTS`) → the full interactive flow. This is the default the statusline nudge (`Run /gaia-harden review (N)`) points at.
+- `review` (or empty `$ARGUMENTS`) → the full interactive flow. This is the default an empty `$ARGUMENTS` resolves to, so the statusline nudge (`Run /gaia-harden (N recurring pattern)` for one, `Run /gaia-harden (N recurring patterns)` for more) points here without carrying a `review` token.
 - `list` → print the live candidates with their distinct-PR counts and the recommended form. No authoring, no prompts.
 - `why` → the remainder of `$ARGUMENTS` is a `finding_class`. Explain that one candidate: the PRs it recurred on, the recommended form, and the rationale. No authoring, no prompts.
 
@@ -46,7 +46,7 @@ It prints JSON to stdout:
 }
 ```
 
-Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error. If `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop.
+Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. Coverage detection is class-level and scope-blind in v1: a promoted rule suppresses its `finding_class` regardless of the rule's `paths:` glob, because coverage keys only on the provenance marker's `finding_class`, not on scope. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error. If `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop.
 
 ## Judge-the-form logic (the heart of the command)
 
@@ -66,7 +66,7 @@ Also check whether the quality gate (`wiki/decisions/Quality Gate.md`) already l
 
 Inspect the `finding_class` prefix and the pattern's nature:
 
-- **Oracle-class finding** (the `finding_class` is a tool id: it starts with `react-doctor/`, `axe/`, `knip/`, or `cve/`). A deterministic check already exists for it. Recommend making that check BLOCKING or adding it to the quality gate, an enforcement edit, NOT a new prose rule. Point at `wiki/decisions/Quality Gate.md` and the tool's wiring (`.claude/rules/knip.md`, `.claude/rules/dep-audit.md`, the `code-review-audit` agent, or the relevant CI workflow). Never draft prose for an oracle class.
+- **Oracle-class finding** (the `finding_class` is a tool id: it starts with `react-doctor/`, `axe/`, `knip/`, or `cve/`). This prefix list mirrors `ORACLE_PREFIXES` in `.gaia/cli/src/schemas/finding-class.ts`; keep the two in sync, a prefix added to the code but not here is misclassified as holistic/rule and mis-routed. A deterministic check already exists for it. Recommend making that check BLOCKING or adding it to the quality gate, an enforcement edit, NOT a new prose rule. Point at `wiki/decisions/Quality Gate.md` and the tool's wiring (`.claude/rules/knip.md`, `.claude/rules/dep-audit.md`, the `code-review-audit` agent, or the relevant CI workflow). A `knip/*` class is the exception to the quality-gate route: the developer Quality Gate intentionally omits knip (see `.claude/rules/knip.md`), so route knip enforcement to the `code-review-audit` agent or CI (`.github/forensics/run-quality-gate.sh`), never the dev gate. Never draft prose for an oracle class.
 
 - **Mechanizable holistic/rule pattern** (the pattern can be caught by a lint rule, a hook, or a test). Recommend a DETERMINISTIC CHECK. v1 produces a hook+script SKETCH only; it activates nothing, writes no `.claude/rules/` file for it, and claims no prune lifecycle over it.
 
@@ -86,29 +86,38 @@ The evidence bar is deliberately low, a couple of before/after task replays or a
 
 ### Present and act
 
-For each candidate, present: the finding_class, its distinct-PR count and the PRs it recurred on, the recommended form, and the one-line rationale. Then offer the action set: **approve / decline / defer / redirect**.
+For each candidate, present: the finding_class, its distinct-PR count and the PRs it recurred on, the recommended form, and the one-line rationale. Then offer the action set: **approve / decline / defer / redirect**. Collect that choice through an explicit user-question step, one question per candidate, and never auto-advance past a candidate without a human answer, the same way `/gaia-spec` gates each of its questions. This reinforces the "Execution model, READ FIRST" note: the call is the human's, not the agent's. The two persisting actions differ: `decline` writes a machine-local, evidence-gated ledger entry; `defer` persists nothing and simply nudges again on the next tally.
 
-`redirect` means the engineer overrides the form choice (e.g. "make it a prose rule even though you recommended a skill"). Honor the override and run that form's action handling.
+`redirect` means the engineer overrides the form choice (e.g. "make it a prose rule even though you recommended a skill"). Honor the override and run that form's action handling. Axis-2 guardrails win over a redirect, though: a redirect cannot force a prose rule for an oracle class, and a redirect toward an enforcement-edit cannot manufacture one where no existing check or quality-gate step exists.
 
 ## Per-form action handling
 
 ### approve, prose rule
 
-Draft the rule file into the working tree using the template below. The rule is MANDATORILY path-scoped: a `paths:` frontmatter glob is always present, derived from the candidate's `area_tags`. Never write a frontmatter-less / always-loaded rule. Immediately after the frontmatter, write the provenance marker verbatim (see the frozen marker below). Then write present-tense body prose describing the anti-pattern and the correct pattern.
+Draft the rule file into the working tree using the template below. The rule is MANDATORILY path-scoped: a `paths:` frontmatter glob is always present, derived from the candidate's `area_tags`. When `area_tags` is empty or holds non-path strings (holistic classes often carry semantic tags, not path globs), fall back: derive the glob from the finding's bucket/surface (e.g. a `rule/*` React class scopes to `app/**/*`) or ask the human for the intended scope. Never write a frontmatter-less / always-loaded rule, and never emit an unscoped `**/*` glob, that defeats the path-scoping invariant that bounds per-task context weight. Immediately after the frontmatter, write the provenance marker verbatim (see the frozen marker below). Then write present-tense body prose describing the anti-pattern and the correct pattern.
 
 After writing, tell the engineer the rule is in the working tree and ships through normal PR review. NEVER `git add`, `git commit`, or `git push`.
 
+### approve, edit existing prose rule
+
+Use this handler, not the new-file path above, when Axis 1 recommended EDITING an existing rule rather than creating one. The new-file template drafts a fresh file; an edit appends to the file Axis 1 named. Reach the new-file path only for a genuinely new rule.
+
+- **Append the new guidance to the existing rule file** Axis 1 named, under the most relevant existing `## …` section or a new `## …` heading in that same file. Body prose is present tense and follows `.claude/rules/wiki-style.md`.
+- **Append a provenance marker for the newly-approved `finding_class`.** The file already carries a marker, but it names the DIFFERENT class the rule was first promoted from; this candidate surfaced precisely because no marker for ITS class exists yet. Coverage keys per-class: `covered-classes.ts` scans every marker in the file (a whole-file `matchAll`) into a `Set` keyed on the captured class, and the tally drops a class only when a marker for that exact class is present. So the second marker is REQUIRED, not redundant, it is what suppresses the newly-covered class on the next tally and drops the candidate immediately, matching the prose-approval semantics. It does not double-count: the `Set` dedupes and each marker captures a distinct class. Write the same verbatim marker (see the frozen marker below) with `<class>` set to the newly-approved `finding_class`, placed adjacent to the appended guidance. The scan is whole-file, so the marker need not be the first line after the frontmatter, that first-line placement is the new-file template's convention, not a coverage requirement.
+- **Do NOT write a second frontmatter block.** Reconcile the existing `paths:` instead: union the candidate's derived glob (same derivation and empty/non-path fallback as the new-file handler, never `**/*`) into the existing frontmatter `paths:` list, adding a line only when the glob is not already covered by an entry there.
+- After editing, tell the engineer the rule change is in the working tree and ships through normal PR review. NEVER `git add`, `git commit`, or `git push`.
+
 ### approve, deterministic check
 
-Produce ONLY a hook+script SKETCH (a proposed hook entry and a script outline the engineer can finish). Activate nothing: do not wire it into `.claude/settings.json`, do not make any file executable, and write no `.claude/rules/` file for it. Make clear the loop claims no prune lifecycle over it. Hand the sketch to the engineer to finish and wire up themselves.
+Produce ONLY a hook+script SKETCH (a proposed hook entry and a script outline the engineer can finish). Activate nothing: do not wire it into `.claude/settings.json`, do not make any file executable, and write no `.claude/rules/` file for it. Make clear the loop claims no prune lifecycle over it. Hand the sketch to the engineer to finish and wire up themselves. Because this form writes no provenance marker, the statusline nudge persists until the pattern stops recurring and ages out of the window (or a promoted rule later covers the class); it is not silenced immediately the way a prose approval is.
 
 ### approve, skill
 
-Produce ONLY a skill-creator handoff. Invoke the `skill-creator` skill (the scaffolding tool) with the captured intent (what the skill should enable, when it should trigger, the expected output), or print a ready-to-run scaffold invocation. Activate nothing and write no `.claude/rules/` file for it.
+Produce ONLY a skill scaffold; activate nothing and write no `.claude/rules/` file for it. LEAD with the plugin-free path: hand-write a `SKILL.md` scaffold, its name, description, trigger conditions, and the ordered steps, for the engineer to drop under `.claude/skills/<name>/`. The `skill-creator` skill is a convenience path only: it is plugin-provided and may be absent on an adopter machine (it is not bundled under `.claude/skills/` and neither `setup-gaia` nor `gaia-init` provisions it). When it IS present, invoke it with the captured intent (what the skill should enable, when it should trigger, the expected output) or print a ready-to-run scaffold invocation in place of hand-writing the file. Because this form writes no provenance marker, the statusline nudge persists until the pattern stops recurring and ages out of the window (or a promoted rule later covers the class); it is not silenced immediately the way a prose approval is.
 
 ### approve, enforcement edit (oracle class)
 
-Make the existing deterministic check blocking or add it to the quality gate. This is an edit to existing enforcement wiring (the tool's rule file, the `code-review-audit` agent, the quality gate doc, or the CI workflow), not a new prose rule. Land the edit in the working tree only; never commit.
+Make the existing deterministic check blocking or add it to the quality gate. This is an edit to existing enforcement wiring (the tool's rule file, the `code-review-audit` agent, the quality gate doc, or the CI workflow), not a new prose rule. Land the edit in the working tree only; never commit. Because this form writes no provenance marker, the statusline nudge persists until the pattern stops recurring and ages out of the window (or a promoted rule later covers the class); it is not silenced immediately the way a prose approval is.
 
 ### decline
 
@@ -118,7 +127,7 @@ Record one bounded entry to the machine-local ledger, passing the candidate's cu
 .gaia/cli/gaia harden-ledger record --finding-class "<finding_class>" --pr-count <distinct_pr_count>
 ```
 
-State that the decline is machine-local only (the ledger is gitignored) and never shared: a teammate still sees the nudge and can approve. The decline re-surfaces on evidence, the ledger handles that; once at least 3 more distinct PRs carrying the class merge, the candidate returns.
+State that the decline is machine-local only (the ledger is gitignored) and never shared: a teammate still sees the nudge and can approve. The decline re-surfaces on evidence, the ledger handles that: the candidate returns when the window's distinct-PR count for the class rises to at least 3 above its count at the time of decline. That count is a snapshot of the rolling 90-day window, not a monotonic tally of PRs merged since the decline, so window churn (old PRs aging out) can lower it and thereby delay or indefinitely prevent re-surface. A mis-decline is reversible: re-record with a corrected count, or let `.gaia/cli/gaia harden-ledger prune` drop the entry once the class leaves the window, the undo and hygiene path for the ledger.
 
 ### defer
 
@@ -133,12 +142,11 @@ Write to `.claude/rules/<slug>.md`, where `<slug>` is a short kebab-case name de
 paths:
   - '<glob derived from area_tags, e.g. app/components/**/*>'
 ---
-
 <!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
 
 # <Rule Title>
 
-<Present-tense prose: name the anti-pattern, then state the correct pattern. No UAT/SPEC IDs, no PR/commit/date references. Describe what the rule enforces and why.>
+<Present-tense prose: name the anti-pattern, then state the correct pattern. Follows `.claude/rules/wiki-style.md`. Describe what the rule enforces and why.>
 
 ## Anti-pattern
 
@@ -151,9 +159,9 @@ paths:
 
 Rules for filling it in:
 
-- **`paths:` is mandatory.** Derive the glob from the candidate's `area_tags` (e.g. an `area_tags` of `["app/components"]` becomes `app/components/**/*`). One or more single-quoted globs, one per line. A rule with no `paths:` frontmatter is never produced; path-scoping is what bounds per-task context weight regardless of how many promoted rules accumulate.
+- **`paths:` is mandatory.** Derive the glob from the candidate's `area_tags` (e.g. an `area_tags` of `["app/components"]` becomes `app/components/**/*`). When `area_tags` is empty or holds non-path strings, fall back: derive the glob from the finding's bucket/surface (e.g. a `rule/*` React class scopes to `app/**/*`) or ask the human for the intended scope. One or more single-quoted globs, one per line. A rule with no `paths:` frontmatter is never produced, and an unscoped `**/*` glob is never emitted; path-scoping is what bounds per-task context weight regardless of how many promoted rules accumulate.
 - **The provenance marker is verbatim and single-line**, placed immediately after the closing `---` of the frontmatter, with `<class>` replaced by the actual finding_class. It references the `finding_class`, never a SPEC or UAT id.
-- **Body prose is present tense** and follows `.claude/rules/wiki-style.md`: no UAT/SPEC references, no inline PR/commit/date references. Use repo-relative paths only (`.claude/rules/coding-guidelines.md`).
+- **Body prose is present tense** and follows `.claude/rules/wiki-style.md`, which carries the authoritative ban list. Use repo-relative paths only (`.claude/rules/coding-guidelines.md`).
 
 ### Frozen provenance marker (PROVENANCE-MARKER CONTRACT)
 

--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -34,6 +34,7 @@ It prints JSON to stdout:
 {
   "candidate_count": 2,
   "window_days": 90,
+  "gh_ok": true,
   "candidates": [
     {
       "finding_class": "rule/use-effect-derived-state",
@@ -46,7 +47,7 @@ It prints JSON to stdout:
 }
 ```
 
-Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. Coverage detection is class-level and scope-blind in v1: a promoted rule suppresses its `finding_class` regardless of the rule's `paths:` glob, because coverage keys only on the provenance marker's `finding_class`, not on scope. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error. If `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop.
+Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. Coverage detection is class-level and scope-blind in v1: a promoted rule suppresses its `finding_class` regardless of the rule's `paths:` glob, because coverage keys only on the provenance marker's `finding_class`, not on scope. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error, and it always exits 0. The emitted JSON carries a `gh_ok` boolean that separates a real all-clear from a failed window read. When `gh_ok` is `false`, the merged-PR window could not be read (a `gh`/network outage), which is NOT an all-clear: report "could not read the merged-PR window; this is not an all-clear, re-run when `gh` is available" and stop, never claim no findings. When `gh_ok` is `true` and `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop.
 
 ## Judge-the-form logic (the heart of the command)
 
@@ -127,6 +128,8 @@ Record one bounded entry to the machine-local ledger, passing the candidate's cu
 .gaia/cli/gaia harden-ledger record --finding-class "<finding_class>" --pr-count <distinct_pr_count>
 ```
 
+Check the `harden-ledger record` exit code before reporting the outcome. On exit `0` the entry is written: report the machine-local decline as described below. On any non-zero exit (notably `CONFIG_INVALID` 30 for a corrupt or version-skewed ledger, or `STORAGE_INACCESSIBLE` 20) the entry was NOT recorded: tell the engineer the decline did not persist and why, and do not claim success. Because nothing was suppressed, the candidate re-surfaces on the next tally.
+
 State that the decline is machine-local only (the ledger is gitignored) and never shared: a teammate still sees the nudge and can approve. The decline re-surfaces on evidence, the ledger handles that: the candidate returns when the window's distinct-PR count for the class rises to at least 3 above its count at the time of decline. That count is a snapshot of the rolling 90-day window, not a monotonic tally of PRs merged since the decline, so window churn (old PRs aging out) can lower it and thereby delay or indefinitely prevent re-surface. A mis-decline is reversible: re-record with a corrected count, or let `.gaia/cli/gaia harden-ledger prune` drop the entry once the class leaves the window, the undo and hygiene path for the ledger.
 
 ### defer
@@ -171,7 +174,7 @@ The marker is this exact line, with `<class>` substituted:
 <!-- gaia-harden: promoted from recurring finding_class <class>; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->
 ```
 
-`/gaia-audit` recognizes this marker only to apply its existing obsolescence / redundancy / supersession / duplication signals without a policy-memory exemption, and to explicitly NOT treat non-recurrence as a prune signal. The marker grants no special lifecycle. Do not alter its wording: `/gaia-audit` binds to this string.
+`/gaia-audit` recognizes this marker only to apply its existing obsolescence / redundancy / supersession / duplication signals without a policy-memory exemption, and to explicitly NOT treat non-recurrence as a prune signal. The marker grants no special lifecycle. Do not alter its wording: three binders key on it. The `covered-classes.ts` `MARKER_RE` matches its prefix (`gaia-harden: promoted from recurring finding_class`) and is deliberately tail-agnostic; `/gaia-audit` (`.claude/skills/gaia/references/audit.md`) keys on the full text; and the `marker.test.ts` guard asserts every doc copy reproduces `markerComment(...)` from `.gaia/cli/src/harden/marker.ts` byte for byte. A wording change that misses any copy silently breaks one binder or the other, so the marker text lives once in `marker.ts` and every copy tracks it.
 
 ## list subcommand
 

--- a/.gaia/cli/src/harden/__tests__/covered-classes.test.ts
+++ b/.gaia/cli/src/harden/__tests__/covered-classes.test.ts
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {coveredClassesFromRules} from '../covered-classes.js';
+import {markerComment} from '../marker.js';
 
 describe('coveredClassesFromRules', () => {
   let dir: string;
@@ -22,7 +23,7 @@ describe('coveredClassesFromRules', () => {
         '---',
         'paths: app/**/*.ts',
         '---',
-        '<!-- gaia-harden: promoted from recurring finding_class rule/switch-statement; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->',
+        markerComment('rule/switch-statement'),
         '',
         '# Rule body',
       ].join('\n')
@@ -41,14 +42,15 @@ describe('coveredClassesFromRules', () => {
   });
 
   it('collects markers across multiple rule files', () => {
+    // Deliberate abbreviated tail: the binder is prefix-bound / tail-agnostic,
+    // so a copy that keeps the frozen prefix but shortens the tail still binds.
+    // This is the ONE fixture that proves tail-agnosticism on purpose; every
+    // other fixture uses markerComment(...) so it cannot silently drift.
     writeFileSync(
       path.join(dir, 'a.md'),
       '<!-- gaia-harden: promoted from recurring finding_class axe/color-contrast; never for non-recurrence -->'
     );
-    writeFileSync(
-      path.join(dir, 'b.md'),
-      '<!-- gaia-harden: promoted from recurring finding_class knip/exports; never for non-recurrence -->'
-    );
+    writeFileSync(path.join(dir, 'b.md'), markerComment('knip/exports'));
 
     const covered = coveredClassesFromRules(dir);
     expect(covered.has('axe/color-contrast')).toBe(true);

--- a/.gaia/cli/src/harden/__tests__/ledger-bridge.test.ts
+++ b/.gaia/cli/src/harden/__tests__/ledger-bridge.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, vi} from 'vitest';
+import {EXIT_CODES} from '../../exit.js';
 import {
   type LedgerRunner,
   makeLedgerSuppressionPredicate,
@@ -36,13 +37,41 @@ describe('makeLedgerSuppressionPredicate', () => {
     expect(args[countIdx + 1]).toBe('5');
   });
 
-  it('treats a non-zero exit as not suppressed (re-surface)', () => {
+  it('treats exit 1 (the legitimate not-suppressed code) as not suppressed', () => {
     const predicate = makeLedgerSuppressionPredicate({
       cwd: '/repo',
       runLedger: notSuppressed,
     });
 
     expect(predicate('axe/color-contrast', 5)).toBe(false);
+  });
+
+  it('fails closed on CONFIG_INVALID (a corrupt / version-skewed ledger)', () => {
+    const predicate = makeLedgerSuppressionPredicate({
+      cwd: '/repo',
+      runLedger: () => ({
+        exitCode: EXIT_CODES.CONFIG_INVALID,
+        stderr: '',
+        stdout: '',
+      }),
+    });
+
+    // Fail-closed: an error exit stays suppressed so a corrupt ledger never
+    // silently re-surfaces a declined candidate.
+    expect(predicate('axe/color-contrast', 5)).toBe(true);
+  });
+
+  it('fails closed on STORAGE_INACCESSIBLE', () => {
+    const predicate = makeLedgerSuppressionPredicate({
+      cwd: '/repo',
+      runLedger: () => ({
+        exitCode: EXIT_CODES.STORAGE_INACCESSIBLE,
+        stderr: '',
+        stdout: '',
+      }),
+    });
+
+    expect(predicate('axe/color-contrast', 5)).toBe(true);
   });
 });
 

--- a/.gaia/cli/src/harden/__tests__/marker.test.ts
+++ b/.gaia/cli/src/harden/__tests__/marker.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Guard for the frozen provenance marker (`marker.ts`).
+ *
+ * The marker is hand-copied into three doc surfaces (`harden.md`, `audit.md`,
+ * and the Policy-Memory Loop wiki page) and matched by two independent binders
+ * (`covered-classes.ts` prefix-bound, `/gaia-audit` full-text). This guard binds
+ * every copy plus the regex to `markerComment(...)` so a drifted copy fails the
+ * suite instead of silently breaking one binder.
+ */
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+import {coveredClassesFromRules} from '../covered-classes.js';
+import {MARKER_PREFIX, markerComment} from '../marker.js';
+
+const resolveRepoRoot = (): string => {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    if (existsSync(path.join(dir, '.git'))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  throw new Error('Could not find repo root (no .git directory found)');
+};
+
+const REPO_ROOT = resolveRepoRoot();
+
+const readRepoFile = (relative: string): string =>
+  readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+
+const occurrences = (haystack: string, needle: string): number =>
+  haystack.split(needle).length - 1;
+
+describe('provenance marker constant', () => {
+  it('MARKER_PREFIX is the stable head of markerComment for any class', () => {
+    const literal = markerComment('anything');
+    expect(literal.startsWith(`<!-- ${MARKER_PREFIX} `)).toBe(true);
+    expect(literal).toContain(MARKER_PREFIX);
+  });
+
+  it('the covered-classes binder matches the marker and captures the class', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'gaia-marker-'));
+
+    try {
+      writeFileSync(
+        path.join(dir, 'rule.md'),
+        markerComment('rule/switch-statement')
+      );
+
+      expect(
+        coveredClassesFromRules(dir).has('rule/switch-statement')
+      ).toBe(true);
+    } finally {
+      rmSync(dir, {force: true, recursive: true});
+    }
+  });
+
+  describe('every doc copy reproduces markerComment verbatim', () => {
+    const literal = markerComment('<class>');
+
+    it('harden.md carries it at the template site and the frozen-marker section', () => {
+      const body = readRepoFile('.claude/skills/gaia/references/harden.md');
+      expect(occurrences(body, literal)).toBeGreaterThanOrEqual(2);
+    });
+
+    it('audit.md carries it', () => {
+      expect(readRepoFile('.claude/skills/gaia/references/audit.md')).toContain(
+        literal
+      );
+    });
+
+    it('the Policy-Memory Loop wiki page carries it', () => {
+      expect(readRepoFile('wiki/concepts/Policy-Memory Loop.md')).toContain(
+        literal
+      );
+    });
+  });
+});

--- a/.gaia/cli/src/harden/__tests__/tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/tally.test.ts
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import * as runProcess from '../../ci/util/run-process.js';
+import {markerComment} from '../marker.js';
 import {run} from '../tally.js';
 import type {ProcessResult} from '../../ci/util/run-process.js';
 
@@ -260,7 +261,7 @@ describe('harden-tally run', () => {
     mkdirSync(sandbox.rulesDir, {recursive: true});
     writeFileSync(
       path.join(sandbox.rulesDir, 'switch.md'),
-      '<!-- gaia-harden: promoted from recurring finding_class rule/switch-statement; never for non-recurrence -->'
+      markerComment('rule/switch-statement')
     );
 
     vi.spyOn(runProcess, 'runGh').mockReturnValue(
@@ -358,7 +359,7 @@ describe('harden-tally run', () => {
     expect((pruneCall ?? [])[idx + 1]).toBe('axe/color-contrast');
   });
 
-  it('falls back to candidate_count 0 when gh fails (non-fatal)', () => {
+  it('falls back to candidate_count 0 and gh_ok false when gh fails (non-fatal)', () => {
     vi.spyOn(runProcess, 'runGh').mockReturnValue({
       exitCode: 4,
       stderr: 'gh: not authenticated',
@@ -370,7 +371,25 @@ describe('harden-tally run', () => {
       runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
     });
     expect(exit).toBe(0);
-    expect(parseStdout(stdout.out).candidate_count).toBe(0);
+
+    const printed = parseStdout(stdout.out);
+    expect(printed.candidate_count).toBe(0);
+    expect(printed.candidates).toEqual([]);
+    expect(printed.gh_ok).toBe(false);
+  });
+
+  it('sets gh_ok true on a successful read of a genuinely empty window', () => {
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(stubGh([]));
+
+    const exit = run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+    expect(exit).toBe(0);
+
+    const printed = parseStdout(stdout.out);
+    expect(printed.gh_ok).toBe(true);
+    expect(printed.candidate_count).toBe(0);
   });
 
   it('queries the 90-day merged-PR window via gh', () => {

--- a/.gaia/cli/src/harden/covered-classes.ts
+++ b/.gaia/cli/src/harden/covered-classes.ts
@@ -12,9 +12,19 @@
  */
 import {readdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
+import {MARKER_PREFIX} from './marker.js';
 
-const MARKER_RE =
-  /gaia-harden: promoted from recurring finding_class\s+(\S+?)\s*(?:;|-->)/g;
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Prefix-bound / tail-agnostic on purpose: derived from the shared
+// `MARKER_PREFIX` constant, then followed by the class-capture tail. It matches
+// any copy that keeps the frozen prefix regardless of the trailing wording, so
+// this binder never silently drifts from `/gaia-audit`'s full-text match.
+const MARKER_RE = new RegExp(
+  `${escapeRegExp(MARKER_PREFIX)}\\s+(\\S+?)\\s*(?:;|-->)`,
+  'g'
+);
 
 export const coveredClassesFromRules = (rulesDir: string): Set<string> => {
   const covered = new Set<string>();

--- a/.gaia/cli/src/harden/ledger-bridge.ts
+++ b/.gaia/cli/src/harden/ledger-bridge.ts
@@ -16,6 +16,7 @@
  */
 import {spawnSync} from 'node:child_process';
 import type {ProcessResult} from '../ci/util/run-process.js';
+import {EXIT_CODES} from '../exit.js';
 
 export type LedgerRunner = (
   argv: readonly string[],
@@ -66,7 +67,19 @@ export const makeLedgerSuppressionPredicate = ({
       cwd
     );
 
-    return result.exitCode === 0;
+    // Exit-code discrimination. OK (0) → suppressed. The legitimate
+    // not-suppressed code (1, returned for both no_decline_entry and
+    // threshold_reached) → not suppressed; mapping 1 → not-suppressed is safe
+    // only because the bridge always supplies well-formed --finding-class /
+    // --current-pr-count args, so is-suppressed's arg-error path (which also
+    // exits 1) is unreachable here. Any OTHER non-zero code (CONFIG_INVALID 30
+    // for a corrupt/version-skewed ledger, STORAGE_INACCESSIBLE 20, ...) is a
+    // read error: fail closed → stay suppressed, so a corrupt ledger never
+    // silently re-surfaces a declined candidate.
+    if (result.exitCode === EXIT_CODES.OK) return true;
+    if (result.exitCode === EXIT_CODES.UNKNOWN_SUBCOMMAND) return false;
+
+    return true;
   };
 
 type PruneOptions = BridgeOptions & {

--- a/.gaia/cli/src/harden/ledger.ts
+++ b/.gaia/cli/src/harden/ledger.ts
@@ -4,8 +4,11 @@
  * The machine-local decline ledger CLI. When an engineer declines a hardening
  * candidate the decline is recorded only on their machine (gitignored), so it
  * never vetoes the rule for a teammate. Re-surfacing is evidence-based, not a
- * timer: a declined class stays suppressed for that engineer until at least 3
- * distinct PRs carrying the class merge after the decline.
+ * timer: a declined class stays suppressed for that engineer until the window's
+ * distinct-PR count for the class rises at least 3 above its snapshot at the
+ * decline. That is a delta between two rolling-window snapshots, not a monotonic
+ * count of PRs merged since the decline, so window churn (old PRs aging out) can
+ * lower the current count and thereby delay or indefinitely prevent re-surface.
  *
  * The tally refresher READS this surface (`is-suppressed`, `prune`); the
  * `/gaia-harden` command WRITES to it (`record`) on decline. Both bind to the
@@ -46,8 +49,11 @@ const HELP_TEXT = `Usage: gaia harden-ledger <subcommand> [args]
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 
-// Re-surface threshold: a declined class stays suppressed until at least this
-// many distinct PRs carrying the class merge after the decline.
+// Re-surface threshold: a declined class stays suppressed until the window's
+// distinct-PR count for the class rises at least this far above its snapshot at
+// the decline. The comparison is a window-snapshot delta, not a monotonic count
+// of PRs merged since the decline, so window churn can delay or prevent
+// re-surface.
 const RESURFACE_THRESHOLD = 3;
 
 type RunOptions = {
@@ -361,8 +367,11 @@ const handleIsSuppressed = (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  // Evidence-based, not a timer: compare distinct PRs merged after the decline
-  // against the re-surface threshold.
+  // Evidence-based, not a timer: subtract the decline-time window snapshot from
+  // the current window snapshot and compare the delta against the re-surface
+  // threshold. This is a window-snapshot delta, not a monotonic count of PRs
+  // merged since the decline, so window churn can lower the current count and
+  // delay or prevent re-surface.
   const mergedSinceDecline = currentPrCount - entry.declined_at_pr_count;
   const suppressed = mergedSinceDecline < RESURFACE_THRESHOLD;
 

--- a/.gaia/cli/src/harden/marker.ts
+++ b/.gaia/cli/src/harden/marker.ts
@@ -1,0 +1,18 @@
+/**
+ * The frozen provenance marker `/gaia-harden` writes into a promoted rule.
+ *
+ * Single source of truth for the marker text. The `covered-classes.ts`
+ * `MARKER_RE` (prefix-bound / tail-agnostic), `/gaia-audit` (full-text), the doc
+ * copies (`harden.md` template + frozen-marker section, `audit.md`, and
+ * `wiki/concepts/Policy-Memory Loop.md`), and the `marker.test.ts` guard all
+ * bind to these two exports. A drifted copy silently breaks one binder or the
+ * other, so the guard test asserts every copy reproduces `markerComment(...)`
+ * byte for byte.
+ */
+
+/** The prefix the covered-classes binder matches; also the stable head of the doc copies. */
+export const MARKER_PREFIX = 'gaia-harden: promoted from recurring finding_class';
+
+/** The full, frozen provenance-marker comment for a given finding_class (or the '<class>' literal). */
+export const markerComment = (findingClass: string): string =>
+  `<!-- ${MARKER_PREFIX} ${findingClass}; pruned by /gaia-audit on obsolescence/redundancy/supersession/duplication only, never for non-recurrence -->`;

--- a/.gaia/cli/src/harden/tally.ts
+++ b/.gaia/cli/src/harden/tally.ts
@@ -19,6 +19,7 @@ import {EXIT_CODES} from '../exit.js';
 import {
   computeTally,
   type TallyPrRecord,
+  type TallyResult,
   windowClasses,
 } from './compute-tally.js';
 import {coveredClassesFromRules} from './covered-classes.js';
@@ -47,6 +48,20 @@ type RunOptions = {
   cwd?: string;
   runLedger?: LedgerRunner;
 };
+
+/**
+ * The window read plus a success flag. `ghOk` is `true` when the merged-PR
+ * window was read successfully (including a genuinely empty window) and `false`
+ * when the `gh` read failed, so a network outage is distinguishable from an
+ * all-clear at the emit boundary.
+ */
+type WindowPrs = {
+  ghOk: boolean;
+  prs: TallyPrRecord[];
+};
+
+/** The emitted tally JSON: the pure result plus the window-read success flag. */
+type EmittedTally = TallyResult & {gh_ok: boolean};
 
 const windowStartDate = (now: Date): string => {
   const start = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
@@ -84,10 +99,13 @@ const parseGhPr = (value: unknown): GhPr | null => {
 /**
  * Reads the merged-PR window via gh. Returns one record per PR that carries a
  * parseable findings block (the latest such comment wins so a re-run audit
- * supersedes an earlier one). Returns an empty array on any gh failure so the
- * refresher never blocks.
+ * supersedes an earlier one), alongside `ghOk`. `ghOk` is `false` on any gh
+ * failure (non-zero exit, unparseable JSON, or a well-formed-but-non-array
+ * response, all read failures rather than empty windows) and `true` otherwise,
+ * including a genuinely empty window. The refresher never blocks: an empty `prs`
+ * list is returned in every failure case.
  */
-const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
+const fetchWindowPrs = (cwd: string, now: Date): WindowPrs => {
   const search = `merged:>=${windowStartDate(now)}`;
   const ghResult: ProcessResult = runGh(
     [
@@ -105,17 +123,17 @@ const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
     {cwd}
   );
 
-  if (ghResult.exitCode !== 0) return [];
+  if (ghResult.exitCode !== 0) return {ghOk: false, prs: []};
 
   let parsed: unknown;
 
   try {
     parsed = JSON.parse(ghResult.stdout);
   } catch {
-    return [];
+    return {ghOk: false, prs: []};
   }
 
-  if (!Array.isArray(parsed)) return [];
+  if (!Array.isArray(parsed)) return {ghOk: false, prs: []};
 
   const records: TallyPrRecord[] = [];
 
@@ -139,7 +157,7 @@ const fetchWindowPrs = (cwd: string, now: Date): TallyPrRecord[] => {
     }
   }
 
-  return records;
+  return {ghOk: true, prs: records};
 };
 
 export const run = (argv: readonly string[], options: RunOptions = {}): number => {
@@ -153,7 +171,7 @@ export const run = (argv: readonly string[], options: RunOptions = {}): number =
   const runLedger = options.runLedger ?? defaultLedgerRunner;
   const now = new Date();
 
-  const prs = fetchWindowPrs(cwd, now);
+  const {ghOk, prs} = fetchWindowPrs(cwd, now);
   const covered = coveredClassesFromRules(
     path.join(cwd, '.claude', 'rules')
   );
@@ -168,7 +186,13 @@ export const run = (argv: readonly string[], options: RunOptions = {}): number =
   // Self-clean the ledger: drop declines whose class no longer recurs.
   pruneLedger({cwd, runLedger, windowClasses: windowClasses(prs)});
 
-  process.stdout.write(`${JSON.stringify(tallyResult)}\n`);
+  // Emit `gh_ok` at the I/O boundary so a gh outage is distinguishable from an
+  // all-clear. It stays off the pure `TallyResult`: the tally core cannot know
+  // whether the window read succeeded. The read is non-fatal, so run() still
+  // exits 0 in every case.
+  const emitted: EmittedTally = {...tallyResult, gh_ok: ghOk};
+
+  process.stdout.write(`${JSON.stringify(emitted)}\n`);
 
   return EXIT_CODES.OK;
 };


### PR DESCRIPTION
Hardens both surfaces of `/gaia-harden`: the playbook the agent executes
(`.claude/skills/gaia/references/harden.md`) and the CLI that backs it
(`.gaia/cli/src/harden/*`). Lands as two sequential commits, doc first, then CLI.

## Invariants preserved (no regression)

- `/gaia-harden` is human-gated end to end and NEVER runs `git add`/`commit`/`push`.
- It is the only writer in the policy-memory loop.
- Every drafted prose rule is mandatorily path-scoped; never an unscoped rule.
- A decline is machine-local (gitignored ledger) only; a defer persists nothing.
- `harden-tally` stays non-fatal on a `gh` outage (still exits 0).

## Phase 1 — doc surface (harden.md)

- **H1**: new "approve, edit existing prose rule" handler so an approved prose EDIT
  appends to the named rule (per-class provenance marker + reconciled `paths:`)
  instead of duplicating it via the new-file path.
- **M2**: empty/non-path `area_tags` fallback; forbid unscoped `**/*`.
- **M3**: Axis-2 guardrails beat a redirect.
- **L1**: reframe decline re-surface as a rolling-window count delta + churn caveat.
- **L2**: note v1 coverage is class-level / scope-blind.
- **L4**: route knip enforcement to `code-review-audit` / CI, not the dev gate.
- **L5**: note delayed silencing in the three non-prose approve handlers.
- **L6**: `skill-creator` marked plugin-provided; plugin-free `SKILL.md` scaffold leads.
- **L7**: sync note tying the oracle-prefix list to `ORACLE_PREFIXES`.
- **N1-N6**: statusline nudge text, decline-vs-defer, one-question-per-candidate
  approval contract, mis-decline undo/prune, marker-first-line template fix,
  wiki-style ban pointer.

## Phase 2 — CLI + tests (follows on this PR)

- **M1**: extract the provenance marker into a single `marker.ts` constant; guard test
  binds all four doc copies + the `covered-classes` regex to it.
- **M4**: `gh_ok` at the tally emit boundary so a `gh` outage is distinguishable from an
  all-clear (still non-fatal).
- **L3**: ledger bridge fails closed on error exit codes; the decline handler checks the
  `record` exit code.
- **L1 (comments)**: fix the three `ledger.ts` re-surface comments to the window-snapshot
  framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)