### PR TITLE
fix(hooks): guard empty id_flag expansion in token-tally-git-op (bash 3.2)

### DIFF
--- a/.claude/hooks/token-tally-git-op.sh
+++ b/.claude/hooks/token-tally-git-op.sh
@@ -77,8 +77,14 @@ esac
 # (token-tally.sh falls back to its $HOME/.claude/projects default), set by
 # bats to point at a fixture so no test run ever touches a real session's
 # transcript search path.
+#
+# id_flag is empty for an unclassifiable key (the case `*)` branch above). The
+# offset-guard `${id_flag[@]+"${id_flag[@]}"}` keeps that empty expansion from
+# firing bare: on stock macOS /bin/bash 3.2 a bare "${id_flag[@]}" over an empty
+# array aborts with `unbound variable` under `set -u` (before the trailing
+# `|| true`, so the tally is silently dropped); bash 4.4+ tolerates it.
 bash .gaia/scripts/token-tally.sh \
-  --action execute "${id_flag[@]}" --plan-slug "$slug" \
+  --action execute ${id_flag[@]+"${id_flag[@]}"} --plan-slug "$slug" \
   --out-dir "$plan_dir" --session-id "$sid" \
   ${GAIA_TALLY_PROJECTS_ROOT:+--projects-root "$GAIA_TALLY_PROJECTS_ROOT"} >/dev/null 2>&1 || true
 

--- a/.gaia/tests/hooks/token-tally-git-op.bats
+++ b/.gaia/tests/hooks/token-tally-git-op.bats
@@ -266,6 +266,32 @@ run_hook() {
   [ "$(jq -r '.plan_id' "$LEDGER")" = "null" ]
 }
 
+# ---------- 6c. Empty id_flag survives stock /bin/bash (bash 3.2 empty-array guard) ----------
+# Same unclassifiable-key path as 6b (id_flag=() empty), but pinned to stock
+# /bin/bash. On macOS's /bin/bash 3.2.57 a bare "${id_flag[@]}" over an empty
+# array aborts with `unbound variable` under `set -u`, killing the hook at exit 1
+# before token-tally runs, so the whole tally is silently dropped; bash 4.4+
+# never trips it. The rest of this suite runs under env bash (Homebrew bash 5),
+# blind to the entire class, so only a run pinned to /bin/bash reproduces the
+# regression. On a bash-5 /bin/bash (Linux CI) this simply passes; on a stock Mac
+# it is the real gate. The hook is invoked as `/bin/bash <hook>` so its
+# `#!/usr/bin/env bash` shebang (which would pick up bash 5) is bypassed.
+@test "unclassifiable key under stock /bin/bash: empty id_flag does not abort the hook" {
+  [ -x /bin/bash ] || skip "no /bin/bash"
+  build_repo
+  cd "$REPO"
+  plan_dir="$REPO/.gaia/local/specs/SPEC-099/plan"
+  write_readme_spec_less "$plan_dir"
+  write_running "$plan_dir" "$(git branch --show-current)" "2026-07-01T00:00:00Z"
+
+  input=$("$HELPERS/mock-hook-input.sh" pre-tool-use "$SESSION" Bash "git commit -m x")
+  run env GAIA_TALLY_PROJECTS_ROOT="$ANCHOR" bash -c "echo '$input' | /bin/bash '$HOOK_ABS'"
+  [ "$status" -eq 0 ]
+  LEDGER="$REPO/.gaia/local/telemetry/cost.jsonl"
+  [ -f "$LEDGER" ]
+  [ "$(jq -r '.partial' "$LEDGER")" = "true" ]
+}
+
 # ---------- 7. Disambiguation by latest started ----------
 @test "two matching plan folders disambiguate on the latest started timestamp" {
   build_repo


### PR DESCRIPTION
## Summary

`token-tally-git-op.sh` runs under `set -euo pipefail`. For any feature key that is neither `SPEC-*` nor `PLAN-*` (the `case` `*)` branch), `id_flag` is set to an empty array, and line 81 expanded it bare as `"${id_flag[@]}"`.

On stock macOS `/bin/bash` (3.2.57), a bare `"${arr[@]}"` over an **empty** array aborts with `id_flag[@]: unbound variable` under `set -u`. The abort happens during expansion, before the command runs, so neither the trailing `... || true` nor the hook's `trap 'exit 0' ERR` catches it (verified: the hook dies at exit 1). Net effect on stock macOS: for any unclassifiable feature key the token tally is silently dropped. bash 4.4+ tolerates the empty bare expansion, so CI and local runs (Homebrew bash 5) are blind to the class.

## Fix

Offset-guard the expansion, matching the `block-env-read.sh` reference fix (#601):

```bash
--action execute ${id_flag[@]+"${id_flag[@]}"} --plan-slug "$slug" \
```

The `SPEC-*` / `PLAN-*` cases (non-empty array) expand identically to two args; the empty case expands to nothing instead of aborting.

## Test

Adds bats test 6c, pinned to `/bin/bash` so it runs the hook under stock bash 3.2 on macOS (a real RED→GREEN gate there) and safely passes under a bash-5 `/bin/bash` on Linux CI. The rest of the suite runs under Homebrew bash 5 and cannot see this class. All 18 tests green.

Closes #602