### PR TITLE
fix(hooks): fire the execute-stage token tally for the git -C <path> form (#770)

### DIFF
--- a/.claude/hooks/token-tally-git-op.sh
+++ b/.claude/hooks/token-tally-git-op.sh
@@ -20,13 +20,17 @@ cmd=$(jq -r '.tool_input.command // ""' <<<"$payload")
 
 # Match `git commit` or `git push` as a real shell invocation, at command
 # start or right after a shell separator (&&, ;, ||, |, newline), not when
-# mentioned mid-line in prose or a quoted string (e.g. a commit message).
-# Bash `=~` gives whole-string semantics; `grep` is line-oriented and would
-# match every heredoc body line. The newline separator here still matches a
-# heredoc body line that begins with the command; that edge is benign (one
-# extra tally row the per-session dedup collapses) and accepted.
-start_re='^[[:space:]]*git[[:space:]]+(commit|push)([[:space:]]|$)'
-sep_re=$'(\\&\\&|;|\\|\\||\\||\n)[[:space:]]*git[[:space:]]+(commit|push)([[:space:]]|$)'
+# mentioned mid-line in prose or a quoted string (e.g. a commit message). The
+# mandated `git -C <path> commit|push` form (.claude/rules/shell-cwd.md) also
+# matches, via an optional `-C <path>` group between `git` and the
+# subcommand; <path> may be quoted as long as it holds no spaces. Bash `=~`
+# gives whole-string semantics; `grep` is line-oriented and would match every
+# heredoc body line. The newline separator here still matches a heredoc body
+# line that begins with the command; that edge is benign (one extra tally row
+# the per-session dedup collapses) and accepted.
+git_op='git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+(commit|push)([[:space:]]|$)'
+start_re="^[[:space:]]*$git_op"
+sep_re=$'(\\&\\&|;|\\|\\||\\||\n)[[:space:]]*'"$git_op"
 if [[ "$cmd" =~ $start_re ]]; then
   :
 elif [[ "$cmd" =~ $sep_re ]]; then

--- a/.gaia/tests/hooks/token-tally-git-op.bats
+++ b/.gaia/tests/hooks/token-tally-git-op.bats
@@ -124,6 +124,69 @@ run_hook() {
   [ "$(jq -r '.kind' "$LEDGER")" = "execute" ]
 }
 
+# ---------- 2a. git -C <path> form (shell-cwd.md mandated form, issue #770) ----------
+@test "git -C <path> commit records an execute record (shell-cwd.md mandated form)" {
+  build_repo
+  cd "$REPO"
+  branch="$(git branch --show-current)"
+  plan_dir="$REPO/.gaia/local/plans/my-plan"
+  write_readme_with_spec "$plan_dir" "/abs/root/.gaia/local/specs/SPEC-013/SPEC.md"
+  write_running "$plan_dir" "$branch" "2026-07-01T00:00:00Z"
+
+  run_hook "git -C /abs/worktree commit -m x"
+  [ "$status" -eq 0 ]
+
+  LEDGER="$REPO/.gaia/local/telemetry/cost.jsonl"
+  [ -f "$LEDGER" ]
+  [ "$(jq -r '.kind' "$LEDGER")" = "execute" ]
+  [ "$(jq -r '.spec_id' "$LEDGER")" = "SPEC-013" ]
+}
+
+@test "git -C <path> push also records" {
+  build_repo
+  cd "$REPO"
+  branch="$(git branch --show-current)"
+  plan_dir="$REPO/.gaia/local/plans/my-plan"
+  write_readme_with_spec "$plan_dir" "/abs/root/.gaia/local/specs/SPEC-013/SPEC.md"
+  write_running "$plan_dir" "$branch" "2026-07-01T00:00:00Z"
+
+  run_hook "git -C /abs/worktree push"
+  [ "$status" -eq 0 ]
+
+  LEDGER="$REPO/.gaia/local/telemetry/cost.jsonl"
+  [ -f "$LEDGER" ]
+  [ "$(jq -r '.kind' "$LEDGER")" = "execute" ]
+}
+
+@test "git -C <path> status: no record (commit/push-only matching preserved)" {
+  build_repo
+  cd "$REPO"
+  branch="$(git branch --show-current)"
+  plan_dir="$REPO/.gaia/local/plans/my-plan"
+  write_readme_with_spec "$plan_dir" "/abs/root/.gaia/local/specs/SPEC-013/SPEC.md"
+  write_running "$plan_dir" "$branch" "2026-07-01T00:00:00Z"
+
+  run_hook "git -C /abs/worktree status"
+  [ "$status" -eq 0 ]
+  [ ! -f "$REPO/.gaia/local/telemetry/cost.jsonl" ]
+}
+
+@test "git -C \"<path>\" commit (quoted path) records an execute record" {
+  build_repo
+  cd "$REPO"
+  branch="$(git branch --show-current)"
+  plan_dir="$REPO/.gaia/local/plans/my-plan"
+  write_readme_with_spec "$plan_dir" "/abs/root/.gaia/local/specs/SPEC-013/SPEC.md"
+  write_running "$plan_dir" "$branch" "2026-07-01T00:00:00Z"
+
+  run_hook 'git -C "/abs/worktree" commit -m x'
+  [ "$status" -eq 0 ]
+
+  LEDGER="$REPO/.gaia/local/telemetry/cost.jsonl"
+  [ -f "$LEDGER" ]
+  [ "$(jq -r '.kind' "$LEDGER")" = "execute" ]
+}
+
 # ---------- 2b. Colocated spec-plan layout: specs/<SPEC-ID>/plan[-N] ----------
 # Spec-derived plans no longer live under plans/<slug>; they colocate inside
 # their SPEC folder at specs/<SPEC-ID>/plan[-N]. The hook's cheap has_plan gate


### PR DESCRIPTION
Closes #770

`token-tally-git-op.sh` records the execute-stage cost tally on `git commit`/`git push`, but its matcher only recognized the bare forms. It missed `git -C <path> commit` / `git -C <path> push` — the form `.claude/rules/shell-cwd.md` **mandates** (every git command uses `git -C /abs/path ...` instead of `cd ... && git ...`). So the tally silently never fired for exactly the shape orchestrators and worktree sessions commit with.

The matcher now accepts an optional `git -C <path>` global-option prefix (shared `git_op` sub-pattern feeding both `start_re` and `sep_re`); bare `git commit`/`git push` still match. Scoped to the `-C <path>` form the rule names, not arbitrary git global options.

TDD: 3 new `-C` positive tests (+1 quoted-path variant) fail against the old matcher and pass after the fix; a `git -C <path> status` negative guards against over-matching. Full suite 22/22, including the `/bin/bash` 3.2 empty-array regression test. shellcheck clean of new findings. Hook is a shipping file (edited in place); tests release-excluded.