### PR TITLE
docs(gaia): add bats assertion-hygiene rule, bash 3.2 safe (SPEC-019 follow-up)

### DIFF
--- a/.claude/rules/bats-assertions.md
+++ b/.claude/rules/bats-assertions.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - '**/*.bats'
+---
+
+# Bats Assertion Hygiene (bash 3.2 safe)
+
+macOS ships bash 3.2.57 as `/bin/bash`, which is what bats-core resolves to by default on a stock Mac. On bash 3.2 a **false** bare `[[ ... ]]` inside a `@test` body does **not** fail the test: bash 3.2 skips a failing `[[ ]]` under `set -e` / the ERR trap, so only the test's **last** command's exit status flows through. A broken assertion greens locally with nothing to catch it.
+
+Repro (bats runs each `@test` body under `set -e`, so mirror it with a plainly-called function -- not `f && ...`, since `&&` suppresses `set -e` inside `f` on *both* versions): `bash -c 'set -e; f(){ [[ 1 == 2 ]]; echo reached; }; f; echo after'` prints `reached` + `after` on bash 3.2 (the false `[[ ]]` is skipped, so only the last command's status flows through) but nothing on bash 5 (it aborts at the `[[ ]]`).
+
+## Write assertions that fail correctly on bash 3.2
+
+For any assertion that is not the test's final command, use a form that fails under 3.2:
+
+- **Substring / prefix:** `grep -qF -- "needle" <<<"$output"`, not `[[ "$output" == *needle* ]]`.
+- **Equality / numeric / empty / file:** POSIX `[ ... ]` fails correctly: `[ "$status" -eq 0 ]`, `[ "$a" = "$b" ]`, `[ -z "$output" ]`.
+- **Keep a `[[ ]]` matcher when you need one:** append `|| return 1` -> `[[ "$output" == *needle* ]] || return 1`.
+- **Custom checks:** end the failing branch with an explicit `return 1`.
+
+Reference pattern: `.gaia/scripts/tests/token-cost-e2e.bats` -- its `assert_contains` / `refute_contains` / `assert_prefix` helper trio and the assertion-style note at the top.
+
+## Backstops, not substitutes
+
+- CI (`.github/workflows/audit-ci-tests.yml`) runs the `.gaia/scripts/tests/`, `.gaia/tests/forensics/`, and `.gaia/tests/hooks/` suites on ubuntu (bash 5), which **does** enforce `[[ ]]`. That is the authoritative gate, but it only catches a hollow assertion after push.
+- Run bats under bash 5 locally so local matches CI: `brew install bash` installs `/opt/homebrew/bin/bash`, and bats picks it up via `env bash` when that dir precedes `/bin` on `PATH`. A false mid-test `[[ ]]` then fails locally too.
+
+## Scope
+
+This steers **new and edited** assertions. Existing suites use bare `[[ ]]` heavily; they are grandfathered and enforced by CI's bash 5. Do not rewrite them for this rule alone.


### PR DESCRIPTION
## What

Adds a path-scoped `.claude/rules/bats-assertions.md` (activates on `**/*.bats`) that steers **new and edited** bats assertions away from bare mid-`@test` `[[ ... ]]` toward forms that fail correctly on macOS's stock bash 3.2.57.

## Why

On bash 3.2 a **false** bare `[[ ... ]]` inside a `@test` body does not fail the test: bash 3.2 skips a failing `[[ ]]` under `set -e`, so only the test's last command's exit status flows through. A broken assertion greens locally with nothing to catch it. This is the hygiene half of the SPEC-019 follow-up; the CI half (#548) makes ubuntu/bash-5 the authoritative backstop, but this keeps developer-local runs honest.

## The rule

Directs authors to `grep -qF`, POSIX `[ ... ]`, `[[ ... ]] || return 1`, or explicit `return 1`, cites `.gaia/scripts/tests/token-cost-e2e.bats` as the reference pattern, and notes `brew install bash` to make local runs match CI. Existing suites' bare `[[ ]]` are grandfathered (CI-enforced under bash 5), not rewritten — per the SPEC-019 plan's "don't rewrite landed Phase-1 suites" constraint.

## Form choice

Lowest-context-weight form for this concern: a path-scoped prose rule, not a deterministic check (which would false-fire on the grandfathered Phase-1 suites) and not a skill (needs explicit invocation). Auto-loads only when a `.bats` file is edited.

## Notes

- No `.gaia/manifest.json` entry: rule classes are regenerated at release (`/gaia-release`), matching the precedent of the last-added rule (`serena-cc-override.md`, still unlisted on main).
- Repro in the rule verified on both bash 3.2 (`/bin/bash`) and bash 5.
- No adopter-facing behavior change; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)