### PR TITLE
docs(rules): prescribe a bash-5 bats pre-flight and surface the 3.2 gap (#766)

### DIFF
--- a/.claude/rules/bats-assertions.md
+++ b/.claude/rules/bats-assertions.md
@@ -9,6 +9,40 @@ macOS ships bash 3.2.57 as `/bin/bash`, which is what bats-core resolves to by d
 
 Repro (bats runs each `@test` body under `set -e`, so mirror it with a plainly-called function -- not `f && ...`, since `&&` suppresses `set -e` inside `f` on *both* versions): `bash -c 'set -e; f(){ [[ 1 == 2 ]]; echo reached; }; f; echo after'` prints `reached` + `after` on bash 3.2 (the false `[[ ]]` is skipped, so only the last command's status flows through) but nothing on bash 5 (it aborts at the `[[ ]]`).
 
+## Run bats under bash 5 (pre-flight)
+
+A bash-3.2 local `bats` run is a **weaker signal than CI** (ubuntu bash 5), and the gap is not limited to the `[[ ]]` skip documented below. A second, independent gap is BSD-vs-GNU CLI divergence: a macOS-only green misses commands that only exist in one flavor. The concrete case is `date -v` (BSD) versus `date -d` (GNU): the losing form exits non-zero on Linux, and under bats' `set -e` that aborts the test before any fallback runs.
+
+Run bats through this guard instead of calling `bats` directly. It prefers a Homebrew bash 5 when one is installed (Apple Silicon: `/opt/homebrew/bin/bash`, Intel: `/usr/local/bin/bash`) and warns loudly on stderr when the bash bats will actually use resolves to major version < 4, so the warning fires only where the gap is real (silent on any bash 5 host, macOS or Linux):
+
+```bash
+bats5() {
+  for d in /opt/homebrew/bin /usr/local/bin; do
+    if [ -x "$d/bash" ]; then
+      PATH="$d:$PATH"
+      export PATH
+      break
+    fi
+  done
+  resolved_bash=$(command -v bash)
+  major=$("$resolved_bash" -c 'echo "${BASH_VERSINFO[0]}"')
+  if [ "$major" -lt 4 ]; then
+    echo "############################################################" >&2
+    echo "# WARNING: bats will run under bash $major ($resolved_bash)." >&2
+    echo "# This local green is a WEAKER signal than CI (ubuntu bash 5):" >&2
+    echo "# a false bare [[ ]] can pass silently, and BSD-only commands" >&2
+    echo "# (e.g. 'date -v') that fail on Linux won't be caught here." >&2
+    echo "# brew install bash, then re-run before trusting this pass count." >&2
+    echo "############################################################" >&2
+  fi
+  bats "$@"
+}
+```
+
+Source it (or paste it into the shell), then call `bats5` wherever the rest of this page says `bats`.
+
+A deterministic lint over `.bats` files and shipped `*.sh` for `date -v` / `date -d` usage would catch the BSD/GNU class statically; that belongs in the shell-lint gate (`.gaia/tests/shell-lint.sh`), outside this rule's scope.
+
 ## Write assertions that fail correctly on bash 3.2
 
 For any assertion that is not the test's final command, use a form that fails under 3.2:
@@ -48,7 +82,7 @@ This is the same principle as the custom-check rule above, end the failing branc
 <!-- gaia:maintainer-only:start -->
 - CI (`.github/workflows/audit-ci-tests.yml`) runs the `.gaia/scripts/tests/`, `.gaia/tests/forensics/`, and `.gaia/tests/hooks/` suites on ubuntu (bash 5), which **does** enforce `[[ ]]`. That is the authoritative gate, but it only catches a hollow assertion after push.
 <!-- gaia:maintainer-only:end -->
-- Run bats under bash 5 locally so local matches CI: `brew install bash` installs `/opt/homebrew/bin/bash`, and bats picks it up via `env bash` when that dir precedes `/bin` on `PATH`. A false mid-test `[[ ]]` then fails locally too.
+- Run bats under bash 5 locally so local matches CI: see "Run bats under bash 5 (pre-flight)" above for the guard.
 
 ## Scope
 


### PR DESCRIPTION
Closes #766

`bats` resolves `/usr/bin/env bash`, which on a stock Mac is `/bin/bash` 3.2.57. A local bats green there is structurally weaker than CI (ubuntu bash 5) while reporting the same pass count: a false bare `[[ ]]` silently does not fail, and BSD-vs-GNU CLI divergence (the observed `date -v` BSD vs `date -d` GNU case, where the losing form exits non-zero on Linux and aborts under bats' `set -e`) passes locally and fails on CI. The rule already documented the bash-5 remedy, but only as buried soft prose.

`.claude/rules/bats-assertions.md` now leads with a **pre-flight** section: a portable, copy-pasteable `bats5()` guard that prefers a Homebrew bash 5 (`/opt/homebrew/bin` Apple Silicon, `/usr/local/bin` Intel) and warns loudly on stderr when the resolved bash is major `< 4` (so it stays silent on any bash-5 host, macOS or Linux). It names both gaps (the `[[ ]]` skip and the BSD/GNU split) and defers the deterministic `date -v`/`date -d` lint to the shell-lint gate (out of this rule's scope). The de-duplicated Backstops bullet points to the new section.

Prose only, present tense, portable paths, maintainer-only markers balanced. No CHANGELOG (internal rule guidance).