### PR TITLE
chore(deps): update cookie to 2.0.0

### DIFF
--- a/app/utils/theme.server.ts
+++ b/app/utils/theme.server.ts
@@ -1,4 +1,4 @@
-import * as cookie from 'cookie';
+import {parseCookie, stringifySetCookie} from 'cookie';
 import {env} from '~/env.server';
 
 const COOKIE_NAME = '__theme';
@@ -8,7 +8,7 @@ export type Theme = 'dark' | 'light';
 export const getTheme = (request: Request): Theme | undefined => {
   const cookieHeader = request.headers.get('Cookie');
   if (!cookieHeader) return undefined;
-  const parsed = cookie.parse(cookieHeader)[COOKIE_NAME];
+  const parsed = parseCookie(cookieHeader)[COOKIE_NAME];
   if (parsed === 'light' || parsed === 'dark') return parsed;
 
   return undefined;
@@ -16,20 +16,24 @@ export const getTheme = (request: Request): Theme | undefined => {
 
 export const setTheme = (theme: 'system' | Theme): string => {
   if (theme === 'system') {
-    return cookie.serialize(COOKIE_NAME, '', {
+    return stringifySetCookie({
       httpOnly: true,
       maxAge: -1,
+      name: COOKIE_NAME,
       path: '/',
       sameSite: 'lax',
       secure: env.NODE_ENV === 'production',
+      value: '',
     });
   }
 
-  return cookie.serialize(COOKIE_NAME, theme, {
+  return stringifySetCookie({
     httpOnly: true,
     maxAge: 31_536_000,
+    name: COOKIE_NAME,
     path: '/',
     sameSite: 'lax',
     secure: env.NODE_ENV === 'production',
+    value: theme,
   });
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@react-router/remix-routes-option-adapter": "8.0.1",
     "@react-router/serve": "8.0.1",
     "autosize": "6.0.1",
-    "cookie": "1.1.1",
+    "cookie": "2.0.0",
     "date-fns": "4.4.0",
     "dotenv": "17.4.2",
     "i18next": "26.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1
       cookie:
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 2.0.0
+        version: 2.0.0
       date-fns:
         specifier: 4.4.0
         version: 4.4.0
@@ -2718,6 +2718,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.0:
+    resolution: {integrity: sha512-hRSFuKJ6SYHrFVNltQdagQFMk7e0Q/VrORTGqZGyUAmmhA3EwPeldHCTg0HqUaDodQOfQDe7qXuOtpf4lwCsaA==}
+    engines: {node: '>=22'}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -7782,6 +7786,8 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cookie@2.0.0: {}
 
   core-js-compat@3.49.0:
     dependencies:


### PR DESCRIPTION
## Migration Report

Automated dependency update via `/update-deps`.

### Updated packages
| Group | Package | From | To | Type |
| --- | --- | --- | --- | --- |
| singleton:cookie | cookie | 1.1.1 | 2.0.0 | major |

### Breaking changes applied
- **[cookie]** `app/utils/theme.server.ts` (the sole root call site): cookie v2 renames its API. `parse()` → `parseCookie()`, and `serialize(name, value, opts)` → `stringifySetCookie({name, value, ...opts})` (object-mode). Verified against the installed `cookie@2.0.0` source that the new functions produce byte-identical Cookie/Set-Cookie output. cookie v2 is ESM-only with an `engines.node >= 22` floor; the project is already ESM and pins Node `>=22.22.0`, so the floor is a non-issue. Exact pin preserved (no caret).

### Overrides audited
- None (`overrides:` map is empty).

### Held by config (not updated)
- `vite` `8.0.16` — held at ceiling `8.0` via `gaia.updateDepsHold`; `8.1.0` is not offered until the hold is lifted.

### Skipped packages
None.

### Snoozed (deferred this run)
None.

### Quality gate
| Step | Result |
| --- | --- |
| typecheck | pass |
| lint | pass |
| test --run | pass (155 passed / 1 skipped) |
| pw | pass (7 passed / 1 skipped) |
| build | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
