### PR TITLE
fix(release): unify release-exclude on literal-path semantics; make manifest --check reporting honest (#679, #680)

### DIFF
--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20689,6 +20689,7 @@ var REJECTED_PATH_CHARACTERS = [
   "$"
 ];
 var ASCII_WHITESPACE = /[\t\n\v\f\r ]/;
+var hasRejectedExcludeMetacharacter = (value) => REJECTED_PATH_CHARACTERS.some((character) => value.includes(character));
 var uniqueSorted = (paths) => {
   const unique = [...new Set(paths)];
   return unique.toSorted((a, b) => a.localeCompare(b));
@@ -20702,9 +20703,7 @@ var findDuplicates = (paths) => {
   }
   return uniqueSorted([...duplicates]);
 };
-var isRejectedWithholdPath = (withholdPath) => withholdPath.length === 0 || withholdPath.startsWith("#") || withholdPath.startsWith("/") || withholdPath.endsWith("/") || ASCII_WHITESPACE.test(withholdPath) || REJECTED_PATH_CHARACTERS.some(
-  (character) => withholdPath.includes(character)
-);
+var isRejectedWithholdPath = (withholdPath) => withholdPath.length === 0 || withholdPath.startsWith("#") || withholdPath.startsWith("/") || withholdPath.endsWith("/") || ASCII_WHITESPACE.test(withholdPath) || hasRejectedExcludeMetacharacter(withholdPath);
 var isRejectedReason = (reason) => reason.trim().length === 0 || reason.includes("\n") || reason.includes("\r");
 var parseCategoryLines = (lines) => lines.flatMap((line, headerLineIndex) => {
   const match = CATEGORY_HEADER.exec(line);
@@ -20901,12 +20900,24 @@ var WIKI_OWNED_PREFIXES = [
   "wiki/sources/"
 ];
 var WIKI_OWNED_EXACT = /* @__PURE__ */ new Set(["wiki/overview.md", "wiki/README.md"]);
-var escapeRegExp = (pattern) => pattern.replaceAll(".", String.raw`\.`).replaceAll("+", String.raw`\+`).replaceAll("?", String.raw`\?`).replaceAll("*", "[^/]*");
+var escapeRegExp = (pattern) => pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 var parseExcludeLines = (text) => text.split("\n").flatMap((line) => {
   const trimmed = line.trim();
   if (trimmed.length === 0 || trimmed.startsWith("#")) return [];
   return [trimmed];
 });
+var validateExcludeText = (text) => {
+  const offenders = text.split("\n").filter((line) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) return false;
+    return line !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
+  });
+  if (offenders.length > 0) {
+    throw new Error(
+      `.gaia/release-exclude entries must be literal paths (no glob/regex metacharacters, no indentation); offending line(s): ${offenders.map((line) => JSON.stringify(line)).join(", ")}`
+    );
+  }
+};
 var parseExcludePatterns = (text) => parseExcludeLines(text).map(
   (line) => new RegExp(`^${escapeRegExp(line)}(/|$)`)
 );
@@ -20947,6 +20958,7 @@ var buildManifest = (cwd, options = {}) => {
   const versionPath = path16.resolve(repoRoot, ".gaia/VERSION");
   const version2 = readFileSync14(versionPath, "utf8").trim();
   const excludeText = options.excludeText ?? readFileSync14(resolveExcludePath(repoRoot), "utf8");
+  validateExcludeText(excludeText);
   const excludePatterns = parseExcludePatterns(excludeText);
   const isExcluded = (candidate) => excludePatterns.some((pattern) => pattern.test(candidate));
   const tracked = listGitFiles(repoRoot);
@@ -21071,10 +21083,14 @@ var renderVersionDriftLines = (result) => result.versionDrift === void 0 ? [] : 
 ];
 var renderMissingLines = (result) => result.missing.length === 0 ? [] : [
   "",
-  `missing from manifest (${result.missing.length}):`,
+  `will newly ship to adopters with no explicit answer (${result.missing.length}):`,
   ...result.missing.map(
     (entry) => `  + ${entry.file}  [${entry.expected}]`
-  )
+  ),
+  "",
+  "Regenerating the manifest does not withhold these files; each one needs an explicit decision:",
+  "  release manifest --ship <path>       accept that it ships",
+  "  release manifest --withhold <path> --category <N> --reason <text>   keep it maintainer-only"
 ];
 var renderExtraLines = (result) => result.extra.length === 0 ? [] : [
   "",
@@ -21107,7 +21123,7 @@ var renderCheckReport = (result, jsonMode) => {
 `;
   const total = result.missing.length + result.extra.length + result.drift.length + result.classifierOverlaps.length + result.scanScopeGaps.length + (result.versionDrift === void 0 ? 0 : 1);
   if (total === 0) {
-    return "release manifest --check: clean (manifest fresh, classifier sets coherent)\n";
+    return "release manifest --check: clean (manifest matches classifier + .gaia/VERSION; this checks bookkeeping, not the distribution boundary)\n";
   }
   const out = [
     `release manifest --check: ${total} issue(s)`,

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20908,9 +20908,10 @@ var parseExcludeLines = (text) => text.split("\n").flatMap((line) => {
 });
 var validateExcludeText = (text) => {
   const offenders = text.split("\n").filter((line) => {
-    const trimmed = line.trim();
+    const normalized = line.replace(/\r$/, "");
+    const trimmed = normalized.trim();
     if (trimmed.length === 0 || trimmed.startsWith("#")) return false;
-    return line !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
+    return normalized !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
   });
   if (offenders.length > 0) {
     throw new Error(

--- a/.gaia/cli/src/release/manifest-answers.ts
+++ b/.gaia/cli/src/release/manifest-answers.ts
@@ -79,6 +79,16 @@ const REJECTED_PATH_CHARACTERS = [
 
 const ASCII_WHITESPACE = /[\t\n\v\f\r ]/;
 
+/**
+ * True when `value` carries a character from `REJECTED_PATH_CHARACTERS`. The
+ * single source of truth for "unsafe exclude-line character", shared by the
+ * withhold-answer gate here and by `manifest.ts`'s raw-exclude-text validator
+ * (`validateExcludeText`), so a metacharacter is rejected identically whether
+ * it arrives via `--withhold` or already sits in the committed boundary file.
+ */
+export const hasRejectedExcludeMetacharacter = (value: string): boolean =>
+  REJECTED_PATH_CHARACTERS.some((character) => value.includes(character));
+
 const uniqueSorted = (paths: readonly string[]): string[] => {
   const unique: string[] = [...new Set(paths)];
 
@@ -112,9 +122,7 @@ const isRejectedWithholdPath = (withholdPath: string): boolean =>
   withholdPath.startsWith('/') ||
   withholdPath.endsWith('/') ||
   ASCII_WHITESPACE.test(withholdPath) ||
-  REJECTED_PATH_CHARACTERS.some((character) =>
-    withholdPath.includes(character)
-  );
+  hasRejectedExcludeMetacharacter(withholdPath);
 
 /**
  * The reason is untrusted input the CLI renders into the boundary file as a

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -24,6 +24,7 @@ import {
   lintScanScopes,
   parseExcludePatterns,
   run,
+  validateExcludeText,
 } from './manifest.js';
 
 type Sandbox = {
@@ -150,10 +151,42 @@ describe('parseExcludePatterns', () => {
     expect(patterns[1]?.test('wiki/entities/Foo.md')).toBe(true);
   });
 
-  test('handles wildcard star segments', () => {
+  test('matches the literal path and its directory-prefix form, not a glob', () => {
     const patterns = parseExcludePatterns('.claude/commands/gaia-release.md\n');
     expect(patterns[0]?.test('.claude/commands/gaia-release.md')).toBe(true);
     expect(patterns[0]?.test('.claude/commands/other.md')).toBe(false);
+  });
+
+  test('treats a literal * as a literal character, never a glob wildcard', () => {
+    const patterns = parseExcludePatterns('foo*bar\n');
+    expect(patterns[0]?.test('foo*bar')).toBe(true);
+    expect(patterns[0]?.test('fooXbar')).toBe(false);
+  });
+});
+
+describe('validateExcludeText', () => {
+  test('accepts an all-literal, unindented exclude body', () => {
+    expect(() =>
+      validateExcludeText('# comment\n\n.gaia/scripts\nwiki/entities\n')
+    ).not.toThrow();
+  });
+
+  test('rejects a line containing a glob metacharacter', () => {
+    expect(() => validateExcludeText('wiki/meta*\n')).toThrow(/literal/);
+  });
+
+  test('rejects a line containing a regex character-class bracket', () => {
+    expect(() => validateExcludeText('docs/notes[1]\n')).toThrow(/literal/);
+  });
+
+  test('rejects an indented line', () => {
+    expect(() => validateExcludeText('  wiki/meta\n')).toThrow(/literal/);
+  });
+
+  test('ignores metacharacters inside a comment line', () => {
+    expect(() =>
+      validateExcludeText('# foo* [bar]\nwiki/entities\n')
+    ).not.toThrow();
   });
 });
 
@@ -213,6 +246,18 @@ describe('buildManifest', () => {
 
     expect(manifest.files['.gaia/scripts/keep-me.mjs']).toBeUndefined();
     expect(manifest.files['app/keep.ts']).toBe('owned');
+  });
+
+  test('rejects a glob-shaped exclude line loudly instead of silently mis-excluding', () => {
+    sandbox.commit('seed', {
+      '.gaia/release-exclude': 'wiki/meta*\n',
+      '.gaia/VERSION': '0.1.0\n',
+      'app/keep.ts': 'export {};\n',
+    });
+
+    expect(() =>
+      buildManifest(sandbox.root, {generatedAt: '2026-05-07T00:00:00.000Z'})
+    ).toThrow(/literal/);
   });
 });
 
@@ -485,8 +530,11 @@ describe('run --check', () => {
 
     expect(exit).toBe(1);
     const out = stdio.outputs.join('');
-    expect(out).toContain('missing from manifest');
+    expect(out).toContain('newly ship');
     expect(out).toContain('app/foo.ts');
+    expect(out).toContain('--ship');
+    expect(out).toContain('--withhold');
+    expect(out).toContain('does not withhold');
   });
 
   test('extra entry: exits non-zero and names the extra file', () => {
@@ -604,6 +652,43 @@ describe('run --check', () => {
 
     expect(exit).toBe(2);
     expect(stdio.errors.join('')).toContain('manifest_parse_failed');
+  });
+
+  test('glob-shaped release-exclude line: exits 2 loudly instead of silently mis-excluding', () => {
+    seedAndGenerate();
+
+    writeFileSync(
+      path.join(sandbox.root, '.gaia/release-exclude'),
+      'app/foo*\n',
+      'utf8'
+    );
+
+    const exit = run(['--check'], {
+      cwd: sandbox.root,
+      generatedAt: '2026-05-07T00:00:00.000Z',
+    });
+
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('manifest_build_failed');
+    expect(stdio.errors.join('')).toContain('literal');
+  });
+
+  test('indented release-exclude line: exits 2 loudly', () => {
+    seedAndGenerate();
+
+    writeFileSync(
+      path.join(sandbox.root, '.gaia/release-exclude'),
+      '  app/foo\n',
+      'utf8'
+    );
+
+    const exit = run(['--check'], {
+      cwd: sandbox.root,
+      generatedAt: '2026-05-07T00:00:00.000Z',
+    });
+
+    expect(exit).toBe(2);
+    expect(stdio.errors.join('')).toContain('manifest_build_failed');
   });
 
   test('missing manifest file: exits non-zero with manifest_missing error', () => {

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -183,6 +183,12 @@ describe('validateExcludeText', () => {
     expect(() => validateExcludeText('  wiki/meta\n')).toThrow(/literal/);
   });
 
+  test('tolerates CRLF line endings on otherwise-valid literal paths', () => {
+    expect(() =>
+      validateExcludeText('.gaia/cli/src\r\nwiki/entities\r\n')
+    ).not.toThrow();
+  });
+
   test('ignores metacharacters inside a comment line', () => {
     expect(() =>
       validateExcludeText('# foo* [bar]\nwiki/entities\n')

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -31,6 +31,7 @@ import {structuredError} from '../stderr.js';
 import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {
   applyWithholds,
+  hasRejectedExcludeMetacharacter,
   parseExcludeCategories,
   validateAnswers,
 } from './manifest-answers.js';
@@ -136,12 +137,15 @@ const WIKI_OWNED_EXACT = new Set(['wiki/overview.md', 'wiki/README.md']);
 
 export type ManifestClass = 'owned' | 'shared' | 'wiki-owned';
 
+// Escapes every regex metacharacter, including `*`. `.gaia/release-exclude`
+// entries are literal paths, matched the same way by the shell staging
+// pipeline (`release.yml`) and the distribution bats suite; a compiler that
+// rewrote `*` into a glob, or left `[](){}^$|` unescaped, would silently
+// disagree with both of them (or crash on a bracketed path). See
+// `validateExcludeText` below, which is the loud-rejection half of the same
+// fix: this escaping is defense-in-depth for any direct caller.
 const escapeRegExp = (pattern: string): string =>
-  pattern
-    .replaceAll('.', String.raw`\.`)
-    .replaceAll('+', String.raw`\+`)
-    .replaceAll('?', String.raw`\?`)
-    .replaceAll('*', '[^/]*');
+  pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
 /**
  * Trimmed, non-blank, non-comment lines from a `.gaia/release-exclude` body.
@@ -157,6 +161,35 @@ export const parseExcludeLines = (text: string): string[] =>
 
     return [trimmed];
   });
+
+/**
+ * Validate the RAW `.gaia/release-exclude` text, before `parseExcludeLines`
+ * trims it. Every non-comment line must be a bare literal path: no glob or
+ * regex metacharacter (the same set `manifest-answers.ts` rejects for a
+ * `--withhold` path, via `hasRejectedExcludeMetacharacter`) and no leading or
+ * trailing whitespace. The shell staging pipeline and the distribution bats
+ * suite both treat every line as a literal path; a glob-shaped or indented
+ * entry would make this TS parser silently omit a still-shipping file from
+ * the manifest, so this throws loudly instead of building a manifest the
+ * other parsers disagree with.
+ */
+export const validateExcludeText = (text: string): void => {
+  const offenders = text.split('\n').filter((line) => {
+    const trimmed = line.trim();
+
+    if (trimmed.length === 0 || trimmed.startsWith('#')) return false;
+
+    return line !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
+  });
+
+  if (offenders.length > 0) {
+    throw new Error(
+      `.gaia/release-exclude entries must be literal paths (no glob/regex metacharacters, no indentation); offending line(s): ${offenders
+        .map((line) => JSON.stringify(line))
+        .join(', ')}`
+    );
+  }
+};
 
 export const parseExcludePatterns = (text: string): RegExp[] =>
   parseExcludeLines(text).map(
@@ -239,6 +272,7 @@ export const buildManifest = (
   const version = readFileSync(versionPath, 'utf8').trim();
   const excludeText =
     options.excludeText ?? readFileSync(resolveExcludePath(repoRoot), 'utf8');
+  validateExcludeText(excludeText);
   const excludePatterns = parseExcludePatterns(excludeText);
   const isExcluded = (candidate: string): boolean =>
     excludePatterns.some((pattern) => pattern.test(candidate));
@@ -554,15 +588,22 @@ const renderVersionDriftLines = (result: ManifestDrift): string[] =>
       `  .gaia/VERSION:    ${result.versionDrift.expected}`,
     ];
 
+// Mirrors `manifest-answers.ts`'s own `unanswered_paths` language ("would
+// newly ship with no explicit answer") so the CLI never describes the same
+// fact two different ways depending on which code path notices it.
 const renderMissingLines = (result: ManifestDrift): string[] =>
   result.missing.length === 0 ?
     []
   : [
       '',
-      `missing from manifest (${result.missing.length}):`,
+      `will newly ship to adopters with no explicit answer (${result.missing.length}):`,
       ...result.missing.map(
         (entry) => `  + ${entry.file}  [${entry.expected}]`
       ),
+      '',
+      'Regenerating the manifest does not withhold these files; each one needs an explicit decision:',
+      '  release manifest --ship <path>       accept that it ships',
+      '  release manifest --withhold <path> --category <N> --reason <text>   keep it maintainer-only',
     ];
 
 const renderExtraLines = (result: ManifestDrift): string[] =>
@@ -623,7 +664,7 @@ const renderCheckReport = (
     (result.versionDrift === undefined ? 0 : 1);
 
   if (total === 0) {
-    return 'release manifest --check: clean (manifest fresh, classifier sets coherent)\n';
+    return 'release manifest --check: clean (manifest matches classifier + .gaia/VERSION; this checks bookkeeping, not the distribution boundary)\n';
   }
 
   const out = [

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -175,11 +175,16 @@ export const parseExcludeLines = (text: string): string[] =>
  */
 export const validateExcludeText = (text: string): void => {
   const offenders = text.split('\n').filter((line) => {
-    const trimmed = line.trim();
+    // A CRLF checkout leaves a trailing `\r` on every line after the `\n`
+    // split; that is a line-ending artifact, not indentation, so it's
+    // stripped before the whitespace comparison. `parseExcludeLines`
+    // tolerates it via `trim()`; this raw-text validator must match.
+    const normalized = line.replace(/\r$/, '');
+    const trimmed = normalized.trim();
 
     if (trimmed.length === 0 || trimmed.startsWith('#')) return false;
 
-    return line !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
+    return normalized !== trimmed || hasRejectedExcludeMetacharacter(trimmed);
   });
 
   if (offenders.length > 0) {

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -1,7 +1,7 @@
 # Paths excluded from the distribution tarball produced by release.yml.
 # These exist in the template repo for the GAIA team's own workflow but have
 # no business on an adopter's machine. Format is tar --exclude-from: one
-# path or glob per line, comments with `#` are honored.
+# literal path per line, comments with `#` are honored.
 #
 # Anything excluded here is ALSO skipped by `gaia-maintainer release manifest`, so the
 # adopter-facing manifest never references files an adopter cannot have.


### PR DESCRIPTION
Batch fix for two same-file (`.gaia/cli/src/release/manifest.ts`) release-CLI defects.

## #679 — three parsers of `.gaia/release-exclude` disagree
The TS regex compiler treated `*` as a glob (`[^/]*`) and left `[](){}^$|` unescaped, while the shell staging pipeline and the distribution bats suite treat every entry as a literal path. A glob-shaped (or indented) entry made the TS side omit a file from the manifest while the file still shipped — a silent leak, latent today because the current boundary file is all-literal.

- `escapeRegExp` now escapes every regex metacharacter, including `*` (literal semantics, matching the other two parsers; can no longer crash on a bracketed path).
- New `validateExcludeText` rejects any non-comment line carrying a metacharacter or leading/trailing whitespace, reusing `manifest-answers.ts`'s `hasRejectedExcludeMetacharacter` (extracted as the single source of truth for "unsafe exclude-line character", shared with the `--withhold` gate). Wired into `buildManifest` before pattern compilation, so a bad boundary file now fails loudly (`manifest_build_failed`, exit 2) instead of silently mis-excluding.
- Doc: `.gaia/release-exclude` header no longer advertises "path or glob"; it now says "literal path".

## #680 — `release manifest --check` reporting was misleading
The `missing from manifest` bucket read as a bookkeeping gap ("just regenerate"), but every missing entry is a file that will newly ship to adopters; regenerating records it as shipping rather than withholding it.

- `renderMissingLines` reframed as a distribution decision: names `--ship` / `--withhold` and states that regenerating does not withhold. Mirrors the answer gate's own `unanswered_paths` language.
- The clean-state message now states it checks bookkeeping + classifier coherence, not the distribution boundary.

Out of this lane's scope (`.gaia/cli/src/release/`): the shell staging pipeline (`release.yml`) and the distribution bats suite's stale comment are untouched — both already treat entries as literal, so they agree with the now-enforced literal-only semantics.

TDD throughout; `manifest.test.ts` extended (literal-`*` matching, `validateExcludeText` accept/reject, `--check` exit-2 on glob/indented lines, new report wording). Committed `.gaia/cli/gaia-maintainer` binary rebuilt (adopter `gaia` unchanged). No CHANGELOG entry — internal maintainer-CLI machinery, adopter-invisible.

Closes #679
Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)