### PR TITLE
fix(gaia): correct stale language-switch Playwright spec name across runbooks and wiki

### DIFF
--- a/.claude/instructions/add-locale.md
+++ b/.claude/instructions/add-locale.md
@@ -116,7 +116,7 @@ For RTL locales **outside** that standard four (e.g. a custom or less common cod
 
 ## Step 6, Playwright spec
 
-Check whether `.playwright/e2e/language-switch.spec.ts` exists.
+Check whether `.playwright/e2e/language-switch-a11y.spec.ts` exists.
 
 **Pick a verification key that genuinely differs between English and `{{LOCALE_CODE}}`.** Do **not** assert against `meta.title`, top-level `title`, or `heroTitle`: `gaia init rename` rewrites all three to the project title, and the Step 1 translation rule copies a brand / proper-noun value verbatim, so they are identical in every locale and a switch assertion against them never changes. Use the seed's `cta` key instead (English `'View on GitHub'`), a normal UI string the index page renders as a visible link. Read the English value from `app/languages/en/pages/_index.ts` and the translated value from `app/languages/{{LOCALE_CODE}}/pages/_index.ts`. Before writing the assertion, confirm the two values actually differ; if `cta` is missing or was copied verbatim for this locale, pick any other body string whose English and `{{LOCALE_CODE}}` values differ.
 

--- a/.claude/instructions/remove-i18n.md
+++ b/.claude/instructions/remove-i18n.md
@@ -218,7 +218,7 @@ rm -rf \
   app/routes/actions+/set-language.ts \
   app/components/LanguageSelect \
   .storybook/i18next.ts \
-  .playwright/e2e/language-switch.spec.ts \
+  .playwright/e2e/language-switch-a11y.spec.ts \
   .claude/rules/i18n.md \
   .claude/agents/code-review-audit/react-i18next.md \
   .claude/skills/react-code/references/translation-patterns.md \
@@ -397,7 +397,7 @@ Remove every key whose path matches any of:
 - `.claude/skills/react-code/references/translation-patterns.md`
 - `.claude/hooks/check-i18n-strings.sh`
 - `.storybook/i18next.ts`
-- `.playwright/e2e/language-switch.spec.ts`
+- `.playwright/e2e/language-switch-a11y.spec.ts`
 - `wiki/modules/i18n.md`
 - `wiki/flows/Language Flow.md`
 - `wiki/dependencies/i18next.md`
@@ -409,7 +409,7 @@ A bare edit is blocked by `.claude/hooks/block-manifest-write.sh`, so the remova
 GAIA_MANIFEST_WRITE=remove-i18n jq '
   .files |= with_entries(
     select(.key
-      | test("^app/languages/|^app/i18n\\.ts$|^app/middleware/i18next\\.ts$|^app/types/i18n/|^app/sessions\\.server/language\\.ts$|^app/routes/actions\\+/set-language\\.ts$|^app/components/LanguageSelect/|^\\.claude/rules/i18n\\.md$|^\\.claude/agents/code-review-audit/react-i18next\\.md$|^\\.claude/skills/react-code/references/translation-patterns\\.md$|^\\.claude/hooks/check-i18n-strings\\.sh$|^\\.storybook/i18next\\.ts$|^\\.playwright/e2e/language-switch\\.spec\\.ts$|^wiki/modules/i18n\\.md$|^wiki/flows/Language Flow\\.md$|^wiki/dependencies/i18next\\.md$|^wiki/dependencies/remix-i18next\\.md$")
+      | test("^app/languages/|^app/i18n\\.ts$|^app/middleware/i18next\\.ts$|^app/types/i18n/|^app/sessions\\.server/language\\.ts$|^app/routes/actions\\+/set-language\\.ts$|^app/components/LanguageSelect/|^\\.claude/rules/i18n\\.md$|^\\.claude/agents/code-review-audit/react-i18next\\.md$|^\\.claude/skills/react-code/references/translation-patterns\\.md$|^\\.claude/hooks/check-i18n-strings\\.sh$|^\\.storybook/i18next\\.ts$|^\\.playwright/e2e/language-switch-a11y\\.spec\\.ts$|^wiki/modules/i18n\\.md$|^wiki/flows/Language Flow\\.md$|^wiki/dependencies/i18next\\.md$|^wiki/dependencies/remix-i18next\\.md$")
       | not))
 ' .gaia/manifest.json > .gaia/manifest.json.tmp \
   && GAIA_MANIFEST_WRITE=remove-i18n mv .gaia/manifest.json.tmp .gaia/manifest.json
@@ -418,7 +418,7 @@ GAIA_MANIFEST_WRITE=remove-i18n jq '
 Discovery sweep, confirm no leftover entries:
 
 ```bash
-grep -nE "i18n|languages/|LanguageSelect|set-language|check-i18n|react-i18next|translation-patterns|Language Flow" .gaia/manifest.json
+grep -nE "i18n|languages/|LanguageSelect|set-language|language-switch-a11y|check-i18n|react-i18next|translation-patterns|Language Flow" .gaia/manifest.json
 ```
 
 The only expected match is this runbook's own entry, `.claude/instructions/remove-i18n.md`, it matches the sweep's broad `i18n` substring but is not an i18n content file and is not pruned here (the runbook self-deletes at the end of this process). Every i18n content key from the pattern list above is gone; that entry alone surviving is a pass.

--- a/wiki/dependencies/Playwright.md
+++ b/wiki/dependencies/Playwright.md
@@ -41,7 +41,7 @@ Prefer ARIA roles and accessible names; fall back to `page.locator()` with text/
 
 ## Locale and language tests
 
-Set locale and `Accept-Language` per `test.describe` block, not globally. See `.claude/rules/playwright.md` and `language-switch.spec.ts` for the canonical pattern.
+Set locale and `Accept-Language` per `test.describe` block, not globally. See `.claude/rules/playwright.md` and `language-switch-a11y.spec.ts` for the canonical pattern.
 
 ## Auth / session setup
 


### PR DESCRIPTION
## The bug

Several docs referenced the Playwright locale a11y spec by an outdated name, `.playwright/e2e/language-switch.spec.ts` (no suffix). GAIA ships `.playwright/e2e/language-switch-a11y.spec.ts` — the only match on disk under `.playwright/e2e/` and the `owned` entry in `.gaia/manifest.json`. The stale name broke two runbooks and left a dead wiki pointer:

- **`/remove-i18n`** neither deleted the a11y spec from disk (Section C) nor pruned its manifest entry (Section G), leaving a stale `owned` entry undetected by the runbook's own discovery sweep.
- **`/add-locale`** Step 6 existence check always resolved "does not exist", steering it to create a wrong-named duplicate spec instead of appending a `test.describe` block to the existing a11y spec.
- **Playwright wiki** pointed readers to `language-switch.spec.ts` for the canonical locale-test pattern, a file that does not exist.

## The fix

### `.claude/instructions/remove-i18n.md`
- **Section C** `rm -rf` list: rename to `language-switch-a11y.spec.ts` so the file is deleted from disk.
- **Section G** pattern-list bullet: same rename.
- **Section G** jq removal regex: `^\.playwright/e2e/language-switch\.spec\.ts$` → `...language-switch-a11y\.spec\.ts$` so the manifest key is pruned.
- **Section G** discovery sweep: add a `language-switch-a11y` alternative so a surviving entry is actually flagged (that filename shares no substring with the sweep's other i18n tokens).

Sections C (delete from disk) and G (prune manifest key) stay in lockstep so the file is never orphaned.

### `.claude/instructions/add-locale.md`
- **Step 6** existence-check reference renamed to `language-switch-a11y.spec.ts` so the check resolves the real file and appends to the existing a11y spec instead of creating a wrong-named duplicate.

### `wiki/dependencies/Playwright.md`
- Canonical-pattern pointer renamed to `language-switch-a11y.spec.ts` so it resolves to the real file.

## Repo-wide sweep

Swept the entire project for stale spec references of this class:

- No bare `language-switch.spec.ts` reference remains in any runbook, skill, or wiki page.
- Cross-checked every `*.spec.ts` filename referenced in prose/config against the specs on disk. The only other non-existent-file hits are intentional: ephemeral probe specs a skill creates then `rm`s at runtime (`react-perf-drive.spec.ts`), fabricated fixtures inside release-excluded maintainer test sandboxes (`.gaia/tests/**`), and documented naming/format placeholders (`things.spec.ts`, `uat-NNN.spec.ts`).
- Deliberately left `.claude/rules/playwright.md`'s "Spec file naming" example (`language-switch.spec.ts`, `things.spec.ts`) unchanged: both are idealized naming-convention placeholders, and adding the `-a11y` test-type suffix would muddy the "match the feature or route" lesson.

## Verification

- The corrected jq filter, run against a scratch copy of the real `.gaia/manifest.json`, removes `.playwright/e2e/language-switch-a11y.spec.ts` along with the other i18n content keys; the old non-suffixed name matches nothing.
- The corrected discovery-sweep grep flags the a11y entry when present; the old sweep missed it.
- `.gaia/manifest.json` is untouched (release-generated); the Section G write keeps its `GAIA_MANIFEST_WRITE=` exemption marker.
- Quality Gate legitimately skips (markdown-only change, no gate-inspectable staged file).
- code-review-audit: clean on the final diff, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)