### PR TITLE
refactor(gaia-cli): use T[] array syntax in scrub.ts (array-type convention)

### DIFF
--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -185,11 +185,11 @@ const walkFiles = (root: string, current: string = root): string[] => {
 export type MarkerStripResult = {
   blocksStripped: number;
   filesTouched: readonly string[];
-  unbalanced: ReadonlyArray<{
+  unbalanced: readonly {
     file: string;
     line: number;
     reason: 'start_without_end' | 'end_without_start';
-  }>;
+  }[];
 };
 
 const stripMarkerBlocks = (
@@ -199,17 +199,17 @@ const stripMarkerBlocks = (
 ): {
   blocks: number;
   output: string;
-  unbalanced: Array<{
+  unbalanced: {
     line: number;
     reason: 'end_without_start' | 'start_without_end';
-  }>;
+  }[];
 } => {
   const lines = source.split('\n');
   const out: string[] = [];
-  const unbalanced: Array<{
+  const unbalanced: {
     line: number;
     reason: 'end_without_start' | 'start_without_end';
-  }> = [];
+  }[] = [];
   let inBlock = false;
   let blockStartLine = 0;
   let blocks = 0;
@@ -259,11 +259,11 @@ const applyMarkerStrip = (
   transform: MarkerStripTransform
 ): MarkerStripResult => {
   const filesTouched: string[] = [];
-  const unbalanced: Array<{
+  const unbalanced: {
     file: string;
     line: number;
     reason: 'end_without_start' | 'start_without_end';
-  }> = [];
+  }[] = [];
   let blocksStripped = 0;
 
   for (const relativePath of files) {
@@ -756,11 +756,11 @@ type Report = {
     blocks_stripped: number;
     files_touched: readonly string[];
   };
-  unbalanced_markers: ReadonlyArray<{
+  unbalanced_markers: readonly {
     file: string;
     line: number;
     reason: string;
-  }>;
+  }[];
 };
 
 type RunOptions = {
@@ -887,7 +887,7 @@ export const run = (
 
   let stripBlocks = 0;
   const stripFiles: string[] = [];
-  const unbalanced: Array<{file: string; line: number; reason: string}> = [];
+  const unbalanced: {file: string; line: number; reason: string}[] = [];
   let jsonStripKeysRemoved = 0;
   const jsonStripFiles: string[] = [];
   const leaks: Leak[] = [];


### PR DESCRIPTION
Replace the six `Array<{...}>` / `ReadonlyArray<{...}>` declarations in `.gaia/cli/src/release/scrub.ts` (lines 188, 202, 209, 262, 759, 890) with `{...}[]` / `readonly {...}[]`, satisfying the shared `@gaia-react/lint` `@typescript-eslint/array-type` rule so a contributor editing these declarations no longer trips an unexpected lint error.

Type-annotation-only change; no runtime behavior change. CLI `typecheck` clean, scrub + scrub-wiki suites (58 tests) pass.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)