### PR TITLE
test(release): prove exclude-parser parity across CLI, staging, and distribution suite (#839)

### DIFF
--- a/.gaia/cli/src/release/exclude-parser-parity.test.ts
+++ b/.gaia/cli/src/release/exclude-parser-parity.test.ts
@@ -60,6 +60,35 @@ const extractStageCommand = (text: string, marker: string): string => {
 };
 
 /**
+ * `grep -vE` exits 1 (not 0) when every candidate line matches the filter
+ * (i.e. zero survivors), which `execFileSync` treats as a thrown error even
+ * though it's a normal "no matches" outcome, not a failure. The fixture
+ * below always leaves a survivor so this can't fire today, but a future
+ * all-excluded fixture would otherwise surface an opaque "Command failed"
+ * instead of a clean empty `kept` set. Only a real error (exit >= 2, e.g. a
+ * malformed regex file) should propagate.
+ */
+const grepKeptLines = (regexPath: string, candidateText: string): string[] => {
+  try {
+    return execFileSync('grep', ['-vE', '-f', regexPath], {
+      encoding: 'utf8',
+      input: candidateText,
+    })
+      .split('\n')
+      .filter((line) => line.length > 0);
+  } catch (error) {
+    const status =
+      error instanceof Error && 'status' in error ?
+        (error as Error & {status?: number}).status
+      : undefined;
+
+    if (status === 1) return [];
+
+    throw error;
+  }
+};
+
+/**
  * Stage 1 (comment/blank strip) also carries a trailing file-path argument
  * that differs between the two callers (`.gaia/release-exclude` vs
  * `"$PROJECT_ROOT/.gaia/release-exclude"`); dropping it makes the awk
@@ -159,12 +188,7 @@ describe('exclude-parser parity (#839)', () => {
       writeFileSync(compiledRegexPath, compiledRegex);
 
       const candidateText = `${candidatePaths.join('\n')}\n`;
-      kept = execFileSync('grep', ['-vE', '-f', compiledRegexPath], {
-        encoding: 'utf8',
-        input: candidateText,
-      })
-        .split('\n')
-        .filter((line) => line.length > 0);
+      kept = grepKeptLines(compiledRegexPath, candidateText);
     } finally {
       rmSync(scratchDir, {force: true, recursive: true});
     }

--- a/.gaia/cli/src/release/exclude-parser-parity.test.ts
+++ b/.gaia/cli/src/release/exclude-parser-parity.test.ts
@@ -1,0 +1,191 @@
+import {describe, expect, test} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {parseExcludePatterns, resolveRepoRoot} from './manifest.js';
+
+/**
+ * Regression test for #839 (the #679 remainder): three surfaces
+ * independently parse `.gaia/release-exclude` into the same anchored-regex
+ * semantics — this CLI compiler, the `sed | awk` compile stage that
+ * `release.yml` and `build-staging.sh` both carry, and the literal `[ -e ]`
+ * presence check in the distribution suite's `01-files-present.sh` (proven
+ * against the shell pipeline separately, in
+ * `.gaia/tests/distribution/09-exclude-parser-parity.sh`). They currently
+ * agree; nothing previously proved they'd stay that way.
+ *
+ * Reads the compile stage straight out of `release.yml` and
+ * `build-staging.sh` at test time (rather than hardcoding a copy), so an
+ * edit to either source drifts this test's input, not just its intent.
+ */
+
+const repoRoot = resolveRepoRoot(process.cwd());
+const releaseYmlPath = path.join(
+  repoRoot,
+  '.github',
+  'workflows',
+  'release.yml'
+);
+const buildStagingPath = path.join(
+  repoRoot,
+  '.gaia',
+  'tests',
+  'distribution',
+  'lib',
+  'build-staging.sh'
+);
+
+/**
+ * Pull one pipeline stage's command text out of a shell script, keyed by a
+ * substring unique to that stage. Strips the leading `|` continuation and
+ * trailing `\` line-continuation so the result is a standalone command.
+ */
+const extractStageCommand = (text: string, marker: string): string => {
+  const line = text.split('\n').find((candidate) => candidate.includes(marker));
+
+  if (line === undefined) {
+    throw new Error(
+      `pipeline stage not found (looked for ${JSON.stringify(marker)})`
+    );
+  }
+
+  const trimmed = line.trim();
+  const withoutContinuation =
+    trimmed.endsWith('\\') ? trimmed.slice(0, -1).trim() : trimmed;
+
+  return withoutContinuation.startsWith('|') ?
+      withoutContinuation.slice(1).trim()
+    : withoutContinuation;
+};
+
+/**
+ * Stage 1 (comment/blank strip) also carries a trailing file-path argument
+ * that differs between the two callers (`.gaia/release-exclude` vs
+ * `"$PROJECT_ROOT/.gaia/release-exclude"`); dropping it makes the awk
+ * program stdin-friendly and comparable across both files.
+ */
+const extractAwkProgram = (text: string, marker: string): string => {
+  const line = extractStageCommand(text, marker);
+  const match = /^awk\s+'([^']*)'/.exec(line);
+
+  if (match === null) {
+    throw new Error(`could not isolate awk program from: ${line}`);
+  }
+
+  return `awk '${match[1]}'`;
+};
+
+const STAGE1_MARKER = "awk '/^[[:space:]]*#/";
+const STAGE2_MARKER = "sed 's|[][";
+const STAGE3_MARKER = 'awk \'{print "^"';
+
+const releaseYmlText = readFileSync(releaseYmlPath, 'utf8');
+const buildStagingText = readFileSync(buildStagingPath, 'utf8');
+
+const releaseYmlStage1 = extractAwkProgram(releaseYmlText, STAGE1_MARKER);
+const releaseYmlStage2 = extractStageCommand(releaseYmlText, STAGE2_MARKER);
+const releaseYmlStage3 = extractStageCommand(releaseYmlText, STAGE3_MARKER);
+
+const buildStagingStage1 = extractAwkProgram(buildStagingText, STAGE1_MARKER);
+const buildStagingStage2 = extractStageCommand(buildStagingText, STAGE2_MARKER);
+const buildStagingStage3 = extractStageCommand(buildStagingText, STAGE3_MARKER);
+
+describe('exclude-parser parity (#839)', () => {
+  test('release.yml and build-staging.sh compile the exclude-filter pipeline byte-identically', () => {
+    // The #679 failure mode this guards: one copy re-diverges (e.g. a
+    // reintroduced glob rewrite) while the other stays literal-only.
+    expect(buildStagingStage1).toBe(releaseYmlStage1);
+    expect(buildStagingStage2).toBe(releaseYmlStage2);
+    expect(buildStagingStage3).toBe(releaseYmlStage3);
+
+    // Sanity: prove the markers actually matched real pipeline content,
+    // not two equally-empty extractions.
+    expect(buildStagingStage2).toContain('sed ');
+    expect(buildStagingStage3).toContain('awk ');
+  });
+
+  test('CLI-excluded set matches the shell pipeline-excluded set for a representative fixture', () => {
+    // Covers: an excluded directory with a child (dir-prefix match), a
+    // near-miss sibling that must NOT match (proves the anchor is a real
+    // `/`-or-end boundary, not a bare prefix), an excluded file with a `.`
+    // (proves `.` is escaped, not treated as regex any-char), a decoy that
+    // only differs by that character, and an excluded literal with a `+`
+    // (mirrors GAIA's own `app/routes/_public+/`; proves `+` is escaped,
+    // not "one-or-more"), plus an untouched path that must survive.
+    const excludeFixture =
+      '# fixture comment, stripped by stage 1\n' +
+      '\n' +
+      '.gaia/scripts\n' +
+      'CHANGELOG.md\n' +
+      'wiki/hot.md\n' +
+      'app/routes/_public+\n';
+
+    const candidatePaths = [
+      '.gaia/scripts/foo.mjs',
+      '.gaia/scriptsOOPS',
+      'CHANGELOG.md',
+      'wiki/hot.md',
+      'wiki/hotXmd',
+      'app/routes/_public+/index.tsx',
+      'app/keep.ts',
+    ];
+
+    // CLI side: a candidate is excluded iff any compiled pattern matches.
+    const cliPatterns = parseExcludePatterns(excludeFixture);
+    const cliExcluded = candidatePaths
+      .filter((candidate) =>
+        cliPatterns.some((pattern) => pattern.test(candidate))
+      )
+      .toSorted((a, b) => a.localeCompare(b));
+
+    // Shell side: the real compile-and-filter pipeline. `grep -vE -f`
+    // needs the compiled regex as a file (no stdin form), so stage the
+    // compiled output in a scratch dir and run `grep` against the
+    // candidate list; whatever `grep` drops (does not keep) is the
+    // shell-excluded set.
+    const compilePipeline = `${buildStagingStage1} | ${buildStagingStage2} | ${buildStagingStage3}`;
+    const compiledRegex = execFileSync('bash', ['-c', compilePipeline], {
+      encoding: 'utf8',
+      input: excludeFixture,
+    });
+
+    const scratchDir = mkdtempSync(path.join(tmpdir(), 'gaia-exclude-parity-'));
+
+    let kept: string[];
+
+    try {
+      const compiledRegexPath = path.join(scratchDir, 'exclude-regex.txt');
+      writeFileSync(compiledRegexPath, compiledRegex);
+
+      const candidateText = `${candidatePaths.join('\n')}\n`;
+      kept = execFileSync('grep', ['-vE', '-f', compiledRegexPath], {
+        encoding: 'utf8',
+        input: candidateText,
+      })
+        .split('\n')
+        .filter((line) => line.length > 0);
+    } finally {
+      rmSync(scratchDir, {force: true, recursive: true});
+    }
+
+    const shellExcluded = candidatePaths
+      .filter((candidate) => !kept.includes(candidate))
+      .toSorted((a, b) => a.localeCompare(b));
+
+    expect(cliExcluded).toEqual(shellExcluded);
+    // Sanity: the fixture actually exercises exclusion, dot-escaping,
+    // plus-escaping, AND the boundary/decoy cases, not a vacuous pass.
+    // Order-independent: the assertion above already pins the two sides
+    // to each other; this only pins both to the expected content.
+    expect(cliExcluded).toHaveLength(4);
+    expect(cliExcluded).toEqual(
+      expect.arrayContaining([
+        '.gaia/scripts/foo.mjs',
+        'CHANGELOG.md',
+        'app/routes/_public+/index.tsx',
+        'wiki/hot.md',
+      ])
+    );
+  });
+});

--- a/.gaia/tests/distribution/01-files-present.sh
+++ b/.gaia/tests/distribution/01-files-present.sh
@@ -34,10 +34,10 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
 fi
 
 # 2. Every release-exclude path is ABSENT from staging.
-# Read literal patterns; skip comments and blanks. For directory entries
-# (no trailing wildcard), assert the directory does not exist. For file
-# entries, assert the file does not exist. Glob-shaped entries (`**`,
-# trailing `*`) are checked via `find … -path` once.
+# Every entry is a literal path, file or directory; skip comments and
+# blanks, then assert the literal path does not exist in staging via
+# `[ -e ]`, which covers both file and directory entries without needing
+# to distinguish them.
 LEAKED=()
 while IFS= read -r raw; do
   # Skip blanks and comments

--- a/.gaia/tests/distribution/09-exclude-parser-parity.sh
+++ b/.gaia/tests/distribution/09-exclude-parser-parity.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# 09-exclude-parser-parity.sh
+#
+# Regression test for #839 (the #679 remainder): three surfaces
+# independently parse `.gaia/release-exclude` and, as of #679, all agree
+# (literal paths only, no glob rewriting). Nothing previously proved
+# they'd stay in sync. This proves two of the three agree on a small
+# fixture: the sed|awk|grep compile-and-filter pipeline that
+# release.yml and build-staging.sh both carry, and the literal `[ -e ]`
+# presence check in 01-files-present.sh. (The third leg, CLI compiler vs
+# the same shell pipeline, is proven in the CLI's own vitest suite:
+# .gaia/cli/src/release/exclude-parser-parity.test.ts.)
+#
+# The pipeline below is a literal copy of build-staging.sh's compile
+# stage (lines ~51-53), byte-identity of which against release.yml is
+# proven by the vitest test above, not here. Deliberately does not shell
+# out to build-staging.sh or the gaia-maintainer binary: this is a fast,
+# isolated check of the exclude-filtering logic against a synthetic
+# fixture, not a full staging build.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "$HERE/lib/lib.sh"
+
+require_cmd rsync "rsync required for fixture staging"
+require_cmd git "git required to build the fixture tracked-file list"
+
+FIXTURE="$(mktemp -d -t gaia-dist-exclude-parity-XXXXXX)"
+trap 'rm -rf "$FIXTURE"' EXIT
+SRC="$FIXTURE/src"
+STAGING="$FIXTURE/staging"
+mkdir -p "$SRC" "$STAGING"
+
+# Fixture tracked-file tree. Covers: a plain excluded file (CHANGELOG.md),
+# an excluded directory with children (.gaia/scripts), a `.`-bearing
+# excluded literal (wiki/hot.md; proves `.` is escaped, not treated as
+# regex any-char), and a `+`-bearing excluded literal (mirrors GAIA's own
+# app/routes/_public+/; proves `+` is escaped, not "one-or-more"). Decoys
+# (.gaia/scriptsOOPS, wiki/hotXmd, app/keep.ts) share a prefix or a
+# near-miss with an excluded pattern and must survive, proving the
+# pipeline does not over-exclude.
+mkdir -p "$SRC/app" "$SRC/.gaia/scripts" "$SRC/wiki" "$SRC/app/routes/_public+"
+touch "$SRC/CHANGELOG.md" \
+  "$SRC/app/keep.ts" \
+  "$SRC/.gaia/scripts/foo.mjs" \
+  "$SRC/.gaia/scripts/bar.mjs" \
+  "$SRC/.gaia/scriptsOOPS" \
+  "$SRC/wiki/hot.md" \
+  "$SRC/wiki/hotXmd" \
+  "$SRC/app/routes/_public+/index.tsx"
+
+EXCLUDE_FILE="$FIXTURE/release-exclude"
+cat > "$EXCLUDE_FILE" <<'FIXTURE_EOF'
+# fixture exclude list for #839 parity test
+CHANGELOG.md
+
+.gaia/scripts
+wiki/hot.md
+app/routes/_public+
+FIXTURE_EOF
+
+# Build ALL_TRACKED the same way build-staging.sh does (git ls-files),
+# scoped to the fixture tree.
+git -C "$SRC" init -q -b main
+git -C "$SRC" add -A
+ALL_TRACKED="$FIXTURE/all-tracked.txt"
+git -C "$SRC" ls-files > "$ALL_TRACKED"
+
+# Phase 1: the compile-and-filter pipeline (literal copy; see header note).
+EXCLUDE_REGEX="$FIXTURE/exclude-regex.txt"
+awk '/^[[:space:]]*#/ {next} NF==0 {next} {print}' "$EXCLUDE_FILE" \
+  | sed 's|[][\\.*^$()+?{}|]|\\&|g' \
+  | awk '{print "^"$0"(/|$)"}' \
+  > "$EXCLUDE_REGEX"
+
+INCLUDE="$FIXTURE/include.txt"
+if [ -s "$EXCLUDE_REGEX" ]; then
+  grep -vE -f "$EXCLUDE_REGEX" "$ALL_TRACKED" > "$INCLUDE"
+else
+  cp "$ALL_TRACKED" "$INCLUDE"
+fi
+
+rsync -a --files-from="$INCLUDE" "$SRC/" "$STAGING/"
+
+# Phase 2: the literal `[ -e ]` presence check, same shape as
+# 01-files-present.sh's release-exclude leak check.
+LEAKED=()
+while IFS= read -r raw; do
+  case "$raw" in ''|\#*) continue ;; esac
+  if [ -e "$STAGING/$raw" ]; then
+    LEAKED+=("$raw")
+  fi
+done < "$EXCLUDE_FILE"
+
+if [ "${#LEAKED[@]}" -gt 0 ]; then
+  log "Release-excluded fixture path(s) leaked into staging:"
+  for p in "${LEAKED[@]}"; do log "  $p"; done
+  fail "${#LEAKED[@]} release-excluded fixture path(s) leaked; pipeline and literal check disagree"
+  exit 1
+fi
+
+# Decoys must survive: proves the pipeline did not over-exclude.
+for decoy in app/keep.ts .gaia/scriptsOOPS wiki/hotXmd; do
+  [ -e "$STAGING/$decoy" ] || { fail "decoy fixture path missing from staging: $decoy (pipeline over-excluded)"; exit 1; }
+done
+
+# Positive control: prove the literal check can actually catch a leak
+# rather than vacuously passing. Reintroduce one excluded path into
+# staging (simulating a broken exclusion) and confirm the same check
+# flags it.
+mkdir -p "$STAGING/.gaia/scripts"
+cp "$SRC/.gaia/scripts/foo.mjs" "$STAGING/.gaia/scripts/foo.mjs"
+
+CAUGHT=0
+while IFS= read -r raw; do
+  case "$raw" in ''|\#*) continue ;; esac
+  if [ -e "$STAGING/$raw" ]; then
+    if [ "$raw" = ".gaia/scripts" ]; then
+      CAUGHT=1
+    fi
+  fi
+done < "$EXCLUDE_FILE"
+
+if [ "$CAUGHT" -ne 1 ]; then
+  fail "literal check failed to catch a deliberately reintroduced leak (positive control)"
+  exit 1
+fi
+
+pass "shell compile-and-filter pipeline and literal presence check agree on the fixture (#839)"

--- a/.gaia/tests/distribution/09-exclude-parser-parity.sh
+++ b/.gaia/tests/distribution/09-exclude-parser-parity.sh
@@ -5,11 +5,11 @@
 # independently parse `.gaia/release-exclude` and, as of #679, all agree
 # (literal paths only, no glob rewriting). Nothing previously proved
 # they'd stay in sync. This proves two of the three agree on a small
-# fixture: the sed|awk|grep compile-and-filter pipeline that
-# release.yml and build-staging.sh both carry, and the literal `[ -e ]`
-# presence check in 01-files-present.sh. (The third leg, CLI compiler vs
-# the same shell pipeline, is proven in the CLI's own vitest suite:
-# .gaia/cli/src/release/exclude-parser-parity.test.ts.)
+# fixture: the awk|sed|awk compile stage followed by a `grep -vE` filter
+# that release.yml and build-staging.sh both carry, and the literal
+# `[ -e ]` presence check in 01-files-present.sh. (The third leg, CLI
+# compiler vs the same shell pipeline, is proven in the CLI's own vitest
+# suite: .gaia/cli/src/release/exclude-parser-parity.test.ts.)
 #
 # The pipeline below is a literal copy of build-staging.sh's compile
 # stage (lines ~51-53), byte-identity of which against release.yml is
@@ -60,7 +60,7 @@ FIXTURE_EOF
 
 # Build ALL_TRACKED the same way build-staging.sh does (git ls-files),
 # scoped to the fixture tree.
-git -C "$SRC" init -q -b main
+git -C "$SRC" init -q
 git -C "$SRC" add -A
 ALL_TRACKED="$FIXTURE/all-tracked.txt"
 git -C "$SRC" ls-files > "$ALL_TRACKED"


### PR DESCRIPTION
Closes #839

## What

The #679 remainder. Three surfaces independently parse `.gaia/release-exclude` and currently agree (all literal-only, post-#679), but nothing proved they stay in sync — a future edit to one parser could silently diverge with no test to catch it. This adds a complement-set regression proof and refreshes the one stale comment, taking the issue's **preferred minimal path** (not full cross-language unification).

## Changes

- **`.gaia/cli/src/release/exclude-parser-parity.test.ts`** (new CLI vitest, release-excluded):
  - Asserts the `awk | sed | awk` exclude-compile pipeline is **byte-identical** between `.github/workflows/release.yml` and `.gaia/tests/distribution/lib/build-staging.sh` — extracted live from both files at test time (not a hardcoded copy), with presence guards so it can't pass vacuously. This catches the exact #679 failure mode (one copy re-diverging).
  - Asserts the CLI compiler's excluded-path set (`parseExcludePatterns`) equals the real shell pipeline's `grep -vE -f` excluded set for a representative fixture (dir-prefix, dot/`+` escaping, near-miss decoys), pinned to the expected set of 4.
- **`.gaia/tests/distribution/09-exclude-parser-parity.sh`** (new, release-excluded): builds a fixture tracked tree + exclude file, runs the real 3-stage compile + staging, then the literal `[ -e ]` check (mirroring `01-files-present.sh`) and asserts agreement, with a positive control that deliberately reintroduces a leak and confirms the check catches it.
- **`.gaia/tests/distribution/01-files-present.sh`**: refreshed the stale comment that still described glob-shaped entries checked via `find … -path`; the code has been literal-only `[ -e ]` since #679.

## Not done (by design)

Full cross-language parser unification (one shared source across TS + shell + workflow YAML) is not clean — `release.yml` cannot depend on a `.gaia/tests/` script. Recommended as a separate follow-up rather than sprawled in here.

## Verify

- No bundled CLI source touched → binaries unchanged (confirmed via `git status`), no rebuild.
- CLI vitest full suite: 1507 passed / 2 pre-existing skips; `typecheck` + `lint --max-warnings=0` clean.
- `09-exclude-parser-parity.sh` under bash 5 → PASS; `shellcheck -S warning` clean; full `shell-lint.sh` gate clean.

All touched surfaces are maintainer-only / release-excluded → no CHANGELOG entry owed.