### PR TITLE
fix(smoke): run telemetry-v1 in the release-gate sweep, fail on unwired harnesses

### DIFF
--- a/.gaia/tests/smoke/README.md
+++ b/.gaia/tests/smoke/README.md
@@ -11,6 +11,7 @@ Artifacts that should NOT be here are markdown walk-through runbooks tied to a s
 - `wiki-sync/`; bash-driven E2E scenarios (billable). See `wiki-sync/README.md`.
 - `wiki-promote/`; bash structural smoke for SPEC-004 `after_implement` hook artifacts. See `wiki-promote/README.md`.
 - `uat-write/`; bash structural smoke for SPEC-003 `before_implement` hook artifacts. See `uat-write/README.md`.
+- `telemetry-v1/`; bash structural smoke for the telemetry three-stream surface (cloud / mentorship / analytics). See `telemetry-v1/README.md`.
 
 ## Running
 
@@ -20,13 +21,16 @@ bash .gaia/tests/smoke/run-all.sh
 
 Two lanes:
 
-- **Blocking** (sets the exit code): the deterministic structural harnesses `wiki-promote/run.sh` and `uat-write/run.sh`.
+- **Blocking** (sets the exit code): the deterministic structural harnesses `wiki-promote/run.sh`, `uat-write/run.sh`, and `telemetry-v1/run.sh`.
 - **Advisory** (never gates): `wiki-sync/run.sh` (billable). It drives real `claude -p` sessions, so its assertions depend on free-form LLM output and cannot block a release on a coin-flip. It retries each scenario to absorb one-off variance and surfaces the captured session output on a final failure. Run it standalone with `bash .gaia/tests/smoke/wiki-sync/run.sh`. See `wiki-sync/README.md` for the rationale.
+
+Every harness in this tree belongs to exactly one lane, and `run-all.sh`'s two lane lists are the whole of it. A `smoke/<feature>/run.sh` that neither lane names fails the run until it is assigned to one, and a harness a lane names but that is missing from the tree fails the run too. A harness no lane runs guards nothing while still reading as coverage, so adding one is not finished until `run-all.sh` names it.
 
 ## When to run
 
 - **Before cutting a GAIA release**; wiki-sync E2E (advisory). Verifies the wiki-sync system works under real Claude judgment, including the post-Serena WORTHY narrowing. Read the advisory summary; an `ADVISORY` line is a signal to investigate, not a hard block.
 - **Before merging a PR that touches the SPEC-003 or SPEC-004 hook surface**; `uat-write/` and `wiki-promote/` structural smokes.
+- **Before merging a PR that touches the telemetry surface** (`.gaia/cli/src/telemetry/`, `.gaia/cli/src/mentorship/`); `telemetry-v1/` structural smoke. It needs `node_modules/.bin/tsx`, so run `pnpm install` first; the harness exits `2` on a missing prerequisite.
 
 ## See also
 

--- a/.gaia/tests/smoke/README.md
+++ b/.gaia/tests/smoke/README.md
@@ -26,7 +26,7 @@ Two lanes:
 
 Every harness in this tree belongs to exactly one lane, and `run-all.sh`'s two lane lists are the whole of it, in both directions: a `smoke/<feature>/run.sh` that neither lane names fails the run until it is assigned to one, and a harness a lane names but that is missing from the tree fails the run too. A harness no lane runs guards nothing while still reading as coverage, so adding one is not finished until `run-all.sh` names it. Only an advisory harness's **result** is non-gating; its **absence** is a config error in `run-all.sh`, not an LLM coin-flip, so it fails like any other.
 
-A blocking harness that exits `2` reports as a missing prerequisite rather than a plain failure (the harnesses reserve exit `2` for pre-flight: no `node_modules/.bin/tsx`, no built `.gaia/cli/gaia`). It still gates, since an unverified harness cannot clear a release, but the summary line tells you to run `pnpm install` instead of implying the feature broke.
+The driver honors exit `2` from a blocking harness as "missing prerequisite" rather than a plain failure, so the summary line tells you to run `pnpm install` instead of implying the feature broke. `telemetry-v1` is the harness implementing that convention today (it exits `2` on a missing `node_modules/.bin/tsx` or an unbuilt `.gaia/cli/gaia`); the others exit `1` on their own pre-flight and report as an ordinary failure. Either way it gates: an unverified harness cannot clear a release.
 
 ## When to run
 

--- a/.gaia/tests/smoke/README.md
+++ b/.gaia/tests/smoke/README.md
@@ -26,7 +26,7 @@ Two lanes:
 
 Every harness in this tree belongs to exactly one lane, and `run-all.sh`'s two lane lists are the whole of it, in both directions: a `smoke/<feature>/run.sh` that neither lane names fails the run until it is assigned to one, and a harness a lane names but that is missing from the tree fails the run too. A harness no lane runs guards nothing while still reading as coverage, so adding one is not finished until `run-all.sh` names it. Only an advisory harness's **result** is non-gating; its **absence** is a config error in `run-all.sh`, not an LLM coin-flip, so it fails like any other.
 
-The driver honors exit `2` from a blocking harness as "missing prerequisite" rather than a plain failure, so the summary line tells you to run `pnpm install` instead of implying the feature broke. `telemetry-v1` is the harness implementing that convention today (it exits `2` on a missing `node_modules/.bin/tsx` or an unbuilt `.gaia/cli/gaia`); the others exit `1` on their own pre-flight and report as an ordinary failure. Either way it gates: an unverified harness cannot clear a release.
+The driver honors exit `2` from a blocking harness as "missing prerequisite" rather than a plain failure, so the summary line tells you to run `pnpm install` instead of implying the feature broke. `telemetry-v1` is the harness implementing that convention today (it exits `2` on a missing `node_modules/.bin/tsx` or an unbuilt `.gaia/cli/gaia`); the others exit `1` (via pre-flight or their summary) and report as an ordinary failure. Either way it gates: an unverified harness cannot clear a release.
 
 ## When to run
 

--- a/.gaia/tests/smoke/README.md
+++ b/.gaia/tests/smoke/README.md
@@ -24,7 +24,9 @@ Two lanes:
 - **Blocking** (sets the exit code): the deterministic structural harnesses `wiki-promote/run.sh`, `uat-write/run.sh`, and `telemetry-v1/run.sh`.
 - **Advisory** (never gates): `wiki-sync/run.sh` (billable). It drives real `claude -p` sessions, so its assertions depend on free-form LLM output and cannot block a release on a coin-flip. It retries each scenario to absorb one-off variance and surfaces the captured session output on a final failure. Run it standalone with `bash .gaia/tests/smoke/wiki-sync/run.sh`. See `wiki-sync/README.md` for the rationale.
 
-Every harness in this tree belongs to exactly one lane, and `run-all.sh`'s two lane lists are the whole of it. A `smoke/<feature>/run.sh` that neither lane names fails the run until it is assigned to one, and a harness a lane names but that is missing from the tree fails the run too. A harness no lane runs guards nothing while still reading as coverage, so adding one is not finished until `run-all.sh` names it.
+Every harness in this tree belongs to exactly one lane, and `run-all.sh`'s two lane lists are the whole of it, in both directions: a `smoke/<feature>/run.sh` that neither lane names fails the run until it is assigned to one, and a harness a lane names but that is missing from the tree fails the run too. A harness no lane runs guards nothing while still reading as coverage, so adding one is not finished until `run-all.sh` names it. Only an advisory harness's **result** is non-gating; its **absence** is a config error in `run-all.sh`, not an LLM coin-flip, so it fails like any other.
+
+A blocking harness that exits `2` reports as a missing prerequisite rather than a plain failure (the harnesses reserve exit `2` for pre-flight: no `node_modules/.bin/tsx`, no built `.gaia/cli/gaia`). It still gates, since an unverified harness cannot clear a release, but the summary line tells you to run `pnpm install` instead of implying the feature broke.
 
 ## When to run
 

--- a/.gaia/tests/smoke/run-all.sh
+++ b/.gaia/tests/smoke/run-all.sh
@@ -88,8 +88,9 @@ for name in ${BLOCKING_LANE[@]+"${BLOCKING_LANE[@]}"}; do
       # assertion, so a maintainer who skipped `pnpm install` does not read it
       # as "the feature is broken". telemetry-v1 is the harness implementing
       # that convention today (no node_modules/.bin/tsx, no built .gaia/cli/gaia);
-      # the others exit 1 on their own pre-flight and land in the branch below.
-      # Either way it gates: an unverified harness cannot clear a release.
+      # the others exit 1 (via pre-flight or their summary) and land in the
+      # branch below. Either way it gates: an unverified harness cannot clear a
+      # release.
       results+=("FAIL      $name/run.sh prerequisite missing (exit 2; run pnpm install)")
       overall=1
       ;;

--- a/.gaia/tests/smoke/run-all.sh
+++ b/.gaia/tests/smoke/run-all.sh
@@ -11,10 +11,13 @@
 # visibility and retries each scenario to absorb one-off variance, but its
 # result never sets this driver's exit code. See wiki-sync/README.md.
 #
-# Every harness under smoke/ belongs to exactly one lane, and the lane lists
-# below are the whole of it. The unclaimed-harness check at the bottom fails the
-# run when a smoke/<feature>/run.sh exists that neither lane names: a harness no
-# lane runs guards nothing while still looking like coverage.
+# The two lane lists below are the whole of the harness tree, in both
+# directions: a harness a lane names must exist, and a harness in the tree must
+# be named by a lane. Either half breaking fails the run. A harness no lane runs
+# guards nothing while still reading as coverage, and a lane naming a harness
+# that is gone has silently lost the coverage it claims. Note the asymmetry:
+# only an advisory harness's RESULT is non-gating; its ABSENCE is a config error
+# in this file, not a coin-flip, so it fails like any other.
 #
 # The observability/serena/ subtree (relocated from .gaia/tests/smoke/serena/
 # per SPEC-005 §Resolutions Q8) is intentionally NOT run from here
@@ -29,11 +32,23 @@ BLOCKING_LANE=(wiki-promote uat-write telemetry-v1)
 results=()
 overall=0
 
-# Advisory: LLM-nondeterministic; runs for visibility, never gates the release.
-for name in "${ADVISORY_LANE[@]}"; do
+# Arrays are expanded with the offset-guard `${arr[@]+"${arr[@]}"}` throughout:
+# on bash 3.2.57 (stock macOS /bin/bash) a bare "${arr[@]}" of an EMPTY array
+# aborts under `set -u`. Neither lane is empty today, but emptying one (deleting
+# the sole advisory harness, say) must not turn this driver into an exit-127
+# abort that never reaches the blocking lane. See .claude/rules/ and
+# .gaia/scripts/lint-hook-array-guard.sh for the class.
+
+missing_harness() {
+  results+=("FAIL      $1/run.sh named by a lane but missing from the tree")
+  overall=1
+}
+
+# Advisory: LLM-nondeterministic; its result never gates the release.
+for name in ${ADVISORY_LANE[@]+"${ADVISORY_LANE[@]}"}; do
   run="$SMOKE_DIR/$name/run.sh"
   if [ ! -f "$run" ]; then
-    results+=("ADVISORY  $name/run.sh missing (does not gate)")
+    missing_harness "$name"
     continue
   fi
   printf '\n=== %s/run.sh (ADVISORY, non-gating) ===\n' "$name"
@@ -44,31 +59,41 @@ for name in "${ADVISORY_LANE[@]}"; do
   fi
 done
 
-# Blocking: deterministic structural release-gate harnesses (PASS/FAIL). A
-# missing one is a failure, not a skip: silently dropping a harness from the
-# gate is the same lost coverage as never wiring it in.
-for name in "${BLOCKING_LANE[@]}"; do
+# Blocking: deterministic structural release-gate harnesses (PASS/FAIL).
+for name in ${BLOCKING_LANE[@]+"${BLOCKING_LANE[@]}"}; do
   run="$SMOKE_DIR/$name/run.sh"
   if [ ! -f "$run" ]; then
-    results+=("FAIL      $name/run.sh missing")
-    overall=1
+    missing_harness "$name"
     continue
   fi
   printf '\n=== %s/run.sh ===\n' "$name"
-  if bash "$run"; then
-    results+=("PASS      $name/run.sh")
-  else
-    results+=("FAIL      $name/run.sh")
-    overall=1
-  fi
+  rc=0
+  bash "$run" || rc=$?
+  case "$rc" in
+    0)
+      results+=("PASS      $name/run.sh")
+      ;;
+    2)
+      # Harness pre-flight contract: exit 2 is a missing prerequisite (no
+      # node_modules/.bin/tsx, say), not a failed assertion. It still gates,
+      # since an unverified harness cannot clear a release, but a maintainer who
+      # skipped `pnpm install` should not read it as "telemetry is broken".
+      results+=("FAIL      $name/run.sh prerequisite missing (exit 2; run pnpm install)")
+      overall=1
+      ;;
+    *)
+      results+=("FAIL      $name/run.sh")
+      overall=1
+      ;;
+  esac
 done
 
-# Unclaimed-harness check: every harness in the tree must be assigned to a lane.
+# Every harness in the tree must be named by a lane above.
 shopt -s nullglob
 for run in "$SMOKE_DIR"/*/run.sh; do
   name="$(basename "$(dirname "$run")")"
   claimed=0
-  for known in "${ADVISORY_LANE[@]}" "${BLOCKING_LANE[@]}"; do
+  for known in ${ADVISORY_LANE[@]+"${ADVISORY_LANE[@]}"} ${BLOCKING_LANE[@]+"${BLOCKING_LANE[@]}"}; do
     if [ "$name" = "$known" ]; then
       claimed=1
       break
@@ -82,7 +107,7 @@ done
 shopt -u nullglob
 
 printf '\n=== Summary ===\n'
-for r in "${results[@]}"; do
+for r in ${results[@]+"${results[@]}"}; do
   printf '%s\n' "$r"
 done
 

--- a/.gaia/tests/smoke/run-all.sh
+++ b/.gaia/tests/smoke/run-all.sh
@@ -35,9 +35,19 @@ overall=0
 # Arrays are expanded with the offset-guard `${arr[@]+"${arr[@]}"}` throughout:
 # on bash 3.2.57 (stock macOS /bin/bash) a bare "${arr[@]}" of an EMPTY array
 # aborts under `set -u`. Neither lane is empty today, but emptying one (deleting
-# the sole advisory harness, say) must not turn this driver into an exit-127
-# abort that never reaches the blocking lane. See .claude/rules/ and
+# the sole advisory harness, say) must not abort this driver before it reaches
+# the blocking lane. That abort exits 1, indistinguishable from a harness that
+# ran and failed, and bash 4.4+ does not reproduce it, so it would read as a
+# real failure on macOS and pass clean on Linux CI. See
 # .gaia/scripts/lint-hook-array-guard.sh for the class.
+
+# A release gate with nothing in it is not a pass. Emptying the blocking lane
+# while the harnesses are also deleted would otherwise print an empty summary
+# and exit 0, verifying nothing.
+if [ "${#BLOCKING_LANE[@]}" -eq 0 ]; then
+  printf 'FAIL: BLOCKING_LANE is empty; this driver would gate on nothing.\n' >&2
+  exit 1
+fi
 
 missing_harness() {
   results+=("FAIL      $1/run.sh named by a lane but missing from the tree")
@@ -74,10 +84,12 @@ for name in ${BLOCKING_LANE[@]+"${BLOCKING_LANE[@]}"}; do
       results+=("PASS      $name/run.sh")
       ;;
     2)
-      # Harness pre-flight contract: exit 2 is a missing prerequisite (no
-      # node_modules/.bin/tsx, say), not a failed assertion. It still gates,
-      # since an unverified harness cannot clear a release, but a maintainer who
-      # skipped `pnpm install` should not read it as "telemetry is broken".
+      # The driver honors exit 2 as "missing prerequisite" rather than a failed
+      # assertion, so a maintainer who skipped `pnpm install` does not read it
+      # as "the feature is broken". telemetry-v1 is the harness implementing
+      # that convention today (no node_modules/.bin/tsx, no built .gaia/cli/gaia);
+      # the others exit 1 on their own pre-flight and land in the branch below.
+      # Either way it gates: an unverified harness cannot clear a release.
       results+=("FAIL      $name/run.sh prerequisite missing (exit 2; run pnpm install)")
       overall=1
       ;;

--- a/.gaia/tests/smoke/run-all.sh
+++ b/.gaia/tests/smoke/run-all.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 # Run the release-gate smoke harnesses, report pass/fail.
 #
-# Blocking lane (gates the release; sets the exit code): wiki-promote/run.sh and
-# uat-write/run.sh. Both are deterministic structural harnesses with PASS/FAIL
-# semantics, so they belong in the gate.
+# Blocking lane (gates the release; sets the exit code): wiki-promote/run.sh,
+# uat-write/run.sh, and telemetry-v1/run.sh. All three are deterministic
+# structural harnesses with PASS/FAIL semantics, so they belong in the gate.
 #
 # Advisory lane (does NOT gate): wiki-sync/run.sh drives real `claude -p`
 # sessions whose assertions ride on free-form LLM output, so they are inherently
 # non-deterministic and cannot block a release on a coin-flip. It runs here for
 # visibility and retries each scenario to absorb one-off variance, but its
 # result never sets this driver's exit code. See wiki-sync/README.md.
+#
+# Every harness under smoke/ belongs to exactly one lane, and the lane lists
+# below are the whole of it. The unclaimed-harness check at the bottom fails the
+# run when a smoke/<feature>/run.sh exists that neither lane names: a harness no
+# lane runs guards nothing while still looking like coverage.
 #
 # The observability/serena/ subtree (relocated from .gaia/tests/smoke/serena/
 # per SPEC-005 §Resolutions Q8) is intentionally NOT run from here
@@ -18,43 +23,63 @@ set -u
 
 SMOKE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+ADVISORY_LANE=(wiki-sync)
+BLOCKING_LANE=(wiki-promote uat-write telemetry-v1)
+
 results=()
 overall=0
 
-# Advisory: wiki-sync E2E (LLM-nondeterministic; never gates the release).
-WIKI_SYNC_RUN="$SMOKE_DIR/wiki-sync/run.sh"
-if [ -f "$WIKI_SYNC_RUN" ]; then
-  printf '\n=== wiki-sync/run.sh (ADVISORY, non-gating) ===\n'
-  if bash "$WIKI_SYNC_RUN"; then
-    results+=("PASS      wiki-sync/run.sh (advisory)")
-  else
-    results+=("ADVISORY  wiki-sync/run.sh failed after retries (does not gate)")
+# Advisory: LLM-nondeterministic; runs for visibility, never gates the release.
+for name in "${ADVISORY_LANE[@]}"; do
+  run="$SMOKE_DIR/$name/run.sh"
+  if [ ! -f "$run" ]; then
+    results+=("ADVISORY  $name/run.sh missing (does not gate)")
+    continue
   fi
-fi
-
-# Blocking: deterministic structural release-gate harness (PASS/FAIL).
-WIKI_PROMOTE_RUN="$SMOKE_DIR/wiki-promote/run.sh"
-if [ -x "$WIKI_PROMOTE_RUN" ]; then
-  printf '\n=== wiki-promote/run.sh ===\n'
-  if bash "$WIKI_PROMOTE_RUN"; then
-    results+=("PASS      wiki-promote/run.sh")
+  printf '\n=== %s/run.sh (ADVISORY, non-gating) ===\n' "$name"
+  if bash "$run"; then
+    results+=("PASS      $name/run.sh (advisory)")
   else
-    results+=("FAIL      wiki-promote/run.sh")
+    results+=("ADVISORY  $name/run.sh failed after retries (does not gate)")
+  fi
+done
+
+# Blocking: deterministic structural release-gate harnesses (PASS/FAIL). A
+# missing one is a failure, not a skip: silently dropping a harness from the
+# gate is the same lost coverage as never wiring it in.
+for name in "${BLOCKING_LANE[@]}"; do
+  run="$SMOKE_DIR/$name/run.sh"
+  if [ ! -f "$run" ]; then
+    results+=("FAIL      $name/run.sh missing")
+    overall=1
+    continue
+  fi
+  printf '\n=== %s/run.sh ===\n' "$name"
+  if bash "$run"; then
+    results+=("PASS      $name/run.sh")
+  else
+    results+=("FAIL      $name/run.sh")
     overall=1
   fi
-fi
+done
 
-# Blocking: uat-write structural smoke (matches wiki-promote shape).
-UAT_WRITE_RUN="$SMOKE_DIR/uat-write/run.sh"
-if [ -x "$UAT_WRITE_RUN" ]; then
-  printf '\n=== uat-write/run.sh ===\n'
-  if bash "$UAT_WRITE_RUN"; then
-    results+=("PASS      uat-write/run.sh")
-  else
-    results+=("FAIL      uat-write/run.sh")
+# Unclaimed-harness check: every harness in the tree must be assigned to a lane.
+shopt -s nullglob
+for run in "$SMOKE_DIR"/*/run.sh; do
+  name="$(basename "$(dirname "$run")")"
+  claimed=0
+  for known in "${ADVISORY_LANE[@]}" "${BLOCKING_LANE[@]}"; do
+    if [ "$name" = "$known" ]; then
+      claimed=1
+      break
+    fi
+  done
+  if [ "$claimed" -eq 0 ]; then
+    results+=("FAIL      $name/run.sh runs in no lane; add it to run-all.sh")
     overall=1
   fi
-fi
+done
+shopt -u nullglob
 
 printf '\n=== Summary ===\n'
 for r in "${results[@]}"; do


### PR DESCRIPTION
## What

The `telemetry-v1` smoke harness was written, executable, and passing (28/28 checks), but **no lane in `.gaia/tests/smoke/run-all.sh` named it**, so it never ran in the pre-release sweep. A telemetry regression could ship undetected.

Two changes:

1. **Wire `telemetry-v1` into the blocking lane.** It is a deterministic structural harness with PASS/FAIL semantics and no billable `claude -p` sessions, which is exactly the blocking-lane shape (same as `wiki-promote` and `uat-write`).
2. **Close the defect class, not just the instance.** The driver now declares its two lane lists explicitly and fails the run when a `smoke/<feature>/run.sh` exists that neither lane names, or when a lane names a harness missing from the tree. A harness no lane runs guards nothing while still reading as coverage, so the next one cannot be written and silently forgotten.

## Verification

The full driver was not used as the verification loop: its advisory lane spawns billable Sonnet sessions (~$0.10 each, up to 2 attempts x 5 scenarios). Instead:

- `bash .gaia/tests/smoke/telemetry-v1/run.sh` from the main checkout: **PASS (28/28 checks)**, so promoting it to the blocking lane does not red the gate.
- Lane semantics driven against stub harnesses in a scratch copy of the real driver:

| Scenario | Expected | Result |
|---|---|---|
| All harnesses green | exit 0 | exit 0, `telemetry-v1` runs |
| `telemetry-v1` fails | exit 1 (gates) | exit 1 |
| `wiki-sync` fails | exit 0 (advisory) | exit 0 |
| Unwired harness in tree | exit 1 | exit 1, `runs in no lane` |
| Blocking harness missing | exit 1 | exit 1, `missing` |

- `shellcheck` clean; `bash -n` clean.

Quality Gate skips by its own rule: the diff is one `.sh` and one `.md`, no `.ts/.tsx/.js/.css` or gate-affecting config. No CHANGELOG entry: `.gaia/tests/` is release-excluded maintainer-only infrastructure, so nothing here is adopter-visible.

## Deferred half, tracked

#645's suggested fix had a second half: track the roughly dozen bundled subcommands with no distribution coverage. That is a much larger piece of work (each scenario pays for a staging-tarball build), so it is filed as #672 rather than scope-stretched into this PR.

Closes #645
