### PR TITLE
refactor(spec-033): decouple comprehensive-audit lens briefs from repo-state seeds

### DIFF
--- a/.gaia/cli/health/comprehensive/lenses/DIST.md
+++ b/.gaia/cli/health/comprehensive/lenses/DIST.md
@@ -1,5 +1,6 @@
 ---
-type: brief
+type: lens-brief
+lens: DIST
 status: active
 audience: maintainer
 ---
@@ -49,93 +50,10 @@ Concretely, look for:
   distribution-integrity angle here.
 - Consent/telemetry posture on adopter machines: does anything phone home by
   default, and is opting out documented and easy to find?
-
-### Discovery-noted real targets (name these so DIST is non-trivial)
-
-These are confirmed present in the current repo. Verify each against the
-cited evidence and raise a finding (do not skip because it is "already
-known" — SPEC UAT-013 requires DIST to return real findings, not an empty
-array, on this surface):
-
-1. **Distribution harness runs only at tag time or manual dispatch, never on
-   normal PRs.** `.gaia/tests/distribution/` (8 scenarios: `01-files-present.sh`
-   through `08-gaia-init-cli-sequence.sh`, driven by
-   `.gaia/tests/distribution/run-all.sh`) is the only thing that validates the
-   *post-scrub, staged* tarball. Its two invocation points:
-   - `.github/workflows/distribution.yml` — `on: workflow_dispatch:` only
-     (no `push`, no `pull_request`).
-   - `.github/workflows/release.yml` — the "Distribution test gate (Layers
-     0+1+2)" step (around line 113, `run: bash .gaia/tests/distribution/run-all.sh`),
-     reachable only via `on: push: tags: 'v*.*.*'` at the top of that file.
-
-   Neither `.github/workflows/cli-tests.yml` nor `.github/workflows/tests.yml`
-   invokes the distribution harness. A bundle/exclude/manifest break that the
-   harness would catch ships green through every normal PR's required checks
-   and is only caught (if at all) at the release tag, after the version bump
-   and CHANGELOG are already committed.
-
-2. **Only `gaia init` runs from the built bundle; every other adopter
-   subcommand is Vitest-tested against source only.**
-   `.github/workflows/cli-tests.yml` runs `pnpm -C .gaia/cli test --run`
-   (Vitest against `.gaia/cli/src/**`, i.e. source, on every PR touching
-   `.gaia/cli/**`). The only scenarios that invoke the actual bundled
-   `.gaia/cli/gaia` binary are `.gaia/tests/distribution/07-gaia-init-strip-branding.sh`
-   (`strip-branding`) and `08-gaia-init-cli-sequence.sh` (the full
-   `strip-branding` → `configure-i18n` → `rename` → `wire-statusline` →
-   `finalize` sequence) — and both run only under target #1's gated triggers.
-   Subcommands like `ping`, `telemetry`, and standalone `configure-i18n
-   --strip true` (the full i18n-removal path) have no bundle-level
-   regression coverage at all, only source-level Vitest.
-
-3. **No `/gaia-*` skill is exercised end-to-end on a clean adopter machine.**
-   `.gaia/tests/distribution/README.md`'s own Layer 2 section
-   (`06-claude-runs-staged.sh`) states explicitly what it does NOT cover:
-   "adopter flows like `/gaia-init` or `/setup-gaia`; those exercise
-   interactive skills." Layer 2 only proves the Claude-in-Docker plumbing
-   (binary on PATH, OAuth auth, staged tree reachable) — not that a skill
-   actually completes successfully against a fresh clone.
-
-4. **Bundle staleness is human-checklist-guarded, not test-asserted.**
-   `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer` are committed binaries
-   (`git ls-files .gaia/cli/gaia .gaia/cli/gaia-maintainer` returns both).
-   The only instruction to rebuild them lives in prose:
-   `.claude/commands/gaia-release.md:97` ("Skip only when no
-   `.gaia/cli/src/` files changed since the last release; when in doubt,
-   rebuild") — a human judgment call inside a manual release runbook step,
-   not a CI assertion that the committed binary's content matches a fresh
-   `pnpm bundle` of current `src/`. Nothing in `.github/workflows/release.yml`
-   or `.github/workflows/cli-tests.yml` diffs the committed bundle against a
-   freshly-built one.
-
-5. **The init/setup/update telemetry ping is opt-out and fires on adopter
-   machines by default (a likely consent finding).** `.gaia/cli/src/ping/send.ts`
-   POSTs to `PING_URL = 'https://telemetry.gaiareact.com/ping'` (line 27) on
-   every `init`/`setup`/`update` event; the only suppression is the
-   environment variable `GAIA_TELEMETRY_PING_DISABLE=1`, checked at
-   `.gaia/cli/src/ping/send.ts:69`. This is opt-out (default-on, adopter must
-   discover and set an env var), not opt-in. Judge whether this needs
-   surfacing as a distribution/consent finding — it fires on every fresh
-   `gaia init` unless the adopter already knows the flag exists.
-
-6. **The manifest references now-absent files** (also a TIDY concern;
-   note it here from the distribution-integrity angle — a manifest entry for
-   a file that doesn't exist misrepresents what actually ships and what
-   `/update-gaia` will try to sync). Derive this at audit time: cross-reference
-   every path in `.gaia/manifest.json`'s `files` array against the working tree
-   and report each entry that has no file on disk. At time of writing two
-   entries dangle — a stale `.claude/rules/` doc and a retired helper under
-   `.specify/extensions/gaia/lib/` — but cite the manifest paths and line
-   numbers you actually find; do not treat the set as fixed.
-
-7. **Recommend proving no unmarked maintainer-only leak with a scrub
-   dry-run.** `gaia-maintainer release scrub <staging-dir>` (implemented in
-   `.gaia/cli/src/release/scrub.ts`) already accepts an arbitrary staging
-   directory and runs marker-strip + json-strip + leak-check against it —
-   nothing currently runs it ad hoc, outside `release.yml`'s tag-triggered
-   path, against a locally-built staging tree to catch a leak before a
-   release tag is cut. Recommend documenting/running that as a pre-PR
-   sanity check for anyone touching release-adjacent surfaces, not building
-   new tooling (the command already exists).
+- Pre-tag scrub verification: is there a documented, easy-to-run way to run
+  the leak-check (marker-strip + json-strip) against a locally-built staging
+  tree before a release tag is cut, or does the only run of it live behind
+  the tag-triggered release path?
 
 ## Reads first
 
@@ -162,10 +80,10 @@ In this order:
 Write full findings to `.gaia/local/audit/comprehensive/findings/DIST.json`
 against the FROZEN findings schema below. **Write the file even when the
 findings array is empty.** For a sub-surface you judge genuinely clean, add
-its name to `clean_surfaces` (e.g. `"manifest.json path integrity"` only if
-you find zero absent-file entries — you will not, see target #6) instead of
-silently omitting it or inventing a zero-severity finding. `clean_surfaces`
-is always present in the file, possibly empty `[]`.
+its name to `clean_surfaces` (e.g. `"manifest.json path integrity"` if you
+find zero absent-file entries) instead of silently omitting it or inventing
+a zero-severity finding. `clean_surfaces` is always present in the file,
+possibly empty `[]`.
 
 **Findings schema (FROZEN):**
 
@@ -202,6 +120,6 @@ bodies staying on disk. The material set is never truncated.
 ## Present-tense, concrete, falsifiable
 
 Every finding cites `file:line` (or `file` when the defect is the file's
-existence/absence, e.g. target #6). Write so a fixer can act by reading one
-file — no vague "could be cleaner" language. State what is true now, not
-what changed or what will happen.
+existence/absence, e.g. a manifest entry pointing at a nonexistent path).
+Write so a fixer can act by reading one file — no vague "could be cleaner"
+language. State what is true now, not what changed or what will happen.

--- a/.gaia/cli/health/comprehensive/lenses/FEAT.md
+++ b/.gaia/cli/health/comprehensive/lenses/FEAT.md
@@ -40,111 +40,34 @@ inconsistency. A finding is real when two files disagree, one file duplicates
 logic that should be single-sourced, or a mechanism is registered/enforced
 in a way that can silently drift or double-fire.
 
-### Discovery-noted real targets (audit these by name; you are guaranteed non-trivial findings here)
+Common defect classes on this surface (audit for the class, not a named
+current defect; file what you actually find, and an empty result is valid
+when the surface is genuinely clean):
 
-1. **Audit/heal/grade cluster: `/gaia-fitness` is a subset of `/health-audit`, sharing one fitness doc.**
-   `.claude/commands/gaia-fitness.md:5` delegates the entire triage/heal/verify
-   protocol to `wiki/decisions/Claude Integration Fitness.md`, running its own
-   dedicated harness (auto-branch, unsafe-state guard, bounded heal loop).
-   `.claude/commands/health-audit.md` (SELF surface, out of scope to edit, but
-   its Bucket E, roughly line 50) runs the *same* seven-category protocol from
-   the same wiki page as one leaf inside a larger audit. `.claude/skills/gaia/references/fitness.md:89`
-   even carries a hand-maintained "mirror" of the model-assignment table from
-   the wiki page, with a note "if the two ever diverge the wiki wins" —
-   evidence the duplication is already a known drift risk. Two independently
-   evolving harnesses wrap one shared protocol; a change validated by
-   retesting only one harness (e.g. `/gaia-fitness`) is not proven safe for
-   the other's different orchestration (Bucket E leaf + Fixer lane vs
-   triage/heal/verify loop). Cite `.claude/commands/gaia-fitness.md:5` and
-   `.claude/skills/gaia/references/fitness.md:87-89` as your FEAT-surface
-   locations (the health-audit.md half belongs to SELF).
+- **Restated contracts.** A canonical page (a wiki concept, a `.claude/rules/`
+  rule) that several reference docs, skills, or commands restate locally
+  instead of pointing at — the PR-merge workflow, a fitness/heal protocol, a
+  code-search routing policy. Every restatement is a spot the mechanics can
+  drift from the source; when you find one, cite the canonical page plus each
+  restating file:line.
+- **Convention inconsistency with no stated rule.** Sibling files that
+  disagree on a convention (frontmatter fields, `model:` pinning across
+  skills/agents, filename shape) where no `.claude/rules/` file says which
+  shape is correct. Confirm no governing rule exists before filing.
+- **Registration fragility.** Hook commands wired with bare relative paths
+  that break under a persisted `cd`, or path-resolution strategies that
+  differ between the create/remove (or start/stop) halves of one feature.
+- **Double-registered hooks.** The same hook script wired to more than one
+  event/matcher — verify each script is idempotent and cheap to re-run, and
+  does not assume single-invocation-per-turn semantics (e.g. a counter that
+  increments per registration rather than per logical event). Read the
+  script bodies, not just the registrations.
+- **Enforcement layered in multiple places.** The same guidance encoded in
+  more than one mechanism (two prose rules plus a runtime hook); verify the
+  layers agree on scope and none is stale.
 
-2. **The PR-merge contract is restated (not pointed-to) in roughly five places.**
-   `.claude/rules/pr-merge.md` is a thin pointer to `wiki/concepts/PR Merge Workflow.md`
-   (the canonical source), but several `.claude/skills/` reference docs restate
-   the concrete mechanics locally instead of pointing at it alone — the
-   poll-for-`MERGED` loop, the `--auto`/`--admin` choice, and the post-merge
-   cleanup sequencing are typed out again and again:
-   - `.claude/skills/gaia/references/debt.md:101-110`
-   - `.claude/skills/gaia/references/plan.md:198,263,279`
-   - `.claude/skills/gaia/references/audit.md:582-626`
-   - `.claude/commands/gaia-release.md:11,120-139,171-203`
-   - `.claude/skills/update-gaia/SKILL.md:649,717-735`
-   - `.claude/skills/update-deps/SKILL.md:456-497`
-   Each restatement is a place the mechanics can drift from the canonical
-   workflow page (e.g. a `--auto` vs `--admin` distinction updated in one file
-   and missed in the other five). Judge whether this rises to a finding (it
-   is a real single-source-of-truth hazard) and cite the concrete file:line
-   set above as evidence.
-
-3. **Serena code-search routing is enforced in roughly three independent places.**
-   `.claude/rules/serena-cc-override.md` (repo-wide prose guidance),
-   `.claude/rules/code-search.md` (path-scoped prose rule, `paths:` frontmatter
-   at line 2-4, restates the same Serena-over-grep guidance for a narrower
-   trigger surface), and `.claude/hooks/serena-code-search-guard.sh` (runtime
-   enforcement, registered twice in `.claude/settings.json` — PreToolUse
-   `Bash` matcher and PreToolUse `Grep` matcher, roughly lines 175 and 204).
-   Three mechanisms (two prose rules plus a hook) independently encode
-   "prefer Serena for symbol work"; verify whether they agree on scope
-   (`code-search.md`'s `Enforcement` section, roughly line 20, describes the
-   guard's TypeScript-conservative narrowing versus the language-agnostic
-   prose above it — check this self-declared gap is accurate and not stale).
-
-4. **Inconsistent `model:` frontmatter across skills, with no stated rule.**
-   `grep -n "^model:" .claude/skills/*/SKILL.md` (check the first ~6 lines of
-   each) shows 9 skills pin `model: haiku` in frontmatter —
-   `a11y-fixes`, `eslint-fixes`, `new-component`, `new-hook`, `new-route`,
-   `new-service`, `tailwind`, `typescript`, `skeleton-loaders` — while others
-   (`gaia`, `gaia-handoff`, `gaia-pickup`, `gaia-react-perf`, `gaia-wiki`,
-   `playwright-cli`, `react-code`, `release-notes`, `tdd`, `update-deps`,
-   `update-gaia`) have no `model:` field at all and inherit the session
-   model. `.claude/agents/code-review-audit.md:4` and
-   `.claude/agents/worthiness-evaluator.md:4` both pin `model: opus`. No file
-   under `.claude/rules/` states when a skill should pin a model vs inherit.
-   Confirm no rule exists (check `.claude/rules/` for a model-pinning
-   convention) before filing; if genuinely absent, this is a real
-   convention-inconsistency finding — cite the split file lists above.
-
-5. **Fragile relative hook paths: one persisted `cd` breaks every lifecycle hook.**
-   `.claude/settings.json` registers essentially every hook command as a
-   bare repo-relative path (e.g. `.claude/hooks/wiki-session-start.sh`,
-   `.claude/hooks/block-rm-rf.sh`, and roughly 30 more across `SessionStart`,
-   `Stop`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`). These resolve
-   only from the shell's current directory. `.claude/rules/shell-cwd.md`
-   documents this exact fragility as the reason for its no-persistent-`cd`
-   rule, but the rule is a mitigation for agent *behavior*, not a fix to the
-   *registration* — the hook paths themselves stay relative and brittle.
-   Judge whether this is worth a finding (a design fragility already
-   partially mitigated by policy) or a `clean_surfaces` entry (if you judge
-   the existing mitigation sufficient, name it explicitly rather than
-   silently skipping).
-
-6. **Worktree-hook parity gap.** In `.claude/settings.json`, `WorktreeCreate`
-   (around line 66-73) invokes `bash .gaia/scripts/create-worktree.sh` — a
-   bare relative path with no root derivation. `WorktreeRemove` (around line
-   77-84) invokes `bash -c 'root="$(dirname "$(git rev-parse --git-common-dir)")"; exec bash "$root/.gaia/scripts/remove-worktree.sh"'`
-   — it robustly derives the repo root before invoking the script. The two
-   lifecycle hooks for the same feature (worktree create/remove) use
-   inconsistent path-resolution strategies; if `WorktreeCreate` ever fires
-   from a cwd other than the repo root, it breaks where `WorktreeRemove`
-   would not. Cite `.claude/settings.json:72` vs `.claude/settings.json:83`.
-
-7. **Several double-registered hooks whose idempotency matters.** The same
-   hook script is wired to fire on more than one event/matcher in
-   `.claude/settings.json`:
-   - `.claude/hooks/block-manifest-write.sh` — PreToolUse `Edit|Write|MultiEdit`
-     (~line 122) and PreToolUse `Bash` (~line 180)
-   - `.claude/hooks/block-env-read.sh` — PreToolUse `Bash` (~line 185) and
-     PreToolUse `Read` (~line 195)
-   - `.claude/hooks/serena-code-search-guard.sh` — PreToolUse `Bash` (~line 175)
-     and PreToolUse `Grep` (~line 204)
-   - `.claude/hooks/token-tally-review.sh` — `Stop` (~line 35) and
-     PostToolUse `Bash` (~line 224)
-   Each registration is plausibly intentional (different tool surfaces need
-   the same guard), but verify each script is idempotent / cheap to re-run
-   and doesn't assume single-invocation-per-turn semantics (e.g. a counter
-   that increments per registration rather than per logical event). Read the
-   script bodies, not just the registrations, before filing.
+Cross-check for duplicated contracts and conflicting instructions beyond
+these classes — the list is a floor, not a ceiling.
 
 ## Reads first
 
@@ -152,10 +75,11 @@ in a way that can silently drift or double-fire.
 - Survey `.claude/skills/` (one `SKILL.md` per folder; note `model:` frontmatter)
 - Survey `.claude/commands/` (all files except `health-audit.md`)
 - Survey `.claude/agents/` and `.claude/rules/`
-- `.claude/hooks/` — at minimum, read the bodies of every hook named in
-  target 7 above, plus `shell-cwd.md` for target 5's cross-reference
+- `.claude/hooks/` — at minimum, read the bodies of any hook registered on
+  more than one event/matcher, plus `.claude/rules/shell-cwd.md` for the
+  relative-hook-path fragility cross-reference
 - Cross-check for duplicated contracts and conflicting instructions beyond
-  the named targets — the list above is a floor, not a ceiling.
+  the classes above — that list is a floor, not a ceiling.
 
 ## Output
 
@@ -174,10 +98,10 @@ against this FROZEN schema, **even when the findings array is empty**:
 For a sub-surface you judge genuinely clean (e.g. `.claude/agents/` if it
 turns out to have no coherence issues), add its name to `clean_surfaces`
 rather than silently omitting it or inventing a zero-severity finding.
-`clean_surfaces` is always present in the file (possibly empty `[]`). Given
-the seven named targets above, an entirely empty `findings` array is not a
-plausible outcome for this run — at minimum, verify each target and either
-file it as a finding or explicitly reason why it does not rise to a finding.
+`clean_surfaces` is always present in the file (possibly empty `[]`). If the
+whole surface is genuinely clean, an empty `findings` array with populated
+`clean_surfaces` is a valid result — do not manufacture a finding to avoid
+an empty array.
 
 ## Return (thin digest only)
 
@@ -200,6 +124,6 @@ stay on disk in the findings file. The material set is never truncated.
 ## Concreteness
 
 Present-tense, concrete, falsifiable. Every finding cites `file:line` (or, if
-the defect is the *relationship* between two files, both locations, as in
-target 1 and target 6). A fixer must be able to act by reading one file. No
-vague "could be cleaner" — name the exact drift, duplication, or conflict.
+the defect is the *relationship* between two files, both locations). A fixer
+must be able to act by reading one file. No vague "could be cleaner" — name
+the exact drift, duplication, or conflict.

--- a/.gaia/cli/health/comprehensive/lenses/SELF.md
+++ b/.gaia/cli/health/comprehensive/lenses/SELF.md
@@ -1,5 +1,6 @@
 ---
-type: audit-lens
+type: lens-brief
+lens: SELF
 status: active
 audience: maintainer
 ---
@@ -36,84 +37,33 @@ move on.
 
 ## What to look for
 
-Audit of `/health-audit`'s own machinery: command-vs-runbook duplication
-(single-source drift hazard — the command should be a thin pointer, not a
-restatement), scope-vs-name mismatch (does "health audit" actually mean
-what it claims), model pinning gaps (every dispatched role should have an
-explicit, deliberate model assignment), and surface weight (is the
-machinery proportionate to what it audits, and is it growing without
-bound).
+Audit of `/health-audit`'s own machinery. Hunt these defect classes; each
+is a class to look for, not a named defect to confirm — file what you
+actually find against the current repo, and an empty result is valid when
+the surface is genuinely clean:
 
-### Mandatory defects (SPEC UAT-010 — a SELF run reporting nothing FAILS)
-
-You MUST surface both of the following as findings. They are real,
-verified against the current repo; this is not a hypothetical prompt.
-
-**1. Command-versus-runbook loop/termination duplication.**
-`.claude/commands/health-audit.md` Step 2 (lines 14-56) restates the
-runbook's cycle-loop pseudocode and the oscillation-threshold definition
-almost verbatim, rather than pointing at it. Compare:
-
-- `.claude/commands/health-audit.md:16-46` — the fenced pseudocode block
-  (`mkdir -p .gaia/local/audit` ... `For cycle in 1..3:` ... clean-exit /
-  oscillation-check / Fixer-dispatch / escalate steps).
-- `.gaia/cli/health/runbook.md:20-43` — the "## Cycle loop" section, the
-  same sequence of steps in the same order, independently worded.
-- `.claude/commands/health-audit.md:48` ("**Oscillation threshold
-  (definition).**" paragraph) restates
-  `.gaia/cli/health/runbook.md:53` (the Oscillation bullet under
-  "## Termination").
-
-Two independently-maintained copies of the same control-flow logic is a
-drift hazard: an edit to one (e.g. a change to the archive-prune count, or
-to what counts as an oscillating fingerprint) can land without the other
-being updated, and nothing catches the divergence. The finding's
-`location` field MUST cite **both** files (see the exact format below).
-
-**2. Orchestrator not pinned to the session model.**
-`.gaia/cli/health/runbook.md:79` (the "## Model selection" table) reads:
-
-```
-| Orchestrator | main thread (session model) |
-```
-
-Every other dispatched role in the same table (Adjudicator, Bucket D,
-Bucket E judgment auditor, all four challenger lenses, all four Fixer
-lanes) carries an explicit model pin (Sonnet, or Haiku for the mechanical
-buckets). The Orchestrator alone inherits "session model" — whatever
-model the invoking session happens to be running under. Because the
-Orchestrator authors the final A-to-F verdict framing, drives the
-oscillation compare, and gates every circuit breaker, an unpinned
-Orchestrator means the audit's own judgment layer can vary in capability
-run to run depending on what model the maintainer happened to invoke
-`/health-audit` from, with no floor. `.gaia/cli/health/comprehensive/runbook.md`
-(the "## Topology" section, line 28) has the identical gap for the same
-Orchestrator role in the comprehensive phase: "the Orchestrator (main
-thread) is the only spawner" with no model pin stated there either.
-
-### Additional real targets
-
-**Surface weight.** At discovery time the health-audit-private surface
-(`.claude/commands/health-audit.md` + `.gaia/cli/health/runbook.md` +
-`.gaia/cli/health/taxonomy.md`) was ~741 lines (108 + 425 + 208). This
-comprehensive-audit phase itself now adds `.gaia/cli/health/comprehensive/`
-(gauge.sh + comprehensive/runbook.md + four lens briefs) on top of that
-base, so the SELF surface has grown past 1,100 lines and keeps growing:
-the audit auditing itself is not exempt from the weight concern it is
-meant to catch elsewhere. Verify the current total with
-`find .gaia/cli/health -type f -name '*.md' -o -name '*.sh' | xargs wc -l`
-and cite it precisely rather than repeating "~741" as if it still held.
-
-**Name vs scope.** The command is named `/health-audit` — "health" reads
-as covering the whole project. In practice it audits only the
-framework-boundary / CLI-distribution surface plus the shared
-Claude-integration fitness categories (`.claude`, `.gaia`, wiki, CLI
-release machinery). It never touches `app/**` (the product source) or its
-tests. A maintainer skimming the command list could reasonably expect
-`/health-audit` to say something about application code health and be
-wrong. This is a naming-clarity finding, not a functional bug: assess
-severity accordingly (most likely `low` or `medium`, not `high`/`blocker`
-absent evidence of a maintainer actually being misled by it).
+- **Command-versus-runbook duplication.** The command entry point should be
+  a thin pointer to the runbook, not a restatement of it. Two
+  independently-maintained copies of the same control-flow logic (the cycle
+  loop, the oscillation threshold, termination/escalation steps) are a
+  drift hazard: an edit to one can land without the other, and nothing
+  catches the divergence. When the defect is a duplicated contract, cite
+  **both** files in `location`.
+- **Model-pinning gaps.** Every dispatched role should carry an explicit,
+  deliberate model assignment. A role that inherits the bare "session
+  model" with no pin means that layer's capability varies run to run with
+  no floor — worth a finding for any role whose judgment gates the audit
+  (the Orchestrator, adjudicators, challenger lenses, Fixer lanes).
+- **Scope-versus-name mismatch.** Does "health audit" actually mean what
+  the command name implies? A naming-clarity gap — the name suggesting
+  broader coverage than the machinery delivers — is a finding; assess
+  severity soberly (usually `low`/`medium`, absent evidence a maintainer
+  was actually misled).
+- **Surface weight.** Is the machinery proportionate to what it audits, and
+  is it growing without bound? Measure the current total with
+  `find .gaia/cli/health -type f \( -name '*.md' -o -name '*.sh' \) | xargs wc -l`
+  and cite the number you observe; the audit auditing itself is not exempt
+  from the weight concern it catches elsewhere.
 
 ## Reads first
 
@@ -136,11 +86,10 @@ cross-reference to it is fine.
 
 Write full findings to
 `.gaia/local/audit/comprehensive/findings/SELF.json` against the FROZEN
-findings schema below, **even when the findings array is empty** (it will
-not be empty this run — the two mandatory defects above are real and
-verified). For any named sub-surface you judge genuinely clean (e.g.
-"taxonomy Decided/not-findings entries are self-consistent"), add its name
-to `clean_surfaces` rather than omitting it or inventing a zero-severity
+findings schema below, **even when the findings array is empty**. For any
+named sub-surface you judge genuinely clean (e.g. "taxonomy
+Decided/not-findings entries are self-consistent"), add its name to
+`clean_surfaces` rather than omitting it or inventing a zero-severity
 finding.
 
 **Findings schema (FROZEN):**
@@ -154,14 +103,10 @@ finding.
       "issue": "...", "evidence": "...", "recommendation": "..." } ] }
 ```
 
-For the mandatory duplication finding (defect 1), set `location` to cite
-both files, e.g.:
-`.claude/commands/health-audit.md:16-56 and .gaia/cli/health/runbook.md:20-53`.
-
-For the mandatory model-pin finding (defect 2), `location` is
-`.gaia/cli/health/runbook.md:79` (add
-`.gaia/cli/health/comprehensive/runbook.md:28` as a second cited location
-since the same gap recurs there).
+When a finding's defect is the *relationship* between two files (e.g.
+duplicated control-flow across the command and its runbook), set `location`
+to cite **both** files, e.g. `fileA:16-56 and fileB:20-53`. When the same
+gap recurs in a second file, cite both locations.
 
 ## Return
 
@@ -169,9 +114,7 @@ Return ONLY the thin digest: `{id, severity, title}` per finding — no
 `body`, `issue`, `evidence`, or `recommendation` field. **Every material
 (non-low: blocker/high/medium) finding MUST appear in the digest**; each
 is verified downstream by one refuter, so an omitted material finding goes
-unverified. Both mandatory defects above are material (at minimum
-`medium`; assess whether repo-observed impact pushes either to `high`) and
-MUST be in your returned digest. **Low** findings are capped at
+unverified. **Low** findings are capped at
 `LENS_DIGEST_CAP = 25` returned lines; beyond the cap emit a single
 `low: <n> more on disk` count line, with the excess low bodies staying on
 disk. The material set is never truncated.
@@ -185,8 +128,8 @@ disk. The material set is never truncated.
 
 ## Concreteness
 
-Present-tense. Every finding cites `file:line` (or, for the mandatory
-duplication finding, both files' line ranges). A fixer must be able to act
-by reading the file(s) named in `location` alone. No vague "could be
-cleaner" findings — if you cannot name a file and line, it is not a
-finding.
+Present-tense. Every finding cites `file:line` (or, when the defect is the
+relationship between two files, both files' line ranges). A fixer must be
+able to act by reading the file(s) named in `location` alone. No vague
+"could be cleaner" findings — if you cannot name a file and line, it is not
+a finding.

--- a/.gaia/cli/health/comprehensive/lenses/TIDY.md
+++ b/.gaia/cli/health/comprehensive/lenses/TIDY.md
@@ -60,75 +60,13 @@ skip it; do not raise it here.
   structure.
 - **Stale manifest references** — `.gaia/manifest.json` entries pointing at
   files that no longer exist on disk (a tidiness signal: dead bookkeeping).
+  Note these from the tidiness angle; DIST separately notes the same entries
+  from the distribution-integrity angle — this manifest overlap is the one
+  deliberate exception to the no-overlap partition, not a scope-boundary bug.
 
-## Discovery-noted real targets (verified; name these so TIDY is non-trivial)
-
-1. **Telemetry `.jsonl` files grow unbounded, no retention.** All three files
-   at `.gaia/local/telemetry/` (`cost.jsonl`, `spec-pacing.jsonl`,
-   `gh-mirror.jsonl`) and every dated file under
-   `.gaia/local/telemetry/cloud/` (`events-YYYY-MM-DD.jsonl`, currently 10
-   files spanning `events-2026-05-06.jsonl` through the present) append
-   forever. `.claude/hooks/local-janitor.sh:203-205` explicitly *keeps alive*
-   `telemetry` and `telemetry/cloud` (excludes them from its stale-artifact
-   sweep) with no rotation, size cap, or age-based trim anywhere in that
-   file. Confirm no other script owns telemetry retention before filing;
-   if none does, this is real.
-
-2. **Gitignored `archived/` trees grow forever.** `.gaia/local/specs/archived/`
-   currently holds 22 SPEC-NNN entries (SPEC-003 through SPEC-025 and
-   others); `.gaia/local/plans/archived/` holds 7. `.claude/hooks/local-janitor.sh:203-205`
-   also keeps `specs/archived` and `plans/archived` alive (excluded from the
-   stale sweep). Per the plan brief, pruning is maintainer-only via
-   `health-audit`'s own `audit/archived` cleanup, not automatic — confirm
-   this against the janitor and health-audit runbook before filing severity.
-
-3. **Split-brain spec/plan/ledger logic.** `.gaia/scripts/` and
-   `.specify/extensions/gaia/lib/` both hold spec/plan/archive/ledger
-   scripts with overlapping responsibility and no cross-reference tying
-   them together as one system: e.g. `.gaia/scripts/plan-archive.sh` and
-   `.gaia/scripts/plan-resume-point.sh` vs.
-   `.specify/extensions/gaia/lib/plan-archive-merged.sh`,
-   `plan-reconcile.sh`, `plan-allocator.sh`, and `plan-ledger-update.sh`;
-   similarly `.gaia/scripts/summary-verify.sh` vs.
-   `.specify/extensions/gaia/lib/spec-archive-merged.sh`,
-   `spec-reconcile.sh`, `spec-allocator.sh`. Two directories, one domain,
-   no documented ownership boundary. Judge this from the layout/ownership
-   angle only (which tree should own which responsibility, and whether that
-   split is documented anywhere) — do not review the scripts' internal
-   correctness, that is DIST's surface.
-
-4. **Two coexisting merged-SPEC layouts.** Compare
-   `.gaia/local/specs/archived/SPEC-025/` (four files: `SPEC.md`,
-   `AUDIT.md`, `cost.md`, `SUMMARY.md`) against
-   `.gaia/local/specs/SPEC-032/` (two files: `SUMMARY.md`, `cost.json`). The
-   old shape (`SPEC.md`+`AUDIT.md`+`cost.md`) and the new shape
-   (`SUMMARY.md`+`cost.json`) coexist across the archived tree with no
-   migration note explaining which specs use which layout or why the older
-   layout wasn't backfilled.
-
-5. **Cache root is a flat grab-bag.** `.gaia/local/cache/` mixes a
-   subdirectory (`ca-research/`), another subdirectory (`shared/`), and a
-   loose file (`v2-update-notes.md`) at the same level, with cleanup relying
-   on `.claude/hooks/local-janitor.sh:221-233`'s filename-glob matching
-   (`gate1-*.json`, `draft-*.md`, `audit-*` dirs, `renders.json`) rather than
-   a subfolder-per-producer convention. Any new cache producer that doesn't
-   pick a glob the janitor already recognizes leaks forever.
-
-6. **Manifest references now-absent files.** Cross-reference
-   `.gaia/manifest.json`'s `files` array against the working tree: some entries
-   marked `"owned"` have no file on disk. At time of writing two dangle — a
-   stale `.claude/rules/` doc and a retired helper under
-   `.specify/extensions/gaia/lib/` — but cite whichever manifest lines you
-   actually find. Note this from the tidiness angle (stale bookkeeping in a
-   workspace artifact); DIST separately notes the same pair from the
-   distribution-integrity angle — this is the one deliberate, named exception
-   to the no-overlap partition (per the plan brief), not a bug in your scope
-   boundary.
-
-Verify each target against the live repo before filing (paths/line numbers
-may drift as the repo evolves) — file what you actually find, using the
-targets above as a guaranteed-non-trivial starting point, not a checklist to
-copy verbatim.
+Verify each class against the live repo before filing (paths and line
+numbers drift as the repo evolves) — file what you actually find; the
+classes above are a floor, not a checklist to copy verbatim.
 
 ## Reads first
 


### PR DESCRIPTION
Drains two `tech-debt` items from the SPEC-033 comprehensive-audit follow-ups.

## What changed

The four persistent comprehensive-audit lens briefs (`.gaia/cli/health/comprehensive/lenses/{SELF,DIST,FEAT,TIDY}.md`) baked in **named current defects** ("seeds") and, in SELF/DIST/FEAT, forbade an empty findings array. Those seeds go stale the moment a maintainer fixes the seeded defect, and the must-find mandate contradicts the comprehensive runbook (which already treats an empty findings array as valid).

- **#618** — Migrate the seeds out of the persistent briefs. Each brief now describes the defect *classes* to hunt rather than the specific defects it MUST find, and the empty-findings-forbidden mandate is dropped so a genuinely clean surface is a valid result. Load-bearing general guidance is preserved by folding it into the `What to look for` class lists (surface-weight measurement method, the pre-tag scrub check, the deliberate DIST/TIDY manifest overlap); stale repo-state numbers and named seeds are dropped.
- **#620** — Normalize all four frontmatter blocks to the shared `type: lens-brief` + `lens: <L>` shape (SELF and DIST were the outliers).

Maintainer-only, release-excluded machinery (`.gaia/cli/health/**`), so nothing ships to adopters and no CHANGELOG entry is owed.

## Scope note

Sibling issue **#619** (CRA workflow posts a duplicate status comment per `synchronize`) was intentionally split out of this bundle: it turned out to be a cross-module CLI build-system change (the comment logic lives in the bundled workflow *template*, not just the rendered `.github/workflows/code-review-audit.yml`), not the one-file cosmetic its severity suggested. It stays open for dedicated handling.

Closes #618
Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)