### PR TITLE
test(audit): pin the debt-key prefix-collision guard in disposition_offenders (#732)

### DIFF
--- a/.gaia/tests/hooks/audit-disposition-check.bats
+++ b/.gaia/tests/hooks/audit-disposition-check.bats
@@ -97,6 +97,22 @@ write_sidecar() { printf '%s\n' "$1" > "$SIDECAR"; }
   [ -z "$output" ]
 }
 
+@test "offenders: a filed line=4 key is NOT satisfied by a sibling line=42 issue (the -->boundary guard)" {
+  install_gh_mock ok '[{"number":9,"body":"title\n\n<!-- gaia-debt-key: v1 class=y path=b line=42 -->"}]'
+  write_sidecar '{"schema":1,"backend":"github","findings":[{"key":"v1 class=y path=b line=4","disposition":"filed"}]}'
+  run disposition_offenders "$SIDECAR"
+  [ "$status" -eq 0 ]
+  grep -q "filed-but-missing: v1 class=y path=b line=4" <<<"$output" || return 1
+}
+
+@test "offenders: a filed line=4 key IS satisfied by an exact line=4 issue" {
+  install_gh_mock ok '[{"number":9,"body":"title\n\n<!-- gaia-debt-key: v1 class=y path=b line=4 -->"}]'
+  write_sidecar '{"schema":1,"backend":"github","findings":[{"key":"v1 class=y path=b line=4","disposition":"filed"}]}'
+  run disposition_offenders "$SIDECAR"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 # ---------------------------------------------------------------------------
 # disposition_offenders: fail-open everywhere else
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #732

The disposition backstop (`audit-disposition-check.sh` / `audit-dispositions.sh`) already gained a 26-test suite under SPEC-044 (#800) covering both deny conditions and every fail-open branch. The one behavior #732 flags as "subtly load-bearing... nothing pins that behavior" — the ` -->` boundary in the reconstructed debt-key needle that stops a `line=4` key digit-prefix-matching a sibling `line=42 -->` issue — was still unpinned.

Adds two focused lib-level tests to `.gaia/tests/hooks/audit-disposition-check.bats`:
- a `line=4` filed key is NOT satisfied by a sibling `line=42` issue (offender flagged) — fails if the ` -->` guard regresses;
- a `line=4` filed key IS satisfied by an exact `line=4` issue (no over-rejection).

Test-only, in a release-excluded dir; no shipped-surface change. Full suite: 28/28 pass.