### PR TITLE
chore(gaia): consolidate .gaia/local audit-data storage under audit/

### DIFF
--- a/.claude/commands/health-audit.md
+++ b/.claude/commands/health-audit.md
@@ -16,8 +16,11 @@ Read `.gaia/cli/health/runbook.md` end-to-end before doing anything else. The ru
 Execute the cycle loop from the runbook (max N=3):
 
 ```
-if .gaia/local/audit/ exists: mv it to .gaia/local/audit.prev-$(date +%s)/
 mkdir -p .gaia/local/audit
+if leftover c1/c2/c3 cycle dirs exist from an interrupted prior run:
+  archive only those into .gaia/local/audit/archived/$(date +%s)/
+  (merge-gate markers, KNOWLEDGE-*.md reports, worthiness.jsonl, and archived/ stay put)
+prune .gaia/local/audit/archived/ to the 3 most recent runs (delete older, by epoch)
 
 For cycle in 1..3:
   you create c<N>/ and bucket sub-dirs
@@ -38,7 +41,7 @@ For cycle in 1..3:
   start the next cycle
 After cycle 3 without clean: escalate (max loops hit)
 
-On clean exit: rm -rf .gaia/local/audit/c* (whitelisted)
+On clean exit: rm -rf .gaia/local/audit/c[0-9] (whitelisted)
 On escalation: preserve all c*/ dirs; surface paths in escalation report
 ```
 
@@ -76,7 +79,7 @@ Shared-fitness grade: <honest floor of seven category grades>
 Cycles: <N>
 Findings closed: <count> (per cycle: <breakdown>)
 Non-blocking residuals: <count> (e.g. wiki/.state.json post-sync drift, recorded not blocking)
-Artifacts: cleaned (.gaia/local/audit/c* removed)
+Artifacts: cleaned (.gaia/local/audit/c[0-9] removed)
 ```
 
 On escalation:
@@ -100,6 +103,6 @@ The overall grade is F-to-A+ and is never higher than the shared-fitness grade. 
 - Do not commit. Fixers leave the working tree dirty; the human commits.
 - Do not write to `wiki/log.md` or `wiki/hot.md`.
 - Do not edit the runbook mid-loop. If the runbook needs changing, escalate first.
-- Do not delete `.gaia/local/audit/c*/` on escalation. Preserve everything for human review.
+- Do not delete `.gaia/local/audit/c[0-9]/` on escalation. Preserve everything for human review.
 
 Begin by reading `.gaia/cli/health/runbook.md`.

--- a/.claude/hooks/local-janitor.sh
+++ b/.claude/hooks/local-janitor.sh
@@ -126,7 +126,7 @@ done
 # --- 4. Stray empty dirs (keep the structural drop-zones) ------------------
 is_drop_zone() {
   case "$1" in
-    audit | audit-ledger | cache | debt | forensics | handoff | plans \
+    audit | audit/archived | cache | debt | forensics | handoff | plans \
       | plans/archived | red-ledger | red-ledger/.tmp | specs | specs/archived \
       | telemetry | telemetry/cloud) return 0 ;;
     *) return 1 ;;

--- a/.claude/hooks/worthiness-presence-check.sh
+++ b/.claude/hooks/worthiness-presence-check.sh
@@ -112,7 +112,7 @@ classifier_script=".gaia/scripts/classifier/classify-determinism.mjs"
 
 # Worthiness ledger location (sibling to the RED ledger). A missing ledger means
 # zero matches, which denies for the clean case below.
-ledger=".gaia/local/audit-ledger/worthiness.jsonl"
+ledger=".gaia/local/audit/worthiness.jsonl"
 
 # ---------------------------------------------------------------------------
 # Resolve the PR base, the default branch this work forks from. Prefer the

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -135,7 +135,7 @@ With no orchestrator to record verdicts, **the tdd skill is the ledger writer**,
 node .gaia/scripts/audit-ledger/append-worthiness.mjs <repo-rel-test-path> <fullName> <verdict> [artifact]
 ```
 
-`<verdict>` is `keep` | `fix` | `delete`; `[artifact]` is REQUIRED for a non-keep verdict (the cited machine-verified sibling for a redundancy delete, the unreachable/missing assertion for a fix) and omitted for `keep`. The writer recomputes the test-identity signal from the file via the RED-ledger signal helper, so it byte-matches what the presence gate later recomputes; the ledger at `.gaia/local/audit-ledger/worthiness.jsonl` is append-only and gitignored.
+`<verdict>` is `keep` | `fix` | `delete`; `[artifact]` is REQUIRED for a non-keep verdict (the cited machine-verified sibling for a redundancy delete, the unreachable/missing assertion for a fix) and omitted for `keep`. The writer recomputes the test-identity signal from the file via the RED-ledger signal helper, so it byte-matches what the presence gate later recomputes; the ledger at `.gaia/local/audit/worthiness.jsonl` is append-only and gitignored.
 
 Surface the evaluator's verdicts in the **same end-of-task summary** as the determinism roll-up above: one summary, not a parallel one. Deletes are proposals: present them for human confirmation, never act on them.
 

--- a/.gaia/cli/health/runbook.md
+++ b/.gaia/cli/health/runbook.md
@@ -33,7 +33,7 @@ For cycle in 1..3:
         if cycle == 3: escalate with reason false-clean-refuted (preserve all c*/ dirs, surface paths), exit   # no next cycle to fix-and-reverify
         else: skip the clean exit; fall through to the oscillation check + Fixer dispatch below (the injected real-fix lands next cycle)
     if still clean (challenger cleared, or already ran this run):
-      Orchestrator removes .gaia/local/audit/c* (whitelisted; top-level dir kept as marker)
+      Orchestrator removes .gaia/local/audit/c[0-9] (whitelisted; top-level dir kept as marker)
       report the honest overall grade (A+ when no findings of any kind, else the floor that non-blocking residuals may cap at A), exit
   Orchestrator checks open-finding fingerprints vs prior cycle (mechanical diff via jq; non-blocking residuals excluded, see §Termination) → if oscillation: escalate (Orchestrator preserves all c*/ dirs, surfaces paths in escalation report)
   Orchestrator spawns parallel Fixers (lane-aware leaf subagents)
@@ -330,7 +330,7 @@ Each lens is a parallel `general-purpose` leaf the Orchestrator spawns, handed: 
 A substantiated finding (any lens) revokes the clean exit. The Orchestrator injects it into `c<N>/findings.json` as a finding with `action: "real-fix"`, `bucket: "challenger"`, a `lane` chosen from the file it targets, and a `fingerprint` in the `<check-id>:<file>:<line>:<first-40-chars>` format. Then:
 
 - **Clean cycle is NOT cycle 3** (budget remains): continue into the normal Fixer → next-cycle machinery. The Orchestrator dispatches Fixers for the injected finding and starts the next cycle. The injected finding participates in the standard oscillation guard (which keys on `action == "real-fix"` fingerprints, bucket-agnostic). A Fixer that reports unable to fix triggers the existing `fixer-unable-to-fix` escalation.
-- **Clean cycle IS cycle 3** (no next cycle to fix-and-reverify): do NOT inject-and-continue (there is nowhere for the fix to land). Escalate with reason `false-clean-refuted` and PRESERVE all `c*/` dirs (skip the clean-exit `rm -rf .gaia/local/audit/c*`).
+- **Clean cycle IS cycle 3** (no next cycle to fix-and-reverify): do NOT inject-and-continue (there is nowhere for the fix to land). Escalate with reason `false-clean-refuted` and PRESERVE all `c*/` dirs (skip the clean-exit `rm -rf .gaia/local/audit/c[0-9]`).
 
 **Oscillation coverage (design note).** A `BS` blind-spot finding is by definition NOT re-detected by the buckets on the next cycle, so the bucket-sourced oscillation guard does not cover a failed fix of a `BS` finding. The concrete protections for a failed challenger fix are: the `fixer-unable-to-fix` escalation (immediate, when a Fixer reports it cannot fix), the cycle-3 `false-clean-refuted` escalation (the terminal backstop), the optional deep `FV` lens (re-detects failed fixes directly), and resurfacing on the next `/health-audit` run. The general oscillation guard covers only the subset of findings the buckets can re-detect; it does not on its own protect a blind-spot finding.
 
@@ -391,17 +391,17 @@ The `verdict` field stores Bucket D's verdict verbatim. It is _not_ a synthesize
 
 Lifecycle:
 
-- **At `/health-audit` start**: Orchestrator runs `[ -d .gaia/local/audit ] && mv .gaia/local/audit .gaia/local/audit.prev-$(date +%s) ; mkdir -p .gaia/local/audit`. Archives stale dirs from prior interrupted runs.
+- **At `/health-audit` start**: Orchestrator runs `mkdir -p .gaia/local/audit; if ls -d .gaia/local/audit/c[0-9] >/dev/null 2>&1; then TS=$(date +%s); mkdir -p ".gaia/local/audit/archived/$TS"; mv .gaia/local/audit/c[0-9] ".gaia/local/audit/archived/$TS/"; fi; find .gaia/local/audit/archived -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -r | tail -n +4 | while IFS= read -r d; do rm -rf "$d"; done`. Archives only leftover cycle dirs from a prior interrupted run into `archived/<epoch>/`, then prunes `archived/` to the 3 most recent runs (older snapshots are deleted; the epoch in each folder name is the numeric sort key). The merge-gate markers, `KNOWLEDGE-*.md` reports, `worthiness.jsonl`, and `archived/` itself stay in place.
 - **At cycle start**: Orchestrator creates `c<N>/` and bucket sub-dirs.
 - **Auditors**: write raw outputs to their per-cycle paths; return summary + file path in their report (not the full content).
 - **Adjudicator**: reads bucket files, classifies, writes `c<N>/findings.json`.
 - **Orchestrator (oscillation detection)**: mechanical diff via `jq -r '.findings[].fingerprint' .gaia/local/audit/c<N>/findings.json | sort` against the prior cycle's same. Non-empty intersection → oscillation, escalate.
-- **Clean exit**: Orchestrator computes `overall_grade` = floor of (Bucket D verdict, open-findings-count signal, Bucket E `shared_fitness_grade`). A clean exit requires no open findings and an _effective_ shared-fitness A+ (non-blocking residuals exempt); the reported grade may be A. On a clean exit: Orchestrator runs `rm -rf .gaia/local/audit/c*` (whitelisted; safe). Top-level dir kept as run marker. The `rm -rf .gaia/local/audit/c*` runs only AFTER the false-clean challenger clears the terminal clean cycle (see §False-clean challenger); a challenger that revokes the exit either continues the loop (non-cycle-3) or escalates `false-clean-refuted` and preserves `c*/` (cycle 3).
+- **Clean exit**: Orchestrator computes `overall_grade` = floor of (Bucket D verdict, open-findings-count signal, Bucket E `shared_fitness_grade`). A clean exit requires no open findings and an _effective_ shared-fitness A+ (non-blocking residuals exempt); the reported grade may be A. On a clean exit: Orchestrator runs `rm -rf .gaia/local/audit/c[0-9]` (whitelisted; safe). Top-level dir kept as run marker. The `rm -rf .gaia/local/audit/c[0-9]` runs only AFTER the false-clean challenger clears the terminal clean cycle (see §False-clean challenger); a challenger that revokes the exit either continues the loop (non-cycle-3) or escalates `false-clean-refuted` and preserves `c*/` (cycle 3).
 - **Escalation**: Orchestrator preserves all `c*/` dirs and surfaces their paths in the escalation report for human review.
 
 ## State
 
-Cycle artifacts persist in `.gaia/local/audit/c<N>/` for the duration of the audit. On a clean exit (which the terminal cycle reaches only after the false-clean challenger clears, see §False-clean challenger), the Orchestrator removes all `c*/` dirs (`rm -rf .gaia/local/audit/c*`; whitelisted; top-level dir kept as run marker). On escalation, all `c*/` dirs are preserved and surfaced in the escalation report for human review; a cycle-3 `false-clean-refuted` escalation preserves them the same way.
+Cycle artifacts persist in `.gaia/local/audit/c<N>/` for the duration of the audit. On a clean exit (which the terminal cycle reaches only after the false-clean challenger clears, see §False-clean challenger), the Orchestrator removes all `c*/` dirs (`rm -rf .gaia/local/audit/c[0-9]`; whitelisted; top-level dir kept as run marker). On escalation, all `c*/` dirs are preserved and surfaced in the escalation report for human review; a cycle-3 `false-clean-refuted` escalation preserves them the same way.
 
 The audit does not write to `wiki/log.md` or `wiki/hot.md`.
 

--- a/.gaia/scripts/audit-ledger/append-worthiness.mjs
+++ b/.gaia/scripts/audit-ledger/append-worthiness.mjs
@@ -26,7 +26,7 @@
 // so the signal byte-matches what the RED ledger and the presence-gate
 // recompute produce. It does NOT reinvent the identity primitive.
 //
-// Ledger path: .gaia/local/audit-ledger/worthiness.jsonl (append-only,
+// Ledger path: .gaia/local/audit/worthiness.jsonl (append-only,
 // gitignored, grows-forever, sibling to the RED ledger). Override with
 // WORTHINESS_LEDGER_PATH (the test seam; production leaves it unset).
 //
@@ -48,7 +48,7 @@ const SIGNAL_HELPER = path.join(
   'extract-test-signals.mjs',
 );
 
-const DEFAULT_LEDGER = '.gaia/local/audit-ledger/worthiness.jsonl';
+const DEFAULT_LEDGER = '.gaia/local/audit/worthiness.jsonl';
 const VERDICTS = new Set(['keep', 'fix', 'delete']);
 
 const fail = (message, code) => {

--- a/.gaia/tests/hooks/worthiness-presence-check.bats
+++ b/.gaia/tests/hooks/worthiness-presence-check.bats
@@ -4,7 +4,7 @@
 # the worthiness audit.
 #
 # The hook denies `gh pr merge` when an emergent test the PR changed has no
-# worthiness-ledger line (.gaia/local/audit-ledger/worthiness.jsonl) matching its
+# worthiness-ledger line (.gaia/local/audit/worthiness.jsonl) matching its
 # current content. It scopes to the emergent test files this PR changed (the diff
 # against the merge base with the default branch), decides emergent membership via
 # the determinism classifier, recomputes each test's signal via the shared RED
@@ -83,15 +83,15 @@ signals_for() {
 # Append a worthiness-ledger line. Args: file fullName signal verdict [artifact].
 seed_ledger() {
   local file="$1" full="$2" sig="$3" verdict="${4:-keep}" artifact="${5:-}"
-  mkdir -p "$REPO/.gaia/local/audit-ledger"
+  mkdir -p "$REPO/.gaia/local/audit"
   if [ -n "$artifact" ]; then
     jq -nc --arg f "$file" --arg n "$full" --arg s "$sig" --arg v "$verdict" --arg a "$artifact" \
       '{schema:1, file:$f, fullName:$n, signal:$s, verdict:$v, auditedAt:"2026-06-23T00:00:00Z", artifact:$a}' \
-      >> "$REPO/.gaia/local/audit-ledger/worthiness.jsonl"
+      >> "$REPO/.gaia/local/audit/worthiness.jsonl"
   else
     jq -nc --arg f "$file" --arg n "$full" --arg s "$sig" --arg v "$verdict" \
       '{schema:1, file:$f, fullName:$n, signal:$s, verdict:$v, auditedAt:"2026-06-23T00:00:00Z"}' \
-      >> "$REPO/.gaia/local/audit-ledger/worthiness.jsonl"
+      >> "$REPO/.gaia/local/audit/worthiness.jsonl"
   fi
 }
 

--- a/wiki/concepts/Local Working State.md
+++ b/wiki/concepts/Local Working State.md
@@ -22,7 +22,7 @@ Because the folder is invisible to git, residue a subsystem leaves behind never 
 | `audit/<sha>.ok`, `audit/<sha>.dispositions.json` | [[Code Review Audit Agent]] merge gate | ephemeral | spent once orphaned |
 | `audit/progress.log` | audit gate | live | overwritten each run |
 | `audit/KNOWLEDGE-*.md` | [[GAIA Audit]] | ephemeral | self-pruned by the next applied run |
-| `audit-ledger/worthiness.jsonl` | worthiness check | live | append-only |
+| `audit/worthiness.jsonl` | worthiness check | live | append-only |
 | `red-ledger/observations.jsonl` | TDD RED-verification | live | append-only |
 | `debt/` | debt sentinel | live | recomputed |
 | `cache/` | [[GAIA Spec]] / gate sessions | ephemeral | per-spec, orphaned on archive |
@@ -47,6 +47,6 @@ The sweep is fail-safe: any inability to prove a thing is dead (no git, an unrea
 
 ## Deciding by hand
 
-Anything under `.gaia/local/` is safe to delete once its owner is done with it: a spent audit marker for an already-merged PR, a plan directory for a merged or abandoned branch, a `KNOWLEDGE-*.md` report already applied, a gate cache for an archived spec. The append-only ledgers (`red-ledger`, `audit-ledger`, `telemetry`), the identity files (`.project-id`, `setup-state.json`, `mentorship.json`), and `.gaia/local/specs/ledger.json` (and the `specs/` store it lives in) are the load-bearing exceptions; deleting the ledger drops per-machine draft-resume state and the local half of SPEC-number allocation.
+Anything under `.gaia/local/` is safe to delete once its owner is done with it: a spent audit marker for an already-merged PR, a plan directory for a merged or abandoned branch, a `KNOWLEDGE-*.md` report already applied, a gate cache for an archived spec. The append-only ledgers (`red-ledger/observations.jsonl`, `audit/worthiness.jsonl`, `telemetry`), the identity files (`.project-id`, `setup-state.json`, `mentorship.json`), and `.gaia/local/specs/ledger.json` (and the `specs/` store it lives in) are the load-bearing exceptions; deleting the ledger drops per-machine draft-resume state and the local half of SPEC-number allocation.
 
 See [[Claude Hooks]] for the hook surface and [[Audit Disposition and Debt Drain]] for the marker lifecycle.

--- a/wiki/decisions/Worthiness Audit.md
+++ b/wiki/decisions/Worthiness Audit.md
@@ -109,7 +109,7 @@ ledger:
 {"schema": 1, "file": "<repo-rel>", "fullName": "<vitest fullName>", "signal": "sha256:...", "verdict": "keep"|"fix"|"delete", "auditedAt": "<iso>", "artifact": "<...>"}
 ```
 
-- Path: `.gaia/local/audit-ledger/worthiness.jsonl` (append-only, gitignored,
+- Path: `.gaia/local/audit/worthiness.jsonl` (append-only, gitignored,
   grows-forever, sibling to `.gaia/local/red-ledger/observations.jsonl`).
 - `signal` is the SAME `sha256`-of-normalized-test-call the RED ledger computes
   via `.gaia/scripts/red-ledger/extract-test-signals.mjs`. The writer reuses


### PR DESCRIPTION
## What

Collapse the scattered audit working-state under `.gaia/local/` into a single `audit/` directory, and give past-run snapshots a bounded lifecycle so they stop accumulating forever.

**Before**
```
.gaia/local/
  audit/                     current run + code-review markers, all mixed at root
  audit.prev-1782847464/     past runs pile up as siblings, never pruned
  audit.prev-1782933061/
  audit.prev-1783020601/
  audit-ledger/worthiness.jsonl
```
**After**
```
.gaia/local/audit/
  <sha>.ok / .dispositions.json / .rerun.json   code-review merge-gate files (untouched)
  progress.log                                  code-review-audit (untouched)
  worthiness.jsonl                              moved in from audit-ledger/
  KNOWLEDGE-*.md                                gaia-audit reports (untouched)
  c1/ c2/ c3/                                   active health-audit run (transient)
  archived/
    <epoch>/                                    past runs (were audit.prev-*), kept to newest 3
```

## Why it's shaped this way

`.gaia/local/audit/` is shared by three subsystems: the **code-review** merge gate (sha-keyed marker *files*, read by exact path by the merge hooks), the maintainer-only **health-audit** loop (`c1/c2/c3` cycle *folders*), and the **gaia-audit** skill (`KNOWLEDGE-*.md` reports). The rotation therefore had to become **selective**: it archives only the cycle dirs and leaves the live merge-gate markers, KNOWLEDGE reports, and the ledger in place. The old blunt `mv audit audit.prev-<epoch>` swept live markers into a dead backup.

## Changes

- **Rotation to selective archival + retention** (`runbook.md`, `health-audit.md`, maintainer-only): archives only `c1/c2/c3` into `audit/archived/<epoch>/`, then prunes `archived/` to the **3 most recent runs** on each run start. This is the answer to "when do old audits get removed": on the next `/health-audit` run.
- **Worthiness ledger relocation**: `.gaia/local/audit-ledger/worthiness.jsonl` -> `.gaia/local/audit/worthiness.jsonl` in the writer (`append-worthiness.mjs`) and the merge-gate reader (`worthiness-presence-check.sh`); `audit-ledger/` is retired.
- **Janitor allowlist** (`local-janitor.sh`): drop `audit-ledger`, add `audit/archived`.
- **Latent-bug fix:** the cycle-dir glob `c*` was greedy and matched any sha marker whose name starts with `c` (the migration actually swept the `cc463d2e` markers before it was caught). Tightened every full-path occurrence to `c[0-9]`, including the pre-existing clean-exit `rm -rf .gaia/local/audit/c*`, which could otherwise delete a live merge-gate marker.
- Docs + bats fixture updated to the new path.

## Scope / non-goals

- `.gaia/local/audit/` is **not** renamed, so the exact-path merge-gate readers, the `code-review-audit` writers, the CI workflow templates, and the `block-rm-rf.sh` whitelist are untouched.
- `red-ledger/observations.jsonl` (separate TDD-RED subsystem) is left alone.

## CHANGELOG / adopter impact

No CHANGELOG entry. The worthiness ledger (SPEC-006, #408) and the janitor (#468) are both still in the current `## [Unreleased]` window and have never shipped (latest released is 1.6.1). An adopter upgrading from 1.6.1 receives only the final `audit/worthiness.jsonl` layout, so this relocation is pre-release internal churn with no adopter-visible migration, and no existing Unreleased entry cites the old path.

## Verification

- `worthiness-presence-check.bats` 14/14, `local-janitor.bats` 7/7, `append-worthiness.test.ts` 6/6.
- Scratch tests: selective rotation (leaves `c`-prefixed markers, ledger, KNOWLEDGE, `archived/` intact, incl. the `c1a2b3...` c+digit case) and keep-newest-3 retention.
- `pnpm typecheck` and `pnpm lint` clean (both scope `app`; the changed files are outside app lint/typecheck jurisdiction, so E2E/build have no runtime surface to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)