### PR TITLE
wiki: sync through 5792046

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "b680034dd73bbe9247b5f3b5aee761e7bfbb9099",
-  "last_evaluated_at": "2026-07-05T06:09:09Z",
+  "last_evaluated_sha": "579204624982d056e2b6f8c7ee8cbfe9d1f9bae3",
+  "last_evaluated_at": "2026-07-05T06:39:50Z",
   "last_consolidated_sha": "15ddaf9676b4fca22031e441e6d70b3c1df1d2a5",
   "last_consolidated_at": "2026-06-30T19:19:44Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,8 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-07-05 5792046 SKIP - Fable top-tier model gate feature already updated GAIA Plan/GAIA Spec/Task Orchestration in-commit
+- 2026-07-05 4e70ade1 SKIP - previous wiki maintenance chain PR (sync+consolidate+lint), self-contained, nothing further to sync
 - 2026-07-05 b680034d WORTHY - health-audit remediations add WorktreeRemove to canonical hook list + clarify no-snapshot fitness case → wiki/decisions/Claude Integration Fitness.md (edited in-commit)
 - 2026-07-05 92b7f424 WORTHY - CI runs .gaia/tests/lib bats + token-tally atomic same-fs rename → wiki/concepts/PR Merge Workflow.md (edited in-commit)
 - 2026-07-05 dd2ff78c WORTHY - SPEC-023 consolidates cost artifacts (tokens.md/jsonl → cost.md/jsonl) → wiki/concepts/Cost Data Contract.md (new), GAIA Plan.md, GAIA Spec.md, Task Orchestration.md, Telemetry.md, Token Cost Readout.md (edited in-commit)


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 5792046.