### PR TITLE
fix(forensics): detect write violations by set-diff, not mtime (#834)

### DIFF
--- a/.gaia/tests/forensics/04-write-surface.bats
+++ b/.gaia/tests/forensics/04-write-surface.bats
@@ -56,18 +56,33 @@ illegal_write_surrogate() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: find files newer than a marker, excluding the two allowed roots.
-# Returns the list of violating paths (empty = no violations).
+# Helper: list regular files under $workdir that are NOT in the two allowed
+# write roots, sorted for a stable set comparison. Snapshot this before and
+# after a surrogate run to detect writes by set difference.
+# ---------------------------------------------------------------------------
+
+list_write_surface() {
+  local workdir="$1"
+
+  find "$workdir" -type f \
+    ! -path "$workdir/.gaia/local/forensics/*" \
+    ! -path "$workdir/.gaia/local/telemetry/*" \
+    2>/dev/null | LC_ALL=C sort
+}
+
+# ---------------------------------------------------------------------------
+# Helper: given a before-snapshot ($before, a file holding list_write_surface
+# output) and the workdir, return files created outside the allowlist since the
+# snapshot. Detection is by set difference (comm -13), independent of mtime
+# granularity: a write landing in the same clock second as the snapshot is
+# still caught.
 # ---------------------------------------------------------------------------
 
 find_write_violations() {
   local workdir="$1"
-  local marker="$2"
+  local before="$2"
 
-  find "$workdir" -type f -newer "$marker" \
-    ! -path "$workdir/.gaia/local/forensics/*" \
-    ! -path "$workdir/.gaia/local/telemetry/*" \
-    2>/dev/null || true
+  list_write_surface "$workdir" | comm -13 "$before" -
 }
 
 # ---------------------------------------------------------------------------
@@ -86,17 +101,19 @@ find_write_violations() {
   git -C "$workdir" add .
   git -C "$workdir" commit -q -m "initial"
 
-  # Snapshot marker
-  local marker
-  marker="$(mktemp "$workdir/.gaia-marker-XXXXXX")"
+  # Snapshot the write surface before the surrogate runs
+  local before
+  before="$(mktemp)"
+  list_write_surface "$workdir" > "$before"
 
   # Run the allowed surrogate
   runbook_surrogate "$workdir" "init"
 
-  # Find any writes outside the allowlist (exclude the marker file itself)
+  # Find any writes outside the allowlist
   local violations
-  violations="$(find_write_violations "$workdir" "$marker" | grep -v '.gaia-marker-' || true)"
+  violations="$(find_write_violations "$workdir" "$before")"
 
+  rm -f "$before"
   rm -rf "$workdir"
 
   [[ -z "$violations" ]]
@@ -108,8 +125,9 @@ find_write_violations() {
   git -C "$workdir" init -q
   mkdir -p "$workdir/.claude"
 
-  local marker
-  marker="$(mktemp "$workdir/.gaia-marker-XXXXXX")"
+  local before
+  before="$(mktemp)"
+  list_write_surface "$workdir" > "$before"
 
   # Write to the allowed path
   mkdir -p "$workdir/.gaia/local/forensics"
@@ -117,8 +135,9 @@ find_write_violations() {
 
   # Find violations; should be empty because the write is in the allowlist
   local violations
-  violations="$(find_write_violations "$workdir" "$marker" | grep -v '.gaia-marker-' || true)"
+  violations="$(find_write_violations "$workdir" "$before")"
 
+  rm -f "$before"
   rm -rf "$workdir"
 
   [[ -z "$violations" ]]
@@ -130,15 +149,17 @@ find_write_violations() {
   git -C "$workdir" init -q
   mkdir -p "$workdir/.claude"
 
-  local marker
-  marker="$(mktemp "$workdir/.gaia-marker-XXXXXX")"
+  local before
+  before="$(mktemp)"
+  list_write_surface "$workdir" > "$before"
 
   # Simulate an illegal write (outside the allowlist)
   illegal_write_surrogate "$workdir"
 
   local violations
-  violations="$(find_write_violations "$workdir" "$marker" | grep -v '.gaia-marker-' || true)"
+  violations="$(find_write_violations "$workdir" "$before")"
 
+  rm -f "$before"
   rm -rf "$workdir"
 
   # Violations must be non-empty (the test validates the detection logic)
@@ -150,15 +171,17 @@ find_write_violations() {
   workdir="$(mktemp -d)"
   git -C "$workdir" init -q
 
-  local marker
-  marker="$(mktemp "$workdir/.gaia-marker-XXXXXX")"
+  local before
+  before="$(mktemp)"
+  list_write_surface "$workdir" > "$before"
 
   mkdir -p "$workdir/.gaia/local/telemetry"
   printf 'telemetry\n' > "$workdir/.gaia/local/telemetry/emit.log"
 
   local violations
-  violations="$(find_write_violations "$workdir" "$marker" | grep -v '.gaia-marker-' || true)"
+  violations="$(find_write_violations "$workdir" "$before")"
 
+  rm -f "$before"
   rm -rf "$workdir"
 
   [[ -z "$violations" ]]
@@ -175,15 +198,17 @@ find_write_violations() {
   git -C "$workdir" add .
   git -C "$workdir" commit -q -m "initial"
 
-  local marker
-  marker="$(mktemp "$workdir/.gaia-marker-XXXXXX")"
+  local before
+  before="$(mktemp)"
+  list_write_surface "$workdir" > "$before"
 
   # Run the allowed surrogate (should not touch app/, wiki/, .claude/)
   runbook_surrogate "$workdir" "init"
 
   local violations
-  violations="$(find_write_violations "$workdir" "$marker" | grep -v '.gaia-marker-' || true)"
+  violations="$(find_write_violations "$workdir" "$before")"
 
+  rm -f "$before"
   rm -rf "$workdir"
 
   [[ -z "$violations" ]]

--- a/.gaia/tests/forensics/04-write-surface.bats
+++ b/.gaia/tests/forensics/04-write-surface.bats
@@ -20,9 +20,15 @@ setup() {
 # Write-surface allowlist: shell harness that re-implements the runbook's
 # write-surface constraint.
 #
+# Each test snapshots the set of files outside the two allowed write roots
+# (via list_write_surface) before the surrogate runs, runs the surrogate,
+# then diffs the after-set against the before-snapshot with comm to find
+# writes outside the allowlist. Detection is by set difference, independent
+# of mtime.
+#
 # The runbook_surrogate function:
-#   1. Snapshots mtimes of all files via a marker file
-#   2. Writes a fake report to the allowed path
+#   1. Creates the two allowed directories
+#   2. Writes a fake report to .gaia/local/forensics/
 #   3. Optionally writes to .gaia/local/telemetry/ (allowed)
 #   4. Returns; does NOT write to any other path
 # ---------------------------------------------------------------------------
@@ -82,7 +88,7 @@ find_write_violations() {
   local workdir="$1"
   local before="$2"
 
-  list_write_surface "$workdir" | comm -13 "$before" -
+  list_write_surface "$workdir" | LC_ALL=C comm -13 "$before" -
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #834

`find_write_violations` in `.gaia/tests/forensics/04-write-surface.bats` detected post-marker writes with `find -newer "$marker"`, a strict mtime comparison at 1-second (or coarser) granularity. When an illegal write landed in the same clock second as the marker's `mktemp` creation, it was not strictly newer, so `find` missed it and the `illegal write IS detected` test flaked red (observed on PR #827's `bats (.github/audit)`, green on rerun).

Detection is now by before/after file-set snapshot diffed with `comm -13`, making it independent of mtime granularity. Two helpers replace the old one: `list_write_surface` (sorted `find` of all files outside the two allowed roots) and `find_write_violations` (diffs a `before` snapshot against the current surface). All five `@test` blocks swap their in-workdir marker + `grep -v '.gaia-marker-'` filter for a system-temp `before` snapshot; the final `[[ -z/-n ]]` assertions are unchanged.

Verified under bash 5 (Homebrew 5.3): full suite green; the detection test green across 120/120 consecutive iterations (FAIL=0); `run-all.sh` reports all forensics tests passed.

Release-excluded test file (`.gaia/tests/`); no shipping file added, no CHANGELOG entry needed.