### PR TITLE
fix(rules): use git grep in the instruction-files audit to skip gitignored worktrees (#756)

### DIFF
--- a/.claude/rules/instruction-files.md
+++ b/.claude/rules/instruction-files.md
@@ -41,7 +41,9 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 Before merging changes to any file under `.claude/`:
 
 ```bash
-grep -rn "/Users/\|/home/" .claude/
+git grep -nIE "/Users/|/home/" -- .claude/
 ```
+
+`git grep` searches tracked files only, so gitignored surfaces (live worktrees under `.claude/worktrees/`, `.claude/settings.local.json`) are skipped automatically.
 
 Any match outside this rule's prose (where `/Users/<name>/...` is shown as a counter-example) is a bug.


### PR DESCRIPTION
Closes #756

The `## Audit` command in `.claude/rules/instruction-files.md` used `grep -rn`, which recurses into gitignored paths. Live worktrees under `.claude/worktrees/` are gitignored full checkouts (they carry this rule's own `/Users/<name>` counter-examples, `.gaia/local/` machine paths, `settings.local.json`), so the audit false-positived on them.

It now uses `git grep -nIE "/Users/|/home/" -- .claude/`, mirroring the sibling rule `repo-relative-paths.md`: `git grep` searches tracked files only, so gitignored surfaces are skipped automatically. Match breadth is unchanged (BRE→ERE only). The trailing note stands, since the rule's own tracked prose still matches by design.

Prose/command only. No CHANGELOG (internal rule guidance).