### PR TITLE
fix(wiki-sync): point route-group rule at the real canonical pages

### DIFF
--- a/.claude/skills/gaia/references/wiki/sync.md
+++ b/.claude/skills/gaia/references/wiki/sync.md
@@ -61,7 +61,7 @@ Read the diff. Decide what wiki page(s) need updating:
 
 - New service in `app/services/`: edit or create `wiki/services/<name>.md`
 - New hook in `app/hooks/`: edit or create `wiki/hooks/<name>.md`
-- New route group: edit `wiki/flows/Routes.md`
+- New route group: edit `wiki/decisions/Thin Routes.md` and/or `wiki/modules/Pages.md`
 - Dependency change: edit `wiki/dependencies/<name>.md` (create if needed)
 - Architectural pattern: edit relevant `wiki/concepts/<topic>.md`
 - ADR-worthy: create new `wiki/decisions/<title>.md` with frontmatter:


### PR DESCRIPTION
## Summary
- `sync.md`'s route-group rule instructed editing `wiki/flows/Routes.md`, which does not exist
- `.claude/rules/routes.md` names the real canonical pages: `wiki/decisions/Thin Routes.md` and `wiki/modules/Pages.md`
- The dangling reference already produced divergent behavior (a third, undocumented page created instead)

## Test plan
- [x] Verified both canonical target pages exist on disk
- [x] Verified no other file references the dead `wiki/flows/Routes.md` path

Closes #647