### PR TITLE
wiki: maintenance chain through 2adc6db

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "c20b4441d1fa278d3e3415caf2e225a89868066d",
-  "last_evaluated_at": "2026-07-01T20:27:50Z",
+  "last_evaluated_sha": "a32406912eaa436440708995e4161f291a3252cb",
+  "last_evaluated_at": "2026-07-02T07:13:55Z",
   "last_consolidated_sha": "15ddaf9676b4fca22031e441e6d70b3c1df1d2a5",
   "last_consolidated_at": "2026-06-30T19:19:44Z"
 }

--- a/wiki/concepts/Code Review Audit CI.md
+++ b/wiki/concepts/Code Review Audit CI.md
@@ -65,9 +65,9 @@ This is a UX/ordering cleanup, not a clean-stamp path. The self-mod-skip stamps 
 
 ## Clean audit, no push
 
-A genuinely-clean audit that produces no self-heal commits and no empty trailer commit leaves the `push-fixes` step with neither `pushed` nor `marker_only` set. Without intervention, HEAD carries no `GAIA-Audit` status and the merge hook blocks the merge even though the audit passed.
+A genuinely-clean audit that produces no self-heal commits and no empty trailer commit leaves the `push-fixes` step with neither `pushed` nor `marker_only` set. Without intervention, HEAD carries no `GAIA-Audit` status and the merge hook blocks the merge even though the audit passed. The same gap opens when the audit is clean but its only tree delta is a **refused** self-heal (see [[#Self-heal staging guards]]): the staged diff landed on an off-limits surface (`.claude/**`, `.specify/**`, `wiki/**`) or exceeded ten files. `refused` means the fix was off-limits to auto-apply, not that the audit failed or the tree is dirty, so it does not gate this stamp either.
 
-The `Write GAIA-Audit commit status (clean, no push)` step closes this gap: it stamps the `GAIA-Audit` commit status directly on the current PR HEAD with no empty commit. A proven-clean guard prevents false passes: the audit agent writes `.gaia/local/audit/<HEAD>.ok` only on a clean pass (no Critical Issues, all Important Issues addressed, all Suggestions resolved). The step checks for this marker before stamping; a dirty audit that pushed nothing has no marker and receives no status, keeping the merge blocked until the audit clears.
+The `Write GAIA-Audit commit status (clean, no push)` step closes this gap: it stamps the `GAIA-Audit` commit status directly on the current PR HEAD with no empty commit, covering both the no-delta case and the refused-self-heal case. A proven-clean guard prevents false passes: the audit agent writes `.gaia/local/audit/<HEAD>.ok` only on a clean pass (no Critical Issues, all Important Issues addressed, all Suggestions resolved). The step checks for this marker before stamping; a dirty audit that pushed nothing has no marker and receives no status, keeping the merge blocked until the audit clears.
 
 This is the audit's instance of the cross-workflow mechanism in [[Incremental CI Skipping]].
 

--- a/wiki/concepts/Local Working State.md
+++ b/wiki/concepts/Local Working State.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-02
 tags: [concept, claude, hooks]
 ---
 
@@ -35,8 +35,9 @@ A **live** entry is load-bearing state that tooling reads. An **ephemeral** entr
 
 ## The session-start janitor
 
-`.claude/hooks/local-janitor.sh` runs from the SessionStart hook (`wiki-session-start.sh`) on `startup` and `resume`. It is the side-effect form of a SessionStart hook: it deletes files and injects nothing into context. It is a backstop, not an owner, so each subsystem still prunes its own residue at its next run. The janitor removes only residue whose death is provable, which makes it safe to run unconditionally every session. It sweeps three things:
+`.claude/hooks/local-janitor.sh` runs from the SessionStart hook (`wiki-session-start.sh`) on `startup` and `resume`. It is the side-effect form of a SessionStart hook: it deletes files and injects nothing into context. It is a backstop, not an owner, so each subsystem still prunes its own residue at its next run. The janitor removes only residue whose death is provable, which makes it safe to run unconditionally every session. It sweeps four things:
 
+- **Merged-and-gone `wiki-sync/*` branches.** The wiki landing CLI (`gaia wiki chain finish` / `wiki sync land`) cuts a throwaway `wiki-sync/<date>-<sha>` branch and enables auto-merge with `gh pr merge --auto`, a call that returns before the merge lands, so the local branch is never deleted inline. Once the PR squash-merges and a later `git fetch --prune` drops the tracking ref, the branch's upstream shows `[gone]`, the provable-death signal; the janitor hard-deletes (`git branch -D`, since a squash merge leaves the tip unmerged by ancestry) any `wiki-sync/*` branch in that state. This sweep is git-scoped, independent of `.gaia/local/`, so it runs before the guard below (a fresh clone can carry an orphaned branch before that directory exists).
 - **Orphaned audit markers.** An `audit/<sha>.ok` or `<sha>.dispositions.json` gates `gh pr merge` only while its `<sha>` equals HEAD. Once a PR squash-merges to a new sha, the audited branch tip is no longer HEAD and is unreachable from any local branch, so the marker is spent. The janitor keeps a marker only when its `<sha>` is HEAD or reachable from a local branch; everything else, including a `<sha>` that is not a valid commit, is removed.
 - **Completed-but-unswept plan dirs.** A `plans/<slug>/` whose `RUNNING` sentinel names a branch that no longer exists and is not marked `DEFERRED`/`PAUSED`/`PARKED` is a plan that merged but whose self-cleanup never ran (an interrupted session). The janitor removes the directory. A parked plan is always kept.
 - **Stray empty dirs.** Empty directories under `.gaia/local/` are removed with `rmdir`, except the structural drop zones tooling expects to find (`audit`, `cache`, `plans`, `forensics`, `handoff`, `specs`, `telemetry`, and the other roots). `rmdir` cannot remove a non-empty directory, so a content-bearing dir is never at risk.

--- a/wiki/concepts/Wiki Sync.md
+++ b/wiki/concepts/Wiki Sync.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-05-03
-updated: 2026-06-24
+updated: 2026-07-02
 tags: [concept, claude, workflow, wiki]
 ---
 
@@ -75,7 +75,7 @@ For each commit since `last_evaluated_sha`:
 3. **Log every decision** (worthy and skipped) to `wiki/log.md` with a one-line reason.
    3b. **Fabrication guard.** Before advancing state, asserts every WORTHY edit was actually written to disk: a per-path porcelain check confirms each claimed page shows as changed or created, and a broader content-change check confirms at least one wiki content file is modified when the WORTHY set is non-empty. Any failure aborts the run before state advances, leaving `last_evaluated_sha` unchanged so the next sync re-evaluates the same range.
 4. **Advance state** to current HEAD.
-5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`. The landing strategy is branch-aware: on `main` (push-protected), it creates `wiki-sync/<date>-<short_sha>`, pushes, opens a PR, and squash-merges; on any other branch (feature/fix/release/worktree), it commits in place so the maintainer's working state isn't fragmented.
+5. **Commit** the wiki changes as `wiki: sync through <short_sha> (N updated, N skipped)`. The landing strategy is branch-aware: on `main` (push-protected), it creates `wiki-sync/<date>-<short_sha>`, pushes, and enables auto-merge (`gh pr merge --squash --auto --delete-branch`), which removes the remote head branch on merge regardless of the repo's auto-delete-head-branches setting; it then returns to the base branch so the local `wiki-sync/*` branch is left behind for [[Local Working State|the session-start janitor]] to prune once its upstream shows `[gone]`. On any other branch (feature/fix/release/worktree), it commits in place so the maintainer's working state isn't fragmented.
 
 When invoked as part of the no-arg `/gaia-wiki` full chain, `gaia wiki chain begin` pre-cuts the branch before sync runs, so this same step commits in place rather than opening its own PR. `gaia wiki chain finish` opens one PR covering all stage commits (sync, consolidate, lint) at the end of the chain. Standalone `/gaia-wiki sync` is unaffected: it still self-lands via `sync land --branch-aware`.
 

--- a/wiki/dependencies/Storybook.md
+++ b/wiki/dependencies/Storybook.md
@@ -5,7 +5,7 @@ package: storybook
 version: 10.4.6
 role: component-development-and-visual-testing
 created: 2026-04-20
-updated: 2026-07-01
+updated: 2026-07-02
 tags: [dependency, storybook]
 ---
 
@@ -21,4 +21,4 @@ See [[Storybook Stories]] module page.
 
 ## Vite version ceiling
 
-Vite is held at 8.0.16. Vite 8.1.x (Rolldown 1.1.2 and up) builds a Storybook iframe bundle that calls the `__commonJS` interop helper without ever defining it, so the published Storybook throws `__commonJS is not defined` and Chromatic cannot extract stories. The app build (`react-router build`) is unaffected, so the local quality gate passes clean; only the Storybook build surfaces the fault, which makes [[Chromatic]] the gate that catches a `vite` 8.1.x bump. The distinction is precise: on 8.0.16 every `__commonJS` call site carries its helper definition, so the bundle runs; on 8.1.x (verified through 8.1.2) the bare `__commonJS` helper is called but never defined, declared, or imported into any chunk, while the sibling `__commonJSMin` and Rolldown's numbered `__commonJS$n` instances still emit correctly. The orphaned helper wraps a CommonJS chain (`react-i18next` → `hoist-non-react-statics` → `react-is`), and the fault only appears once that graph is large enough, so plain `vite` and a stripped-down Storybook both build clean. The `vite` companion group stays pinned to 8.0.16 until an upstream Rolldown release fixes the helper emission (tracked upstream at rolldown/rolldown#10048).
+Vite is held at 8.0.16. Vite 8.1.x (Rolldown 1.1.2 and up) builds a Storybook iframe bundle that calls the `__commonJS` interop helper without ever defining it, so the published Storybook throws `__commonJS is not defined` and Chromatic cannot extract stories. The app build (`react-router build`) is unaffected, so the local quality gate passes clean; only the Storybook build surfaces the fault, which makes [[Chromatic]] the gate that catches a `vite` 8.1.x bump. The distinction is precise: on 8.0.16 every `__commonJS` call site carries its helper definition, so the bundle runs; on 8.1.x (verified through 8.1.2) the bare `__commonJS` helper is called but never defined, declared, or imported into any chunk, while the sibling `__commonJSMin` and Rolldown's numbered `__commonJS$n` instances still emit correctly. The orphaned helper wraps a CommonJS chain (`react-i18next` → `hoist-non-react-statics` → `react-is`), and the fault only appears once that graph is large enough, so plain `vite` and a stripped-down Storybook both build clean. The `vite` companion group stays pinned to 8.0.16 until an upstream Rolldown release fixes the helper emission (tracked upstream at rolldown/rolldown#10048). The ceiling is enforced twice: `pnpm.overrides` pins the installed version, and `gaia.updateDepsHold` in `package.json` (`{"vite": "8.0"}`) tells the `/update-deps` skill to cap discovery at the 8.0 line so the hold survives in CI runs too, not just local snoozes.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,16 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-07-02 a3240691 SKIP - command-file (gaia-init.md) CODEOWNERS auto-detect gate logic, no wiki-page surface; pnpm-workspace.yaml quarantine-allowlist aging already covered generically by wiki/decisions/pnpm.md
+- 2026-07-02 1c572b51 WORTHY - local-janitor gains a wiki-sync/* branch-pruning sweep + sync land returns to base branch → wiki/concepts/Local Working State.md, wiki/concepts/Wiki Sync.md
+- 2026-07-02 2565e7d0 SKIP - chore(deps): major bump with call-site update, no architectural change
+- 2026-07-02 96ecc305 SKIP - command-file (gaia-init.md) interactive-gate hardening; author-declared no wiki-page surface, already narrated in wiki/log.md by the commit itself
+- 2026-07-02 e771b316 SKIP - chore(deps): version bump only
+- 2026-07-02 761e39cb SKIP - wiki change landed inline in commit (Code Review Audit CI.md three-copy section); no new surface
+- 2026-07-02 6d8549e8 WORTHY - clean-audit-no-push stamp now also covers a refused self-heal → wiki/concepts/Code Review Audit CI.md
+- 2026-07-02 095005f8 WORTHY - durable gaia.updateDepsHold config generalizes the vite 8.0 pin → wiki/dependencies/Storybook.md notes the config-backed enforcement
+- 2026-07-02 e30fdf8b SKIP - internal regex hardening of an existing workflow-denylist leak-check pattern; already self-documented in .gaia/cli/health/taxonomy.md and CHANGELOG, no new wiki fact
+- 2026-07-02 49fad99b SKIP - self-referential prior wiki-sync commit (wiki: sync through c20b444); no code change to reflect
 - 2026-07-02 gaia-init: interactive-gate non-response hardening. Adds a run-mode question (Interactive, recommended, vs Automatic) as the first gate, a fixed HARD-BLOCK vs SAFE-DEFAULT gate taxonomy, a no-cascade rule that overrides the harness away-from-keyboard note, and a never-fabricate guard for the CODEOWNERS handle (loud `REPLACE-WITH-YOUR-GITHUB-HANDLE` placeholder in Automatic mode). Automatic mode prints a corrected defaults table (single Mentorship row covering mentorship + analytics; CODEOWNERS shows the placeholder, never a git-inferred handle). Command-file change (.claude/commands/gaia-init.md); no wiki-page surface.
 - 2026-07-01 c20b4441 WORTHY - health-audit remediations already carry their own wiki/decisions/Claude Integration Fitness.md edit (shared-reference SKILL.md exemption) in the commit; no further sync edit needed
 - 2026-07-01 da32c76d WORTHY - sentinel mtime probe now GNU-first with numeric validation so the settle grace works on Linux → same edit as 757f51c2, wiki/concepts/Audit Disposition and Debt Drain.md


### PR DESCRIPTION
Automated /gaia-wiki full-chain landing (sync + consolidate + lint) via `gaia wiki chain finish`.