### PR TITLE
wiki: sync through c20b444

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "9b5668d104c8d0fd1d08d534ff1a468ba3dc379d",
-  "last_evaluated_at": "2026-07-01T17:57:35Z",
+  "last_evaluated_sha": "c20b4441d1fa278d3e3415caf2e225a89868066d",
+  "last_evaluated_at": "2026-07-01T20:27:50Z",
   "last_consolidated_sha": "15ddaf9676b4fca22031e441e6d70b3c1df1d2a5",
   "last_consolidated_at": "2026-06-30T19:19:44Z"
 }

--- a/wiki/concepts/Audit Disposition and Debt Drain.md
+++ b/wiki/concepts/Audit Disposition and Debt Drain.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-06-30
-updated: 2026-07-01
+updated: 2026-07-02
 tags: [concept, claude, review]
 ---
 
@@ -129,6 +129,8 @@ A statusline segment, `Run /gaia-debt (N issues)` (`issue` singular at N==1), su
 `.gaia/scripts/debt-count-refresh.sh` runs detached in the background each tick. It recomputes `openCount` via `gh issue list --label tech-debt --state open` and rewrites the cache when a staleness sentinel (`.gaia/local/debt/refresh-requested`, an empty marker file) is present or the cache is older than its own TTL, independent of the aggregate update-check TTL. On any `gh` failure it preserves the previous count rather than blanking it; a backend-absent run with no prior cache seeds `openCount` 0 so no segment renders.
 
 Two first-party events set the sentinel deterministically: the audit filing a `tech-debt` issue, and a `/gaia-debt` PR merging. The merge event is a `gh pr merge` PostToolUse hook (`.claude/hooks/debt-sentinel-touch.sh`) that touches the sentinel after a successful merge, since the merge usually lands via the orchestrator or human after the skill has left the conversation; the skill's own in-conversation touch is best-effort belt-and-suspenders. Every sentinel or cache writer runs `mkdir -p .gaia/local/debt` first, because the directory is not assumed to pre-exist on a fresh clone or in CI. External (web-UI or teammate) mutations are best-effort and surface by the next TTL or session refresh.
+
+GitHub's issue-list index is eventually consistent, so a recompute fired immediately after a merge can still count the just-closed issue for a few seconds. The refresher holds the sentinel armed through a 120-second settle grace after each recompute, writing the fresh count but not yet clearing the sentinel, so a later tick re-reads the now-consistent count before the nudge clears; a sentinel older than the grace clears normally on the next genuine recompute. Sentinel age is read via a portable mtime probe, GNU `stat -c %Y` first, falling back to BSD/macOS `stat -f %m`, with a numeric check between the two attempts (GNU's `-f` variant exits 0 with a non-numeric result instead of failing, so the check rejects rather than accepts that garbage); an unreadable mtime reads as already past the grace so a stat failure never wedges the sentinel armed indefinitely.
 
 ## Relationship to the Policy-Memory Loop
 

--- a/wiki/concepts/Policy-Memory Loop.md
+++ b/wiki/concepts/Policy-Memory Loop.md
@@ -3,7 +3,7 @@ type: concept
 title: Policy-Memory Loop
 status: active
 created: 2026-06-05
-updated: 2026-06-24
+updated: 2026-07-02
 tags: [concept, claude, audit, self-improvement, governance]
 ---
 
@@ -16,7 +16,7 @@ The Policy-Memory Loop turns a recurring code-review finding into a durable, hum
 1. **Emission contract.** [[Code Review Audit Agent]] tags every eligible finding with a stable `finding_class` and a `severity`. Oracle buckets use tool ids verbatim (`react-doctor/...`, `axe/...`, `knip/...`, `cve/...`); holistic and rule-subagent buckets draw from a constrained vocabulary. A finding with no stable class is not emitted as a countable finding, the schema rejects free-text drift. Recurrence counts only `error` and `warning`; `suggestion` is ineligible.
 2. **PR substrate.** The pull request is the durable record, not a committed sidecar. CI posts a machine-readable finding block in its PR comment; local runs emit the same fields through the telemetry trailer. The cross-machine signal lives on GitHub, read back via `gh`.
 3. **TTL tally.** A background refresher recomputes, each TTL, how many distinct PRs carry each `finding_class` (warning-floor) across a rolling 90-day window. It drops classes already promoted (a rule exists) or locally declined without fresh evidence, and writes a candidate count to the statusline cache. The tally is an ephemeral projection: nothing is staged, an un-acted pattern decays by ageing out of the window.
-4. **Statusline nudge.** When the candidate count is above zero, the statusline shows a `Run /gaia-harden (N recurring patterns)` segment, alongside the `/update-deps` and `/update-gaia` indicators and under the same worktree + setup-complete suppression.
+4. **Statusline nudge.** When the candidate count is above zero, the statusline shows a `Run /gaia-harden (N recurring patterns)` segment, alongside the `/update-deps` and `/update-gaia` indicators and under the same worktree + setup-complete suppression. The tally carries a `gh_ok` flag alongside `candidate_count`; on a `gh`/network outage it emits `candidate_count 0` with `gh_ok false`, and the statusline refresher keeps the previously cached count instead of treating the failure as a genuine all-clear.
 5. **Judge the form.** `/gaia-harden review` judges the lowest-context-weight form that fits the finding (deterministic check, skill, or path-scoped prose rule) and whether to edit an existing artifact or author a new one, then drafts it into the working tree for the engineer to **approve**, **decline**, **defer**, or **redirect**.
    - **Approve** ships a prose rule under `.claude/rules/` carrying a mandatory `paths:` glob and a provenance marker (see below). It is never frontmatter-less / always-loaded. The rule goes through normal PR review and becomes the shared suppression signal.
    - **Decline** records `finding_class -> timestamp` in machine-local, gitignored state only. It re-surfaces to that engineer once three or more distinct PRs carrying the class merge after the decline; teammates still see and can approve the same candidate.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,12 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-07-01 c20b4441 WORTHY - health-audit remediations already carry their own wiki/decisions/Claude Integration Fitness.md edit (shared-reference SKILL.md exemption) in the commit; no further sync edit needed
+- 2026-07-01 da32c76d WORTHY - sentinel mtime probe now GNU-first with numeric validation so the settle grace works on Linux → same edit as 757f51c2, wiki/concepts/Audit Disposition and Debt Drain.md
+- 2026-07-01 757f51c2 WORTHY - debt sentinel holds armed through a 120s settle grace so the /gaia-debt nudge clears cleanly after merge → wiki/concepts/Audit Disposition and Debt Drain.md
+- 2026-07-01 3a30099f WORTHY - statusline consumer honors gh_ok so a gh outage keeps the /gaia-harden nudge → wiki/concepts/Policy-Memory Loop.md
+- 2026-07-01 fbcc3d76 WORTHY - harden-tally now emits gh_ok distinguishing a gh outage from all-clear (with marker/ledger internal hardening) → wiki/concepts/Policy-Memory Loop.md
+- 2026-07-01 bf9478cd SKIP - self-referential prior wiki sync/lint maintenance commit, no code change to reflect
 - 2026-07-01 9b5668d1 WORTHY - new repo-relative-paths.md rule added to harness-discipline rule enumeration → wiki/modules/Claude Integration.md
 - 2026-07-01 c58bd0e4 SKIP - wiki changes landed inline in commit (README.md, Code Review Audit CI.md, Incremental CI Skipping.md); no new surface
 - 2026-07-01 da922476 SKIP - wiki change landed inline in commit (Code Review Audit CI.md); no new surface


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to c20b444.