### PR TITLE
fix(audit): pin the guard's read-failure door directly, not just at the callers

### DIFF
--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -1149,7 +1149,7 @@ run_comment_step() {
 }
 
 @test "guard: an unresolvable repo slug is unanswerable (exit 2), never 'no success live'" {
-  # The FOURTH and last "could not ask" door. With $GITHUB_REPOSITORY unset the
+  # The THIRD "could not ask" door. With $GITHUB_REPOSITORY unset the
   # guard falls back to `gh repo view` to name the repo; when that yields nothing
   # it has no repo to query and cannot ask. Unset, not empty-string: the script
   # reads `${GITHUB_REPOSITORY:-}`, so an empty value takes the same branch, but
@@ -1162,6 +1162,15 @@ run_comment_step() {
   # guard -- a hook, a local script, the by-hand debugging its own header invites
   # -- which is exactly the future the other pins were written for.
   run env -u GITHUB_REPOSITORY PATH="$GH_BIN:$PATH" bash "$PRESENT" "deadbeef" "cafe"
+  [ "$status" -eq 2 ]
+}
+
+@test "guard: an unreadable status is unanswerable (exit 2), never 'no success live'" {
+  # The FOURTH door, and the one exit 2 exists for: the status read itself fails
+  # (auth blip, rate limit, network). $GITHUB_REPOSITORY is set so this exercises
+  # the read failure in isolation, never the unresolved-slug door pinned above.
+  status_read_fails
+  run env GITHUB_REPOSITORY="gaia-react/gaia" PATH="$GH_BIN:$PATH" bash "$PRESENT" "deadbeef" "cafe"
   [ "$status" -eq 2 ]
 }
 


### PR DESCRIPTION
## Summary
`audit-success-present.sh` has four "could not ask" doors, each meant to `exit 2` and never `exit 1`. Three are pinned by a direct case that runs the guard and asserts its exit code; the read-failure door was only exercised indirectly through caller-level "stands down" tests, which pin the caller's behavior but not the guard's own contract in kind. A refactor that stubs those callers instead of running the guard for real would silently orphan the pin.

Adds the missing direct case (`guard: an unreadable status is unanswerable (exit 2), never 'no success live'`), matching the pattern of its three siblings. Also corrects a stale "FOURTH and last" comment on the neighboring repo-slug test, since it's no longer the last door pinned.

## Test plan
- [x] Full suite green: `bats .github/audit/tests/ci-status-member-gate.bats` (50/50 passing)
- [x] Verified the new test actually catches the regression: temporarily collapsed the guard's read-failure `exit 2` to `exit 1`, confirmed the new test (and only that test) failed, then restored the original script

Closes #746