### PR TITLE
fix(scripts): fail loud when the required-checks ruleset read errors (#809)

### DIFF
--- a/.gaia/scripts/tests/verify-required-checks.bats
+++ b/.gaia/scripts/tests/verify-required-checks.bats
@@ -130,6 +130,9 @@ Vitest and Playwright"
 }
 
 @test "drift: an empty live ruleset reports every declared-required context missing" {
+  # Injected-empty path (--ruleset-contexts <(printf '')): a real, legitimate
+  # empty answer. Distinct from the gh-api-failure path below, which must NOT
+  # be treated as a legitimate empty answer.
   run "$SCRIPT" --repo gaia-react/gaia --branch main \
     --ruleset-contexts <(printf '') \
     --workflows-dir "$FIX/workflows-clean"
@@ -139,6 +142,22 @@ Vitest and Playwright"
   assert_contains "Run Chromatic"
   assert_contains "Unanswered newly-shipping files"
   assert_contains "Vitest and Playwright"
+}
+
+# ---------------------------------------------------------------------------
+# gh api failure on the live ruleset read (exit 2, not a drift verdict) (#809)
+# ---------------------------------------------------------------------------
+
+@test "gh api failure reading the live ruleset exits 2 with a loud diagnostic, not a false drift verdict" {
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+  cat > "$BATS_TEST_TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+  run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" "$SCRIPT" --repo gaia-react/gaia --branch main
+  [ "$status" -eq 2 ]
+  assert_contains "could not read the live ruleset"
 }
 
 # ---------------------------------------------------------------------------

--- a/.gaia/scripts/verify-required-checks.sh
+++ b/.gaia/scripts/verify-required-checks.sh
@@ -26,7 +26,7 @@
 #   0  every declared-required context is confirmed in the live ruleset.
 #   1  at least one declared-required context is missing from the live
 #      ruleset, the exact drift class #807 exists to catch.
-#   2  usage error.
+#   2  usage error, or the live ruleset could not be read (gh api failed).
 #
 # DO NOT add `set -e` (matches audit-noop-detect.sh): the missing/advisory
 # loops below rely on grep/comparison exit status without aborting the script.
@@ -91,9 +91,12 @@ if [ -n "$ruleset_contexts_src" ]; then
     ruleset_contexts=$(cat "$ruleset_contexts_src")
   fi
 else
-  ruleset_contexts=$(gh api "repos/${repo}/rules/branches/${branch}" \
+  if ! ruleset_contexts=$(gh api "repos/${repo}/rules/branches/${branch}" \
     --jq '.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context' \
-    2>/dev/null || true)
+    2>/dev/null); then
+    echo "verify-required-checks: could not read the live ruleset for ${repo} branch ${branch} (gh api failed: auth, token, rate limit, network, or outage). Refusing to report drift from data gh could not supply." >&2
+    exit 2
+  fi
 fi
 
 missing=()


### PR DESCRIPTION
## What

`verify-required-checks.sh` read the live GitHub ruleset with `gh api ... || true`, discarding the exit status. An auth failure, expired token, rate limit, network error, or GitHub outage each produced an empty result **byte-identical** to a legitimately empty ruleset, so the script reported all five declared required contexts MISSING (exit 1) — a confident, wrong drift alarm. Meanwhile the repo-resolution guard 20 lines up already fails loud (`>&2` + exit 2); the two failure postures disagreed.

## Change

- Capture the `gh api` exit status instead of discarding it. On non-zero, emit a `>&2` diagnostic and `exit 2` (matching the repo-resolution guard's shape — a non-drift "the script could not do its job" outcome, distinct from exit 1 = drift and exit 0 = all-confirmed).
- Header exit-code doc updated to note exit 2 now covers a failed ruleset read.
- The injected `--ruleset-contexts` test path is unchanged: it legitimately supplies an empty set and still reports drift.
- New bats test stubs `gh` to exit non-zero and asserts exit 2 + the loud diagnostic (RED→GREEN verified); the existing injected-empty test is retained to prove the two empty-results are now distinguished.

Verify: `shellcheck` clean; `bats` 13/13 pass. Both files are release-excluded.

Closes #809