### PR TITLE
fix(spec-032): propagate failure from gaia_audit_window_write (#615)

### DIFF
--- a/.gaia/scripts/audit-window-lib.sh
+++ b/.gaia/scripts/audit-window-lib.sh
@@ -10,9 +10,12 @@
 #   { usage: [ {id, u, m} ], tmin, tmax, file_agent, file_id }
 # where `file_agent` is "main" for the main transcript or the sidecar's
 # agentType, and `file_id` is the sidecar basename (agent-<hash>) or "" for
-# main. No side effects at source time; defines functions only. Every
-# function returns 0 and degrades to empty / {} / [] on any failure -- never
-# blocks the caller, never fabricates a figure.
+# main. No side effects at source time; defines functions only. The read/query
+# functions return 0 and degrade to empty / {} / [] on any failure -- never
+# blocking the caller, never fabricating a figure. The one writer,
+# gaia_audit_window_write, instead PROPAGATES failure (non-zero when it wrote
+# nothing) so a lost breadcrumb is detectable; its callers guard with `|| true`
+# so that too never blocks.
 #
 # Timestamp precision (COV-003): a breadcrumb's started_at/ended_at are
 # written at SECOND precision (date -u +%Y-%m-%dT%H:%M:%SZ) while sidecar
@@ -133,26 +136,48 @@ gaia_window_subset() {
 # The single breadcrumb writer (DP-001). Writes the FC-1 breadcrumb JSON to
 # <breadcrumb_path> via `jq -n` (never string-concatenated), omitting the
 # `intensity` key entirely when the 6th arg is empty/absent (plan audits).
-# Best-effort: the JSON is built in a variable first (nothing touches disk
-# until it validates), so an invalid <lenses_json> or a jq failure leaves no
-# partial file; an unwritable target path likewise writes nothing. Always
-# returns 0, never blocks the caller.
+# The JSON is built in a variable first (nothing touches disk until it
+# validates), so an invalid <lenses_json> or a jq failure leaves no partial
+# file; an unwritable target path likewise writes nothing.
+#
+# Unlike the read/query helpers above, this writer PROPAGATES failure: it
+# returns 0 only when a valid breadcrumb reached disk, and non-zero (with a
+# diagnostic on stderr) when it wrote nothing -- an empty target path, jq
+# absent from PATH, a jq failure / empty or non-object JSON, or an unwritable
+# target. jq's stderr flows through rather than being discarded, so the real
+# cause surfaces. This makes a lost breadcrumb detectable and unit-testable
+# rather than silently swallowed. Callers guard the call with `|| true`, so a
+# non-zero return still
+# never blocks them; it just stops converting a recoverable error into silent
+# data loss.
 gaia_audit_window_write() {
   local path="${1:-}" session_id="${2:-}" started_at="${3:-}" ended_at="${4:-}" lenses_json="${5:-}" intensity="${6:-}"
-  [[ -z "$path" ]] && return 0
+  if [[ -z "$path" ]]; then
+    printf 'gaia_audit_window_write: no breadcrumb path given; nothing written\n' >&2
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'gaia_audit_window_write: jq not found on PATH; breadcrumb %s not written\n' "$path" >&2
+    return 1
+  fi
   local json
   if [[ -z "$intensity" ]]; then
     json="$(jq -n --arg sid "$session_id" --arg st "$started_at" --arg en "$ended_at" --argjson lenses "$lenses_json" '
       {session_id: $sid, started_at: $st, ended_at: $en, lenses: $lenses}
-    ' 2>/dev/null)"
+    ')" || json=""
   else
     json="$(jq -n --arg sid "$session_id" --arg st "$started_at" --arg en "$ended_at" --argjson lenses "$lenses_json" --arg it "$intensity" '
       {session_id: $sid, started_at: $st, ended_at: $en, lenses: $lenses, intensity: $it}
-    ' 2>/dev/null)"
+    ')" || json=""
   fi
-  [[ -z "$json" ]] && return 0
-  jq -e 'type == "object"' >/dev/null 2>&1 <<<"$json" || return 0
-  printf '%s\n' "$json" >"$path" 2>/dev/null
+  if [[ -z "$json" ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$json"; then
+    printf 'gaia_audit_window_write: could not build a valid breadcrumb for %s; nothing written\n' "$path" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$json" >"$path" 2>/dev/null; then
+    printf 'gaia_audit_window_write: cannot write breadcrumb to %s\n' "$path" >&2
+    return 1
+  fi
   return 0
 }
 

--- a/.gaia/scripts/tests/audit-window-lib.bats
+++ b/.gaia/scripts/tests/audit-window-lib.bats
@@ -262,7 +262,7 @@ setup() {
 }
 
 # ---------- 10. gaia_audit_window_write (DP-001, AC10) ----------
-@test "gaia_audit_window_write: writes the FC-1 shape, omits intensity for plan audits, never leaves a partial file" {
+@test "gaia_audit_window_write: writes the FC-1 shape on success, omits intensity for plan audits" {
   bc="$BATS_TEST_TMPDIR/spec-breadcrumb.json"
   run gaia_audit_window_write "$bc" "sess-1" "2026-07-08T01:00:00Z" "2026-07-08T01:05:00Z" '["FG","TST","COV","RT"]' "standard"
   [ "$status" -eq 0 ]
@@ -278,13 +278,37 @@ setup() {
   [ "$status" -eq 0 ]
   jq -e 'has("intensity")' >/dev/null 2>&1 <"$bc2" && return 1
   [ "$(jq -r '.session_id' <"$bc2")" = "sess-2" ]
+}
 
-  run gaia_audit_window_write "$BATS_TEST_TMPDIR/nonexistent-dir/bc.json" "s" "a" "b" '[]' ""
-  [ "$status" -eq 0 ]
+# The breadcrumb writer PROPAGATES failure: it returns non-zero and writes
+# nothing when it cannot produce a valid breadcrumb, so a lost breadcrumb is
+# detectable and unit-testable instead of silently swallowed behind return 0.
+# Callers keep their `|| true`, so a non-zero return still never blocks them.
+@test "gaia_audit_window_write: returns non-zero and writes nothing on jq/write failure" {
+  # unwritable target (parent dir absent): the printf redirect fails -> non-zero
+  run gaia_audit_window_write "$BATS_TEST_TMPDIR/nonexistent-dir/bc.json" "s" "2026-07-08T01:00:00Z" "2026-07-08T01:05:00Z" '[]' ""
+  [ "$status" -ne 0 ]
   [ ! -e "$BATS_TEST_TMPDIR/nonexistent-dir/bc.json" ]
 
+  # malformed lenses arg: jq -n fails -> non-zero, no partial file left behind
   bc3="$BATS_TEST_TMPDIR/bad-lenses.json"
-  run gaia_audit_window_write "$bc3" "s" "a" "b" "not-json" ""
-  [ "$status" -eq 0 ]
+  run gaia_audit_window_write "$bc3" "s" "2026-07-08T01:00:00Z" "2026-07-08T01:05:00Z" "not-json" ""
+  [ "$status" -ne 0 ]
   [ ! -e "$bc3" ]
+
+  # empty target path: nothing to write -> non-zero
+  run gaia_audit_window_write "" "s" "2026-07-08T01:00:00Z" "2026-07-08T01:05:00Z" '[]' ""
+  [ "$status" -ne 0 ]
+
+  # jq unavailable on PATH (the issue's primary reproduction): the `command -v`
+  # guard fires, the writer returns non-zero and writes nothing. PATH is
+  # restored right after the call so the remaining assertions keep jq.
+  bc4="$BATS_TEST_TMPDIR/nojq.json"
+  saved_path="$PATH"
+  # shellcheck disable=SC2123 # deliberately blank PATH to make jq unfindable; restored right after the call
+  PATH=""
+  run gaia_audit_window_write "$bc4" "s" "2026-07-08T01:00:00Z" "2026-07-08T01:05:00Z" '["FG"]' ""
+  PATH="$saved_path"
+  [ "$status" -ne 0 ]
+  [ ! -e "$bc4" ]
 }


### PR DESCRIPTION
Closes #615.

## Problem

`gaia_audit_window_write()` in `.gaia/scripts/audit-window-lib.sh` silenced jq errors (`2>/dev/null`) and returned `0` unconditionally even when it wrote nothing. Every failure mode, jq unresolvable inside the called shell function, a malformed `lenses_json`, an unwritable target, was invisible to callers and to the `|| true`-guarded call sites in `/gaia-spec` step 7d and `/gaia-plan`. The breadcrumb file went missing, so `token-tally.sh` found no `audit-window-<id>.json` to consume and the `spec`/`plan` cost record silently carried no `audit.adversarial` annotation, with zero signal that data was lost.

## Fix

The read/query helpers keep their always-return-0, degrade-to-empty contract. The one **writer** now **propagates failure**: it returns `0` only when a valid breadcrumb reached disk, and non-zero (with a stderr diagnostic) otherwise, an empty path, jq absent from `PATH`, a jq failure / empty or non-object JSON, or an unwritable target. jq's stderr flows through instead of being discarded, and a `command -v jq` guard degrades loudly against the shell-function PATH quirk that triggered the original loss.

Callers keep their `|| true`, so a non-zero return still never blocks them; it just converts silent data loss into a detectable, unit-testable regression.

## Tests

- The two write-failure assertions that encoded the old silent-`0` behavior are flipped to expect non-zero + no file written.
- New cases cover jq-absent (the issue's primary reproduction, via a scoped blank `PATH`) and an empty target path.
- `.gaia/scripts/tests/audit-window-lib.bats` (13) and `spec032-e2e.bats` (9) both green under bash 5; `shellcheck -x` clean on both files.

Contract change is confined to the lib and its suite. No call-site edits: both writers already guard with `|| true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)