### PR TITLE
fix(harden): merge findings-block per auditor, not last-block-wins (#731)

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -17213,14 +17213,15 @@ var parseFindingsBlock = (body, onReject = defaultOnReject) => {
     return null;
   }
   if (typeof parsed !== "object" || parsed === null) return null;
-  const { findings } = parsed;
+  const { auditor: rawAuditor, findings } = parsed;
   if (!Array.isArray(findings)) return null;
+  const auditor = typeof rawAuditor === "string" && rawAuditor.length > 0 ? rawAuditor : "";
   const result = [];
   for (const entry of findings) {
     const finding = parseFinding(entry, onReject);
     if (finding !== null) result.push(finding);
   }
-  return result;
+  return { auditor, findings: result };
 };
 
 // src/harden/tally.ts
@@ -17255,12 +17256,13 @@ var parseGhPr = (value) => {
   return { comments, number: v.number };
 };
 var recordFromGhPr = (pr) => {
-  let findings;
+  const byAuditor = /* @__PURE__ */ new Map();
   for (const comment of pr.comments) {
     const block = parseFindingsBlock(comment.body);
-    if (block !== null) findings = block;
+    if (block !== null) byAuditor.set(block.auditor, block.findings);
   }
-  return findings === void 0 ? null : { findings, pr_number: pr.number };
+  if (byAuditor.size === 0) return null;
+  return { findings: [...byAuditor.values()].flat(), pr_number: pr.number };
 };
 var fetchWindowPrs = (cwd, now) => {
   const search = `merged:>=${windowStartDate(now)}`;

--- a/.gaia/cli/src/harden/__tests__/parse-findings-block.test.ts
+++ b/.gaia/cli/src/harden/__tests__/parse-findings-block.test.ts
@@ -34,26 +34,29 @@ describe('parseFindingsBlock', () => {
       })
     );
 
-    const findings = parseFindingsBlock(body);
-    expect(findings).toEqual([
-      {
-        area_tags: ['app/components'],
-        finding_class: 'react-doctor/no-generic-handler-names',
-        severity: 'warning',
-      },
-      {
-        area_tags: ['app/routes'],
-        finding_class: 'holistic/missing-auth-check',
-        severity: 'error',
-      },
-    ]);
+    const parsedBlock = parseFindingsBlock(body);
+    expect(parsedBlock).toEqual({
+      auditor: 'ci',
+      findings: [
+        {
+          area_tags: ['app/components'],
+          finding_class: 'react-doctor/no-generic-handler-names',
+          severity: 'warning',
+        },
+        {
+          area_tags: ['app/routes'],
+          finding_class: 'holistic/missing-auth-check',
+          severity: 'error',
+        },
+      ],
+    });
   });
 
-  test('returns [] for an explicit empty findings block', () => {
+  test('returns the auditor verbatim alongside [] for an explicit empty findings block', () => {
     const body = block(
       JSON.stringify({auditor: 'ci', findings: [], pr_number: 7, schema: 1})
     );
-    expect(parseFindingsBlock(body)).toEqual([]);
+    expect(parseFindingsBlock(body)).toEqual({auditor: 'ci', findings: []});
   });
 
   test('returns null when no sentinels are present', () => {
@@ -86,9 +89,16 @@ describe('parseFindingsBlock', () => {
       })
     );
 
-    expect(parseFindingsBlock(body)).toEqual([
-      {area_tags: ['app'], finding_class: 'knip/exports', severity: 'warning'},
-    ]);
+    expect(parseFindingsBlock(body)).toEqual({
+      auditor: 'local',
+      findings: [
+        {
+          area_tags: ['app'],
+          finding_class: 'knip/exports',
+          severity: 'warning',
+        },
+      ],
+    });
   });
 
   test('fires onReject naming the unaccepted severity token, UAT-036', () => {
@@ -107,7 +117,10 @@ describe('parseFindingsBlock', () => {
     );
     const onReject = vi.fn();
 
-    expect(parseFindingsBlock(body, onReject)).toEqual([]);
+    expect(parseFindingsBlock(body, onReject)).toEqual({
+      auditor: '',
+      findings: [],
+    });
     expect(onReject).toHaveBeenCalledExactlyOnceWith('severity', 'Critical');
   });
 
@@ -121,7 +134,10 @@ describe('parseFindingsBlock', () => {
     );
     const onReject = vi.fn();
 
-    expect(parseFindingsBlock(body, onReject)).toEqual([]);
+    expect(parseFindingsBlock(body, onReject)).toEqual({
+      auditor: '',
+      findings: [],
+    });
     expect(onReject).toHaveBeenCalledExactlyOnceWith(
       'finding_class',
       'undefined'
@@ -144,7 +160,10 @@ describe('parseFindingsBlock', () => {
     );
     const onReject = vi.fn();
 
-    expect(parseFindingsBlock(body, onReject)).toEqual([]);
+    expect(parseFindingsBlock(body, onReject)).toEqual({
+      auditor: '',
+      findings: [],
+    });
     expect(onReject).toHaveBeenCalledExactlyOnceWith('area_tags', '[1,2]');
   });
 
@@ -154,7 +173,10 @@ describe('parseFindingsBlock', () => {
     );
     const onReject = vi.fn();
 
-    expect(parseFindingsBlock(body, onReject)).toEqual([]);
+    expect(parseFindingsBlock(body, onReject)).toEqual({
+      auditor: '',
+      findings: [],
+    });
     expect(onReject).toHaveBeenCalledExactlyOnceWith('shape', 'not-an-object');
   });
 
@@ -173,6 +195,25 @@ describe('parseFindingsBlock', () => {
       )
     ).toBeNull();
     expect(onReject).not.toHaveBeenCalled();
+  });
+
+  test('normalizes a missing auditor field to the "" bucket', () => {
+    const body = block(JSON.stringify({findings: [], pr_number: 1, schema: 1}));
+    expect(parseFindingsBlock(body)).toEqual({auditor: '', findings: []});
+  });
+
+  test('normalizes an empty-string auditor to the "" bucket', () => {
+    const body = block(
+      JSON.stringify({auditor: '', findings: [], pr_number: 1, schema: 1})
+    );
+    expect(parseFindingsBlock(body)).toEqual({auditor: '', findings: []});
+  });
+
+  test('normalizes a non-string auditor to the "" bucket', () => {
+    const body = block(
+      JSON.stringify({auditor: 7, findings: [], pr_number: 1, schema: 1})
+    );
+    expect(parseFindingsBlock(body)).toEqual({auditor: '', findings: []});
   });
 
   test('accepts every declared reject reason', () => {

--- a/.gaia/cli/src/harden/__tests__/tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/tally.test.ts
@@ -52,7 +52,7 @@ type BlockFinding = {
 
 const findingsComment = (
   prNumber: number,
-  auditor: 'ci' | 'local',
+  auditor: string,
   findings: BlockFinding[]
 ): {body: string} => ({
   body: [
@@ -60,6 +60,22 @@ const findingsComment = (
     '<!-- gaia-harden:findings:start -->',
     '<!--',
     JSON.stringify({auditor, findings, pr_number: prNumber, schema: 1}),
+    '-->',
+    '<!-- gaia-harden:findings:end -->',
+  ].join('\n'),
+});
+
+// Same shape as `findingsComment` but omits the `auditor` key entirely, for
+// exercising the parser's missing-auditor normalization to the `''` bucket.
+const anonymousFindingsComment = (
+  prNumber: number,
+  findings: BlockFinding[]
+): {body: string} => ({
+  body: [
+    'Audit summary.',
+    '<!-- gaia-harden:findings:start -->',
+    '<!--',
+    JSON.stringify({findings, pr_number: prNumber, schema: 1}),
     '-->',
     '<!-- gaia-harden:findings:end -->',
   ].join('\n'),
@@ -185,6 +201,196 @@ describe('harden-tally run', () => {
     expect(printed.candidate_count).toBe(1);
     const candidates = printed.candidates as Record<string, unknown>[];
     expect(candidates[0]?.severity_max).toBe('error');
+  });
+
+  test('two different auditors posting on the same PR both count (#731 regression)', () => {
+    // PR 1201 carries a 'ci' block for classA and a 'local' block for classB
+    // in the SAME comment list. Under the old last-block-on-the-PR-wins bug,
+    // only the local/classB block would survive, so classA would be short one
+    // PR and fall below the recurrence threshold.
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1201, [
+          findingsComment(1201, 'ci', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+          findingsComment(1201, 'local', [
+            {
+              area_tags: ['app'],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(1188, [
+          findingsComment(1188, 'ci', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(1175, [
+          findingsComment(1175, 'ci', [
+            {
+              area_tags: ['app'],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    const printed = parseStdout(stdout.out);
+    const candidates = printed.candidates as Record<string, unknown>[];
+    const switchCandidate = candidates.find(
+      (c) => c.finding_class === 'rule/switch-statement'
+    );
+    expect(switchCandidate?.distinct_pr_count).toBe(3);
+    expect(switchCandidate?.pr_numbers).toContain(1201);
+  });
+
+  test('same auditor re-running on a PR supersedes its own earlier block, not merges', () => {
+    // PR 1 carries two 'ci' blocks: the second (classB) must fully replace
+    // the first (classA) for that auditor, so classA gets no credit from PR 1.
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1, [
+          findingsComment(1, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+          findingsComment(1, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(2, [
+          findingsComment(2, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(3, [
+          findingsComment(3, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(4, [
+          findingsComment(4, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(5, [
+          findingsComment(5, 'ci', [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    const printed = parseStdout(stdout.out);
+    // classA (rule/switch-statement) only reaches PRs 2 and 3 (2 distinct):
+    // PR 1's ci/classA block was superseded by ci/classB on the same PR, so
+    // it must not qualify. classB (axe/color-contrast) reaches PRs 1, 4, 5.
+    expect(printed.candidate_count).toBe(1);
+    const candidates = printed.candidates as Record<string, unknown>[];
+    expect(candidates[0]?.finding_class).toBe('axe/color-contrast');
+    expect(candidates[0]?.pr_numbers).toEqual(
+      expect.arrayContaining([1, 4, 5])
+    );
+  });
+
+  test('two anonymous (missing-auditor) blocks on the same PR collapse, latest wins', () => {
+    // Both blocks omit `auditor`, so the parser normalizes each to the same
+    // '' bucket: the second (classB) must supersede the first (classA), the
+    // same as a same-auditor re-run, not merge as if from different auditors.
+    vi.spyOn(runProcess, 'runGh').mockReturnValue(
+      stubGh([
+        ghPr(1, [
+          anonymousFindingsComment(1, [
+            {
+              area_tags: [],
+              finding_class: 'rule/switch-statement',
+              severity: 'warning',
+            },
+          ]),
+          anonymousFindingsComment(1, [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(2, [
+          anonymousFindingsComment(2, [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+        ghPr(3, [
+          anonymousFindingsComment(3, [
+            {
+              area_tags: [],
+              finding_class: 'axe/color-contrast',
+              severity: 'warning',
+            },
+          ]),
+        ]),
+      ])
+    );
+
+    run([], {
+      cwd: sandbox.root,
+      runLedger: () => ({exitCode: 1, stderr: '', stdout: ''}),
+    });
+
+    const printed = parseStdout(stdout.out);
+    expect(printed.candidate_count).toBe(1);
+    const candidates = printed.candidates as Record<string, unknown>[];
+    expect(candidates[0]?.finding_class).toBe('axe/color-contrast');
+    expect(candidates[0]?.distinct_pr_count).toBe(3);
   });
 
   test('does not surface a class on only 2 distinct PRs', () => {

--- a/.gaia/cli/src/harden/parse-findings-block.ts
+++ b/.gaia/cli/src/harden/parse-findings-block.ts
@@ -28,6 +28,18 @@ export type ParsedFinding = {
 };
 
 /**
+ * A parsed block: the findings plus the producer that posted them. `auditor`
+ * is read verbatim from the payload's `auditor` field when it is a non-empty
+ * string; a missing, empty, or non-string `auditor` normalizes to `''`, the
+ * shared "anonymous producer" bucket (see `recordFromGhPr` in `tally.ts`,
+ * which keys its per-auditor merge on this field).
+ */
+export type ParsedFindingsBlock = {
+  auditor: string;
+  findings: ParsedFinding[];
+};
+
+/**
  * The one accepted severity set. `severity-map.ts`'s `SEVERITY_BY_GRADING`
  * maps every agent grading onto it; it is the one source and no test may
  * re-declare it (README FC-7).
@@ -94,19 +106,22 @@ const parseFinding = (
 };
 
 /**
- * Returns the well-formed findings in `body`, `[]` for an explicit empty block,
- * or `null` when no parseable block is present. `onReject` (default: a stderr
- * writer) fires once per dropped finding, bad severity, missing/empty
- * finding_class, malformed area_tags, or a non-object entry, naming the
- * offending token. It never fires on a `null` return: that means "no
- * parseable block" (no sentinels, no inner comment, bad JSON, `findings` not
- * an array), a different thing from a dropped finding, and the overwhelmingly
- * common case of a comment carrying no block at all must stay silent.
+ * Returns `{auditor, findings}` for a parseable block, or `null` when no
+ * parseable block is present. `findings` is `[]` for an explicit empty block.
+ * `auditor` is the payload's `auditor` field verbatim when it is a non-empty
+ * string; a missing, empty, or non-string `auditor` normalizes to `''` (see
+ * `ParsedFindingsBlock`). `onReject` (default: a stderr writer) fires once per
+ * dropped finding, bad severity, missing/empty finding_class, malformed
+ * area_tags, or a non-object entry, naming the offending token. It never
+ * fires on a `null` return: that means "no parseable block" (no sentinels, no
+ * inner comment, bad JSON, `findings` not an array), a different thing from a
+ * dropped finding, and the overwhelmingly common case of a comment carrying
+ * no block at all must stay silent.
  */
 export const parseFindingsBlock = (
   body: string,
   onReject: OnReject = defaultOnReject
-): null | ParsedFinding[] => {
+): null | ParsedFindingsBlock => {
   const startIndex = body.indexOf(START_SENTINEL);
 
   if (startIndex === -1) return null;
@@ -138,9 +153,12 @@ export const parseFindingsBlock = (
 
   if (typeof parsed !== 'object' || parsed === null) return null;
 
-  const {findings} = parsed as Record<string, unknown>;
+  const {auditor: rawAuditor, findings} = parsed as Record<string, unknown>;
 
   if (!Array.isArray(findings)) return null;
+
+  const auditor =
+    typeof rawAuditor === 'string' && rawAuditor.length > 0 ? rawAuditor : '';
 
   const result: ParsedFinding[] = [];
 
@@ -150,5 +168,5 @@ export const parseFindingsBlock = (
     if (finding !== null) result.push(finding);
   }
 
-  return result;
+  return {auditor, findings: result};
 };

--- a/.gaia/cli/src/harden/tally.ts
+++ b/.gaia/cli/src/harden/tally.ts
@@ -95,29 +95,37 @@ const parseGhPr = (value: unknown): GhPr | null => {
   return {comments, number: v.number};
 };
 
-// Builds a tally record from a parsed gh PR, taking the LATEST comment that
-// carries a parseable findings block (a re-run audit supersedes an earlier
-// one on the same PR). Returns null when no comment carries a block.
+// Builds a tally record from a parsed gh PR, merging findings PER AUDITOR: for
+// each parseable block, the block's `auditor` field (normalized to `''` for a
+// missing/empty/non-string auditor by the parser) keys a Map, so a later
+// block from the SAME auditor supersedes its own earlier one (a re-run audit
+// supersedes an earlier run), while blocks from DIFFERENT auditors on the
+// same PR both survive. The merged record flattens every auditor's surviving
+// findings in Map insertion order (gh's chronological comment order).
+// Returns null when no comment carries a parseable block.
 const recordFromGhPr = (pr: GhPr): null | TallyPrRecord => {
-  let findings: TallyPrRecord['findings'] | undefined;
+  const byAuditor = new Map<string, TallyPrRecord['findings']>();
 
   for (const comment of pr.comments) {
     const block = parseFindingsBlock(comment.body);
 
-    if (block !== null) findings = block;
+    if (block !== null) byAuditor.set(block.auditor, block.findings);
   }
 
-  return findings === undefined ? null : {findings, pr_number: pr.number};
+  if (byAuditor.size === 0) return null;
+
+  return {findings: [...byAuditor.values()].flat(), pr_number: pr.number};
 };
 
 /**
  * Reads the merged-PR window via gh. Returns one record per PR that carries a
- * parseable findings block (the latest such comment wins so a re-run audit
- * supersedes an earlier one), alongside `ghOk`. `ghOk` is `false` on any gh
- * failure (non-zero exit, unparseable JSON, or a well-formed-but-non-array
- * response, all read failures rather than empty windows) and `true` otherwise,
- * including a genuinely empty window. The refresher never blocks: an empty `prs`
- * list is returned in every failure case.
+ * parseable findings block, merging every auditor's findings on that PR
+ * (latest block wins per auditor; see `recordFromGhPr`), alongside `ghOk`.
+ * `ghOk` is `false` on any gh failure (non-zero exit, unparseable JSON, or a
+ * well-formed-but-non-array response, all read failures rather than empty
+ * windows) and `true` otherwise, including a genuinely empty window. The
+ * refresher never blocks: an empty `prs` list is returned in every failure
+ * case.
  */
 const fetchWindowPrs = (cwd: string, now: Date): WindowPrs => {
   const search = `merged:>=${windowStartDate(now)}`;


### PR DESCRIPTION
## What

`recordFromGhPr` walked every comment on a PR and overwrote `findings` with each parseable findings block, so only the **last** block survived. Correct for one auditor re-running (superseding its own earlier block), but the moment a second producer posts a block on the same PR, one producer's findings were silently discarded, the recurrence tally under-counted, and `distinct_pr_count` was wrong. This was the single reason a second findings-block producer could not be added to the audit.

## Fix

Key the merge on the block's `auditor` field: **latest block wins per auditor, findings merge across auditors.** The re-run-supersedes property is preserved within a single auditor.

- `parseFindingsBlock` now returns `{auditor, findings}` (was a bare `ParsedFinding[]`). A missing / empty / non-string `auditor` normalizes to the `''` anonymous-producer bucket.
- `recordFromGhPr` accumulates `auditor -> findings` in a Map (later block for the same auditor overwrites), then flattens all auditors' findings in chronological order.
- `compute-tally`'s `collapsePr` already dedups findings per-PR-per-class, so merging across auditors does not inflate `distinct_pr_count`.

Only production consumer of `parseFindingsBlock` is `tally.ts`; its tests and the parser tests are updated to the new shape, plus new coverage for the two-auditor, same-auditor-re-run, and anonymous-bucket cases.

Both committed CLI binaries rebuilt (`pnpm -C .gaia/cli bundle`). No CHANGELOG entry (internal maintainer machinery, adopter-invisible).

Closes #731