### PR TITLE
fix(specify): validate SPEC frontmatter parses as YAML in lint (#682)

### DIFF
--- a/.specify/extensions/gaia/lib/lint.sh
+++ b/.specify/extensions/gaia/lib/lint.sh
@@ -16,6 +16,8 @@
 #
 # Checks performed:
 #   - frontmatter present (--- ... ---)
+#   - frontmatter parses as valid YAML (best-effort: python3+pyyaml or yq;
+#     skipped silently when neither parser is available)
 #   - required frontmatter fields: spec_id, type, status, immutable, wiki_promote_default,
 #     chain_trigger, intent, success_criteria, uats, scope_boundaries, clarifications,
 #     research_summary, created, updated
@@ -91,6 +93,43 @@ done < "$spec_file"
 
 if [ "$state" != "post" ]; then
   add_finding "no_frontmatter" "SPEC has no closed YAML frontmatter (--- ... ---)." "head"
+fi
+
+# --- Frontmatter YAML parse validation ---
+# The checks below (has_fm_key, get_fm_field) are line-oriented greps: they
+# confirm required keys are present but never confirm the block is
+# well-formed YAML. A plain scalar that opens with a backtick, or contains
+# ": " or " #", reads fine to grep but breaks a real parser. Pipe $fm
+# through whichever real YAML parser is available and fail on a parse
+# error. Best-effort: with no parser present, skip silently rather than
+# regress every currently-clean SPEC on a parser-less machine.
+if [ -n "$fm" ]; then
+  yaml_err=""
+  yaml_parse_failed=0
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    if ! yaml_err=$(printf '%s' "$fm" | python3 -c '
+import sys
+import yaml
+try:
+    yaml.safe_load(sys.stdin.read())
+except Exception as e:
+    print(str(e).replace(chr(10), " "))
+    sys.exit(1)
+' 2>&1); then
+      yaml_parse_failed=1
+    fi
+  elif command -v yq >/dev/null 2>&1; then
+    if ! yaml_err_raw=$(printf '%s' "$fm" | yq -e '.' 2>&1 >/dev/null); then
+      yaml_parse_failed=1
+      yaml_err=$(printf '%s' "$yaml_err_raw" | tr '\n' ' ')
+    fi
+  else
+    echo "lint.sh: no YAML parser found (python3+pyyaml or yq); skipping frontmatter YAML parse check" >&2
+  fi
+
+  if [ "$yaml_parse_failed" -eq 1 ]; then
+    add_finding "yaml_parse_error" "Frontmatter is not valid YAML: $yaml_err" "frontmatter"
+  fi
 fi
 
 # --- Frontmatter field extraction (top-level keys only) ---

--- a/.specify/extensions/gaia/test/lint-yaml.bats
+++ b/.specify/extensions/gaia/test/lint-yaml.bats
@@ -30,6 +30,20 @@ assert_all_required_keys_present() {
   done
 }
 
+# Skip a parse-fail test when no YAML parser is available. lint.sh's parse
+# check is best-effort: with neither python3+pyyaml nor yq present it skips
+# the check silently, so the hazard fixtures below lint clean and would fail
+# these tests spuriously. Detection mirrors lint.sh (python3+pyyaml, then yq).
+require_yaml_parser() {
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v yq >/dev/null 2>&1; then
+    return 0
+  fi
+  skip "no YAML parser available (python3+pyyaml or yq); lint.sh skips the parse check"
+}
+
 @test "valid GAIA frontmatter lints clean, no yaml_parse_error" {
   spec="$BATS_TMPDIR/lint-yaml-valid.spec.md"
   cat > "$spec" <<'SPEC'
@@ -84,6 +98,7 @@ SPEC
 }
 
 @test "backtick-leading plain scalar fails yaml_parse_error even though all required keys are present" {
+  require_yaml_parser
   spec="$BATS_TMPDIR/lint-yaml-backtick.spec.md"
   cat > "$spec" <<'SPEC'
 ---
@@ -135,6 +150,7 @@ SPEC
 }
 
 @test "colon-space inside a plain scalar fails yaml_parse_error even though all required keys are present" {
+  require_yaml_parser
   spec="$BATS_TMPDIR/lint-yaml-colonspace.spec.md"
   cat > "$spec" <<'SPEC'
 ---
@@ -186,6 +202,7 @@ SPEC
 }
 
 @test "space-hash inside a plain scalar fails yaml_parse_error even though all required keys are present" {
+  require_yaml_parser
   spec="$BATS_TMPDIR/lint-yaml-hash.spec.md"
   cat > "$spec" <<'SPEC'
 ---

--- a/.specify/extensions/gaia/test/lint-yaml.bats
+++ b/.specify/extensions/gaia/test/lint-yaml.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+#
+# Regression guard for the frontmatter YAML parse-error check in lint.sh
+# (issue #682). Before that check existed, lint.sh only confirmed that
+# each required frontmatter key was present on its own line (a grep, not
+# a parse); a SPEC frontmatter that is syntactically invalid YAML still
+# lints clean under that check alone. Each hazard fixture below keeps
+# every required key present on its own line -- the exact blind spot the
+# pre-existing key-presence checks never caught -- and relies solely on
+# the new parser-backed check to fail lint. Release-excluded (this dir
+# does not ship).
+#
+# Assertion style note (`.claude/rules/bats-assertions.md`): assertions
+# use POSIX `[ ]` or an explicit `return 1`, never a bare mid-test `[[ ]]`,
+# so a broken assertion fails correctly even under macOS's bash 3.2.
+
+setup() {
+  EXT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  LINT="$EXT_DIR/lib/lint.sh"
+}
+
+required_keys="spec_id type status immutable wiki_promote_default chain_trigger intent success_criteria uats scope_boundaries clarifications research_summary created updated"
+
+# Fails (returns 1) unless every required top-level frontmatter key is
+# present on its own line in $1 -- i.e. unless the fixture would have
+# passed the pre-existing grep-only key-presence checks.
+assert_all_required_keys_present() {
+  for k in $required_keys; do
+    grep -qE "^${k}:" "$1" || return 1
+  done
+}
+
+@test "valid GAIA frontmatter lints clean, no yaml_parse_error" {
+  spec="$BATS_TMPDIR/lint-yaml-valid.spec.md"
+  cat > "$spec" <<'SPEC'
+---
+spec_id: SPEC-001
+type: feature
+status: in-progress
+immutable: true
+wiki_promote_default: yes
+chain_trigger: gaia-plan
+intent: |
+  Plain paragraph describing the feature.
+success_criteria:
+  - Outcome one.
+uats:
+  - uat_id: UAT-001
+    given: Some precondition.
+    when: Some action.
+    then: Some outcome.
+scope_boundaries:
+  always:
+    - Always do X.
+  ask_first:
+    - Ask before Y.
+  never:
+    - Never do Z.
+clarifications:
+  answered:
+    - q: A question?
+      a: An answer.
+  pending: []
+research_summary: |
+  Some research findings.
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Title
+
+## One-line summary
+
+Summary.
+SPEC
+
+  assert_all_required_keys_present "$spec" || return 1
+
+  run bash "$LINT" "$spec"
+  [ "$status" -eq 0 ] || return 1
+  grep -qF '"ok":true' <<<"$output" || return 1
+  grep -qF 'yaml_parse_error' <<<"$output" && return 1
+  return 0
+}
+
+@test "backtick-leading plain scalar fails yaml_parse_error even though all required keys are present" {
+  spec="$BATS_TMPDIR/lint-yaml-backtick.spec.md"
+  cat > "$spec" <<'SPEC'
+---
+spec_id: SPEC-001
+type: feature
+status: in-progress
+immutable: true
+wiki_promote_default: yes
+chain_trigger: `gaia-plan`
+intent: |
+  Plain paragraph describing the feature.
+success_criteria:
+  - Outcome one.
+uats:
+  - uat_id: UAT-001
+    given: Some precondition.
+    when: Some action.
+    then: Some outcome.
+scope_boundaries:
+  always:
+    - Always do X.
+  ask_first:
+    - Ask before Y.
+  never:
+    - Never do Z.
+clarifications:
+  answered:
+    - q: A question?
+      a: An answer.
+  pending: []
+research_summary: |
+  Some research findings.
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Title
+
+## One-line summary
+
+Summary.
+SPEC
+
+  assert_all_required_keys_present "$spec" || return 1
+
+  run bash "$LINT" "$spec"
+  [ "$status" -eq 1 ] || return 1
+  grep -qF 'yaml_parse_error' <<<"$output" || return 1
+}
+
+@test "colon-space inside a plain scalar fails yaml_parse_error even though all required keys are present" {
+  spec="$BATS_TMPDIR/lint-yaml-colonspace.spec.md"
+  cat > "$spec" <<'SPEC'
+---
+spec_id: SPEC-001
+type: feature
+status: in-progress
+immutable: true
+wiki_promote_default: yes
+chain_trigger: gaia-plan: extra
+intent: |
+  Plain paragraph describing the feature.
+success_criteria:
+  - Outcome one.
+uats:
+  - uat_id: UAT-001
+    given: Some precondition.
+    when: Some action.
+    then: Some outcome.
+scope_boundaries:
+  always:
+    - Always do X.
+  ask_first:
+    - Ask before Y.
+  never:
+    - Never do Z.
+clarifications:
+  answered:
+    - q: A question?
+      a: An answer.
+  pending: []
+research_summary: |
+  Some research findings.
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Title
+
+## One-line summary
+
+Summary.
+SPEC
+
+  assert_all_required_keys_present "$spec" || return 1
+
+  run bash "$LINT" "$spec"
+  [ "$status" -eq 1 ] || return 1
+  grep -qF 'yaml_parse_error' <<<"$output" || return 1
+}
+
+@test "space-hash inside a plain scalar fails yaml_parse_error even though all required keys are present" {
+  spec="$BATS_TMPDIR/lint-yaml-hash.spec.md"
+  cat > "$spec" <<'SPEC'
+---
+spec_id: SPEC-001
+type: feature
+status: in-progress
+immutable: true
+wiki_promote_default: yes
+chain_trigger: gaia-plan
+intent: |
+  Plain paragraph describing the feature.
+success_criteria:
+  - Outcome one.
+uats:
+  - uat_id: UAT-001
+    given: Some precondition.
+    when: Some action.
+    then: the result is 42 #percent complete
+      and remains stable afterward.
+scope_boundaries:
+  always:
+    - Always do X.
+  ask_first:
+    - Ask before Y.
+  never:
+    - Never do Z.
+clarifications:
+  answered:
+    - q: A question?
+      a: An answer.
+  pending: []
+research_summary: |
+  Some research findings.
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Title
+
+## One-line summary
+
+Summary.
+SPEC
+
+  assert_all_required_keys_present "$spec" || return 1
+
+  run bash "$LINT" "$spec"
+  [ "$status" -eq 1 ] || return 1
+  grep -qF 'yaml_parse_error' <<<"$output" || return 1
+}


### PR DESCRIPTION
Closes #682

The SPEC lint (`.specify/extensions/gaia/lib/lint.sh`) never parsed YAML — its key checks are line-oriented greps, so a SPEC whose frontmatter is syntactically invalid YAML lints clean (`{"ok":true}`, exit 0) as long as every required key sits on its own line. This fired twice while authoring SPEC-035 (a backtick-leading scalar; a `: ` inside a plain scalar), green both times, then failed wherever the frontmatter was actually loaded as YAML.

Adds a real YAML-parse validation of the extracted frontmatter block: on a parse error it records a `yaml_parse_error` finding and lint fails.

## Portability
`lint.sh` ships to adopters and previously had zero external-tool dependencies. The parse check is additive and degrades gracefully: it uses `python3`+`pyyaml` if available, else `yq`, else skips silently (no finding, no failure) so a parser-less machine is never regressed. The parser call is guarded so `set -euo pipefail` never aborts on a parse failure.

## Tests
New `.specify/extensions/gaia/test/lint-yaml.bats` (release-excluded): a valid SPEC lints clean, and each of the three hazard classes (backtick-leading scalar, `: ` in a scalar, ` #`-plus-continuation in a scalar) fails `yaml_parse_error`. Every fixture still passes the old grep key-presence checks, proving the exact blind spot is closed. shellcheck clean.

Deferred (out of surgical scope, noted for follow-up): rejecting unknown keys inside `uats[]`; asserting `clarifications.pending` exists.

No CHANGELOG entry: internal maintainer machinery.