### PR TITLE
docs(gaia): say "elapsed" not "wall-clock" in the cost readout

### DIFF
--- a/.claude/skills/gaia/references/plan.md
+++ b/.claude/skills/gaia/references/plan.md
@@ -187,7 +187,7 @@ Then write the following files directly to `{PLAN_DIR}/`:
 
       **Token tally (execute-time).** Execute-phase token tallies are recorded automatically: a `PreToolUse` hook on the orchestrator's per-phase git commit/push records this session's execute tally to the durable ledger, keyed to the feature (the SPEC id resolved from the active plan folder, or the plan slug when spec-less). Resumed, halted, and worktree sessions are all captured. The orchestrator does not run a manual execute tally, doing so would double-count the phase.
 
-      After the pre-merge `code-review-audit`'s clean-pass marker is written and before the Final self-cleanup phase archives the plan folder, the orchestrator reports the full-cycle cost by running the roll-up reader and surfacing its spec / plan / execute / total breakdown plus wall-clock elapsed to the user. Substitute the plan's real SPEC id (from the `## Source SPEC` section of `README.md`, or the plan slug if the plan has no SPEC, the spec-less case):
+      After the pre-merge `code-review-audit`'s clean-pass marker is written and before the Final self-cleanup phase archives the plan folder, the orchestrator reports the full-cycle cost by running the roll-up reader and surfacing its spec / plan / execute / total breakdown plus elapsed time to the user. Substitute the plan's real SPEC id (from the `## Source SPEC` section of `README.md`, or the plan slug if the plan has no SPEC, the spec-less case):
 
       ```bash
       if [ -x .gaia/scripts/token-rollup.sh ]; then
@@ -412,7 +412,7 @@ handoff. The call sums `message.usage` across the main transcript AND every sub-
 (deduped by message id, so it equals what the API billed), appends one record keyed to the feature
 identity to the durable ledger resolved to the main checkout (so it survives archival of the plan
 folder and a linked worktree), writes the **Planning** section of the plan folder's `cost.md`, and
-prints the four billing buckets plus a total and the wall-clock elapsed. The KICKOFF execution phase
+prints the four billing buckets plus a total and the elapsed time. The KICKOFF execution phase
 later adds an independent **Execution** section to the same `cost.md` (via the git-op hook, on each
 commit); the two sections are tracked separately and never overwrite or sum each other. A spec-derived
 plan passes its SPEC id via `--spec-id`; a SPEC-less plan passes its `PLAN-NNN` id via `--plan-id`

--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -878,7 +878,7 @@ bash .gaia/scripts/token-tally.sh \
   --out-dir ".gaia/local/specs/${SPEC_ID}" || true
 ```
 
-The helper reads `CLAUDE_CODE_SESSION_ID` from the environment, sums `message.usage` across the main transcript and every sub-agent sidecar (deduped to ground truth), appends one record keyed to `SPEC_ID` to the durable ledger (`.gaia/local/telemetry/cost.jsonl`, resolved to the main checkout so a worktree run still records there), writes `cost.md` into the SPEC folder, and prints the four-bucket tally, total, and wall-clock elapsed. Surface the helper's printed tally to the user as part of the save confirmation, so the readout is reported when the action finishes.
+The helper reads `CLAUDE_CODE_SESSION_ID` from the environment, sums `message.usage` across the main transcript and every sub-agent sidecar (deduped to ground truth), appends one record keyed to `SPEC_ID` to the durable ledger (`.gaia/local/telemetry/cost.jsonl`, resolved to the main checkout so a worktree run still records there), writes `cost.md` into the SPEC folder, and prints the four-bucket tally, total, and elapsed time. Surface the helper's printed tally to the user as part of the save confirmation, so the readout is reported when the action finishes.
 
 **Auto-mode:** the tally fires identically in interactive and auto mode; it is a mechanical helper call, not a user prompt, so no auto-mode branch is needed. In auto mode the printed tally simply lands in the transcript, nothing to prompt.
 

--- a/.gaia/scripts/tests/token-tally-price.bats
+++ b/.gaia/scripts/tests/token-tally-price.bats
@@ -278,7 +278,7 @@ EOF
   # The generation stamp is inherently non-deterministic (real `date -u` at
   # run time); capture the REAL footer line as rendered and reuse it verbatim
   # in the golden expectation, so this proves byte-identity of every OTHER
-  # line without pinning wall-clock time.
+  # line without pinning elapsed time.
   footer_line="$(printf '%s\n' "$actual" | tail -n1)"
   case "$footer_line" in
     'Session `fixturesession0001`'*) : ;;

--- a/.gaia/scripts/token-tally.sh
+++ b/.gaia/scripts/token-tally.sh
@@ -3,7 +3,7 @@
 #
 # Reads the ground-truth token usage the API already recorded for a GAIA action
 # (/gaia-spec, /gaia-plan, or a KICKOFF plan-execution run) and turns it into a
-# per-action readout: four billing buckets plus a total, a wall-clock elapsed
+# per-action readout: four billing buckets plus a total, an elapsed
 # span, a durable machine-local ledger record (cost.jsonl), a human-readable
 # cost.md, and a printed tally block.
 #
@@ -14,7 +14,7 @@
 # `.message.id` and the same usage, so the tally DEDUPS by `.message.id`
 # (fallback `.uuid`) before summing; without this it overcounts output ~3x.
 #
-# Alongside the tokens it reports wall-clock elapsed = max(.timestamp) -
+# Alongside the tokens it reports elapsed time = max(.timestamp) -
 # min(.timestamp) over the usage-bearing lines (first to last billed model turn),
 # across main + sidecars. Bookkeeping lines (pr-link/system/attachment) and
 # leading user think-time carry no usage and are excluded, so the span sits on


### PR DESCRIPTION
The per-action token tally and the full-cycle roll-up already print `Elapsed:` / `(elapsed …)`, but the `/gaia-spec` and `/gaia-plan` skill references instructed the orchestrator to surface "wall-clock elapsed" to the user, and `token-tally.sh`'s header comments used the same term. Since an adopter reads whatever word their orchestrator's cost summary carries, "wall-clock" leaks to them and reads less clearly than "elapsed".

Aligns the wording on **"elapsed"** across the cost-readout surfaces:
- `.claude/skills/gaia/references/plan.md` (×2) and `spec.md` (×1) — the instructions that tell the orchestrator how to phrase the cost summary
- `.gaia/scripts/token-tally.sh` (×2 header comments)
- `.gaia/scripts/tests/token-tally-price.bats` (×1 comment)

Comment and instruction wording only; no behavior change. Deliberately untouched: the unrelated "wall-clock **budget**" in the audit CI, the Worthiness pages, and `spec.md`'s "continuous wall-clock duration across resumes" (resume semantics, not an output label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)