### PR TITLE
fix(tests): anchor distribution marker-fragment greps on live delimiters (#688 #719)

### DIFF
--- a/.gaia/tests/distribution/02-leak-replay.sh
+++ b/.gaia/tests/distribution/02-leak-replay.sh
@@ -60,7 +60,7 @@ fi
 
 # Belt-and-suspenders: also assert the post-build-staging tree contains
 # no marker fragments that the strip should have caught.
-MARKER_FRAGMENTS=$(grep -rn 'gaia:maintainer-only' "$STAGING" 2>/dev/null || true)
+MARKER_FRAGMENTS=$(grep -rnE 'gaia:maintainer-only:(start|end)' "$STAGING" 2>/dev/null || true)
 if [ -n "$MARKER_FRAGMENTS" ]; then
   log "Marker fragments survived strip:"
   printf '%s\n' "$MARKER_FRAGMENTS" >&2

--- a/.gaia/tests/distribution/03-marker-strip.sh
+++ b/.gaia/tests/distribution/03-marker-strip.sh
@@ -19,7 +19,7 @@ trap 'rm -rf "$STAGING"' EXIT
   || { fail "build-staging failed"; exit 1; }
 
 # 1. No marker fragments survive in staging tree.
-SURVIVING=$(grep -rln 'gaia:maintainer-only' "$STAGING" 2>/dev/null || true)
+SURVIVING=$(grep -rlnE 'gaia:maintainer-only:(start|end)' "$STAGING" 2>/dev/null || true)
 if [ -n "$SURVIVING" ]; then
   log "Marker fragments survived strip in staging:"
   printf '%s\n' "$SURVIVING" >&2


### PR DESCRIPTION
Both `02-leak-replay.sh` and `03-marker-strip.sh` asserted "no maintainer-only marker survived the scrub" with a bare substring grep for `gaia:maintainer-only`, which false-positives on shipped files whose prose legitimately *describes* the marker syntax (e.g. `wiki/decisions/Code Audit Team.md`, `.gaia/scripts/resolve-audit-members.sh`). Their live `:start`/`:end` delimiters are correctly stripped; only the descriptive prose remains, which is correct.

Anchor both greps on a live delimiter (`gaia:maintainer-only:(start|end)`), mirroring the already-correct sibling assertion at `03-marker-strip.sh:59`. A genuine unstripped delimiter is still caught; descriptive prose no longer trips the gate.

Verified by direct pattern proof: the old bare pattern matches the two prose files; the new anchored pattern does not match their prose but does match real `<!-- gaia:maintainer-only:start -->` / `:end` delimiters and a leak fixture.

Closes #688
Closes #719
