### PR TITLE
fix(wiki-lint): scope UAT narrative-ref check to shipped surfaces

### DIFF
--- a/.claude/rules/wiki-style.md
+++ b/.claude/rules/wiki-style.md
@@ -38,7 +38,10 @@ Wiki readers (maintainers, adopters) need to understand the system as it is now.
 - **`wiki/hot.md`**: auto-loaded recent-context cache. Body is by design a recap of recent commits / threads; historical phrasing is the point. The cache is overwritten by `/gaia-wiki sync`, not edited by hand.
 - **`wiki/meta/`**: audit artifacts (lint reports, consolidate reports). Their purpose is referencing specific commits / SHAs / dates, so the no-inline-refs rule does not apply.
 - **Frontmatter (`created`, `updated`, `status`, etc.)**: metadata, not prose.
-- **Structural UAT/SPEC references in `.claude/`, `.specify/`, `.gaia/tests/`**: narrowly exempt: template format examples (`> - UAT-NNN, Given … when … then …` showing the SPEC artifact shape), fixture data (CLI args like `--uat-id UAT-007`, JS/Python/YAML literals like `uat_id: 'UAT-099'`, regex targets that match SPEC YAML structure), filename literals (`uat-001.spec.ts`), and identifier fragments inside variable names (`uat_id`, `uats_block`, `seen_uat_files`). Narrative references, section-header parentheticals (`#### 5b. Discuss-this escape (UAT-004)`), inline narrative parentheticals, comments naming specific working-doc IDs, and pass/fail label prefixes, are NOT exempt and must be scrubbed.
+- **Structural UAT/SPEC references in `.claude/`, `.specify/extensions/gaia/`**: narrowly exempt: template format examples (`> - UAT-NNN, Given … when … then …` showing the SPEC artifact shape), fixture data (CLI args like `--uat-id UAT-007`, JS/Python/YAML literals like `uat_id: 'UAT-099'`, regex targets that match SPEC YAML structure), filename literals (`uat-001.spec.ts`), and identifier fragments inside variable names (`uat_id`, `uats_block`, `seen_uat_files`). Narrative references, section-header parentheticals (`#### 5b. Discuss-this escape (UAT-004)`), inline narrative parentheticals, comments naming specific working-doc IDs, and pass/fail label prefixes, are NOT exempt and must be scrubbed.
+<!-- gaia:maintainer-only:start -->
+- **`.gaia/tests/` is out of scope entirely.** It is release-excluded maintainer-only test infrastructure that never reaches an adopter, so a UAT/SPEC reference there is never shipped-surface drift. Its suites use `UAT-NNN` / `SEC-N` / `TST-NN` test-name prefixes, header comments, and section headers as deliberate SPEC-conformance traceability; those stay. Both audit greps below omit `.gaia/tests/` for this reason, matching the release boundary. Do not re-add `.gaia/tests/` to either grep.
+<!-- gaia:maintainer-only:end -->
 - **Concrete maintainer SPEC IDs.** Adopter-shipped surfaces must not reference specific maintainer SPECs by ID (`SPEC-001`, `SPEC-003`, etc.) as if they were system-wide constants. On adopter clones those IDs identify whatever the adopter authored first, not the maintainer artifact. Rephrase to generic placeholders (`the SPEC's <field>`, `## Composition with` heading prefix match) or drop the reference. Generic placeholder forms (`SPEC-NNN`, `SPEC-NNN.md`, illustrative `(e.g. SPEC-002)` examples in usage docs) are fine.
 - **Targeted archival labels**: e.g. the `## Historical context (from <older-title>)` heading `/gaia-wiki consolidate` writes when merging a superseded page is a deliberate label that identifies lifted content; not the prose pattern this rule bans.
 
@@ -60,8 +63,7 @@ grep -rEn "UAT-[0-9]{3}" \
   .claude/skills/ .claude/commands/ .claude/agents/ .claude/rules/ .claude/hooks/ \
   .specify/extensions/gaia/README.md .specify/extensions/gaia/commands/ \
   .specify/extensions/gaia/lib/ .specify/extensions/gaia/rules/ \
-  .specify/extensions/gaia/templates/ \
-  .gaia/tests/
+  .specify/extensions/gaia/templates/
 
 # Concrete maintainer SPEC IDs in instruction files and shipped extension surfaces
 grep -rEn "\bSPEC-00[1-9]\b" \
@@ -74,4 +76,4 @@ grep -rEn "\bSPEC-00[1-9]\b" \
 grep -rEn "\bchanged from|was changed|previously (did|was|stated|had|used|set)|as of [0-9]{4}|in PR #?[0-9]+|in commit [a-f0-9]{6,}" wiki/ --include="*.md" --exclude="log.md" --exclude="hot.md" --exclude-dir="meta"
 ```
 
-Any non-empty match outside this rule's prose is a candidate for rewrite. The narrative-vs-structural triage for the `.claude/`/`.specify/`/`.gaia/tests/` greps is a human read, the regex flags candidates; the Exceptions section above codifies what stays.
+Any non-empty match outside this rule's prose is a candidate for rewrite. The narrative-vs-structural triage for the `.claude/` / `.specify/` greps is a human read, the regex flags candidates; the Exceptions section above codifies what stays.

--- a/.claude/skills/gaia/references/wiki/lint.md
+++ b/.claude/skills/gaia/references/wiki/lint.md
@@ -146,7 +146,11 @@ List every dead reference (one per line). Do not truncate: the count is small en
 
 ## Step 4: GAIA check #13: UAT/SPEC narrative-ref drift
 
-Detects narrative `UAT-NNN` and concrete maintainer `SPEC-NNN` references that crept into instruction files (`.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.claude/rules/`, `.claude/hooks/`) and shipped extension surfaces (`.specify/extensions/gaia/{README.md, commands, lib, rules, templates}`) plus the maintainer-only `.gaia/tests/` smoke harnesses. The rule rationale + structural-vs-narrative triage table lives in `.claude/rules/wiki-style.md` (Exceptions section).
+Detects narrative `UAT-NNN` and concrete maintainer `SPEC-NNN` references that crept into instruction files (`.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.claude/rules/`, `.claude/hooks/`) and shipped extension surfaces (`.specify/extensions/gaia/{README.md, commands, lib, rules, templates}`). The rule rationale + structural-vs-narrative triage table lives in `.claude/rules/wiki-style.md` (Exceptions section).
+
+<!-- gaia:maintainer-only:start -->
+Both scans deliberately exclude `.gaia/tests/`: it is release-excluded maintainer-only test infrastructure that never reaches an adopter, so its UAT/SEC/TST test labels are legitimate SPEC-conformance traceability, not shipped-surface drift. Do not re-add `.gaia/tests/` to either grep.
+<!-- gaia:maintainer-only:end -->
 
 ### 4a. Run the greps
 
@@ -158,8 +162,7 @@ grep -rEn "UAT-[0-9]{3}" \
   .claude/skills/ .claude/commands/ .claude/agents/ .claude/rules/ .claude/hooks/ \
   .specify/extensions/gaia/README.md .specify/extensions/gaia/commands/ \
   .specify/extensions/gaia/lib/ .specify/extensions/gaia/rules/ \
-  .specify/extensions/gaia/templates/ \
-  .gaia/tests/
+  .specify/extensions/gaia/templates/
 
 # Concrete maintainer SPEC IDs
 grep -rEn "\bSPEC-00[1-9]\b" \

--- a/.gaia/release-scrub.yml
+++ b/.gaia/release-scrub.yml
@@ -147,15 +147,14 @@ transforms:
           - ".specify/extensions/gaia/rules/**"
           - ".specify/extensions/gaia/templates/**"
         path-allowlist:
-          # Self-referential: the rule's body cites the audit greps it
-          # codifies, including the maintainer-only `.gaia/tests/` scope.
-          - ".claude/rules/wiki-style.md"
-          # Self-referential: the lint playbook's documentation describes
-          # the same audit greps and target paths.
-          - ".claude/skills/gaia/references/wiki/lint.md"
           # Policy-documenting rule: its own body and Audit git-grep commands
           # cite the maintainer-only .gaia/tests/forensics/ path as the
-          # sanctioned exception it governs; same rationale as wiki-style.md.
+          # sanctioned exception it governs; the exclusion globs are
+          # load-bearing and kept unwrapped, so the file stays allowlisted.
+          # (wiki-style.md and the wiki-lint playbook formerly sat here too;
+          # they now wrap their `.gaia/tests/` rationale in maintainer-only
+          # markers, so the strip removes it and the leak-check now actively
+          # guards them against an unwrapped re-add.)
           - ".claude/rules/repo-relative-paths.md"
           # Documents the smoke-harness convention split between
           # `.specify/extensions/gaia/test/` (UAT runbooks) and


### PR DESCRIPTION
## Summary

`/gaia-wiki lint` (check #13) and its `wiki-style.md` rule were scanning `.gaia/tests/` for `UAT-NNN` references, surfacing 111 in the forensics SPEC-conformance suites on every run. That subtree is **release-excluded maintainer-only test infrastructure** (`.gaia/release-exclude` category 3), so its `UAT-NNN` / `SEC-N` / `TST-NN` test labels are deliberate SPEC traceability, never adopter-facing drift. The fix is in the checker, not the tests.

## Changes

- **`.claude/rules/wiki-style.md`** and **`.claude/skills/gaia/references/wiki/lint.md`**: drop `.gaia/tests/` from the UAT grep, making it symmetric with the sibling concrete-SPEC-ID grep (which already omitted it). The maintainer-only rationale for the exclusion is wrapped in `gaia:maintainer-only` markers so it is stripped from the adopter bundle.
- **`.gaia/release-scrub.yml`**: with the rationale wrapped, both files carry zero `.gaia/tests/` references post-strip, so their `maintainer-paths` leak-check allowlist entries are removed. The leak-check now actively guards them against an unwrapped re-add. Their separate concrete-SPEC-ID allowlisting is untouched.

## Verification

- Narrowed UAT grep: forensics false positives 111 to 0; shipped surfaces still scanned (7 pre-existing structural matches unchanged); UAT and SPEC-ID greps now scan an identical path set.
- Maintainer-only markers balanced in both files; bundle-strip simulation confirms zero `.gaia/tests/` (and zero full `maintainer-paths`) references reach adopters.
- `release-scrub.yml` parses as valid YAML; the remaining allowlist entries are preserved.

## Adopter impact

None. Adopters do not carry `.gaia/tests/`, and the wrapped rationale is stripped from their bundle. No CHANGELOG entry warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
