### PR TITLE
test(specify): assert every command file is registered in extension.yml (#651)

### DIFF
--- a/.specify/extensions/gaia/test/README.md
+++ b/.specify/extensions/gaia/test/README.md
@@ -4,6 +4,8 @@ Artifacts here are markdown UAT runbooks: maintainer-reading walk-throughs that 
 
 Artifacts that should NOT be here are runnable harnesses with `pass()`/`fail()`/exit-code reporting, those are release-gate harnesses and live at `.gaia/tests/smoke/<feature>/` instead. The classifying axis is shape, not origin.
 
+A structural-invariant assertion such as `registry.bats` is a distinct third category: a bats suite that guards a manifest/filesystem invariant rather than walking a SPEC's UATs or gating a release.
+
 ## Inventory
 
 - `smoke.md`: `/gaia-spec` lifecycle smoke runbook.

--- a/.specify/extensions/gaia/test/registry.bats
+++ b/.specify/extensions/gaia/test/registry.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+#
+# Structural manifest-integrity guard for the GAIA spec-kit extension
+# registry: asserts every commands/*.md file is registered under
+# extension.yml's provides.commands list, and every registered `file:`
+# value resolves to a real file on disk. Release-excluded (this dir does
+# not ship); a regression guard, not a feature smoke harness -- it exists
+# because commands/plan-close.md was once authored but left unregistered,
+# caught only by manual audit (issue #651).
+#
+# Assertion style note (`.claude/rules/bats-assertions.md`): assertions
+# use POSIX `[ ]` or an explicit `return 1`, never a bare mid-test `[[ ]]`,
+# so a broken assertion fails correctly even under macOS's bash 3.2.
+
+setup() {
+  EXT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  MANIFEST="$EXT_DIR/extension.yml"
+}
+
+# Echoes each `file:` value under provides.commands, one per line, e.g.
+# "commands/spec.md". Scoped to the provides: block (stops at hooks:) so a
+# future unrelated `file:` key elsewhere in the manifest can't leak in.
+# No yq on this machine -- extracted with awk/grep/sed instead.
+registered_files() {
+  awk '/^provides:/{p=1} /^hooks:/{p=0} p' "$MANIFEST" \
+    | grep -E '^[[:space:]]*file:[[:space:]]*"[^"]+"' \
+    | sed -E 's/^[[:space:]]*file:[[:space:]]*"([^"]+)".*/\1/'
+}
+
+@test "every commands/*.md file is registered in extension.yml's provides.commands" {
+  registered="$(registered_files)"
+  missing=""
+  for f in "$EXT_DIR"/commands/*.md; do
+    rel="commands/$(basename "$f")"
+    grep -qxF "$rel" <<<"$registered" || missing="$missing $rel"
+  done
+  if [ -n "$missing" ]; then
+    echo "unregistered command file(s):$missing" >&2
+    return 1
+  fi
+}
+
+@test "every extension.yml provides.commands file: value resolves to an existing file" {
+  registered="$(registered_files)"
+  missing=""
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    [ -f "$EXT_DIR/$rel" ] || missing="$missing $rel"
+  done <<<"$registered"
+  if [ -n "$missing" ]; then
+    echo "registered file(s) missing on disk:$missing" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
Closes #651

Adds a bats regression guard for the GAIA spec-kit extension registry. Two directions, both green on the current tree:

1. Every `.specify/extensions/gaia/commands/*.md` file is registered as a `file:` value under `provides.commands` in `extension.yml`.
2. Every registered `file:` value resolves to an existing file.

This guards the drift that let `commands/plan-close.md` ship unregistered (caught only by a manual audit, not any test).

## Notes
- The test lives in `.specify/extensions/gaia/test/` (release-excluded, does not ship), per the L4 campaign instruction that new tests go there.
- CI's `bats (.github/audit)` job does not currently scan `.specify/extensions/gaia/test/`, so this guard is locally runnable but not yet CI-wired. Wiring it (relocating to `.gaia/tests/lib/` and/or adding `.specify/extensions/gaia/commands/**` to the audit-ci-tests paths-filter) touches other lanes' scope and is flagged for follow-up, not done here.
- No CHANGELOG entry: internal maintainer machinery, adopter-invisible.