### PR TITLE
fix(audit): detect and retry a silently no-op'd top-level Code Audit Team dispatch

### DIFF
--- a/.gaia/scripts/audit-noop-detect.sh
+++ b/.gaia/scripts/audit-noop-detect.sh
@@ -14,7 +14,7 @@
 # invariant).
 #
 # Usage:
-#   audit-noop-detect.sh --shape <SHAPE> --path <PATH> [--audit-md <AUDIT_MD_PATH>]
+#   audit-noop-detect.sh --shape <SHAPE> --path <PATH> [--audit-md <AUDIT_MD_PATH>] [--marker <MARKER_PATH>]
 #
 #   --shape       one of the caller shape ids below (FC-2).
 #   --path        file-backed shape: the expected output file, which the
@@ -26,6 +26,13 @@
 #                 passed, that AUDIT.md path must also exist for a REAL
 #                 classification (the 7c-with-directives dispatch). Ignored
 #                 for every other shape.
+#   --marker      optional; honored ONLY for --shape audit-team-member. When
+#                 the file at this path exists, classification short-circuits
+#                 to REAL without inspecting --path: the dispatched member
+#                 already wrote its clearance marker (a clean pass, or an
+#                 advisory member's non-Critical dirty pass), which is proof
+#                 enough of a real dispatch on its own. Ignored for every
+#                 other shape.
 #
 # Caller shapes (FC-2), REAL iff:
 #   spec-selfreview-file  file exists AND `jq -e .` parses AND (top-level is
@@ -51,6 +58,21 @@
 #                         no-op.
 #   cra-refuter           content contains a standalone verdict token
 #                         REFUTED, DOWNGRADE, or STANDS
+#   audit-team-member     --marker path exists (a clean or non-blocking-dirty
+#                         pass already wrote its clearance marker), OR the
+#                         captured return in --path carries a backticked
+#                         `` `<path>:<line>` `` finding-location token (any
+#                         Code Audit Team member's shared Output Format
+#                         template bolds every reported finding's Location
+#                         field this way, blocking or not), OR the return
+#                         carries code-audit-frontend's terse LOCAL
+#                         return-contract preamble, the literal string
+#                         "Remaining in-scope:". Covers every real outcome a
+#                         top-level member can return: clean, advisory-dirty,
+#                         blocking-dirty full report, and blocking-dirty terse
+#                         ledger-pointer. A bare harness-reminder / output-
+#                         style echo carries none of the three and classifies
+#                         NO-OP.
 #
 # Exit code IS the boolean: 0 = REAL (not a no-op), 1 = NO-OP, 2 = usage
 # error (unknown --shape, missing --shape/--path). Also prints `real` or
@@ -75,14 +97,15 @@ set -uo pipefail
 
 usage() {
   cat <<'EOF' >&2
-usage: audit-noop-detect.sh --shape <SHAPE> --path <PATH> [--audit-md <AUDIT_MD_PATH>]
+usage: audit-noop-detect.sh --shape <SHAPE> --path <PATH> [--audit-md <AUDIT_MD_PATH>] [--marker <MARKER_PATH>]
 
   --shape  one of: spec-selfreview-file, spec-findings-file,
            spec-verdict-file, applier-summary, plan-findings,
-           cra-specialist, cra-refuter
+           cra-specialist, cra-refuter, audit-team-member
   --path   file-backed shape: expected output file.
            return-conformance shape: captured-return temp file.
   --audit-md  optional; honored only for --shape applier-summary.
+  --marker    optional; honored only for --shape audit-team-member.
 
 exit 0 = real, 1 = noop, 2 = usage error.
 EOF
@@ -104,6 +127,7 @@ noop() {
 SHAPE=""
 TARGET_PATH=""
 AUDIT_MD=""
+MARKER_PATH=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -117,6 +141,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --audit-md)
       AUDIT_MD="${2:-}"
+      shift 2 2>/dev/null || shift
+      ;;
+    --marker)
+      MARKER_PATH="${2:-}"
       shift 2 2>/dev/null || shift
       ;;
     *)
@@ -134,7 +162,7 @@ if [ -z "$SHAPE" ] || [ -z "$TARGET_PATH" ]; then
 fi
 
 case "$SHAPE" in
-  spec-selfreview-file|spec-findings-file|spec-verdict-file|applier-summary|plan-findings|cra-specialist|cra-refuter)
+  spec-selfreview-file|spec-findings-file|spec-verdict-file|applier-summary|plan-findings|cra-specialist|cra-refuter|audit-team-member)
     ;;
   *)
     echo "audit-noop-detect: unknown --shape '$SHAPE'" >&2
@@ -223,6 +251,27 @@ case "$SHAPE" in
     [ -f "$TARGET_PATH" ] || noop
     content="$(cat "$TARGET_PATH" 2>/dev/null)"
     if printf '%s' "$content" | grep -Eq '\b(REFUTED|DOWNGRADE|STANDS)\b'; then
+      real
+    else
+      noop
+    fi
+    ;;
+
+  audit-team-member)
+    # The marker is conditional (withheld on a blocking finding), unlike the
+    # file-backed shapes above whose file always writes on any real
+    # completion, so its absence alone cannot mean no-op. Check it first as a
+    # same-cost short-circuit; fall through to content inspection either way
+    # it does not conclusively rule NO-OP on its own.
+    if [ -n "$MARKER_PATH" ] && [ -f "$MARKER_PATH" ]; then
+      real
+    fi
+    [ -f "$TARGET_PATH" ] || noop
+    content="$(cat "$TARGET_PATH" 2>/dev/null)"
+    # shellcheck disable=SC2016
+    if printf '%s' "$content" | grep -Eq '`[^`]+:[0-9]+`'; then
+      real
+    elif printf '%s' "$content" | grep -Fq 'Remaining in-scope:'; then
       real
     else
       noop

--- a/.gaia/scripts/audit-noop-detect.sh
+++ b/.gaia/scripts/audit-noop-detect.sh
@@ -268,10 +268,17 @@ case "$SHAPE" in
     fi
     [ -f "$TARGET_PATH" ] || noop
     content="$(cat "$TARGET_PATH" 2>/dev/null)"
+    # Here-string, not a `printf | grep -q` pipe: under `pipefail`, grep -q's
+    # early exit on a large early match SIGPIPEs the upstream writer, and the
+    # pipeline's exit code collapses to that SIGPIPE, not grep's match. A
+    # full audit report comfortably exceeds the pipe buffer, so this is the
+    # same hazard #748 removed from the success-present guard, not a
+    # theoretical one. shellcheck disable=SC2016 (literal backticks, not a
+    # command substitution).
     # shellcheck disable=SC2016
-    if printf '%s' "$content" | grep -Eq '`[^`]+:[0-9]+`'; then
+    if grep -Eq '`[^`]+:[0-9]+`' <<<"$content"; then
       real
-    elif printf '%s' "$content" | grep -Fq 'Remaining in-scope:'; then
+    elif grep -Fq 'Remaining in-scope:' <<<"$content"; then
       real
     else
       noop

--- a/.gaia/scripts/tests/audit-noop-detect.bats
+++ b/.gaia/scripts/tests/audit-noop-detect.bats
@@ -259,6 +259,60 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
+# audit-team-member (return-conformance, optional --marker companion check)
+# ---------------------------------------------------------------------------
+
+@test "audit-team-member: --marker path exists is REAL regardless of --path content" {
+  marker="$BATS_TEST_TMPDIR/marker.ok"
+  : > "$marker"
+  run "$SCRIPT" --shape audit-team-member --path "$FIX/shared/reminder-echo.txt" --marker "$marker"
+  [ "$status" -eq 0 ]
+  [ "$output" = "real" ]
+}
+
+@test "audit-team-member: no marker, backticked Location finding is REAL" {
+  run "$SCRIPT" --shape audit-team-member --path "$FIX/audit-team-member/finding-block.txt" --marker "$BATS_TEST_TMPDIR/does-not-exist.ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "real" ]
+}
+
+@test "audit-team-member: no marker, terse LOCAL return-contract preamble is REAL" {
+  run "$SCRIPT" --shape audit-team-member --path "$FIX/audit-team-member/terse-return.txt" --marker "$BATS_TEST_TMPDIR/does-not-exist.ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "real" ]
+}
+
+@test "audit-team-member: no marker, harness-reminder-echo return is NO-OP" {
+  run "$SCRIPT" --shape audit-team-member --path "$FIX/shared/reminder-echo.txt"
+  [ "$status" -eq 1 ]
+  [ "$output" = "noop" ]
+}
+
+@test "audit-team-member: no marker, absent --path is NO-OP" {
+  run "$SCRIPT" --shape audit-team-member --path "$BATS_TEST_TMPDIR/does-not-exist.txt" --marker "$BATS_TEST_TMPDIR/also-does-not-exist.ok"
+  [ "$status" -eq 1 ]
+  [ "$output" = "noop" ]
+}
+
+@test "audit-team-member: large (>64KB) blocking-dirty report with an early Location token is still REAL, not a pipefail/SIGPIPE misclassification" {
+  large="$BATS_TEST_TMPDIR/large-finding.txt"
+  {
+    printf '### Critical Issues (Must Fix)\n'
+    printf -- '- **Location**: `app/foo.ts:42`\n'
+    printf -- '- **Issue**: a real finding near the front of a large report.\n'
+    # Pad well past a pipe buffer (64KB) so a `printf | grep -q` pipe would
+    # SIGPIPE the writer under `pipefail` before the file is fully consumed.
+    for _ in $(seq 1 1000); do
+      printf '%s\n' "padding padding padding padding padding padding padding padding padding padding"
+    done
+  } > "$large"
+  [ "$(wc -c < "$large" | tr -d ' ')" -gt 65536 ]
+  run "$SCRIPT" --shape audit-team-member --path "$large" --marker "$BATS_TEST_TMPDIR/does-not-exist.ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "real" ]
+}
+
+# ---------------------------------------------------------------------------
 # Cross-cutting: exit-code-is-the-boolean contract, purity
 # ---------------------------------------------------------------------------
 

--- a/.gaia/scripts/tests/fixtures/audit-noop/audit-team-member/finding-block.txt
+++ b/.gaia/scripts/tests/fixtures/audit-noop/audit-team-member/finding-block.txt
@@ -1,0 +1,5 @@
+### Critical Issues (Must Fix)
+
+- **Location**: `app/foo.ts:42`
+- **Issue**: a real finding, not a no-op.
+- **Fix**: do the thing.

--- a/.gaia/scripts/tests/fixtures/audit-noop/audit-team-member/terse-return.txt
+++ b/.gaia/scripts/tests/fixtures/audit-noop/audit-team-member/terse-return.txt
@@ -1,0 +1,5 @@
+Audit round 2 for base abc1234 -> HEAD def5678.
+Remaining in-scope: 1 Critical, 0 Important, 0 Suggestion (0 escalated).
+Fixed this round: 2.
+Out-of-scope dispositions: 0.
+Ledger: .gaia/local/audit/abc1234.rerun.json  (removed on a clean pass)

--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -103,6 +103,20 @@ The failure mode is only about wasted work. Dispatch all members at once and a m
 
 So when a self-heal is plausible (any diff `code-audit-frontend` owns, which is most in-scope diffs), **run `code-audit-frontend` first and alone, let the tree settle, then dispatch the remaining members in parallel against the settled tree.** When the frontend is not in the spawn set, or the diff is one it cannot self-heal (an instruction/convention surface such as `.claude/**`, `.specify/**`, or `wiki/**`, where it refuses by design), the plain parallel dispatch above applies with no sequencing.
 
+#### No-op detection and retry for each dispatched member
+
+A dispatched member can silently no-op: zero tool uses, a return that is just a harness-reminder-echo or output-style fragment instead of a real review. Nothing about the marker gate catches this on its own, fail-closed means no marker and no merge, but with no diagnosis of *why* the gate is stuck, just a stuck gate a human has to notice and investigate by hand. This mirrors, one layer up, the same deterministic classifier `code-audit-frontend` already runs on its own internal specialist and refuter fan-outs (`.claude/agents/code-audit-frontend.md`, "No-op detection and retry for each refuter").
+
+After each dispatched member's `Agent` call returns, write its returned text to a temp file and classify it:
+
+```bash
+bash .gaia/scripts/audit-noop-detect.sh --shape audit-team-member --path <tempfile> --marker <expected-marker-path>
+```
+
+`<expected-marker-path>` is `.gaia/local/audit/<tree-sha>.ok` for `code-audit-frontend`, `.gaia/local/audit/<tree-sha>.<member>.ok` for a specialized member, the same marker key each member's own gate handshake writes (see Signals below). Exit 0 = real, exit 1 = no-op. A dispatch that already wrote its marker, or whose return carries a backticked `` `path:line` `` finding location, or (for `code-audit-frontend`'s terse LOCAL return) the literal `Remaining in-scope:` preamble, is real; a return matching none of those, most often a bare harness-reminder / available-agent-types echo, is a no-op.
+
+On a no-op, re-dispatch that member **exactly one** time with the hardened retry prefix (`.claude/agents/code-audit-frontend.md`, "No-op detection and retry for each refuter"), substituting the concrete target with the member's original changed-file list. A second consecutive no-op does not re-dispatch a third time: stop and surface to the operator which member no-op'd twice, rather than looping or silently proceeding to a merge attempt. The marker gate stays fail-closed either way, no marker still means no merge, but a surfaced double no-op tells the operator why the gate is stuck instead of leaving them to notice an odd reply on their own.
+
 ### 2. Fix all issues
 
 The local fix loop reads the re-run carry-forward ledger (`.gaia/local/audit/<BASE_SHA>.rerun.json`) for a deterministic, lossless briefing rather than a main-thread-authored prompt summary: the fixer reads `remaining[]` for what to fix and `fixed_last_round[]` for what the previous round already cleared, and the next re-audit reads the same ledger. The filename keys on the incremental base, which is stable across fix rounds, so the path does not change as HEAD moves. Fail-open: when the ledger is absent, corrupt, or stale (a different branch or base), the loop falls back to the full report in the audit's return, which the agent emits whenever it could not write the ledger.


### PR DESCRIPTION
## Summary

- The internal specialist/refuter fan-outs inside `code-audit-frontend` already classify a no-op return (zero tool uses, a harness-reminder echo) via `audit-noop-detect.sh` and run a hardened retry before falling back inline. The top-level dispatch a session makes directly per `PR Merge Workflow.md`'s "Spawn the dispatched Code Audit Team members" step (also followed by `/gaia-debt`) had no equivalent: a silent no-op there relied entirely on a human noticing an odd reply, as happened once in practice.
- Adds a new `audit-team-member` shape to `audit-noop-detect.sh`: real iff the member's clearance marker exists, or its returned text carries a backticked `` `path:line` `` finding location, or (for `code-audit-frontend`'s terse LOCAL return contract) the literal `Remaining in-scope:` preamble. Covers every legitimate return shape (clean, advisory-dirty, blocking-dirty full report, blocking-dirty terse ledger-pointer) without misclassifying a real-but-marker-withheld result as a no-op.
- Documents the classify → one hardened retry → surface-on-second-no-op flow in `wiki/concepts/PR Merge Workflow.md`'s spawn step, mirroring the existing internal pattern. The marker gate stays fail-closed either way; the fix only makes a stuck gate legible instead of silent.

## Test plan

- [x] `shellcheck .gaia/scripts/audit-noop-detect.sh` clean
- [x] Manual smoke test of the new shape's branches: marker-exists, no-marker/no-signal, no-marker/backtick-finding, no-marker/terse-preamble, no-`--marker`-flag — all classify as expected
- [x] Regression check: existing shapes (`spec-findings-file`, `cra-refuter`) unaffected
- [x] Quality Gate skipped per `wiki/decisions/Quality Gate.md` (no staged `.ts|tsx|js|jsx|mjs|cjs|css` or gate-affecting config; changed files are `.gaia/scripts/*.sh` and `wiki/**`)

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)