### PR TITLE
fix(cli): guard top-level router dispatch against Object.prototype members (#700)

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -6,6 +6,10 @@ var __export = (target, all) => {
     __defProp(target, name, { get: all[name], enumerable: true });
 };
 
+// src/index.ts
+import { realpathSync as realpathSync2 } from "node:fs";
+import { pathToFileURL } from "node:url";
+
 // src/exit.ts
 var EXIT_CODES = {
   CONFIG_INVALID: 30,
@@ -30153,14 +30157,14 @@ var SUBCOMMAND_HANDLERS11 = {
   "update-deps": run52,
   wiki: run70
 };
-var main = async () => {
-  const subcommand = process.argv[2];
-  const rest = process.argv.slice(3);
+var run71 = async (argv) => {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
   if (subcommand === void 0 || HELP_TOKENS67.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS11[subcommand];
+  const handler = Object.hasOwn(SUBCOMMAND_HANDLERS11, subcommand) ? SUBCOMMAND_HANDLERS11[subcommand] : void 0;
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -30168,16 +30172,23 @@ var main = async () => {
   structuredError({ code: "unknown_subcommand", subcommand });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-try {
-  const exitCode = await main();
-  process.exit(exitCode);
-} catch (error51) {
-  structuredError({
-    code: "cli_internal_error",
-    message: error51 instanceof Error ? error51.message : String(error51)
-  });
-  process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+var invokedPath = process.argv[1];
+var isDirectRun = invokedPath !== void 0 && import.meta.url === pathToFileURL(realpathSync2(invokedPath)).href;
+if (isDirectRun) {
+  try {
+    const exitCode = await run71(process.argv.slice(2));
+    process.exit(exitCode);
+  } catch (error51) {
+    structuredError({
+      code: "cli_internal_error",
+      message: error51 instanceof Error ? error51.message : String(error51)
+    });
+    process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+  }
 }
+export {
+  run71 as run
+};
 /*! Bundled license information:
 
 js-yaml/dist/js-yaml.mjs:

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -6,6 +6,10 @@ var __export = (target, all) => {
     __defProp(target, name, { get: all[name], enumerable: true });
 };
 
+// src/index.maintainer.ts
+import { realpathSync as realpathSync2 } from "node:fs";
+import { pathToFileURL } from "node:url";
+
 // src/exit.ts
 var EXIT_CODES = {
   CONFIG_INVALID: 30,
@@ -29156,14 +29160,14 @@ var SUBCOMMAND_HANDLERS10 = {
   "update-deps": run41,
   wiki: run58
 };
-var main = async () => {
-  const subcommand = process.argv[2];
-  const rest = process.argv.slice(3);
+var run59 = async (argv) => {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
   if (subcommand === void 0 || HELP_TOKENS56.has(subcommand)) {
     printHelp2();
     return EXIT_CODES.OK;
   }
-  const handler = SUBCOMMAND_HANDLERS10[subcommand];
+  const handler = Object.hasOwn(SUBCOMMAND_HANDLERS10, subcommand) ? SUBCOMMAND_HANDLERS10[subcommand] : void 0;
   if (handler !== void 0) {
     const result = await handler(rest);
     return typeof result === "number" ? result : EXIT_CODES.OK;
@@ -29171,16 +29175,23 @@ var main = async () => {
   structuredError({ code: "unknown_subcommand", subcommand });
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
-try {
-  const exitCode = await main();
-  process.exit(exitCode);
-} catch (error51) {
-  structuredError({
-    code: "cli_internal_error",
-    message: error51 instanceof Error ? error51.message : String(error51)
-  });
-  process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+var invokedPath = process.argv[1];
+var isDirectRun = invokedPath !== void 0 && import.meta.url === pathToFileURL(realpathSync2(invokedPath)).href;
+if (isDirectRun) {
+  try {
+    const exitCode = await run59(process.argv.slice(2));
+    process.exit(exitCode);
+  } catch (error51) {
+    structuredError({
+      code: "cli_internal_error",
+      message: error51 instanceof Error ? error51.message : String(error51)
+    });
+    process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+  }
 }
+export {
+  run59 as run
+};
 /*! Bundled license information:
 
 js-yaml/dist/js-yaml.mjs:

--- a/.gaia/cli/src/index.maintainer.test.ts
+++ b/.gaia/cli/src/index.maintainer.test.ts
@@ -1,0 +1,105 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {EXIT_CODES} from './exit.js';
+import {run} from './index.maintainer.js';
+import {run as runRelease} from './release/index.js';
+
+vi.mock('./release/index.js', () => ({run: vi.fn()}));
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+let stdio: ReturnType<typeof captureStdio>;
+
+beforeEach(() => {
+  vi.mocked(runRelease).mockReset();
+  stdio = captureStdio();
+});
+
+afterEach(() => {
+  stdio.restore();
+});
+
+// Read every chunk, not just the first: a lone `calls[0]` read misses a payload
+// that arrives in a later write.
+const readStderrPayload = (): Record<string, unknown> =>
+  JSON.parse(stdio.errors.join('').trim().split('\n').at(-1) ?? '{}') as Record<
+    string,
+    unknown
+  >;
+
+describe('gaia-maintainer top-level router', () => {
+  test.each(['--help', '-h', 'help'])(
+    '%s prints help and exits 0',
+    async (token) => {
+      await expect(run([token])).resolves.toBe(EXIT_CODES.OK);
+      expect(stdio.outputs.join('')).toContain('Usage: gaia-maintainer');
+      expect(stdio.errors).toHaveLength(0);
+    }
+  );
+
+  test('no subcommand prints help and exits 0', async () => {
+    await expect(run([])).resolves.toBe(EXIT_CODES.OK);
+    expect(stdio.outputs.join('')).toContain('Usage: gaia-maintainer');
+  });
+
+  // The guard this suite exists to pin only earns its keep if dispatch still
+  // works. Without this case, emptying SUBCOMMAND_HANDLERS leaves the suite
+  // green while every real subcommand is dead.
+  test('a known subcommand runs its handler and propagates its exit code', async () => {
+    vi.mocked(runRelease).mockResolvedValue(7);
+
+    await expect(run(['release', 'bump'])).resolves.toBe(7);
+    expect(runRelease).toHaveBeenCalledWith(['bump']);
+  });
+
+  test('an unknown subcommand is rejected', async () => {
+    await expect(run(['bogus'])).resolves.toBe(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+    expect(readStderrPayload()).toMatchObject({code: 'unknown_subcommand'});
+  });
+
+  // A bare `Record` index resolves every `Object.prototype` member, so these
+  // tokens would dispatch to an inherited method: the callable ones ran and
+  // returned a non-number (silently exiting 0 without doing anything), and
+  // `__proto__` resolved to a non-callable and crashed the router. Each must be
+  // rejected as an unknown subcommand like any other typo.
+  test.each([
+    'toString',
+    'constructor',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__',
+  ])('the Object.prototype member %s is not a subcommand', async (token) => {
+    await expect(run([token])).resolves.toBe(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+    expect(readStderrPayload()).toMatchObject({code: 'unknown_subcommand'});
+    expect(runRelease).not.toHaveBeenCalled();
+  });
+});

--- a/.gaia/cli/src/index.maintainer.ts
+++ b/.gaia/cli/src/index.maintainer.ts
@@ -13,6 +13,8 @@
  * added here too unless it is intentionally adopter-only.
  */
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
+import {realpathSync} from 'node:fs';
+import {pathToFileURL} from 'node:url';
 import {run as runAutomation} from './automation/index.js';
 import {EXIT_CODES} from './exit.js';
 import {run as runFitness} from './fitness/index.js';
@@ -67,9 +69,9 @@ const SUBCOMMAND_HANDLERS: Readonly<
   wiki: runWiki,
 };
 
-const main = async (): Promise<number> => {
-  const subcommand = process.argv[2] as string | undefined;
-  const rest = process.argv.slice(3);
+export const run = async (argv: readonly string[]): Promise<number> => {
+  const subcommand = argv[0] as string | undefined;
+  const rest = argv.slice(1);
 
   if (subcommand === undefined || HELP_TOKENS.has(subcommand)) {
     printHelp();
@@ -77,7 +79,13 @@ const main = async (): Promise<number> => {
     return EXIT_CODES.OK;
   }
 
-  const handler = SUBCOMMAND_HANDLERS[subcommand];
+  // Own-property lookup. A bare `Record` index resolves every `Object.prototype`
+  // member, so `gaia-maintainer toString` would otherwise be accepted as a
+  // valid subcommand and exit 0 without running anything.
+  const handler =
+    Object.hasOwn(SUBCOMMAND_HANDLERS, subcommand) ?
+      SUBCOMMAND_HANDLERS[subcommand]
+    : undefined;
 
   if (handler !== undefined) {
     const result = await handler(rest);
@@ -90,14 +98,25 @@ const main = async (): Promise<number> => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-try {
-  const exitCode = await main();
+// Auto-execute only when invoked directly as the bundled binary, not when a
+// test imports this module. Both binaries are invoked by explicit path
+// (`node .gaia/cli/gaia ...`), so argv[1] is this file; a test runner's
+// argv[1] is vitest, so the guard is false and no process.exit fires.
+const invokedPath = process.argv[1] as string | undefined;
+const isDirectRun =
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(realpathSync(invokedPath)).href;
 
-  process.exit(exitCode);
-} catch (error: unknown) {
-  structuredError({
-    code: 'cli_internal_error',
-    message: error instanceof Error ? error.message : String(error),
-  });
-  process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+if (isDirectRun) {
+  try {
+    const exitCode = await run(process.argv.slice(2));
+
+    process.exit(exitCode);
+  } catch (error: unknown) {
+    structuredError({
+      code: 'cli_internal_error',
+      message: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+  }
 }

--- a/.gaia/cli/src/index.test.ts
+++ b/.gaia/cli/src/index.test.ts
@@ -1,0 +1,105 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {EXIT_CODES} from './exit.js';
+import {run as runPing} from './ping/index.js';
+import {run} from './index.js';
+
+vi.mock('./ping/index.js', () => ({run: vi.fn()}));
+
+const captureStdio = (): {
+  errors: string[];
+  outputs: string[];
+  restore: () => void;
+} => {
+  const outputs: string[] = [];
+  const errors: string[] = [];
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown) => {
+      outputs.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: unknown) => {
+      errors.push(typeof chunk === 'string' ? chunk : String(chunk));
+
+      return true;
+    });
+
+  return {
+    errors,
+    outputs,
+    restore: () => {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+};
+
+let stdio: ReturnType<typeof captureStdio>;
+
+beforeEach(() => {
+  vi.mocked(runPing).mockReset();
+  stdio = captureStdio();
+});
+
+afterEach(() => {
+  stdio.restore();
+});
+
+// Read every chunk, not just the first: a lone `calls[0]` read misses a payload
+// that arrives in a later write.
+const readStderrPayload = (): Record<string, unknown> =>
+  JSON.parse(stdio.errors.join('').trim().split('\n').at(-1) ?? '{}') as Record<
+    string,
+    unknown
+  >;
+
+describe('gaia top-level router', () => {
+  test.each(['--help', '-h', 'help'])(
+    '%s prints help and exits 0',
+    async (token) => {
+      await expect(run([token])).resolves.toBe(EXIT_CODES.OK);
+      expect(stdio.outputs.join('')).toContain('Usage: gaia');
+      expect(stdio.errors).toHaveLength(0);
+    }
+  );
+
+  test('no subcommand prints help and exits 0', async () => {
+    await expect(run([])).resolves.toBe(EXIT_CODES.OK);
+    expect(stdio.outputs.join('')).toContain('Usage: gaia');
+  });
+
+  // The guard this suite exists to pin only earns its keep if dispatch still
+  // works. Without this case, emptying SUBCOMMAND_HANDLERS leaves the suite
+  // green while every real subcommand is dead.
+  test('a known subcommand runs its handler and propagates its exit code', async () => {
+    vi.mocked(runPing).mockResolvedValue(7);
+
+    await expect(run(['ping', '--x'])).resolves.toBe(7);
+    expect(runPing).toHaveBeenCalledWith(['--x']);
+  });
+
+  test('an unknown subcommand is rejected', async () => {
+    await expect(run(['bogus'])).resolves.toBe(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+    expect(readStderrPayload()).toMatchObject({code: 'unknown_subcommand'});
+  });
+
+  // A bare `Record` index resolves every `Object.prototype` member, so these
+  // tokens would dispatch to an inherited method: the callable ones ran and
+  // returned a non-number (silently exiting 0 without doing anything), and
+  // `__proto__` resolved to a non-callable and crashed the router. Each must be
+  // rejected as an unknown subcommand like any other typo.
+  test.each([
+    'toString',
+    'constructor',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__',
+  ])('the Object.prototype member %s is not a subcommand', async (token) => {
+    await expect(run([token])).resolves.toBe(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+    expect(readStderrPayload()).toMatchObject({code: 'unknown_subcommand'});
+    expect(runPing).not.toHaveBeenCalled();
+  });
+});

--- a/.gaia/cli/src/index.ts
+++ b/.gaia/cli/src/index.ts
@@ -9,6 +9,8 @@
  * bundle by construction.
  */
 /* eslint-disable unicorn/no-process-exit -- this IS a CLI binary */
+import {realpathSync} from 'node:fs';
+import {pathToFileURL} from 'node:url';
 import {run as runAutomation} from './automation/index.js';
 import {run as runCiRevert} from './ci/revert.js';
 import {run as runCiStaleCheck} from './ci/stale-check.js';
@@ -79,12 +81,12 @@ const SUBCOMMAND_HANDLERS: Readonly<
   wiki: runWiki,
 };
 
-const main = async (): Promise<number> => {
-  // process.argv[2] is undefined when no subcommand is supplied. Node's
-  // typings model argv as `string[]` (no `noUncheckedIndexedAccess`),
-  // so we coerce through unknown to express the runtime reality.
-  const subcommand = process.argv[2] as string | undefined;
-  const rest = process.argv.slice(3);
+export const run = async (argv: readonly string[]): Promise<number> => {
+  // argv[0] is undefined when no subcommand is supplied. Node's typings
+  // model argv as `string[]` (no `noUncheckedIndexedAccess`), so we cast
+  // to express the runtime reality.
+  const subcommand = argv[0] as string | undefined;
+  const rest = argv.slice(1);
 
   if (subcommand === undefined || HELP_TOKENS.has(subcommand)) {
     printHelp();
@@ -92,7 +94,13 @@ const main = async (): Promise<number> => {
     return EXIT_CODES.OK;
   }
 
-  const handler = SUBCOMMAND_HANDLERS[subcommand];
+  // Own-property lookup. A bare `Record` index resolves every `Object.prototype`
+  // member, so `gaia toString` would otherwise be accepted as a valid
+  // subcommand and exit 0 without running anything.
+  const handler =
+    Object.hasOwn(SUBCOMMAND_HANDLERS, subcommand) ?
+      SUBCOMMAND_HANDLERS[subcommand]
+    : undefined;
 
   if (handler !== undefined) {
     const result = await handler(rest);
@@ -105,14 +113,25 @@ const main = async (): Promise<number> => {
   return EXIT_CODES.UNKNOWN_SUBCOMMAND;
 };
 
-try {
-  const exitCode = await main();
+// Auto-execute only when invoked directly as the bundled binary, not when a
+// test imports this module. Both binaries are invoked by explicit path
+// (`node .gaia/cli/gaia ...`), so argv[1] is this file; a test runner's
+// argv[1] is vitest, so the guard is false and no process.exit fires.
+const invokedPath = process.argv[1] as string | undefined;
+const isDirectRun =
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(realpathSync(invokedPath)).href;
 
-  process.exit(exitCode);
-} catch (error: unknown) {
-  structuredError({
-    code: 'cli_internal_error',
-    message: error instanceof Error ? error.message : String(error),
-  });
-  process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+if (isDirectRun) {
+  try {
+    const exitCode = await run(process.argv.slice(2));
+
+    process.exit(exitCode);
+  } catch (error: unknown) {
+    structuredError({
+      code: 'cli_internal_error',
+      message: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(EXIT_CODES.UNKNOWN_SUBCOMMAND);
+  }
 }


### PR DESCRIPTION
Both top-level CLI subcommand routers (`gaia` and `gaia-maintainer`) resolved their handler with a bare `Record` index, so `Object.prototype` members (`toString`, `constructor`, `valueOf`, `hasOwnProperty`, `__proto__`) dispatched as if registered: the callable ones ran, returned a non-number, and the router coerced that into a silent exit 0, while `__proto__` crashed. A genuine unknown subcommand was correctly rejected, so the failure was precisely inverted.

Gate both lookups with `Object.hasOwn`, mirroring the fix already in `release/index.ts`. To pin it, each router's dispatch is extracted into an exported `run(argv)` and its auto-execution is main-guarded (fires only when invoked as the bundled binary, not when a test imports it), so a co-located test can exercise it. `SUBCOMMAND_HANDLERS` stays in place in each entrypoint so `command-reachability.test.ts` is unaffected. Both committed binaries are rebuilt.

This is the last two of four instances of the class first fixed in #686 (the two `release/` routers).

Closes #700
