### PR TITLE
fix(spec-032): rename zsh-special local `path` in audit-window-lib (#625)

### DIFF
--- a/.gaia/scripts/audit-window-lib.sh
+++ b/.gaia/scripts/audit-window-lib.sh
@@ -42,10 +42,10 @@
 # parses as a JSON object carrying string started_at and string ended_at;
 # otherwise echoes nothing. Never errors, always returns 0.
 gaia_audit_window_read() {
-  local path="${1:-}"
-  [[ -n "$path" && -f "$path" ]] || return 0
+  local bc_path="${1:-}"
+  [[ -n "$bc_path" && -f "$bc_path" ]] || return 0
   local content
-  content="$(cat "$path" 2>/dev/null)" || return 0
+  content="$(cat "$bc_path" 2>/dev/null)" || return 0
   [[ -z "$content" ]] && return 0
   if jq -e 'type == "object" and (.started_at | type) == "string" and (.ended_at | type) == "string"' \
       >/dev/null 2>&1 <<<"$content"; then
@@ -151,13 +151,13 @@ gaia_window_subset() {
 # never blocks them; it just stops converting a recoverable error into silent
 # data loss.
 gaia_audit_window_write() {
-  local path="${1:-}" session_id="${2:-}" started_at="${3:-}" ended_at="${4:-}" lenses_json="${5:-}" intensity="${6:-}"
-  if [[ -z "$path" ]]; then
+  local bc_path="${1:-}" session_id="${2:-}" started_at="${3:-}" ended_at="${4:-}" lenses_json="${5:-}" intensity="${6:-}"
+  if [[ -z "$bc_path" ]]; then
     printf 'gaia_audit_window_write: no breadcrumb path given; nothing written\n' >&2
     return 1
   fi
   if ! command -v jq >/dev/null 2>&1; then
-    printf 'gaia_audit_window_write: jq not found on PATH; breadcrumb %s not written\n' "$path" >&2
+    printf 'gaia_audit_window_write: jq not found on PATH; breadcrumb %s not written\n' "$bc_path" >&2
     return 1
   fi
   local json
@@ -171,11 +171,11 @@ gaia_audit_window_write() {
     ')" || json=""
   fi
   if [[ -z "$json" ]] || ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$json"; then
-    printf 'gaia_audit_window_write: could not build a valid breadcrumb for %s; nothing written\n' "$path" >&2
+    printf 'gaia_audit_window_write: could not build a valid breadcrumb for %s; nothing written\n' "$bc_path" >&2
     return 1
   fi
-  if ! printf '%s\n' "$json" >"$path" 2>/dev/null; then
-    printf 'gaia_audit_window_write: cannot write breadcrumb to %s\n' "$path" >&2
+  if ! printf '%s\n' "$json" >"$bc_path" 2>/dev/null; then
+    printf 'gaia_audit_window_write: cannot write breadcrumb to %s\n' "$bc_path" >&2
     return 1
   fi
   return 0

--- a/.gaia/scripts/tests/audit-window-lib.bats
+++ b/.gaia/scripts/tests/audit-window-lib.bats
@@ -312,3 +312,26 @@ setup() {
   [ "$status" -ne 0 ]
   [ ! -e "$bc4" ]
 }
+
+# ---------- 11. zsh ambient-shell safety: no $path/$PATH special-var collision ----------
+# The lib carries `#!/bin/bash` but is sourced in-process into the session's
+# ambient shell, which is zsh on a macOS default. zsh ties the special array
+# $path to the scalar $PATH, so a `local path=<file>` local would overwrite
+# $PATH with a single non-directory value for the function's duration -- making
+# `command -v jq` fail even with jq on $PATH. The writer would then return
+# non-zero writing nothing, and the reader would silently degrade to empty.
+# Both functions use a non-special local name, so they round-trip under zsh.
+# The subprocess inherits $PATH (jq present); a $path clobber, not a missing
+# jq, is what this pins.
+@test "gaia_audit_window_write/read: round-trips under zsh (no \$path/\$PATH special-var collision)" {
+  command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
+  bc="$BATS_TEST_TMPDIR/zsh-bc.json"
+  run zsh -c "source '$LIB'; gaia_audit_window_write '$bc' sess-z 2026-07-08T01:00:00Z 2026-07-08T01:05:00Z '[\"FG\"]' standard"
+  [ "$status" -eq 0 ]
+  [ -f "$bc" ]
+  [ "$(jq -r '.session_id' <"$bc")" = "sess-z" ]
+  # the reader must also round-trip under zsh, otherwise it silently degrades to empty
+  run zsh -c "source '$LIB'; gaia_audit_window_read '$bc'"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.session_id' <<<"$output")" = "sess-z" ]
+}


### PR DESCRIPTION
## What

`gaia_audit_window_write` and `gaia_audit_window_read` in `.gaia/scripts/audit-window-lib.sh` declared their breadcrumb-path argument as `local path=…`. The lib carries `#!/bin/bash` but is **sourced and called in-process** by `/gaia-plan` and `/gaia-spec`'s audit-window close into the session's ambient shell, which is zsh on a macOS default.

zsh ties the special array `$path` to the scalar `$PATH`, so `local path=<breadcrumb-file>` overwrote `$PATH` with a single non-directory value for the function's duration. The next `command -v jq` guard then failed even with jq on `$PATH`: the writer returned non-zero writing nothing (`jq not found on PATH`), and `token-tally.sh` found no breadcrumb to nest, so the per-feature `audit.adversarial` cost annotation was silently dropped on every macOS-default-shell run. The reader hit the same collision and silently degraded to empty.

This is the root trigger the #615 fix (PR #624) deferred: that PR made the writer *propagate* the failure; this one removes the cause.

## Fix

Rename the zsh-special local `path` → `bc_path` in both functions, so the bash lib is safe when sourced into any ambient shell (the fix protects every in-process caller, versus patching each call site to invoke via `bash -c`). No other function in the lib uses a zsh-special local name (`path`, `status`, `cdpath`, `fpath`, `manpath`, `argv`).

## Test

Adds a zsh-subprocess regression test to `audit-window-lib.bats` (test 14) that round-trips the writer and reader under `zsh -c` with jq on `$PATH`; it `skip`s where zsh is absent. Verified RED against the pre-fix code (writer returns non-zero, no file) and GREEN after. Full suite (14/14) and the sibling `spec032-e2e.bats` (9/9) pass; `shellcheck -x` clean.

Closes #625