### PR TITLE
fix(release): make runtime-deps bare mode marker-aware (#661)

### DIFF
--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -21860,6 +21860,41 @@ var run24 = (argv, options = {}) => {
 // src/release/runtime-deps.ts
 import { readdirSync as readdirSync2, readFileSync as readFileSync17, statSync as statSync2 } from "node:fs";
 import path19 from "node:path";
+
+// src/release/marker-strip.ts
+var stripMarkerBlocks = (source, startMarker, endMarker) => {
+  const lines = source.split("\n");
+  const out = [];
+  const unbalanced = [];
+  let inBlock = false;
+  let blockStartLine = 0;
+  let blocks = 0;
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    const hasStart = line.includes(startMarker);
+    const hasEnd = line.includes(endMarker);
+    if (!inBlock && hasStart && hasEnd) {
+      blocks += 1;
+    } else if (!inBlock && hasStart) {
+      inBlock = true;
+      blockStartLine = lineNumber;
+    } else if (inBlock && hasEnd) {
+      inBlock = false;
+      blocks += 1;
+    } else if (!inBlock && hasEnd) {
+      unbalanced.push({ line: lineNumber, reason: "end_without_start" });
+      out.push(line);
+    } else if (!inBlock) {
+      out.push(line);
+    }
+  }
+  if (inBlock) {
+    unbalanced.push({ line: blockStartLine, reason: "start_without_end" });
+  }
+  return { blocks, output: out.join("\n"), unbalanced };
+};
+
+// src/release/runtime-deps.ts
 var HELP_TEXT25 = `Usage: gaia-maintainer release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
 
   Scan shipped shell scripts for runtime path references that resolve to
@@ -22127,11 +22162,18 @@ var tryWalkScriptsOrReport = (root) => {
     return null;
   }
 };
+var MAINTAINER_ONLY_START = "# gaia:maintainer-only:start";
+var MAINTAINER_ONLY_END = "# gaia:maintainer-only:end";
 var collectLeaks = (root, scriptFiles, manifest) => {
   const leaks = [];
   const shippedDirs = computeShippedDirs(manifest);
   for (const scriptPath of scriptFiles) {
-    const source = readFileSync17(path19.join(root, scriptPath), "utf8");
+    const rawSource = readFileSync17(path19.join(root, scriptPath), "utf8");
+    const source = stripMarkerBlocks(
+      rawSource,
+      MAINTAINER_ONLY_START,
+      MAINTAINER_ONLY_END
+    ).output;
     const refs = extractPathRefs(scriptPath, source);
     for (const ref of refs) {
       const isLeak = ref.path !== scriptPath && !isShippedPath(ref.path, manifest, shippedDirs);
@@ -22430,37 +22472,6 @@ var walkFiles = (root, current = root) => {
     }
   }
   return out;
-};
-var stripMarkerBlocks = (source, startMarker, endMarker) => {
-  const lines = source.split("\n");
-  const out = [];
-  const unbalanced = [];
-  let inBlock = false;
-  let blockStartLine = 0;
-  let blocks = 0;
-  for (const [index, line] of lines.entries()) {
-    const lineNumber = index + 1;
-    const hasStart = line.includes(startMarker);
-    const hasEnd = line.includes(endMarker);
-    if (!inBlock && hasStart && hasEnd) {
-      blocks += 1;
-    } else if (!inBlock && hasStart) {
-      inBlock = true;
-      blockStartLine = lineNumber;
-    } else if (inBlock && hasEnd) {
-      inBlock = false;
-      blocks += 1;
-    } else if (!inBlock && hasEnd) {
-      unbalanced.push({ line: lineNumber, reason: "end_without_start" });
-      out.push(line);
-    } else if (!inBlock) {
-      out.push(line);
-    }
-  }
-  if (inBlock) {
-    unbalanced.push({ line: blockStartLine, reason: "start_without_end" });
-  }
-  return { blocks, output: out.join("\n"), unbalanced };
 };
 var applyMarkerStrip = (stagingRoot, files, transform2) => {
   const filesTouched = [];

--- a/.gaia/cli/src/release/marker-strip.ts
+++ b/.gaia/cli/src/release/marker-strip.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure line-block stripper for `# gaia:maintainer-only` / `<!-- gaia:maintainer-only -->`
+ * style marker blocks. Shared by two callers:
+ *
+ *   - `scrub.ts`'s marker-strip transform, which writes the stripped output
+ *     back into the release staging tree ahead of leak-check.
+ *   - `runtime-deps.ts`'s bare-mode scan, which strips maintainer-only
+ *     blocks from each `.sh` source in-memory before extracting path refs,
+ *     so an unstaged bare run agrees with the authoritative post-scrub
+ *     `--staging` run instead of false-positiving on maintainer-only
+ *     references.
+ *
+ * Extracted to one shared module so there is a single marker parser rather
+ * than two independently-maintained copies.
+ */
+
+export type StripMarkerBlocksResult = {
+  blocks: number;
+  output: string;
+  unbalanced: {
+    line: number;
+    reason: 'end_without_start' | 'start_without_end';
+  }[];
+};
+
+export const stripMarkerBlocks = (
+  source: string,
+  startMarker: string,
+  endMarker: string
+): StripMarkerBlocksResult => {
+  const lines = source.split('\n');
+  const out: string[] = [];
+  const unbalanced: {
+    line: number;
+    reason: 'end_without_start' | 'start_without_end';
+  }[] = [];
+  let inBlock = false;
+  let blockStartLine = 0;
+  let blocks = 0;
+
+  for (const [index, line] of lines.entries()) {
+    const lineNumber = index + 1;
+    const hasStart = line.includes(startMarker);
+    const hasEnd = line.includes(endMarker);
+
+    if (!inBlock && hasStart && hasEnd) {
+      // Single-line block: drop the entire line.
+      blocks += 1;
+    } else if (!inBlock && hasStart) {
+      inBlock = true;
+      blockStartLine = lineNumber;
+    } else if (inBlock && hasEnd) {
+      inBlock = false;
+      blocks += 1;
+    } else if (!inBlock && hasEnd) {
+      unbalanced.push({line: lineNumber, reason: 'end_without_start'});
+      out.push(line);
+    } else if (!inBlock) {
+      out.push(line);
+    }
+  }
+
+  if (inBlock) {
+    unbalanced.push({line: blockStartLine, reason: 'start_without_end'});
+  }
+
+  return {blocks, output: out.join('\n'), unbalanced};
+};

--- a/.gaia/cli/src/release/runtime-deps.test.ts
+++ b/.gaia/cli/src/release/runtime-deps.test.ts
@@ -478,6 +478,48 @@ describe('release runtime-deps CLI', () => {
     expect(stdio.errors.join('')).toContain('unknown flag');
   });
 
+  test('agrees with staging mode: a reference inside a maintainer-only block is not a leak', () => {
+    // Regression for #661: bare mode (no --staging) used to be marker-unaware,
+    // so a .gaia/cli/src reference wrapped in a
+    // `# gaia:maintainer-only:start` / `:end` block (which the scrub's
+    // `**/*.sh` marker-strip transform removes before --staging ever scans
+    // it) false-positived as a leak. Bare mode must now strip the same
+    // blocks in-memory so it agrees with the authoritative staging run.
+    sandbox.writeManifest({
+      '.gaia/cli/gaia': 'owned',
+    });
+    sandbox.writeFile(
+      '.gaia/scripts/resolve-audit-members.sh',
+      [
+        '#!/usr/bin/env bash',
+        '# gaia:maintainer-only:start',
+        'echo .gaia/cli/src',
+        '# gaia:maintainer-only:end',
+        '',
+      ].join('\n')
+    );
+
+    const exit = run([], {cwd: sandbox.rootDir});
+    expect(exit).toBe(0);
+    expect(stdio.outputs.join('')).toContain('runtime-dependency leaks: none');
+  });
+
+  test('still flags the same kind of reference outside a maintainer-only block', () => {
+    // Control for the regression above: the marker strip must not disable
+    // leak detection wholesale, only the wrapped block.
+    sandbox.writeManifest({
+      '.gaia/cli/gaia': 'owned',
+    });
+    sandbox.writeFile(
+      '.gaia/scripts/resolve-audit-members.sh',
+      ['#!/usr/bin/env bash', 'echo .gaia/cli/src', ''].join('\n')
+    );
+
+    const exit = run([], {cwd: sandbox.rootDir});
+    expect(exit).toBe(1);
+    expect(stdio.outputs.join('')).toContain('.gaia/cli/src');
+  });
+
   test('skips self-references', () => {
     sandbox.writeManifest({});
     sandbox.writeFile(

--- a/.gaia/cli/src/release/runtime-deps.ts
+++ b/.gaia/cli/src/release/runtime-deps.ts
@@ -37,6 +37,7 @@ import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';
 import {ADOPTER_OWNED_SENTINELS as GIT_TRACKED_SENTINELS} from './manifest.js';
+import {stripMarkerBlocks} from './marker-strip.js';
 import {SCAN_GLOBS} from './scan-globs.js';
 
 const HELP_TEXT = `Usage: gaia-maintainer release runtime-deps [--staging <dir>] [--manifest <path>] [--json]
@@ -584,6 +585,12 @@ const tryWalkScriptsOrReport = (root: string): null | readonly string[] => {
   }
 };
 
+// Mirrors the scrub `**/*.sh` marker-strip transform in
+// `.gaia/release-scrub.yml` (the source of truth): maintainer-only blocks
+// wrapped in these markers never reach the release tarball.
+const MAINTAINER_ONLY_START = '# gaia:maintainer-only:start';
+const MAINTAINER_ONLY_END = '# gaia:maintainer-only:end';
+
 // Scans every script's extracted path refs for leaks: a reference that is
 // neither a self-reference nor a shipped/adopter-owned/runtime path.
 const collectLeaks = (
@@ -595,7 +602,17 @@ const collectLeaks = (
   const shippedDirs = computeShippedDirs(manifest);
 
   for (const scriptPath of scriptFiles) {
-    const source = readFileSync(path.join(root, scriptPath), 'utf8');
+    const rawSource = readFileSync(path.join(root, scriptPath), 'utf8');
+    // Strip maintainer-only blocks before extracting refs so a bare (no
+    // --staging) run agrees with the authoritative post-scrub staging run.
+    // A no-op on already-scrubbed staging files (no markers present); a
+    // reference inside a maintainer-only block never ships, so it can
+    // never be a real leak.
+    const source = stripMarkerBlocks(
+      rawSource,
+      MAINTAINER_ONLY_START,
+      MAINTAINER_ONLY_END
+    ).output;
     const refs = extractPathRefs(scriptPath, source);
 
     for (const ref of refs) {

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -37,6 +37,7 @@ import {structuredError} from '../stderr.js';
 import {atomicWriteFileSync} from '../util/atomic-write.js';
 import {extractWikilinks} from '../wiki/util/wikilinks.js';
 import {parseExcludeLines} from './manifest.js';
+import {stripMarkerBlocks} from './marker-strip.js';
 
 const HELP_TEXT = `Usage: gaia-maintainer release scrub <staging-dir> [--config <path>] [--json]
 
@@ -187,57 +188,6 @@ export type MarkerStripResult = {
     line: number;
     reason: 'end_without_start' | 'start_without_end';
   }[];
-};
-
-const stripMarkerBlocks = (
-  source: string,
-  startMarker: string,
-  endMarker: string
-): {
-  blocks: number;
-  output: string;
-  unbalanced: {
-    line: number;
-    reason: 'end_without_start' | 'start_without_end';
-  }[];
-} => {
-  const lines = source.split('\n');
-  const out: string[] = [];
-  const unbalanced: {
-    line: number;
-    reason: 'end_without_start' | 'start_without_end';
-  }[] = [];
-  let inBlock = false;
-  let blockStartLine = 0;
-  let blocks = 0;
-
-  for (const [index, line] of lines.entries()) {
-    const lineNumber = index + 1;
-    const hasStart = line.includes(startMarker);
-    const hasEnd = line.includes(endMarker);
-
-    if (!inBlock && hasStart && hasEnd) {
-      // Single-line block: drop the entire line.
-      blocks += 1;
-    } else if (!inBlock && hasStart) {
-      inBlock = true;
-      blockStartLine = lineNumber;
-    } else if (inBlock && hasEnd) {
-      inBlock = false;
-      blocks += 1;
-    } else if (!inBlock && hasEnd) {
-      unbalanced.push({line: lineNumber, reason: 'end_without_start'});
-      out.push(line);
-    } else if (!inBlock) {
-      out.push(line);
-    }
-  }
-
-  if (inBlock) {
-    unbalanced.push({line: blockStartLine, reason: 'start_without_end'});
-  }
-
-  return {blocks, output: out.join('\n'), unbalanced};
 };
 
 const applyMarkerStrip = (


### PR DESCRIPTION
`gaia-maintainer release runtime-deps` run bare (no `--staging`, defaults to the source tree) was marker-unaware and false-positived: a `.sh` script referencing a non-shipped path inside a `# gaia:maintainer-only:start` / `:end` block reported a phantom leak, because the authoritative `--staging` run strips that block (via `release scrub`) before runtime-deps ever sees it. The divergence trapped anyone debugging bare.

- Extracted scrub's private `stripMarkerBlocks` primitive into a shared `marker-strip.ts` (one marker parser, not two); `scrub.ts` imports it, behavior unchanged.
- `runtime-deps` `collectLeaks` now strips `# gaia:maintainer-only` blocks from each `.sh` source before `extractPathRefs`, using constants that mirror the scrub `**/*.sh` transform. Applied unconditionally: a no-op on already-scrubbed staging files, and a reference inside a maintainer-only block never ships, so it can never be a real leak — no false negatives introduced.
- Did NOT touch `PROSE_PATH_ALLOWLIST` (the issue forbids it — it would suppress a genuine leak class in staging too).

Regression tests: a wrapped non-shipped ref no longer false-positives in bare mode; a control ref outside any block still flags. `scrub.test.ts` stays green. Committed `.gaia/cli/gaia-maintainer` rebuilt (adopter `gaia` unchanged). No CHANGELOG entry (internal maintainer-CLI machinery).

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)