### PR TITLE
fix(gaia): dollar partial marker names all three causes, not just "corrupt record" (SPEC-019 follow-up)

### DIFF
--- a/.gaia/scripts/tests/token-price.bats
+++ b/.gaia/scripts/tests/token-price.bats
@@ -157,7 +157,7 @@ setup() {
   [[ "$output" == *'(partial lower bound: some records predate per-model attribution)'* ]]
   [[ "$output" != *'unpriced model'* ]]
   [[ "$output" != *'run-time anchor'* ]]
-  [[ "$output" != *'corrupt record'* ]]
+  [[ "$output" != *'unreadable, corrupt, or lacked timing'* ]]
 }
 
 # ---------- 8. UAT-009 arm 1: rate table unreadable ----------
@@ -176,7 +176,7 @@ setup() {
   [[ "$output" == *'(partial: some ledger input was unreadable or lacked timing; figures are a lower bound)'* ]]
   [[ "$output" == *'execute:   $1.00'* ]]
   [[ "$output" == *'Total:     $1.00'* ]]
-  [[ "$output" == *'(partial lower bound: the ledger had a corrupt record)'* ]]
+  [[ "$output" == *'(partial lower bound: some ledger input was unreadable, corrupt, or lacked timing)'* ]]
 }
 
 # ---------- 10. UAT-008, DP-002: byte-unchanged token render, exact prefix ----------

--- a/.gaia/scripts/token-rollup.sh
+++ b/.gaia/scripts/token-rollup.sh
@@ -432,7 +432,7 @@ else
   printf '    %-11s%*s\n' "Total:" "$dw" "$grand_dollars_fmt"
 
   [[ "$cost_pre_attribution_present" == "true" ]] && printf '    (partial lower bound: some records predate per-model attribution)\n'
-  [[ "$cost_corrupt_present" == "true" ]] && printf '    (partial lower bound: the ledger had a corrupt record)\n'
+  [[ "$cost_corrupt_present" == "true" ]] && printf '    (partial lower bound: some ledger input was unreadable, corrupt, or lacked timing)\n'
   [[ -n "$cost_unpriced_models" ]] && printf '    (lower bound: unpriced model(s) %s)\n' "$cost_unpriced_models"
   [[ "$cost_missing_anchor" == "true" ]] && printf '    (lower bound: a session lacked a run-time anchor)\n'
 fi


### PR DESCRIPTION
## What

Relabels the dollar block's partial marker so it no longer mislabels a writer-side partial as a corrupt ledger record — the wording follow-up flagged in the SPEC-019 dollar-cost merge (#547).

```
- (partial lower bound: the ledger had a corrupt record)
+ (partial lower bound: some ledger input was unreadable, corrupt, or lacked timing)
```

## Why

The marker's trigger (`cost_corrupt_present`, token-rollup.sh:401) fires on the **inclusive** `corrupt || grand_elapsed_partial || grand_session_partial` condition — the same signal the token block words accurately as `unreadable or lacked timing`. But the dollar marker named only the *corrupt* cause, so a writer-side partial (an unreadable transcript input, nothing literally corrupt) printed "the ledger had a corrupt record". The new wording names all **three** possible causes truthfully, so no trigger condition is mislabeled — and stays parallel to the token block's marker right above it.

> Note: this covers all three triggers, including the timing-only (`elapsed_partial`) case that the originally-proposed two-cause wording (`unreadable or corrupt`) would still have mislabeled.

## Deliberate, not silent

The FC-3/FC-4 strings were frozen during implementation; the SPEC-019 SUMMARY pre-flagged this relabel as a post-merge follow-up. The change updates the two `token-price.bats` pins that fixed the old wording (the corrupt-ledger positive assertion; the pre-attribution negative assertion, retargeted so it still proves the two markers stay distinct).

## Verification

- Rendered in situ against the corrupt fixture: the `$1.00` figure prints with the new marker line.
- Non-hollow: the positive assertion fails if the marker doesn't render; it passes only because the marker genuinely fires with the new string.
- `token-price` (11/0), `token-rollup` (17/0), `token-cost-e2e` (1/0), `token-rollup-merge` (13/0) all green under bash 5. `shellcheck` clean on `token-rollup.sh`.

## CHANGELOG

No entry: the entire dollar-cost surface is still in `## [Unreleased]` (last tag 1.6.1; #547 merged today). This wording lands before the feature's first release, so its eventual release note carries the final wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)