### PR TITLE
ci(gaia): run .gaia/tests/hooks bats suites under bash 5 in CI (SPEC-019 follow-up)

### DIFF
--- a/.gaia/tests/hooks/capture-red-observations.bats
+++ b/.gaia/tests/hooks/capture-red-observations.bats
@@ -25,6 +25,10 @@
 
 setup() {
   REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  # The hook recomputes RED signals via the Node helper, which resolves
+  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
+  # lean audit-ci-tests CI box) so `bats .gaia/tests/hooks/` stays green there.
+  [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HOOK="$REPO_ROOT/.claude/hooks/capture-red-observations.sh"
   FIX_REL=".gaia/tests/hooks/fixtures/red-ledger"
   JSON_REL="$FIX_REL/json"

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -12,6 +12,10 @@
 
 setup() {
   REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  # This suite runs the Node signal helper, which resolves `typescript` from
+  # node_modules; skip where deps aren't installed (e.g. the lean
+  # audit-ci-tests CI box) so `bats .gaia/tests/hooks/` stays green there.
+  [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HELPER="$REPO_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LIB="$REPO_ROOT/.claude/hooks/lib/red-ledger.sh"
   FIX="$BATS_TEST_DIRNAME/fixtures/red-ledger"

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -27,6 +27,10 @@
 
 setup() {
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  # The hook recomputes RED signals via the Node helper, which resolves
+  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
+  # lean audit-ci-tests CI box) so `bats .gaia/tests/hooks/` stays green there.
+  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HOOK_ABS="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
 

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -28,6 +28,10 @@
 
 setup() {
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  # Both hooks recompute RED signals via the Node helper, which resolves
+  # `typescript` from node_modules; skip where deps aren't installed (e.g. the
+  # lean audit-ci-tests CI box) so `bats .gaia/tests/hooks/` stays green there.
+  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   CAPTURE_HOOK="$HOME_ROOT/.claude/hooks/capture-red-observations.sh"
   CHECK_HOOK="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   BARE_TEST_HOOK="$HOME_ROOT/.claude/hooks/block-bare-test.sh"

--- a/.gaia/tests/hooks/worthiness-presence-check.bats
+++ b/.gaia/tests/hooks/worthiness-presence-check.bats
@@ -29,6 +29,11 @@
 
 setup() {
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
+  # The hook (and this suite's seed helpers) recompute signals via the Node
+  # helper, which resolves `typescript` from node_modules; skip where deps
+  # aren't installed (e.g. the lean audit-ci-tests CI box) so
+  # `bats .gaia/tests/hooks/` stays green there.
+  [ -d "$HOME_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HOOK_ABS="$HOME_ROOT/.claude/hooks/worthiness-presence-check.sh"
   HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
 

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -39,11 +39,14 @@ jobs:
             code:
               - '.github/audit/**'
               - '.github/workflows/audit-ci-tests.yml'
-              - '.claude/hooks/lib/repo-scope.sh'
-              - '.claude/hooks/pr-merge-audit-check.sh'
-              - '.claude/hooks/post-audit-status.sh'
+              # '.claude/hooks/**' is the superset of the specific hooks this
+              # suite used to filter on (repo-scope.sh, pr-merge-audit-check.sh,
+              # post-audit-status.sh); it now also covers every hook exercised
+              # by the .gaia/tests/hooks/ suites below.
+              - '.claude/hooks/**'
               - '.gaia/scripts/**'
               - '.gaia/tests/forensics/**'
+              - '.gaia/tests/hooks/**'
               - '.claude/skills/gaia/references/forensics*'
               - '.github/forensics/**'
       - if: steps.filter.outputs.code == 'true'
@@ -58,3 +61,13 @@ jobs:
       - if: steps.filter.outputs.code == 'true'
         name: Run .gaia/tests/forensics bats suites
         run: bash .gaia/tests/forensics/run-all.sh
+      # The hook suites are authored/run locally on macOS bash 3.2.57, where a
+      # false mid-test `[[ ... ]]` does NOT fail the test (bash 3.2 skips it
+      # under set -e), so a broken assertion can green locally. Ubuntu bats runs
+      # under bash 5, which enforces `[[ ]]`, making this the authoritative gate
+      # for token-tally-git-op.bats, token-rollup-merge.bats, and siblings. The
+      # four node-dependent RED-verify suites self-skip here (no node_modules on
+      # this lean box); see their setup() guards.
+      - if: steps.filter.outputs.code == 'true'
+        name: Run .gaia/tests/hooks bats suites
+        run: bats .gaia/tests/hooks/


### PR DESCRIPTION
## What

Wire `.gaia/tests/hooks/` into `audit-ci-tests.yml` so the hook bats suites run under **bash 5** in CI, and widen the paths-filter to trigger on `.gaia/tests/hooks/**` and `.claude/hooks/**`.

Closes the **CI coverage gap** from the SPEC-019 dollar-cost merge (#547): the workflow ran `.gaia/scripts/tests/` and `.gaia/tests/forensics/` on ubuntu but not `.gaia/tests/hooks/`, so `token-tally-git-op.bats`, `token-rollup-merge.bats`, and siblings were only ever exercised locally.

## Why it matters

On stock macOS bash 3.2.57 a **false** mid-`@test` `[[ ... ]]` does **not** fail the test — bats runs each test body under `set -e`, but bash 3.2 skips a failing `[[ ]]` under `set -e`, so only the test's last command's exit status flows through. A broken assertion greens locally with nothing to catch it. Ubuntu bats runs under bash 5, which enforces `[[ ]]`, so this step is the authoritative gate.

Repro (a plainly-called function mirrors a bats test body; note `f;` not `f &&`, since `&&` suppresses `set -e` inside `f` on both versions):
```
bash -c 'set -e; f(){ [[ 1 == 2 ]]; echo reached; }; f; echo after'
# bash 3.2 -> prints "reached" + "after" (the [[ ]] is skipped);  bash 5 -> prints nothing (aborts)
```

## Node-dependent suites self-skip

**Five** suites (`red-ledger-lib`, `capture-red-observations`, `red-verify-commit-check`, `red-verify-e2e`, `worthiness-presence-check`) recompute RED signals via a Node helper that resolves `typescript` from `node_modules`. The lean CI box installs only bats — no `pnpm install` — so those five `skip` in `setup()` when `node_modules/typescript` is absent, keeping the run green. They still run in full locally (and any node-equipped context). Covering them in CI would require a full-app `pnpm install`; deferred as out of scope for this lean workflow.

## Verification

- All 257 hooks tests pass locally under **bash 5** (`brew install bash`), 0 failures (typescript present).
- Faithful deps-free CI simulation (the 5 node suites run from a root with no `node_modules`): all 81 of their tests **skip**, 0 failures.
- The first CI run confirmed the guard works end-to-end: the 4 originally-guarded suites skipped cleanly; a fifth (`worthiness-presence-check`) was missed and failed — now guarded (this force-push).
- Other hooks touching external tools are safe on `ubuntu-latest`: `gh` calls run against remoteless tmp repos and degrade to `return 1` (already proven — `.github/audit/tests/{pr-merge-audit-check,post-audit-status}.bats` run in CI today); `serena` is faked via `~/.claude.json`; `pnpm`/`vitest`/`playwright` appear only as inspected command strings, never executed.
- `actionlint` clean; YAML valid.

## CHANGELOG

No entry: maintainer-only CI/test-infra hardening, no adopter-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)