### PR TITLE
test(spec-032): isolate audit-window cache across all tally test suites

### DIFF
--- a/.gaia/scripts/tests/cost-sidecar-e2e.bats
+++ b/.gaia/scripts/tests/cost-sidecar-e2e.bats
@@ -46,6 +46,15 @@ setup() {
   OUTDIR="$BATS_TEST_TMPDIR/out"
   LEDGER="$BATS_TEST_TMPDIR/cost.jsonl"
 
+  # Isolated, empty audit-window cache. --action spec/plan consume-on-tally a
+  # breadcrumb from --cache-dir (SPEC-032, audit-window-<id>.json); an empty
+  # per-test dir keeps the tally off the real .gaia/local/cache, which it would
+  # otherwise fall through to and DELETE a developer's live breadcrumb if a
+  # fixture id matched the SPEC/PLAN they are mid-audit on. Add --cache-dir
+  # "$CACHE" to every new spec/plan invocation (execute never reads a breadcrumb).
+  CACHE="$BATS_TEST_TMPDIR/cache"
+  mkdir -p "$CACHE"
+
   export GIT_AUTHOR_NAME="GAIA Test"
   export GIT_AUTHOR_EMAIL="gaia-test@example.com"
   export GIT_COMMITTER_NAME="GAIA Test"
@@ -56,7 +65,7 @@ setup() {
 @test "spec action: real tally writes a well-shaped cost.json sidecar, no cost.md" {
   run bash "$TALLY" --action spec --spec-id SPEC-X \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$SINGLE" --ledger "$LEDGER"
+    --projects-root "$SINGLE" --ledger "$LEDGER" --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   [ -f "$OUTDIR/cost.json" ]
@@ -70,7 +79,7 @@ setup() {
 @test "spec action: gate passes when the real sidecar matches the real ledger row" {
   run bash "$TALLY" --action spec --spec-id SPEC-X \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$SINGLE" --ledger "$LEDGER"
+    --projects-root "$SINGLE" --ledger "$LEDGER" --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # shellcheck source=/dev/null
@@ -84,7 +93,7 @@ setup() {
 @test "spec action: gate blocks on a mutated bucket and on unparseable JSON" {
   run bash "$TALLY" --action spec --spec-id SPEC-X \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$SINGLE" --ledger "$LEDGER"
+    --projects-root "$SINGLE" --ledger "$LEDGER" --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # shellcheck source=/dev/null
@@ -109,7 +118,7 @@ setup() {
 @test "plan then execute: gate passes for both sidecar keys, plan key byte-unchanged" {
   run bash "$TALLY" --action plan --plan-id PLAN-X --plan-slug my-plan \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$SINGLE" --ledger "$LEDGER"
+    --projects-root "$SINGLE" --ledger "$LEDGER" --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   before="$(jq -c '.plan' "$OUTDIR/cost.json")"

--- a/.gaia/scripts/tests/token-review.bats
+++ b/.gaia/scripts/tests/token-review.bats
@@ -38,6 +38,14 @@ setup() {
 
   LEDGER="$BATS_TEST_TMPDIR/ledger.jsonl"
 
+  # Isolated, empty audit-window cache. The one --action spec tally below
+  # consume-on-tally a breadcrumb from --cache-dir (SPEC-032, audit-window-<id>
+  # .json); an empty per-test dir keeps it off the real .gaia/local/cache, which
+  # it would otherwise fall through to and DELETE a developer's live
+  # audit-window-SPEC-032.json. (--action review never reads a breadcrumb.)
+  CACHE="$BATS_TEST_TMPDIR/cache"
+  mkdir -p "$CACHE"
+
   export GIT_AUTHOR_NAME="GAIA Test"
   export GIT_AUTHOR_EMAIL="gaia-test@example.com"
   export GIT_COMMITTER_NAME="GAIA Test"
@@ -163,7 +171,7 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "6: back-compat -- token-rollup.sh's kind filter excludes a review row from a feature's totals" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-032 \
     --out-dir "$BATS_TEST_TMPDIR/out" --session-id "$AR_SESSION" \
-    --projects-root "$AR" --ledger "$LEDGER"
+    --projects-root "$AR" --ledger "$LEDGER" --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   spec_total="$(led '.total')"
 

--- a/.gaia/scripts/tests/token-tally-price.bats
+++ b/.gaia/scripts/tests/token-tally-price.bats
@@ -66,6 +66,16 @@ setup() {
   OUTDIR="$BATS_TEST_TMPDIR/out"
   LEDGER="$BATS_TEST_TMPDIR/ledger.jsonl"
 
+  # Isolated, empty audit-window cache. --action spec/plan consume-on-tally a
+  # breadcrumb from --cache-dir (SPEC-032, audit-window-<id>.json); an empty
+  # per-test dir keeps the tally off the real .gaia/local/cache, which it would
+  # otherwise fall through to and DELETE a developer's live breadcrumb when a
+  # fixture id (SPEC-013/SPEC-022) matches the SPEC/PLAN they are mid-audit on.
+  # Add --cache-dir "$CACHE" to every new spec/plan invocation (execute never
+  # reads a breadcrumb).
+  CACHE="$BATS_TEST_TMPDIR/cache"
+  mkdir -p "$CACHE"
+
   export GIT_AUTHOR_NAME="GAIA Test"
   export GIT_AUTHOR_EMAIL="gaia-test@example.com"
   export GIT_COMMITTER_NAME="GAIA Test"
@@ -80,11 +90,13 @@ setup() {
     if [ "$action" = "spec" ]; then
       run bash "$SCRIPT" --action spec --spec-id SPEC-022 \
         --out-dir "$out" --session-id fixturemultimodel0001 \
-        --projects-root "$MULTIMODEL" --ledger "$ledger" --rate-table "$RATES_E2E"
+        --projects-root "$MULTIMODEL" --ledger "$ledger" --rate-table "$RATES_E2E" \
+        --cache-dir "$CACHE"
     else
       run bash "$SCRIPT" --action "$action" --spec-id SPEC-022 --plan-slug spec-022-dollar-cost \
         --out-dir "$out" --session-id fixturemultimodel0001 \
-        --projects-root "$MULTIMODEL" --ledger "$ledger" --rate-table "$RATES_E2E"
+        --projects-root "$MULTIMODEL" --ledger "$ledger" --rate-table "$RATES_E2E" \
+        --cache-dir "$CACHE"
     fi
     [ "$status" -eq 0 ]
 
@@ -116,7 +128,8 @@ setup() {
 @test "UAT-006: legacy model-less session -> dollars null (no attribution), token record intact, exit 0" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-013 \
     --out-dir "$OUTDIR" --session-id fixturesession0001 \
-    --projects-root "$LEGACY" --ledger "$LEDGER" --rate-table "$RATES_E2E"
+    --projects-root "$LEGACY" --ledger "$LEDGER" --rate-table "$RATES_E2E" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   sc="$OUTDIR/cost.json"

--- a/.gaia/scripts/tests/token-tally.bats
+++ b/.gaia/scripts/tests/token-tally.bats
@@ -106,6 +106,17 @@ setup() {
   OUTDIR="$BATS_TEST_TMPDIR/out"
   LEDGER="$BATS_TEST_TMPDIR/ledger.jsonl"
 
+  # Isolated, empty audit-window cache for spec/plan tallies. --action spec/plan
+  # consume-on-tally a breadcrumb from --cache-dir (SPEC-032, audit-window-<id>
+  # .json); an empty per-test dir keeps every such invocation off the real
+  # .gaia/local/cache, which it would otherwise fall through to and DELETE a
+  # developer's live breadcrumb when a fixture id matches. Add --cache-dir
+  # "$CACHE" to every new spec/plan invocation that runs from the repo cwd. (The
+  # SPEC-032 audit-nesting tests pass their own fixture $AR_CACHE and are
+  # unaffected; execute never reads a breadcrumb.)
+  CACHE="$BATS_TEST_TMPDIR/cache"
+  mkdir -p "$CACHE"
+
   # Git identity for the worktree sandbox (CI without a configured user).
   export GIT_AUTHOR_NAME="GAIA Test"
   export GIT_AUTHOR_EMAIL="gaia-test@example.com"
@@ -229,7 +240,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "plan then execute: cost.json keeps independent plan + execute keys (no overwrite, no sum)" {
   run bash "$SCRIPT" --action plan --spec-id SPEC-013 --plan-slug my-plan \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/l-plan.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/l-plan.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(jq -r '.plan.total' "$OUTDIR/cost.json")" -eq 562 ]
   [ "$(jq -r '.execute // "absent"' "$OUTDIR/cost.json")" = "absent" ]
@@ -258,7 +270,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "repeated execute writes preserve the plan key and never duplicate keys" {
   run bash "$SCRIPT" --action plan --spec-id SPEC-013 --plan-slug my-plan \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/lp.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/lp.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   for n in 1 2 3; do
@@ -278,7 +291,8 @@ led() { jq -r "$1" "$LEDGER"; }
   run bash "$SCRIPT" \
     --action plan --spec-id SPEC-013 --plan-slug spec-013-token-accounting \
     --out-dir "$OUTDIR" --session-id "$SESSION" \
-    --projects-root "$ANCHOR" --ledger "$BATS_TEST_TMPDIR/durable.jsonl"
+    --projects-root "$ANCHOR" --ledger "$BATS_TEST_TMPDIR/durable.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # exactly one valid JSON line with the right key fields
@@ -329,7 +343,8 @@ led() { jq -r "$1" "$LEDGER"; }
   run bash "$SCRIPT" \
     --action spec --spec-id SPEC-013 \
     --out-dir "$OUTDIR" --session-id "no-such-session-9999" \
-    --projects-root "$ANCHOR" --ledger "$LEDGER"
+    --projects-root "$ANCHOR" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # stdout marker + zero buckets
@@ -362,7 +377,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "empty session id (no --session-id, unset env): exit 0, partial, no crash" {
   run env -u CLAUDE_CODE_SESSION_ID bash "$SCRIPT" \
     --action spec --spec-id SPEC-013 \
-    --out-dir "$OUTDIR" --projects-root "$ANCHOR" --ledger "$LEDGER"
+    --out-dir "$OUTDIR" --projects-root "$ANCHOR" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(led '.partial')" = "true" ]
   [ "$(led '.total')" -eq 0 ]
@@ -443,7 +459,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "single usage line: duration 0, available true" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-000 \
     --out-dir "$OUTDIR" --session-id "fixturesingle0001" \
-    --projects-root "$FIX/single/projects" --ledger "$LEDGER"
+    --projects-root "$FIX/single/projects" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(led '.duration_seconds')" -eq 0 ]
   [ "$(led '.duration_available')" = "true" ]
@@ -453,7 +470,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "zero usage lines (timestamped non-usage only): unavailable/null, buckets 0, partial false" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-000 \
     --out-dir "$OUTDIR" --session-id "fixturezero0001" \
-    --projects-root "$FIX/zero/projects" --ledger "$LEDGER"
+    --projects-root "$FIX/zero/projects" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(led '.duration_available')" = "false" ]
   [ "$(led '.duration_seconds')" = "null" ]
@@ -466,7 +484,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "malformed extremal timestamp: unavailable, buckets intact, partial false (flag independence)" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-000 \
     --out-dir "$OUTDIR" --session-id "fixturemalformed0001" \
-    --projects-root "$FIX/malformed/projects" --ledger "$LEDGER"
+    --projects-root "$FIX/malformed/projects" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # duration unavailable ...
@@ -590,7 +609,8 @@ led() { jq -r "$1" "$LEDGER"; }
 @test "spec: schema_version 1, kind spec, seq 0/final, cost.json keyed by spec, only cost.json written" {
   run bash "$SCRIPT" --action spec --spec-id SPEC-013 \
     --out-dir "$OUTDIR" --session-id "$SESSION" \
-    --projects-root "$ANCHOR" --ledger "$LEDGER"
+    --projects-root "$ANCHOR" --ledger "$LEDGER" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   [ "$(led '.schema_version')" -eq 1 ]
@@ -623,7 +643,8 @@ led() { jq -r "$1" "$LEDGER"; }
   # spec-derived plan: --spec-id SPEC-* -> spec_id set, plan_id null
   run bash "$SCRIPT" --action plan --spec-id SPEC-023 --plan-slug p \
     --out-dir "$OUTDIR/sd-plan" --session-id fixturesingle0001 \
-    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/sd-plan.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/sd-plan.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(jq -r '.kind' "$BATS_TEST_TMPDIR/sd-plan.jsonl")" = "plan" ]
   [ "$(jq -r '.spec_id' "$BATS_TEST_TMPDIR/sd-plan.jsonl")" = "SPEC-023" ]
@@ -632,7 +653,8 @@ led() { jq -r "$1" "$LEDGER"; }
   # spec-less plan: --plan-id PLAN-* -> plan_id set, spec_id null
   run bash "$SCRIPT" --action plan --plan-id PLAN-007 --plan-slug p \
     --out-dir "$OUTDIR/sl-plan" --session-id fixturesingle0001 \
-    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/sl-plan.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$BATS_TEST_TMPDIR/sl-plan.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ "$(jq -r '.kind' "$BATS_TEST_TMPDIR/sl-plan.jsonl")" = "plan" ]
   [ "$(jq -r '.spec_id' "$BATS_TEST_TMPDIR/sl-plan.jsonl")" = "null" ]
@@ -697,6 +719,9 @@ led() { jq -r "$1" "$LEDGER"; }
     git -C "$1" commit --allow-empty -q -m init
   }
   runproj() {
+    # Deliberately no --cache-dir: this cd's into a fresh mkrepo'd git repo, so
+    # token-tally.sh derives its cache from THAT repo's git-common-dir, never the
+    # real .gaia/local/cache. Isolated by construction.
     ( cd "$1" && bash "$SCRIPT" --action spec --spec-id SPEC-013 \
         --out-dir "$1/out" --session-id fixturesingle0001 \
         --projects-root "$FIX/single/projects" --ledger "$1/cost.jsonl" >/dev/null 2>&1 )
@@ -747,7 +772,8 @@ led() { jq -r "$1" "$LEDGER"; }
 
   run bash "$SCRIPT" --action spec --spec-id SPEC-013 \
     --out-dir "$dir/out" --session-id fixturesingle0001 \
-    --projects-root "$FIX/single/projects" --ledger "$dir/cost.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$dir/cost.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
   # old ledger moved to .bak (never read, never deleted); fresh cost.jsonl holds
@@ -763,7 +789,8 @@ led() { jq -r "$1" "$LEDGER"; }
   printf '%s\n' '{"stray":"do-not-move"}' > "$dir/tokens.jsonl"
   run bash "$SCRIPT" --action spec --spec-id SPEC-013 \
     --out-dir "$dir/out" --session-id fixturesingle0001 \
-    --projects-root "$FIX/single/projects" --ledger "$dir/cost.jsonl"
+    --projects-root "$FIX/single/projects" --ledger "$dir/cost.jsonl" \
+    --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
   [ -f "$dir/tokens.jsonl" ]
   [ "$(jq -r '.stray' "$dir/tokens.jsonl")" = "do-not-move" ]
@@ -815,7 +842,10 @@ led() { jq -r "$1" "$LEDGER"; }
   mkdir -p "$workdir_raw"
   workdir="$(cd "$workdir_raw" && pwd)"
 
-  # missing/unresolvable session id -> partial run, record still built
+  # missing/unresolvable session id -> partial run, record still built.
+  # Deliberately no --cache-dir: this cd's into a non-repo tmpdir, so
+  # git-common-dir resolution fails and token-tally.sh leaves CACHE_DIR empty,
+  # skipping the breadcrumb block entirely. Never touches the real cache.
   run bash -c "cd '$workdir' && bash '$SCRIPT' \
     --action spec --spec-id SPEC-013 \
     --out-dir '$OUTDIR' --session-id no-such-session-9999 \


### PR DESCRIPTION
## Problem

SPEC-032 (#613) made `token-tally.sh --action spec/plan` **consume-on-tally** an `audit-window-<feature>.json` breadcrumb from `--cache-dir` (which defaults to `<main_root>/.gaia/local/cache`): it reads the breadcrumb, then `rm -f`s it. Any bats invocation of `--action spec/plan` that omits `--cache-dir` falls through to the developer's **real** `.gaia/local/cache`. A developer running these suites while genuinely mid-audit on a SPEC/PLAN whose id collides with a hardcoded fixture id would have their live breadcrumb consumed and deleted, silently degrading their real `audit.adversarial` annotation.

The original report named two suites; a comprehensive sweep of every `token-tally.sh` test caller found the same latent hazard in two more.

## Fix

Give every repo-cwd `--action spec/plan` invocation an isolated, empty per-test `--cache-dir "$CACHE"` (`$BATS_TEST_TMPDIR/cache`), reusing the SPEC-032 idiom already used by `token-tally.bats`'s audit-nesting tests and `spec032-e2e.bats`.

| Suite | Change |
|---|---|
| `token-tally-price.bats` | spec + the plan iteration of the `for action` loop |
| `cost-sidecar-e2e.bats` | 3 spec + 1 plan |
| `token-tally.bats` | 13 pre-SPEC-032 spec/plan invocations |
| `token-review.bats` | the lone `--action spec` setup step |

**Deliberately left as-is** (verified they cannot reach the real cache, now documented inline): `token-tally.bats`'s `runproj()` helper (runs inside a fresh temp git repo, so cache derivation resolves to that repo) and the test-23 degraded path (runs in a non-repo tmpdir → `git-common-dir` fails → `CACHE_DIR` stays empty → breadcrumb block skipped).

**Already isolated / untouched:** `spec032-e2e.bats` (all 8 invocations use per-test caches); execute/review-only suites never read a breadcrumb.

## Why assertions are unaffected

These suites don't assert on `.audit`. An empty cache dir finds no breadcrumb, so no annotation is nested — output is byte-identical to the no-breadcrumb path they always exercised. The fix removes the dependency on the real cache happening to be empty.

## Verification

- All affected suites green: **150 tests, 0 failures**.
- **Sentinel proof:** dropped valid breadcrumbs in the real cache for all 10 feature keys the fixed invocations resolve to, ran the suites, confirmed **all 10 survived** (0 consumed). A negative control (an un-isolated invocation) consumed its sentinel, proving the guard has teeth.
- Pre-merge `code-review-audit`: **clean** (no Critical/Important/correctness findings); it independently traced `token-tally.sh` and confirmed the two exempt invocations are safe.

Test-only; no production code changed. No CHANGELOG entry: this touches release-excluded maintainer test infrastructure (`.gaia/scripts/tests/`), invisible to adopters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
