### PR TITLE
test(hooks): silence shellcheck SC2016/SC2317 false positives in block-env-read.bats

### DIFF
--- a/.gaia/tests/hooks/block-env-read.bats
+++ b/.gaia/tests/hooks/block-env-read.bats
@@ -12,6 +12,14 @@
 # guard is heuristic defense-in-depth, not a sandbox: it always exits 0,
 # carrying the allow/deny decision in stdout JSON.
 
+# shellcheck disable=SC2317
+# SC2317 (command appears unreachable) is a structural false positive on every
+# @test block below: bats invokes each test body through its own runner, which
+# static shellcheck cannot see, so it marks the blocks unreachable. The directive
+# is file-wide because the false positive is intrinsic to the bats structure, not
+# to any single test, and it masks no genuine signal: SC2317 cannot reason about
+# an indirectly-invoked bats suite at all.
+
 setup() {
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-env-read.sh"
@@ -110,6 +118,10 @@ assert_allowed() {
 }
 
 @test "x=\$(<.env) is denied" {
+  # The single-quoting is deliberate: the payload must reach the hook verbatim
+  # so it classifies the literal command text. Never double-quote it, which
+  # would expand $(<.env) here and defeat the test.
+  # shellcheck disable=SC2016
   run_hook_bash 'x=$(<.env)'
   assert_denied
 }


### PR DESCRIPTION
## What

Silences two `info`-tier `shellcheck` advisories that `.gaia/tests/hooks/block-env-read.bats` re-triggers on every touch:

- **SC2016** on line 113 (`run_hook_bash 'x=$(<.env)'`) — the single-quoting is deliberate; the payload must reach the hook verbatim so the hook classifies the literal command text. A targeted inline `# shellcheck disable=SC2016` documents the intent at the site; a file-wide disable would mask a genuine SC2016 elsewhere.
- **SC2317** (command appears unreachable) on every `@test` block — a structural false positive: `bats` invokes each test body through its own runner, which static `shellcheck` cannot see. A single file-wide `# shellcheck disable=SC2317` directive covers all current and future test blocks; the code carries no genuine signal in an indirectly-invoked bats suite.

## Why

Both advisories are non-blocking (the `shell-lint.sh` gate has a `warning` floor and lints `*.sh` only), but the `code-audit-maintainer-shell` oracle and any manual `shellcheck` run re-report them on every review of this file, obscuring genuinely new findings and adding review friction.

## Verification

- `shellcheck .gaia/tests/hooks/block-env-read.bats` — clean (exit 0), no SC2016/SC2317.
- `bats .gaia/tests/hooks/block-env-read.bats` — 37/37 pass; the directives do not break bats parsing.

Quality Gate: skipped — the diff touches only a `.bats` file (no `.ts|tsx|js|jsx|mjs|cjs|css`, no gate-affecting config).

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)
