### PR TITLE
fix(setup-ci): preserve unknown automation.json keys on write (#753)

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -22878,11 +22878,10 @@ var run43 = (argv, options = {}) => {
     return EXIT_CODES.CONFIG_INVALID;
   }
   const key = TOOL_ID_TO_CONFIG_KEY[tool];
-  const existing = result.config[key];
-  const nextSlot = existing.schedule === void 0 ? { mode } : { mode, schedule: existing.schedule };
+  const existingSlot = result.raw[key] ?? {};
   writeAutomationConfig(repoRoot, {
     ...result.raw,
-    [key]: nextSlot
+    [key]: { ...existingSlot, mode }
   });
   process.stdout.write(`${JSON.stringify({ mode, tool })}
 `);

--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -22163,7 +22163,7 @@ var run37 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
   if (result.status === "missing") {
     structuredError({
       code: "config_missing",
@@ -22182,7 +22182,7 @@ var run37 = (argv, options = {}) => {
   }
   const alreadyFinalized = result.config.setup_complete;
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     setup_complete: true
   });
   process.stdout.write(
@@ -22224,7 +22224,7 @@ var run38 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
   if (result.status === "missing") {
     structuredError({
       code: "config_missing",
@@ -22242,7 +22242,7 @@ var run38 = (argv, options = {}) => {
     return EXIT_CODES.CONFIG_INVALID;
   }
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     setup_opted_out: true
   });
   process.stdout.write(`${JSON.stringify({ opted_out: true })}
@@ -22860,7 +22860,7 @@ var run43 = (argv, options = {}) => {
     });
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
   if (result.status === "missing") {
     structuredError({
       code: "config_missing",
@@ -22881,7 +22881,7 @@ var run43 = (argv, options = {}) => {
   const existing = result.config[key];
   const nextSlot = existing.schedule === void 0 ? { mode } : { mode, schedule: existing.schedule };
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     [key]: nextSlot
   });
   process.stdout.write(`${JSON.stringify({ mode, tool })}

--- a/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {writeFileSync} from 'node:fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {automationConfigPath} from '../../automation/paths.js';
 import {readAutomationConfig} from '../../schemas/automation-config.js';
 import {run} from '../finalize.js';
@@ -51,6 +51,31 @@ describe('setup-ci finalize', () => {
     stdio.restore();
     sandbox.cleanup();
     vi.restoreAllMocks();
+  });
+
+  test('read-merge preservation: an unknown key a newer binary wrote survives (#753)', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({
+        ...VALID_BASE_CONFIG,
+        future_slice_key: 'x',
+        setup_complete: false,
+      }),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const written = JSON.parse(
+      readFileSync(automationConfigPath(sandbox.root), 'utf8')
+    ) as Record<string, unknown>;
+    expect(written.future_slice_key).toBe('x');
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+    assertStatusOk(result);
+    expect(result.config.setup_complete).toBe(true);
   });
 
   test('flips setup_complete=true on a pending config', () => {

--- a/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {writeFileSync} from 'node:fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {automationConfigPath} from '../../automation/paths.js';
 import {readAutomationConfig} from '../../schemas/automation-config.js';
 import {run} from '../opt-out-team.js';
@@ -51,6 +51,27 @@ describe('setup-ci opt-out-team', () => {
     stdio.restore();
     sandbox.cleanup();
     vi.restoreAllMocks();
+  });
+
+  test('read-merge preservation: an unknown key a newer binary wrote survives (#753)', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({...VALID_BASE_CONFIG, future_slice_key: 'x'}),
+      'utf8'
+    );
+
+    const exit = run([], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const written = JSON.parse(
+      readFileSync(automationConfigPath(sandbox.root), 'utf8')
+    ) as Record<string, unknown>;
+    expect(written.future_slice_key).toBe('x');
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+    assertStatusOk(result);
+    expect(result.config.setup_opted_out).toBe(true);
   });
 
   test('flips setup_opted_out=true preserving other fields', () => {

--- a/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
@@ -77,6 +77,25 @@ describe('setup-ci write-tool-mode', () => {
     expect(result.config.wiki.mode).toBe('off');
   });
 
+  test('read-merge preservation: an unknown sub-field inside the modified slot survives (#753)', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({
+        ...VALID_BASE_CONFIG,
+        wiki: {future_subfield: 'keep-me', mode: 'off'},
+      }),
+      'utf8'
+    );
+
+    const exit = run(['wiki', 'ci'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const written = JSON.parse(
+      readFileSync(automationConfigPath(sandbox.root), 'utf8')
+    ) as Record<string, unknown>;
+    expect(written.wiki).toEqual({future_subfield: 'keep-me', mode: 'ci'});
+  });
+
   test('flips a tool mode to off and preserves schedule', () => {
     sandbox.writeConfig(VALID_BASE_CONFIG);
 

--- a/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {writeFileSync} from 'node:fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {automationConfigPath} from '../../automation/paths.js';
 import {readAutomationConfig} from '../../schemas/automation-config.js';
 import {run} from '../write-tool-mode.js';
@@ -51,6 +51,30 @@ describe('setup-ci write-tool-mode', () => {
     stdio.restore();
     sandbox.cleanup();
     vi.restoreAllMocks();
+  });
+
+  test('read-merge preservation: an unknown key a newer binary wrote survives (#753)', () => {
+    writeFileSync(
+      automationConfigPath(sandbox.root),
+      JSON.stringify({
+        ...VALID_BASE_CONFIG,
+        future_slice_key: {foo: 'bar'},
+      }),
+      'utf8'
+    );
+
+    const exit = run(['wiki', 'off'], {cwd: sandbox.root});
+    expect(exit).toBe(0);
+
+    const written = JSON.parse(
+      readFileSync(automationConfigPath(sandbox.root), 'utf8')
+    ) as Record<string, unknown>;
+    expect(written.future_slice_key).toEqual({foo: 'bar'});
+
+    const result = readAutomationConfig(sandbox.root);
+    expect(result.status).toBe('ok');
+    assertStatusOk(result);
+    expect(result.config.wiki.mode).toBe('off');
   });
 
   test('flips a tool mode to off and preserves schedule', () => {

--- a/.gaia/cli/src/setup-ci/finalize.ts
+++ b/.gaia/cli/src/setup-ci/finalize.ts
@@ -8,7 +8,8 @@
  * file's content (the write itself runs and is a no-op shape-wise).
  */
 import {EXIT_CODES} from '../exit.js';
-import {readAutomationConfig} from '../schemas/automation-config.js';
+import {readAutomationConfigRaw} from '../schemas/automation-config.js';
+import type {AutomationConfig} from '../schemas/automation-config.js';
 import {structuredError} from '../stderr.js';
 import {resolveRepoRoot} from '../wiki/util/git.js';
 import {writeAutomationConfig} from './util/automation-write.js';
@@ -62,7 +63,7 @@ export const run = (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
 
   if (result.status === 'missing') {
     structuredError({
@@ -87,9 +88,9 @@ export const run = (
   const alreadyFinalized = result.config.setup_complete;
 
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     setup_complete: true,
-  });
+  } as AutomationConfig);
 
   process.stdout.write(
     `${JSON.stringify({already_finalized: alreadyFinalized, finalized: true})}\n`

--- a/.gaia/cli/src/setup-ci/opt-out-team.ts
+++ b/.gaia/cli/src/setup-ci/opt-out-team.ts
@@ -10,7 +10,8 @@
  * fail-closed, no destructive write on a broken state.
  */
 import {EXIT_CODES} from '../exit.js';
-import {readAutomationConfig} from '../schemas/automation-config.js';
+import {readAutomationConfigRaw} from '../schemas/automation-config.js';
+import type {AutomationConfig} from '../schemas/automation-config.js';
 import {structuredError} from '../stderr.js';
 import {resolveRepoRoot} from '../wiki/util/git.js';
 import {writeAutomationConfig} from './util/automation-write.js';
@@ -65,7 +66,7 @@ export const run = (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
 
   if (result.status === 'missing') {
     structuredError({
@@ -88,9 +89,9 @@ export const run = (
   }
 
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     setup_opted_out: true,
-  });
+  } as AutomationConfig);
 
   process.stdout.write(`${JSON.stringify({opted_out: true})}\n`);
 

--- a/.gaia/cli/src/setup-ci/write-tool-mode.ts
+++ b/.gaia/cli/src/setup-ci/write-tool-mode.ts
@@ -14,12 +14,13 @@
  */
 import {EXIT_CODES} from '../exit.js';
 import {
-  readAutomationConfig,
+  readAutomationConfigRaw,
   TOOL_ID_TO_CONFIG_KEY,
   TOOL_IDS,
   ToolModeSchema,
 } from '../schemas/automation-config.js';
 import type {
+  AutomationConfig,
   ToolConfig,
   ToolId,
   ToolMode,
@@ -114,7 +115,7 @@ export const run = (
     return EXIT_CODES.UNKNOWN_SUBCOMMAND;
   }
 
-  const result = readAutomationConfig(repoRoot);
+  const result = readAutomationConfigRaw(repoRoot);
 
   if (result.status === 'missing') {
     structuredError({
@@ -146,9 +147,9 @@ export const run = (
     : {mode, schedule: existing.schedule};
 
   writeAutomationConfig(repoRoot, {
-    ...result.config,
+    ...result.raw,
     [key]: nextSlot,
-  });
+  } as AutomationConfig);
 
   process.stdout.write(`${JSON.stringify({mode, tool})}\n`);
 

--- a/.gaia/cli/src/setup-ci/write-tool-mode.ts
+++ b/.gaia/cli/src/setup-ci/write-tool-mode.ts
@@ -21,7 +21,6 @@ import {
 } from '../schemas/automation-config.js';
 import type {
   AutomationConfig,
-  ToolConfig,
   ToolId,
   ToolMode,
 } from '../schemas/automation-config.js';
@@ -138,17 +137,15 @@ export const run = (
   }
 
   const key = TOOL_ID_TO_CONFIG_KEY[tool];
-  // The config slot is `ToolConfig` (mode + optional schedule) for the
-  // four tool keys. Preserve `schedule` when present.
-  const existing = result.config[key] as ToolConfig;
-  const nextSlot: ToolConfig =
-    existing.schedule === undefined ?
-      {mode}
-    : {mode, schedule: existing.schedule};
+  // Spread the RAW slot (not the Zod-stripped `result.config[key]`) so an
+  // unknown sub-field a newer binary wrote inside this slot survives the
+  // round-trip; only `mode` is overridden. A raw slot with no `schedule`
+  // spreads to no `schedule`; one with a `schedule` keeps it.
+  const existingSlot = (result.raw[key] ?? {}) as Record<string, unknown>;
 
   writeAutomationConfig(repoRoot, {
     ...result.raw,
-    [key]: nextSlot,
+    [key]: {...existingSlot, mode},
   } as AutomationConfig);
 
   process.stdout.write(`${JSON.stringify({mode, tool})}\n`);


### PR DESCRIPTION
## What

`writeAutomationConfig` serializes whatever object it is handed verbatim, so unknown keys a newer CLI binary wrote to `.gaia/automation.json` are meant to survive a round-trip. But its three callers defeated that guarantee: `write-tool-mode`, `finalize`, and `opt-out-team` each read `readAutomationConfig(repoRoot)` and spread the Zod-**stripped** `result.config` into the write payload, so any key the current binary's `AutomationConfigSchema` did not know about was silently dropped and `/setup-gaia` committed the deletion. Silent data loss on every affected write.

## Fix

Switch all three callers to `readAutomationConfigRaw` and read-merge the intended change onto the unstripped `result.raw`, mirroring the existing `write-isolation-policy` primitive exactly. `write-tool-mode` still reads the typed `result.config[key]` for its schedule-preservation logic (the raw reader returns both `config` and `raw`). `automation-write.ts` is unchanged (the helper was already correct); no signature widening, same `as AutomationConfig` cast the precedent uses.

TDD: each primitive gains a round-trip test (write a config with an unknown key, run the primitive, assert the unknown key survives and the intended field changed) — red before the fix, green after. Both CLI binaries rebuilt (only `.gaia/cli/gaia` changed; the maintainer binary never bundled `setup-ci`). No CHANGELOG entry (internal maintainer machinery, adopter-invisible).

Closes #753