### PR TITLE
test(specify): relocate spec-kit bats guards into .gaia/tests/lib for audit + CI coverage (#837)

### DIFF
--- a/.gaia/tests/lib/lint-yaml.bats
+++ b/.gaia/tests/lib/lint-yaml.bats
@@ -15,8 +15,7 @@
 # so a broken assertion fails correctly even under macOS's bash 3.2.
 
 setup() {
-  EXT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-  LINT="$EXT_DIR/lib/lint.sh"
+  LINT=".specify/extensions/gaia/lib/lint.sh"
 }
 
 required_keys="spec_id type status immutable wiki_promote_default chain_trigger intent success_criteria uats scope_boundaries clarifications research_summary created updated"

--- a/.gaia/tests/lib/registry.bats
+++ b/.gaia/tests/lib/registry.bats
@@ -13,7 +13,7 @@
 # so a broken assertion fails correctly even under macOS's bash 3.2.
 
 setup() {
-  EXT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  EXT_DIR=".specify/extensions/gaia"
   MANIFEST="$EXT_DIR/extension.yml"
 }
 

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -87,6 +87,13 @@ jobs:
               # filters above already use (.gaia/tests/hooks/** + .claude/hooks/**;
               # .gaia/tests/forensics/** + .github/forensics/**).
               - '.specify/extensions/gaia/lib/**'
+              # registry.bats (.gaia/tests/lib/) asserts every commands/*.md
+              # file is registered in extension.yml's provides.commands and
+              # every registered file: resolves on disk; trigger on both
+              # guarded surfaces so an unregistered command file (the #651
+              # drift the suite exists to catch) re-runs the suite.
+              - '.specify/extensions/gaia/commands/**'
+              - '.specify/extensions/gaia/extension.yml'
               - '.claude/skills/gaia/references/forensics*'
               - '.github/forensics/**'
               # The statusline suite (.gaia/tests/statusline/) exercises the

--- a/.specify/extensions/gaia/test/README.md
+++ b/.specify/extensions/gaia/test/README.md
@@ -4,7 +4,7 @@ Artifacts here are markdown UAT runbooks: maintainer-reading walk-throughs that 
 
 Artifacts that should NOT be here are runnable harnesses with `pass()`/`fail()`/exit-code reporting, those are release-gate harnesses and live at `.gaia/tests/smoke/<feature>/` instead. The classifying axis is shape, not origin.
 
-A structural-invariant assertion such as `registry.bats` is a distinct third category: a bats suite that guards a manifest/filesystem invariant rather than walking a SPEC's UATs or gating a release.
+A structural-invariant assertion is a distinct third category: a bats suite that guards a manifest/filesystem invariant rather than walking a SPEC's UATs or gating a release. This extension's two such suites, `lint-yaml.bats` and `registry.bats`, live at `.gaia/tests/lib/` alongside GAIA's other `.specify` lib suites, where they get an audit owner and a CI runner; this directory holds only the manual UAT runbooks.
 
 ## Inventory
 
@@ -15,3 +15,4 @@ A structural-invariant assertion such as `registry.bats` is a distinct third cat
 ## See also
 
 - `.gaia/tests/smoke/README.md`: the sibling tree of release-gate harnesses.
+- `.gaia/tests/lib/`: the bats suites guarding this extension's registry completeness and SPEC frontmatter YAML lint.


### PR DESCRIPTION
Closes #837

## Problem

The two regression guards behind the spec-kit extension — `.specify/extensions/gaia/test/lint-yaml.bats` (frontmatter YAML parse check) and `registry.bats` (every `commands/*.md` registered in `extension.yml`) — were **neither Code-Audit-owned nor CI-run**. A commit weakening/deleting them, or breaking what they guard, could merge with nothing catching it.

## Fix: relocate (not glob-extend)

`code-audit-maintainer-shell` already owns `.gaia/**/*.bats` in all three roster surfaces, and the CI `bats (.github/audit)` job already runs `bats .gaia/tests/lib/`. So moving the suites into `.gaia/tests/lib/` gives them an audit owner **and** a CI runner with zero roster edits and no `audit-scope.sh` digest churn — following the existing precedent that `.gaia/tests/lib/spec-*.bats` already test `.specify` libs.

- `git mv` both suites into `.gaia/tests/lib/` (history preserved).
- Rewrote each `setup()` to reference targets by repo-relative path (`.specify/extensions/gaia/lib/lint.sh`, `.specify/extensions/gaia/extension.yml`), matching the `.gaia/tests/lib/` precedent (resolved from repo-root cwd), since the old `$BATS_TEST_DIRNAME/..` anchoring breaks on the move.
- Extended `audit-ci-tests.yml`'s `dorny/paths-filter` with `.specify/extensions/gaia/commands/**` and `.specify/extensions/gaia/extension.yml` so `registry.bats` actually fires when its guarded surface changes (an unregistered command — the #651 drift it exists to catch — now re-runs the suite). `lint-yaml.bats`'s target (`.specify/extensions/gaia/lib/**`) was already in the filter.
- Refreshed `.specify/extensions/gaia/test/README.md` present-tense (bats guards now live in `.gaia/tests/lib/`; this dir holds the manual UAT runbooks).

No roster surfaces touched — `verify-audit-roster.sh` passes unchanged.

## Verify

- `verify-audit-roster.sh` → roster clean.
- Both relocated suites under bash 5 from repo root → 6/6 pass; full `.gaia/tests/lib/` run-all → 20 suites, 0 failures (no sibling regression).
- `shellcheck` clean on `registry.bats`; `lint-yaml.bats` carries 3 pre-existing info-tier SC2317 (bats skip-helper false positive), identical against the pre-move file.
- Workflow YAML re-parsed clean.

All touched surfaces are maintainer-only / release-excluded (`.gaia/tests/`, `.specify/.../test/`, maintainer CI) → no CHANGELOG entry owed.