### PR TITLE
fix(scripts): scope-disable the deliberate SC2069 redirections in resolve-audit-spawn.bats (#802)

### DIFF
--- a/.gaia/scripts/tests/resolve-audit-spawn.bats
+++ b/.gaia/scripts/tests/resolve-audit-spawn.bats
@@ -127,6 +127,8 @@ YAML
 tree_sha() { git -C "$SANDBOX" rev-parse "HEAD^{tree}"; }
 commit_sha() { git -C "$SANDBOX" rev-parse HEAD; }
 resolve_members() { ( cd "$SANDBOX" && bash .gaia/scripts/resolve-audit-members.sh 2>/dev/null ); }
+# SC2069: deliberate capture-stderr / discard-stdout order (2>&1 then 1>/dev/null); sibling oracle_stdout on the next line is the mirror image.
+# shellcheck disable=SC2069
 oracle_stderr() { ( cd "$SANDBOX" && "$SCRIPT" "$@" 2>&1 1>/dev/null ); }
 oracle_stdout() { ( cd "$SANDBOX" && "$SCRIPT" "$@" 2>/dev/null ); }
 
@@ -357,6 +359,8 @@ code-audit-maintainer-shell"
 }
 
 @test "unknown flag prints a warning to stderr" {
+  # SC2069: deliberate; capture stderr, discard stdout (2>&1 then 1>/dev/null).
+  # shellcheck disable=SC2069
   stderr_out="$( ( cd "$SANDBOX" && "$SCRIPT" --bogus ) 2>&1 1>/dev/null )"
   grep -qF -- "resolve-audit-spawn" <<<"$stderr_out" || return 1
 }


### PR DESCRIPTION
## What

`resolve-audit-spawn.bats` has two deliberate `2>&1 1>/dev/null` redirections (`oracle_stderr` at :130 and the inline stderr capture at :360) that trip shellcheck SC2069. The ordering is the intentional capture-stderr / discard-stdout idiom (`2>&1` duplicates fd2 to the capture, then `1>/dev/null` discards stdout); the sibling `oracle_stdout` on the next line is the mirror image. No live failure mode — the unsuppressed advisory is standing noise that erodes the shellcheck oracle's signal.

## Change

Add a scoped `# shellcheck disable=SC2069` directive with a one-line rationale above each redirection, matching how the codebase documents its other deliberate shellcheck exceptions (e.g. `audit-noop-detect.sh:240`). No behavior change.

Note: in shellcheck 0.11.0 only `:130` currently emits SC2069; the directive at `:360` is kept per the issue's explicit instruction since the idiom is identical (harmless, future-proof).

Verify: shellcheck SC2069 count 1 → 0, no new warnings; bats 32/32 pass. File is release-excluded.

Closes #802