### PR TITLE
fix(scripts): reap orphaned coaching-active.txt in the mentorship sweep (#775)

### DIFF
--- a/.gaia/scripts/mentorship-cleanup-sweep.sh
+++ b/.gaia/scripts/mentorship-cleanup-sweep.sh
@@ -21,6 +21,10 @@
 #                                 symlink to it)
 #     telemetry/cloud/            the cloud projection event stream
 #     telemetry/analytics/        the analytics reports
+#     cache/shared/coaching-active.txt
+#                                 orphaned coaching marker: its former writer
+#                                 (wiki-session-start.sh) and reader
+#                                 (gaia-statusline.sh) are both gone
 #
 # Two things make the sweep unconditional rather than opt-in-gated. The memory
 # file instructs Claude to protect a subtree that does not exist and to reach for
@@ -161,6 +165,14 @@ fi
 # holds cost.jsonl and spec-pacing.jsonl, and both outlive this sweep.
 rm -rf -- "${main_root:?}/.gaia/local/telemetry/cloud" 2>/dev/null || true
 rm -rf -- "${main_root:?}/.gaia/local/telemetry/analytics" 2>/dev/null || true
+
+# .gaia/local/cache/shared/coaching-active.txt: orphaned residue. Its former
+# writer (wiki-session-start.sh) and reader (gaia-statusline.sh) are both gone,
+# so nothing else ever reaps it. cache/shared/ is symlinked in a linked
+# worktree back to this same main-checkout path (link-worktree.sh), which is
+# exactly why this targets $main_root rather than $repo_root, matching every
+# other real-file deletion in this sweep.
+rm -f -- "$main_root/.gaia/local/cache/shared/coaching-active.txt" 2>/dev/null || true
 
 # --- Sentinel --------------------------------------------------------------
 # Written last, and written even when nothing above matched, so a checkout that

--- a/.gaia/scripts/tests/mentorship-cleanup-sweep.bats
+++ b/.gaia/scripts/tests/mentorship-cleanup-sweep.bats
@@ -81,9 +81,9 @@ seed_inrepo_residue() {
   echo '{"report":1}' > "$MAIN/.gaia/local/telemetry/analytics/report.json"
 }
 
-# seed_survivors: the load-bearing state that shares telemetry/ with the streams
-# above and must outlive the sweep byte-for-byte, plus the stale coaching marker
-# in the symlinked shared cache the sweep is forbidden to reach into.
+# seed_survivors: the load-bearing state that shares telemetry/ with the
+# streams above and must outlive the sweep byte-for-byte, plus the orphaned
+# coaching marker in the symlinked shared cache, which the sweep now reaps.
 seed_survivors() {
   mkdir -p "$MAIN/.gaia/local/telemetry" "$MAIN/.gaia/local/cache/shared"
   echo '{"kind":"execute","total":11110}' > "$MAIN/.gaia/local/telemetry/cost.jsonl"
@@ -136,16 +136,15 @@ tree_digest() {
 
 # --- 2. The survivors sharing telemetry/ are untouched -----------------------
 
-@test "cost.jsonl, spec-pacing.jsonl, telemetry/ and coaching-active.txt all survive intact" {
+@test "cost.jsonl, spec-pacing.jsonl and telemetry/ survive intact; coaching-active.txt is reaped" {
   make_main
   seed_offrepo_residue
   seed_inrepo_residue
   seed_survivors
 
-  local cost pacing marker
+  local cost pacing
   cost="$(cksum < "$MAIN/.gaia/local/telemetry/cost.jsonl")"
   pacing="$(cksum < "$MAIN/.gaia/local/telemetry/spec-pacing.jsonl")"
-  marker="$(cksum < "$MAIN/.gaia/local/cache/shared/coaching-active.txt")"
 
   run run_sweep
   [ "$status" -eq 0 ]
@@ -156,8 +155,10 @@ tree_digest() {
 
   [ "$(cksum < "$MAIN/.gaia/local/telemetry/cost.jsonl")" = "$cost" ]
   [ "$(cksum < "$MAIN/.gaia/local/telemetry/spec-pacing.jsonl")" = "$pacing" ]
-  # Outside the enumerated set, and behind the worktree-symlinked shared cache.
-  [ "$(cksum < "$MAIN/.gaia/local/cache/shared/coaching-active.txt")" = "$marker" ]
+  # Orphaned residue: reaped now, unlike the load-bearing streams above. Final
+  # line of the test, so its own exit status is the test result; the `[ ! -e ]`
+  # form (not the earlier `&& return 1` pattern) is what actually fails here.
+  [ ! -e "$MAIN/.gaia/local/cache/shared/coaching-active.txt" ]
 }
 
 # --- 3. MEMORY.md is unlinked when the pointer was its only line -------------
@@ -198,9 +199,11 @@ tree_digest() {
   tree_digest | diff "$snapshot" -
 }
 
-# --- 5. A never-enabled checkout's run touches nothing but the sentinel ------
+# --- 5. A never-enabled checkout's run adds only the sentinel; the orphaned --
+#        coaching marker is reaped regardless, since it is unconditional like
+#        every other entry in the closed deletion set.
 
-@test "no residue at all: nothing changes but the sentinel, exit 0, silent" {
+@test "no residue at all: only the sentinel is added and the coaching marker is reaped, exit 0, silent" {
   make_main
   seed_survivors
 
@@ -213,9 +216,13 @@ tree_digest() {
   [ "$status" -eq 0 ]
   [ -z "$output" ]
   [ -f "$SENTINEL" ]
+  [ ! -e "$MAIN/.gaia/local/cache/shared/coaching-active.txt" ]
 
-  # The sentinel is the only path the sweep added, and it removed none.
-  printf '%s\n' "$SENTINEL" | cat "$before" - | sort > "$expected"
+  # The sentinel is the only path the sweep added; the orphaned coaching
+  # marker is the only one it removed, unconditionally like every other entry
+  # in the closed deletion set.
+  grep -vxF -- "$MAIN/.gaia/local/cache/shared/coaching-active.txt" "$before" \
+    | cat - <(printf '%s\n' "$SENTINEL") | sort > "$expected"
   file_list | diff "$expected" -
 }
 


### PR DESCRIPTION
## What

`.gaia/local/cache/shared/coaching-active.txt` is orphaned residue: its former writer (`wiki-session-start.sh`) and reader (`gaia-statusline.sh`) are both gone, and nothing else reaps it (the janitor's cache sweep is `-maxdepth 1` and never descends into `cache/shared/`). The mentorship sweep advertises reaping "the mentorship residue a checkout carries", so the file belongs in its closed literal deletion set.

## Change

- `mentorship-cleanup-sweep.sh`: add `coaching-active.txt` to the closed literal deletion set, targeting `$main_root` like every other real-file deletion (the file lives in the worktree-symlinked `cache/shared/`, so `$main_root` reaps the real file rather than following a symlink). Docstring enumeration updated to match.
- `mentorship-cleanup-sweep.bats` (release-excluded): flip the test that asserted the marker survives to assert it is reaped; update the never-enabled-checkout test whose `seed_survivors` seeds the now-reaped file.

Verify: `shellcheck` clean; `bats` 9/9 pass; RED→GREEN confirmed.

Closes #775