### PR TITLE
docs(gaia-spec): use canonical `ready` ledger status at spec.md:319

### DIFF
--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -316,7 +316,7 @@ find .gaia/local/cache -maxdepth 1 -type d -name 'audit-*' -mtime +1 \
   -exec rm -rf {} + 2>/dev/null || true
 ```
 
-Then run `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"`. If the output is a `SPEC-NNN` id (not `none`), an unfinalized **draft** SPEC already exists, a prior authoring session that never reached the canonical save (step 9). The allocator reports only drafts; a finalized SPEC (`specified`/`merged`) is never surfaced here, because you resume a draft, not a frozen artifact.
+Then run `bash .specify/extensions/gaia/lib/spec-allocator.sh in_progress "$PWD"`. If the output is a `SPEC-NNN` id (not `none`), an unfinalized **draft** SPEC already exists, a prior authoring session that never reached the canonical save (step 9). The allocator reports only drafts; a finalized SPEC (`ready`/`merged`) is never surfaced here, because you resume a draft, not a frozen artifact.
 
 The id may name a **draft-phase** session, a SPEC allocated in another terminal whose interactive loop has not yet reached the canonical save (step 9), so `.gaia/local/specs/SPEC-NNN/SPEC.md` may not exist yet and the live draft is at `.gaia/local/cache/draft-SPEC-NNN.md`. The `WORKING`-selection below resolves this correctly, preferring the draft cache when the canonical file is absent or older.
 


### PR DESCRIPTION
## Summary

`.claude/skills/gaia/references/spec.md:319` described a finalized SPEC as ledger status `` `specified` `` — a value retired when the spec/plan ledger vocabularies were unified (#609). The tooling enforces exactly `draft | ready | merged | abandoned` (`.specify/extensions/gaia/lib/ledger-update.sh` rejects anything else with exit 6). This changes `` (`specified`/`merged`) `` → `` (`ready`/`merged`) ``.

## Whole-repo sweep

Rather than fix only the one flagged line, swept the entire tracked tree for **any** retired ledger-status string presented as canonical, across both the spec (`draft | ready | merged | abandoned`) and plan (`ready | merged | abandoned`) vocabularies. The retired set (per #609): `specified`, `allocated`, `completed`, `archived`, `in-progress`.

**spec.md:319 was the only drift.** Every other occurrence is legitimate and left untouched:

- **Different status axes** that reuse the same words: wiki-page frontmatter `status: archived` (`active | superseded | archived`), SPEC-artifact frontmatter `status: in-progress` (`in-progress | reopened | closed`), and the ledger `source: allocated` provenance field.
- **Deliberate references** to the retired values: the #609 CHANGELOG entry, the self-heal note in `wiki/concepts/GAIA Spec.md`, the `spec-reconcile.sh` alias-mapping code (`shipped → merged`), and the `.gaia/tests/` migration fixtures that seed off-vocabulary rows on purpose.

## Why it matters

A reader (human or agent) following line 319 could re-introduce `specified` and revive the silent finalize-failure the earlier fix closed (the ledger PATCH fails under `|| true`, leaving a finalized SPEC stuck at `draft` and re-surfacing in the resume-vs-start prompt).

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)