### PR TITLE
fix(schemas): tolerate unknown mode/schedule/version at read; drop dead barrel (#755 #777)

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -14575,8 +14575,8 @@ var TOOL_IDS = [
 var ToolModeSchema = external_exports.literal(["ci", "local", "off"]);
 var ScheduleSchema = external_exports.literal(["daily", "monthly", "weekly"]);
 var ToolConfigSchema = external_exports.object({
-  mode: ToolModeSchema,
-  schedule: ScheduleSchema.optional()
+  mode: ToolModeSchema.catch("off"),
+  schedule: ScheduleSchema.optional().catch(void 0)
 });
 var UpdateGaiaConfigSchema = external_exports.object({
   mode: external_exports.literal("local")
@@ -14602,7 +14602,10 @@ var AutomationConfigSchema = external_exports.object({
   stale_branches: ToolConfigSchema,
   update_deps: ToolConfigSchema,
   update_gaia: UpdateGaiaConfigSchema,
-  version: external_exports.literal(1),
+  // Same permissive-at-read pattern as isolation_policy above: an
+  // unrecognized or absent version degrades to 1 rather than malforming
+  // the config.
+  version: external_exports.literal(1).catch(1),
   wiki: ToolConfigSchema
 });
 var TOOL_ID_TO_CONFIG_KEY = {

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -14574,8 +14574,8 @@ var TOOL_IDS = [
 var ToolModeSchema = external_exports.literal(["ci", "local", "off"]);
 var ScheduleSchema = external_exports.literal(["daily", "monthly", "weekly"]);
 var ToolConfigSchema = external_exports.object({
-  mode: ToolModeSchema,
-  schedule: ScheduleSchema.optional()
+  mode: ToolModeSchema.catch("off"),
+  schedule: ScheduleSchema.optional().catch(void 0)
 });
 var UpdateGaiaConfigSchema = external_exports.object({
   mode: external_exports.literal("local")
@@ -14601,7 +14601,10 @@ var AutomationConfigSchema = external_exports.object({
   stale_branches: ToolConfigSchema,
   update_deps: ToolConfigSchema,
   update_gaia: UpdateGaiaConfigSchema,
-  version: external_exports.literal(1),
+  // Same permissive-at-read pattern as isolation_policy above: an
+  // unrecognized or absent version degrades to 1 rather than malforming
+  // the config.
+  version: external_exports.literal(1).catch(1),
   wiki: ToolConfigSchema
 });
 var TOOL_ID_TO_CONFIG_KEY = {

--- a/.gaia/cli/src/automation/__tests__/read-config.test.ts
+++ b/.gaia/cli/src/automation/__tests__/read-config.test.ts
@@ -78,7 +78,10 @@ describe('automation read-config', () => {
   });
 
   test('exits non-zero with config_malformed for malformed JSON', () => {
-    sandbox.writeConfig({...VALID_BASE_CONFIG, version: 2 as unknown as 1});
+    sandbox.writeConfig({
+      ...VALID_BASE_CONFIG,
+      setup_complete: 'not-a-boolean' as unknown as boolean,
+    });
     const exit = run([], {cwd: sandbox.root});
     expect(exit).not.toBe(0);
     expect(stdio.errors.join('')).toContain('config_malformed');

--- a/.gaia/cli/src/schemas/__tests__/automation-config.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/automation-config.test.ts
@@ -10,8 +10,10 @@ import {
   ISOLATION_POLICIES,
   parseAutomationConfig,
   readAutomationConfig,
+  ScheduleSchema,
   TOOL_ID_TO_CONFIG_KEY,
   TOOL_IDS,
+  ToolModeSchema,
 } from '../automation-config.js';
 
 type Sandbox = {
@@ -53,19 +55,36 @@ describe('schemas/automation-config', () => {
       expect(() => parseAutomationConfig(VALID_CONFIG)).not.toThrow();
     });
 
-    test('rejects version != 1', () => {
-      expect(() =>
-        AutomationConfigSchema.parse({...VALID_CONFIG, version: 2})
-      ).toThrow(z.ZodError);
+    test('tolerates an unrecognized version, defaulting to 1', () => {
+      const parsed = AutomationConfigSchema.parse({
+        ...VALID_CONFIG,
+        version: 2,
+      });
+      expect(parsed.version).toBe(1);
     });
 
-    test('rejects unknown tool mode', () => {
-      expect(() =>
-        AutomationConfigSchema.parse({
-          ...VALID_CONFIG,
-          wiki: {mode: 'ci2'},
-        })
-      ).toThrow(z.ZodError);
+    test('tolerates an unrecognized tool mode, defaulting to "off"', () => {
+      const parsed = AutomationConfigSchema.parse({
+        ...VALID_CONFIG,
+        wiki: {mode: 'ci2'},
+      });
+      expect(parsed.wiki.mode).toBe('off');
+    });
+
+    test('tolerates an unrecognized schedule, defaulting to undefined', () => {
+      const parsed = AutomationConfigSchema.parse({
+        ...VALID_CONFIG,
+        wiki: {mode: 'ci', schedule: 'hourly'},
+      });
+      expect(parsed.wiki.schedule).toBeUndefined();
+    });
+
+    test('ToolModeSchema still rejects an unrecognized mode (write boundary stays strict)', () => {
+      expect(ToolModeSchema.safeParse('banana').success).toBe(false);
+    });
+
+    test('ScheduleSchema still rejects an unrecognized schedule (write boundary stays strict)', () => {
+      expect(ScheduleSchema.safeParse('hourly').success).toBe(false);
     });
 
     test('rejects missing wiki section', () => {
@@ -153,22 +172,6 @@ describe('schemas/automation-config', () => {
         })
       ).not.toThrow();
     });
-
-    test('version is still 1', () => {
-      expect(() =>
-        AutomationConfigSchema.parse({
-          ...VALID_CONFIG,
-          isolation_policy: 'prefer-branch',
-          version: 2,
-        })
-      ).toThrow(z.ZodError);
-
-      const parsed = AutomationConfigSchema.parse({
-        ...VALID_CONFIG,
-        isolation_policy: 'prefer-branch',
-      });
-      expect(parsed.version).toBe(1);
-    });
   });
 
   describe('TOOL_ID_TO_CONFIG_KEY <-> CONFIG_KEY_TO_TOOL_ID round-trip', () => {
@@ -204,6 +207,60 @@ describe('schemas/automation-config', () => {
       expect(result.config.wiki.mode).toBe('ci');
     });
 
+    test('round-trips a fully-valid config unchanged (no regression)', () => {
+      writeFileSync(sandbox.configPath, JSON.stringify(VALID_CONFIG), 'utf8');
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('ok');
+      assert.ok(result.status === 'ok');
+      expect(result.config).toEqual(VALID_CONFIG);
+    });
+
+    test('returns {status: "ok"} for an unrecognized mode on one tool, defaulting that tool to "off" and leaving every other field intact', () => {
+      writeFileSync(
+        sandbox.configPath,
+        JSON.stringify({...VALID_CONFIG, wiki: {mode: 'banana'}}),
+        'utf8'
+      );
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('ok');
+      assert.ok(result.status === 'ok');
+      expect(result.config.wiki.mode).toBe('off');
+      expect(result.config.pnpm_audit).toEqual(VALID_CONFIG.pnpm_audit);
+      expect(result.config.stale_branches).toEqual(VALID_CONFIG.stale_branches);
+      expect(result.config.update_deps).toEqual(VALID_CONFIG.update_deps);
+      expect(result.config.setup_complete).toBe(true);
+      expect(result.config.setup_opted_out).toBe(false);
+      expect(result.config.version).toBe(1);
+    });
+
+    test('returns {status: "ok"} for an unrecognized schedule on one tool, defaulting that tool\'s schedule to undefined', () => {
+      writeFileSync(
+        sandbox.configPath,
+        JSON.stringify({
+          ...VALID_CONFIG,
+          wiki: {mode: 'ci', schedule: 'hourly'},
+        }),
+        'utf8'
+      );
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('ok');
+      assert.ok(result.status === 'ok');
+      expect(result.config.wiki.schedule).toBeUndefined();
+      expect(result.config.wiki.mode).toBe('ci');
+    });
+
+    test('returns {status: "ok"} for version: 2, defaulting version to 1', () => {
+      writeFileSync(
+        sandbox.configPath,
+        JSON.stringify({...VALID_CONFIG, version: 2}),
+        'utf8'
+      );
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('ok');
+      assert.ok(result.status === 'ok');
+      expect(result.config.version).toBe(1);
+    });
+
     test('returns {status: "malformed"} for invalid JSON', () => {
       writeFileSync(sandbox.configPath, '{not json', 'utf8');
       const result = readAutomationConfig(sandbox.root);
@@ -216,21 +273,31 @@ describe('schemas/automation-config', () => {
     test('returns {status: "malformed"} for schema-violating JSON', () => {
       writeFileSync(
         sandbox.configPath,
-        JSON.stringify({...VALID_CONFIG, wiki: {mode: 'wat'}}),
+        JSON.stringify({...VALID_CONFIG, setup_complete: 'yes'}),
         'utf8'
       );
       const result = readAutomationConfig(sandbox.root);
       expect(result.status).toBe('malformed');
       assert.ok(result.status === 'malformed');
-      expect(result.error).toContain('wiki.mode');
+      expect(result.error).toContain('setup_complete');
     });
 
-    test('returns {status: "malformed"} when version is missing', () => {
+    test('returns {status: "malformed"} when the wiki section is entirely missing', () => {
+      const rest: Record<string, unknown> = {...VALID_CONFIG};
+      delete rest.wiki;
+      writeFileSync(sandbox.configPath, JSON.stringify(rest), 'utf8');
+      const result = readAutomationConfig(sandbox.root);
+      expect(result.status).toBe('malformed');
+    });
+
+    test('returns {status: "ok"} with version defaulted to 1 when version is missing', () => {
       const rest: Record<string, unknown> = {...VALID_CONFIG};
       delete rest.version;
       writeFileSync(sandbox.configPath, JSON.stringify(rest), 'utf8');
       const result = readAutomationConfig(sandbox.root);
-      expect(result.status).toBe('malformed');
+      expect(result.status).toBe('ok');
+      assert.ok(result.status === 'ok');
+      expect(result.config.version).toBe(1);
     });
 
     test('returns {status: "ok"} for an unrecognized isolation_policy value', () => {

--- a/.gaia/cli/src/schemas/automation-config.ts
+++ b/.gaia/cli/src/schemas/automation-config.ts
@@ -29,9 +29,16 @@ export const ScheduleSchema = z.literal(['daily', 'monthly', 'weekly']);
 
 export type Schedule = z.infer<typeof ScheduleSchema>;
 
+/**
+ * `mode` and `schedule` are read permissively here, the same pattern as
+ * `isolation_policy` below: an unrecognized value degrades to a safe
+ * default (`mode` -> 'off', `schedule` -> undefined) instead of failing
+ * the whole config. `ToolModeSchema`/`ScheduleSchema` themselves stay
+ * strict and validate at the WRITE boundary (`setup-ci/write-tool-mode.ts`).
+ */
 export const ToolConfigSchema = z.object({
-  mode: ToolModeSchema,
-  schedule: ScheduleSchema.optional(),
+  mode: ToolModeSchema.catch('off'),
+  schedule: ScheduleSchema.optional().catch(undefined),
 });
 
 export type ToolConfig = z.infer<typeof ToolConfigSchema>;
@@ -75,7 +82,10 @@ export const AutomationConfigSchema = z.object({
   stale_branches: ToolConfigSchema,
   update_deps: ToolConfigSchema,
   update_gaia: UpdateGaiaConfigSchema,
-  version: z.literal(1),
+  // Same permissive-at-read pattern as isolation_policy above: an
+  // unrecognized or absent version degrades to 1 rather than malforming
+  // the config.
+  version: z.literal(1).catch(1),
   wiki: ToolConfigSchema,
 });
 

--- a/.gaia/cli/src/schemas/index.ts
+++ b/.gaia/cli/src/schemas/index.ts
@@ -1,9 +1,0 @@
-// Barrel re-exports for `.gaia/cli/src/schemas/**`.
-
-export * from './automation-config.js';
-
-export * from './finding-class.js';
-
-export * from './local-automation.js';
-
-export * from './react-perf-summary.js';

--- a/.gaia/cli/src/setup-ci/__tests__/check-drift.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/check-drift.test.ts
@@ -192,7 +192,7 @@ describe('setup-ci check-drift', () => {
   test('exits non-zero with config_malformed for an invalid config', () => {
     sandbox.writeConfig({
       ...VALID_BASE_CONFIG,
-      version: 99 as unknown as 1,
+      setup_complete: 'not-a-boolean' as unknown as boolean,
     });
 
     const exit = run(['--json'], {cwd: sandbox.root});

--- a/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/finalize.test.ts
@@ -121,7 +121,7 @@ describe('setup-ci finalize', () => {
   test('exits config_malformed for malformed config', () => {
     writeFileSync(
       automationConfigPath(sandbox.root),
-      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      JSON.stringify({...VALID_BASE_CONFIG, setup_complete: 'not-a-boolean'}),
       'utf8'
     );
 

--- a/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/opt-out-team.test.ts
@@ -99,7 +99,7 @@ describe('setup-ci opt-out-team', () => {
   test('exits config_malformed when config fails schema validation', () => {
     writeFileSync(
       automationConfigPath(sandbox.root),
-      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      JSON.stringify({...VALID_BASE_CONFIG, setup_complete: 'not-a-boolean'}),
       'utf8'
     );
 

--- a/.gaia/cli/src/setup-ci/__tests__/status.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/status.test.ts
@@ -130,7 +130,7 @@ describe('setup-ci status', () => {
   test('exits non-zero when committed config is malformed', () => {
     sandbox.writeConfig({
       ...VALID_BASE_CONFIG,
-      version: 99 as unknown as 1,
+      setup_complete: 'not-a-boolean' as unknown as boolean,
     });
 
     const exit = run(['--json'], {cwd: sandbox.root});

--- a/.gaia/cli/src/setup-ci/__tests__/write-isolation-policy.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/write-isolation-policy.test.ts
@@ -138,7 +138,7 @@ describe('setup-ci write-isolation-policy', () => {
   test('exits CONFIG_INVALID and writes nothing when config is malformed', () => {
     writeFileSync(
       automationConfigPath(sandbox.root),
-      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      JSON.stringify({...VALID_BASE_CONFIG, setup_complete: 'not-a-boolean'}),
       'utf8'
     );
 
@@ -147,7 +147,7 @@ describe('setup-ci write-isolation-policy', () => {
     expect(stdio.err.join('')).toContain('config_malformed');
 
     const written = readRaw(sandbox.root);
-    expect(written.version).toBe(99);
+    expect(written.setup_complete).toBe('not-a-boolean');
   });
 
   test('exits 1 on an unrecognized value and writes nothing', () => {

--- a/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
+++ b/.gaia/cli/src/setup-ci/__tests__/write-tool-mode.test.ts
@@ -167,7 +167,7 @@ describe('setup-ci write-tool-mode', () => {
   test('exits config_malformed when config fails schema', () => {
     writeFileSync(
       automationConfigPath(sandbox.root),
-      JSON.stringify({...VALID_BASE_CONFIG, version: 99}),
+      JSON.stringify({...VALID_BASE_CONFIG, setup_complete: 'not-a-boolean'}),
       'utf8'
     );
 

--- a/.gaia/cli/src/setup-ci/util/__tests__/automation-write.test.ts
+++ b/.gaia/cli/src/setup-ci/util/__tests__/automation-write.test.ts
@@ -49,7 +49,7 @@ describe('writeAutomationConfig', () => {
     expect(() =>
       writeAutomationConfig(sandbox.root, {
         ...VALID_BASE_CONFIG,
-        version: 99 as unknown as 1,
+        setup_complete: 'not-a-boolean' as unknown as boolean,
       })
     ).toThrow(z.ZodError);
   });


### PR DESCRIPTION
## #755 — one unknown value no longer malforms the whole automation.json

`ToolModeSchema`, `ScheduleSchema`, and the `version` field were bare closed `z.literal` unions. Any value outside the closed set (a hand-typed typo, or a value a future GAIA release introduces) failed the whole `AutomationConfigSchema.parse`, so `readAutomationConfig` returned `malformed` for the **entire** config and every consumer exited `CONFIG_INVALID`. `cron-decide` runs under `set -euo pipefail` in every adopter's scheduled workflow, so one unrecognized `mode`/`schedule`/`version` redded the cron on every tick.

**Fix (mirrors the existing `isolation_policy` precedent in the same file):** the read boundary degrades gracefully per field via `.catch(<safe-default>)` — `mode` → `off` (fail-safe: an older binary disables a tool whose mode it cannot interpret rather than acting on it), `schedule` → `undefined`, `version` → `1`. The exported `ToolModeSchema`/`ScheduleSchema` stay **strict** and remain the write-boundary validators (`setup-ci/write-tool-mode.ts` rejects an invalid `--mode` arg through them); a pinned test guards that they still reject bad values. Inferred `ToolConfig`/`AutomationConfig` types are unchanged, so no consumer ripple. Gross corruption (a whole tool section missing, invalid JSON, a wrong-type scalar) still malforms.

Some pre-existing tests simulated a "malformed config" by writing an invalid `version`; since `version` now tolerates unknowns, those fixtures were switched to a still-strict field (`setup_complete`) so they keep exercising the malformed path.

## #777 — delete the dead schemas barrel

`.gaia/cli/src/schemas/index.ts` had no importer (every consumer imports the concrete module directly) and was also incomplete (omitted three real modules). Simultaneously unused and inaccurate; `knip` cannot see it (`.gaia/cli` is outside the root scan). Deleted outright — the smaller, honest change.

Both CLI binaries rebuilt. No CHANGELOG entry (internal maintainer machinery, adopter-invisible).

Closes #755
Closes #777