### PR TITLE
feat(gaia): /gaia-debt uses AskUserQuestion for drain selection

### DIFF
--- a/.claude/skills/gaia/references/debt.md
+++ b/.claude/skills/gaia/references/debt.md
@@ -56,7 +56,12 @@ The entire ordering is this one `--jq` expression over fields GitHub returns. Th
 
 ## Recommend and present (drain)
 
-Recommend the top candidate (first in the sorted list). Print the ordered backlog so the human can override: per issue, the number, title, severity band, and age (derived from `createdAt`). The human picks the candidate to drain; if they pick a different one, honor it. The skill never auto-advances past the human's choice.
+The top candidate is the first in the sorted list. How you present it depends on backlog size:
+
+- **Exactly one open issue** → do not prompt. State the issue (number, title, severity band, age derived from `createdAt`) and drain it directly.
+- **Two or more open issues** → offer the choice with a single `AskUserQuestion` prompt (header `Debt item`, single-select). Present the top **three** candidates as options, or both when only two exist, top candidate first and its label suffixed `(Recommended)`. Each option's label is the issue number and a short title; its description carries the severity band and age. The tool's built-in **Other** entry lets the human type a different issue number when the target sits below the top three. When the backlog has more than three issues, first print the full ordered backlog (per issue: number, title, severity band, age) so the human can see the numbers beyond the top three before choosing.
+
+Honor whatever the human picks or types into **Other**. If a typed value is not an open `tech-debt` issue number in the backlog, say so and re-prompt; do not drain an off-list issue. The skill never auto-advances past the human's choice.
 
 ## Drain-time security screen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ### Changed
 
+- `/gaia-debt` drain now presents the candidate choice through a structured `AskUserQuestion` prompt rather than a free-text override: it offers the top three backlog candidates (recommended one first) plus the built-in Other entry for a lower-ranked issue number, and skips the prompt entirely when only one `tech-debt` issue is open. The deterministic severity-then-age ordering, one-issue-per-invocation limit, drain-time security screen, and merge handshake are unchanged (#564)
 - SPEC-number allocation moves from the tracked `.gaia/specs.json` ledger to immutable `spec/NNN` git tags on the remote (SPEC-021): the next number is max+1 over the union of the remote's `spec/*` tags and local signals, and a non-force tag push is the cross-machine collision lock, so a shared team no longer depends on everyone committing, pushing, and pulling a working-tree file in time. The ledger survives only as a local, gitignored per-machine cache at `.gaia/local/specs/ledger.json`. No `/update-gaia` migration ships and no lib dual-reads the old tracked ledger. **Action required:** the maintainer and existing adopters with a populated `.gaia/specs.json` run the following one-time, idempotent, safe-to-re-run cutover once per existing clone (a clone without a populated `.gaia/specs.json`, i.e. a fresh scaffold, needs to do nothing: the allocator creates the local ledger on the first `/gaia-spec`, and the first online allocation seeds the remote tag namespace):
 
   ```bash


### PR DESCRIPTION
## What

`/gaia-debt` drain selection now uses a structured `AskUserQuestion` prompt instead of a free-text override:

- **One open issue** → no prompt; state it and drain directly.
- **Two or more** → single `AskUserQuestion` (header `Debt item`, single-select) offering the top three candidates (top labelled `(Recommended)`), with the tool's built-in **Other** entry for typing a lower-ranked issue number. When the backlog exceeds three, the full ordered backlog prints first so the numbers beyond the top three are visible.
- Typed-in values are validated against the open backlog; an off-list number re-prompts rather than draining.

Deterministic severity-then-age ordering, one-issue-per-invocation, the drain-time security screen, and the PR merge handshake are unchanged.

## Scope

Docs-only: `.claude/skills/gaia/references/debt.md` plus a `CHANGELOG.md` entry. Entirely out of audit scope (root markdown + `.claude/`), so the merge clears via the out-of-scope bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)