### PR TITLE
test(shell-lint): tighten .sh to style floor and bring .bats under the gate (#690, #771)

### DIFF
--- a/.claude/hooks/block-rm-rf.sh
+++ b/.claude/hooks/block-rm-rf.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted case patterns match the literal
+# text $HOME/$PWD/${PWD}, so shell expansion is deliberately suppressed.
+# shellcheck disable=SC2016
 # PreToolUse Bash hook: deny dangerous `rm -rf` invocations.
 #
 # The `rm` command word is matched case-insensitively and through quote/backslash

--- a/.gaia/scripts/check-updates.sh
+++ b/.gaia/scripts/check-updates.sh
@@ -177,7 +177,7 @@ audit_nudge_reason=""
 
 # (a) Memory entry count proxy: number of *.md files under the machine-local
 # memory dir (same derivation /gaia-audit uses).
-MEMORY_DIR="$HOME/.claude/projects/$(echo "$PROJECT_ROOT" | sed 's|/|-|g')/memory"
+MEMORY_DIR="$HOME/.claude/projects/${PROJECT_ROOT//\//-}/memory"
 if [ -d "$MEMORY_DIR" ]; then
   mem_count=$(find "$MEMORY_DIR" -type f -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
   case "$mem_count" in

--- a/.gaia/scripts/ledger-status-migrate.sh
+++ b/.gaia/scripts/ledger-status-migrate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted jq filters where $s and friends
+# are jq bindings, not shell variables.
+# shellcheck disable=SC2016
 # ledger-status-migrate.sh: one-time, idempotent, best-effort migration of
 # .gaia/local/specs/ledger.json and .gaia/local/plans/ledger.json rows onto the
 # unified status vocabulary (draft|ready|merged|abandoned).
@@ -57,6 +60,7 @@ retired_status_pred='.status as $s | (["specified","in-progress","allocated","co
 
 # migrate_specs: jq-to-tmp-then-mv rewrite of specs_ledger's .status through the
 # unified map. No field rename here (specs already key on merged_at).
+# shellcheck disable=SC2329  # invoked indirectly via `with_ledger_lock ... migrate_specs`
 migrate_specs() {
   local tmp
   tmp="$(mktemp)"
@@ -75,6 +79,7 @@ migrate_specs() {
 # migrate_plans: jq-to-tmp-then-mv rewrite of plans_ledger's .status through the
 # same map, plus completed_at -> merged_at on any row that still carries it.
 # source is never named in the jq, so it passes through byte-unchanged.
+# shellcheck disable=SC2329  # invoked indirectly via `with_ledger_lock ... migrate_plans`
 migrate_plans() {
   local tmp
   tmp="$(mktemp)"

--- a/.gaia/scripts/remove-worktree.sh
+++ b/.gaia/scripts/remove-worktree.sh
@@ -25,7 +25,8 @@ fi
 common="$(git rev-parse --git-common-dir 2>/dev/null || echo .git)"
 case "$common" in
   /*) main_root="$(dirname "$common")" ;;
-  *)  main_root="$(cd "$(dirname "$common")" 2>/dev/null && pwd || pwd)" ;;
+  *)  main_root="$(cd "$(dirname "$common")" 2>/dev/null && pwd)"
+      [ -n "$main_root" ] || main_root="$(pwd)" ;;
 esac
 base="$main_root/.claude/worktrees"
 

--- a/.gaia/scripts/tests/link-worktree.bats
+++ b/.gaia/scripts/tests/link-worktree.bats
@@ -1,5 +1,10 @@
 #!/usr/bin/env bats
 #
+# SC2010 is intentional file-wide: the *.bak.<timestamp> backup filenames the
+# assertions below match are test-created with no special characters, so
+# `ls | grep` cannot hit its unsafe-filename failure mode here.
+# shellcheck disable=SC2010
+#
 # Bats suite for .gaia/scripts/link-worktree.sh (SPEC-005 task-link-script).
 #
 # Each test gets a fresh tmp directory containing a main checkout + a linked

--- a/.gaia/scripts/tests/token-tally.bats
+++ b/.gaia/scripts/tests/token-tally.bats
@@ -126,6 +126,7 @@ setup() {
 
 # Run the helper against the anchor fixture with an ISOLATED ledger (never the
 # machine's real .gaia/local/telemetry/cost.jsonl).
+# shellcheck disable=SC2120  # "$@" forwards optional extra args; most call sites pass none by design
 run_anchor() {
   run bash "$SCRIPT" \
     --action execute --spec-id SPEC-013 --plan-slug spec-013-token-accounting \
@@ -274,7 +275,7 @@ led() { jq -r "$1" "$LEDGER"; }
     --cache-dir "$CACHE"
   [ "$status" -eq 0 ]
 
-  for n in 1 2 3; do
+  for _ in 1 2 3; do
     run bash "$SCRIPT" --action execute --spec-id SPEC-013 --plan-slug my-plan \
       --out-dir "$OUTDIR" --session-id "$SESSION" \
       --projects-root "$ANCHOR" --ledger "$BATS_TEST_TMPDIR/le.jsonl"
@@ -749,7 +750,7 @@ led() { jq -r "$1" "$LEDGER"; }
 # ---------- 20. seq/final over repeated execute writes (AC7) ----------
 @test "three execute writes: seq 0,1,2, only the last final:true, final row is cumulative" {
   L="$BATS_TEST_TMPDIR/seq.jsonl"
-  for n in 1 2 3; do
+  for _ in 1 2 3; do
     run bash "$SCRIPT" --action execute --spec-id SPEC-013 --plan-slug s \
       --out-dir "$OUTDIR" --session-id "$SESSION" \
       --projects-root "$ANCHOR" --ledger "$L"

--- a/.gaia/scripts/verify-audit-roster.sh
+++ b/.gaia/scripts/verify-audit-roster.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted printf format strings where any
+# $ or backtick is literal output text, not a shell expansion.
+# shellcheck disable=SC2016
 # verify-audit-roster.sh: the Code Audit Team roster's deterministic check.
 #
 # The roster is meant to grow, by adopters and by the maintainer, as a project

--- a/.gaia/tests/README.md
+++ b/.gaia/tests/README.md
@@ -4,7 +4,7 @@ Internal tests for GAIA's Claude Code hooks, commands, and wiki sync system. Not
 
 ## Layout
 
-- `shell-lint.sh`; shellcheck gate over every tracked `*.sh` in the repo. Free, deterministic, runs in CI on every PR that touches a shell script (`.github/workflows/shell-lint.yml`).
+- `shell-lint.sh`; shellcheck gate over every tracked `*.sh` and `*.bats` in the repo. Free, deterministic, runs in CI on every PR that touches a shell script or bats suite (`.github/workflows/shell-lint.yml`).
 - `hooks/`; bats tests for shell hooks. Free, deterministic, runs on every commit.
 - `smoke/`; release-gate harnesses with PASS/FAIL semantics. Subdirs: `wiki-sync/`, `wiki-promote/`, `uat-write/`. Routing rule: `.claude/rules/maintainers/smoke.md`. See `smoke/README.md`.
 - `observability/`; measurement tools that watch agent behavior over time and report metrics. NO PASS/FAIL. Subdirs: `serena/`. See `observability/serena/README.md` (no observability tree-level README needed for a single-occupant tree; revisit if a second observability tool lands).
@@ -17,7 +17,7 @@ Internal tests for GAIA's Claude Code hooks, commands, and wiki sync system. Not
 bash .gaia/tests/shell-lint.sh
 ```
 
-Requires `shellcheck` (`brew install shellcheck`). Lints every tracked `*.sh` at severity `warning`; exits non-zero on any finding. The `info`/`style` tiers are below the gate's floor because they are dominated here by intentional single-quoted `jq`/`awk` programs (SC2016) and unresolvable dynamic `source` paths (SC1091); see those tiers with `shellcheck -S style <file>`.
+Requires `shellcheck` (`brew install shellcheck`). Lints at a per-type severity floor and exits non-zero on any finding: tracked `*.sh` at `style` (the strictest tier) and tracked `*.bats` at `warning`. On `*.sh`, the intentional single-quoted `jq`/`awk` programs (SC2016) carry file-level disable directives and the unresolvable dynamic `source` paths (SC1091/SC1090) are excluded as tooling artifacts, so a genuine style-tier bug still gates. On `*.bats`, the `warning` floor sits above the structural false positives of the bats execution model (SC2317 unreachable `@test` bodies, SC2030/SC2031 subshell state from `run`, SC2016 assertion strings) while still catching live failure modes (SC2314 masked `!` assertions, SC2155, SC2164). See the sub-floor tiers with `shellcheck -S style <file>`.
 
 This is the deterministic backstop for the `code-audit-maintainer-shell` agent, which already treats shellcheck as an authoritative oracle but is model-dispatched and advisory-only. The agent keeps the lenses shellcheck cannot model (hook fail-open, stdin-JSON shape, `jq -n` injection safety).
 

--- a/.gaia/tests/distribution/03-marker-strip.sh
+++ b/.gaia/tests/distribution/03-marker-strip.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted sed program where $ is a regex
+# anchor, not a shell variable.
+# shellcheck disable=SC2016
 # 03-marker-strip.sh
 #
 # Asserts the marker-strip transform fired correctly:

--- a/.gaia/tests/distribution/09-exclude-parser-parity.sh
+++ b/.gaia/tests/distribution/09-exclude-parser-parity.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted sed program where $ is a regex
+# anchor, not a shell variable.
+# shellcheck disable=SC2016
 # 09-exclude-parser-parity.sh
 #
 # Regression test for #839 (the #679 remainder): three surfaces

--- a/.gaia/tests/distribution/lib/build-staging.sh
+++ b/.gaia/tests/distribution/lib/build-staging.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted sed regex ($ is a regex anchor)
+# and printf text with literal backticks, neither a shell expansion.
+# shellcheck disable=SC2016
 # Build a release-staging tree from the source repo into <output-dir>.
 # Pure replication of `.github/workflows/release.yml` Stage + Scrub +
 # Runtime-deps phases. Read-only on the source repo.

--- a/.gaia/tests/forensics/01-redaction-roundtrip.bats
+++ b/.gaia/tests/forensics/01-redaction-roundtrip.bats
@@ -61,7 +61,7 @@ setup() {
 
 @test "UAT-003: gho_ GitHub OAuth token is redacted" {
   # Construct a synthetic token-shaped string at runtime
-  local fake_token="gho_$(python3 -c 'print("A"*20)' 2>/dev/null || printf 'AAAAAAAAAAAAAAAAAAAA')"
+  local fake_token; fake_token="gho_$(python3 -c 'print("A"*20)' 2>/dev/null || printf 'AAAAAAAAAAAAAAAAAAAA')"
   local input="Token: $fake_token in the env"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -70,7 +70,7 @@ setup() {
 }
 
 @test "UAT-003: ghp_ GitHub PAT is redacted" {
-  local fake_token="ghp_$(python3 -c 'print("B"*20)' 2>/dev/null || printf 'BBBBBBBBBBBBBBBBBBBB')"
+  local fake_token; fake_token="ghp_$(python3 -c 'print("B"*20)' 2>/dev/null || printf 'BBBBBBBBBBBBBBBBBBBB')"
   local input="GITHUB_TOKEN=$fake_token"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -78,7 +78,7 @@ setup() {
 }
 
 @test "UAT-003: sk-ant- Anthropic API key is redacted" {
-  local fake_key="sk-ant-api03-$(python3 -c 'print("C"*20)' 2>/dev/null || printf 'CCCCCCCCCCCCCCCCCCCC')"
+  local fake_key; fake_key="sk-ant-api03-$(python3 -c 'print("C"*20)' 2>/dev/null || printf 'CCCCCCCCCCCCCCCCCCCC')"
   local input="ANTHROPIC_API_KEY=$fake_key"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -86,8 +86,8 @@ setup() {
 }
 
 @test "UAT-003: sk- OpenAI key is redacted (and sk-ant- takes priority)" {
-  local fake_openai="sk-$(python3 -c 'print("D"*20)' 2>/dev/null || printf 'DDDDDDDDDDDDDDDDDDDD')"
-  local fake_anthropic="sk-ant-$(python3 -c 'print("E"*20)' 2>/dev/null || printf 'EEEEEEEEEEEEEEEEEEEE')"
+  local fake_openai; fake_openai="sk-$(python3 -c 'print("D"*20)' 2>/dev/null || printf 'DDDDDDDDDDDDDDDDDDDD')"
+  local fake_anthropic; fake_anthropic="sk-ant-$(python3 -c 'print("E"*20)' 2>/dev/null || printf 'EEEEEEEEEEEEEEEEEEEE')"
   local result_openai
   result_openai="$(redact_body "$FAKE_ROOT" "key=$fake_openai")"
   [[ "$result_openai" != *"$fake_openai"* ]]
@@ -98,7 +98,7 @@ setup() {
 }
 
 @test "UAT-003: glpat- GitLab PAT is redacted" {
-  local fake_token="glpat-$(python3 -c 'print("F"*20)' 2>/dev/null || printf 'FFFFFFFFFFFFFFFFFFFF')"
+  local fake_token; fake_token="glpat-$(python3 -c 'print("F"*20)' 2>/dev/null || printf 'FFFFFFFFFFFFFFFFFFFF')"
   local input="GITLAB_TOKEN=$fake_token"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -106,7 +106,7 @@ setup() {
 }
 
 @test "UAT-003: xoxb- Slack token is redacted" {
-  local fake_token="xoxb-$(python3 -c 'print("G"*10)' 2>/dev/null || printf 'GGGGGGGGGG')"
+  local fake_token; fake_token="xoxb-$(python3 -c 'print("G"*10)' 2>/dev/null || printf 'GGGGGGGGGG')"
   local input="SLACK_TOKEN=$fake_token"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -120,7 +120,7 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "SEC-1: github_pat_ fine-grained PAT is redacted" {
-  local fake_token="github_pat_$(python3 -c 'print("a"*30)' 2>/dev/null || printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')"
+  local fake_token; fake_token="github_pat_$(python3 -c 'print("a"*30)' 2>/dev/null || printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')"
   local input="Found in shell environment: $fake_token was present"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -154,7 +154,7 @@ setup() {
 }
 
 @test "SEC-3: xapp- Slack app-level token is redacted" {
-  local fake_token="xapp-$(python3 -c 'print("1-" + "G"*12)' 2>/dev/null || printf '1-GGGGGGGGGGGG')"
+  local fake_token; fake_token="xapp-$(python3 -c 'print("1-" + "G"*12)' 2>/dev/null || printf '1-GGGGGGGGGGGG')"
   local input="Slack app credential $fake_token present"
   local result
   result="$(redact_body "$FAKE_ROOT" "$input")"
@@ -216,7 +216,7 @@ setup() {
 
 @test "TST-03: recheck halts with no partial body when a token survives the forward passes" {
   sed() { cat; }
-  local fake_token="gho_$(python3 -c 'print("Z"*24)' 2>/dev/null || printf 'ZZZZZZZZZZZZZZZZZZZZZZZZ')"
+  local fake_token; fake_token="gho_$(python3 -c 'print("Z"*24)' 2>/dev/null || printf 'ZZZZZZZZZZZZZZZZZZZZZZZZ')"
   run --separate-stderr redact_body "$FAKE_ROOT" "leaked credential: $fake_token"
   [ "$status" -ne 0 ]
   [ -z "$output" ]

--- a/.gaia/tests/forensics/04-write-surface.bats
+++ b/.gaia/tests/forensics/04-write-surface.bats
@@ -5,6 +5,7 @@
 # of the runbook branch and, where used, the `lib/*.sh` mirrors, never the shipped
 # skill body. Real end-to-end guard: integration.md "Local skill end-to-end" diff.
 
+# shellcheck disable=SC2034  # unused test-dir anchor; pre-existing dead code, kept (not deleted) per surgical-changes policy
 HERE="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
 
 setup() {

--- a/.gaia/tests/forensics/07-gh-not-installed.bats
+++ b/.gaia/tests/forensics/07-gh-not-installed.bats
@@ -6,6 +6,7 @@
 # of the runbook branch and, where used, the `lib/*.sh` mirrors, never the shipped
 # skill body. Real end-to-end guard: integration.md "Local skill end-to-end" diff.
 
+# shellcheck disable=SC2034  # unused test-dir anchor; pre-existing dead code, kept (not deleted) per surgical-changes policy
 HERE="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
 
 # ---------------------------------------------------------------------------

--- a/.gaia/tests/forensics/08-user-config-no-gh.bats
+++ b/.gaia/tests/forensics/08-user-config-no-gh.bats
@@ -17,6 +17,7 @@ LIB="$HERE/lib"
 # ---------------------------------------------------------------------------
 
 diagnose_branch() {
+  # shellcheck disable=SC2034  # positional arg documented but intentionally unused in this helper
   local description="$1"
   local node_version="${2:-}"
   local dirty="${3:-false}"

--- a/.gaia/tests/forensics/lib/redact.sh
+++ b/.gaia/tests/forensics/lib/redact.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted sed program where $ is a regex
+# metacharacter, not a shell variable.
+# shellcheck disable=SC2016
 # Shell implementation of the redaction algorithm defined in
 # .claude/skills/gaia/references/forensics/redaction.md
 #

--- a/.gaia/tests/hooks/block-spec-plan-chain.bats
+++ b/.gaia/tests/hooks/block-spec-plan-chain.bats
@@ -22,7 +22,7 @@ setup() {
   # A real git repo: the hook resolves its sentinel against the main checkout
   # (git rev-parse --git-common-dir), so it is a no-op outside one.
   REPO=$(bash "$HELPERS/tmp-git-repo.sh")
-  cd "$REPO"
+  cd "$REPO" || return 1
 
   SESSION="sess-abc123"
   SENTINEL="$REPO/.gaia/local/cache/spec-chain-${SESSION}.json"

--- a/.gaia/tests/hooks/debt-sentinel-touch.bats
+++ b/.gaia/tests/hooks/debt-sentinel-touch.bats
@@ -26,7 +26,7 @@ teardown() {
 # hook, from inside a fresh tmp repo. Leaves $REPO set for assertions.
 run_hook() {
   REPO=$("$HELPERS/tmp-git-repo.sh")
-  cd "$REPO"
+  cd "$REPO" || return 1
   local input
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "$1")
   run bash -c "printf '%s' '$input' | '$HOOK_ABS'"
@@ -73,7 +73,7 @@ assert_not_armed() { [ ! -f "$REPO/$SENTINEL_REL" ]; }
 
 @test "non-Bash tool: no-op, not armed" {
   REPO=$("$HELPERS/tmp-git-repo.sh")
-  cd "$REPO"
+  cd "$REPO" || return 1
   input=$(jq -n '{tool_name:"Edit",tool_input:{file_path:"x"}}')
   run bash -c "printf '%s' '$input' | '$HOOK_ABS'"
   [ "$status" -eq 0 ]

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -18,6 +18,7 @@ setup() {
   [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HELPER="$REPO_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LIB="$REPO_ROOT/.claude/hooks/lib/red-ledger.sh"
+  # shellcheck disable=SC2034  # unused fixture-path var; pre-existing dead code, kept (not deleted) per surgical-changes policy
   FIX="$BATS_TEST_DIRNAME/fixtures/red-ledger"
 
   # Repo-relative fixture paths (helper + lib expect repo-relative input run

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -253,7 +253,7 @@ test("brand new test", () => {
   stage_file "app/utils/x/index.test.ts" "$PASSING_TEST"
   run_commit_hook "git -C '$OTHER' commit -m change"
   [ "$status" -eq 0 ]
-  ! denied
+  denied && return 1
   rm -rf "$OTHER"
 }
 

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -35,6 +35,7 @@ setup() {
   CAPTURE_HOOK="$HOME_ROOT/.claude/hooks/capture-red-observations.sh"
   CHECK_HOOK="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   BARE_TEST_HOOK="$HOME_ROOT/.claude/hooks/block-bare-test.sh"
+  # shellcheck disable=SC2034  # unused helper-path var; pre-existing dead code, kept (not deleted) per surgical-changes policy
   HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LEDGER_REL=".gaia/local/red-ledger/observations.jsonl"
 

--- a/.gaia/tests/hooks/token-rollup-merge.bats
+++ b/.gaia/tests/hooks/token-rollup-merge.bats
@@ -71,7 +71,8 @@ ledger_path() {
 
 # write_record <action> <spec_id> <session_id> <total> <ts> [<ended_at>]
 write_record() {
-  local action="$1" spec_id="$2" sid="$3" total="$4" ts="$5" ended="${6:-$ts}"
+  local action="$1" spec_id="$2" sid="$3" total="$4" ts="$5"
+  local ended="${6:-$ts}"
   mkdir -p "$(dirname "$(ledger_path)")"
   jq -nc --arg kind "$action" --arg spec_id "$spec_id" --arg sid "$sid" \
     --argjson total "$total" --arg ts "$ts" --arg ended "$ended" \

--- a/.gaia/tests/lib/ledger-title-repair.bats
+++ b/.gaia/tests/lib/ledger-title-repair.bats
@@ -133,7 +133,7 @@ EOF
   [ "$status" -eq 0 ]
 
   new_subject="$(_plans_field PLAN-001 subject)"
-  ! grep -qF "plain-la" <<<"$new_subject"
+  grep -qF "plain-la" <<<"$new_subject" && return 1
   [ "$new_subject" != "Reframe /gaia-plan worktree isolation prompt: drop the experimental disclaimer, add a brief plain-la" ]
 }
 
@@ -182,7 +182,7 @@ EOF
   subj_anchor="$(_plans_field PLAN-100 subject)"
   [ "$subj_anchor" = "Real prose line describing the phase." ]
   [ "$subj_anchor" != "Commit: abc1234" ]
-  ! grep -qF "abc1234" <<<"$subj_anchor"
+  grep -qF "abc1234" <<<"$subj_anchor" && return 1
 
   subj_guard="$(_plans_field PLAN-101 subject)"
   [ "$subj_guard" = "Committed the parser cleanly." ]

--- a/.gaia/tests/shell-lint.sh
+++ b/.gaia/tests/shell-lint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shell-lint.sh: run shellcheck over every tracked shell script in the repo.
+# shell-lint.sh: run shellcheck over every tracked shell script and bats suite.
 # Exit 0 when clean, 1 on any finding at or above the severity floor.
 # Run it directly from anywhere: `bash .gaia/tests/shell-lint.sh`.
 #
@@ -14,12 +14,26 @@
 # the lenses shellcheck cannot model (hook fail-open, stdin-JSON shape,
 # `jq -n` injection safety).
 #
-# Severity floor: `warning`. Errors and warnings are the tiers with live failure
-# modes (unquoted expansions that word-split, BSD-vs-GNU portability breaks,
-# subshell scoping bugs). The `info`/`style` tiers are dominated here by
-# SC2016 (single-quoted jq/awk programs, intentional) and SC1091 (shellcheck
-# cannot resolve a dynamically sourced path), which would gate on noise. Run
-# `shellcheck -S style <file>` by hand to see those tiers.
+# Two severity floors, one per file type, because the two file types carry
+# different noise profiles:
+#
+#   *.sh   -> `style`, the strictest floor. The genuine style/info-tier codes are
+#            curated: SC1091/SC1090 (shellcheck cannot follow a dynamically
+#            sourced path) are excluded below as pure tooling artifacts, and the
+#            intentional single-quoted jq/awk programs (SC2016) carry file-level
+#            `# shellcheck disable=SC2016` directives, so the gate stays live to a
+#            genuine SC2016 bug in any file that does not opt out.
+#
+#   *.bats -> `warning`. Errors and warnings are the tiers with live failure
+#            modes (a masked `!` assertion that never fails a test [SC2314], a
+#            `local x=$(...)` that swallows the command's exit [SC2155], a `cd`
+#            with no `|| exit` guard [SC2164]). The `info`/`style` tiers on bats
+#            are dominated by structural false positives from the bats execution
+#            model (SC2317 unreachable `@test`/`setup`/`teardown` bodies,
+#            SC2030/SC2031 subshell state from `run`, SC2016 assertion strings);
+#            those sit below the `warning` floor and never fire, so bats needs no
+#            blunt per-code exclude list. Run `shellcheck -S style <file>` by hand
+#            to see the sub-floor tiers.
 #
 # Never begin a comment line with the bare word `shellcheck`: a comment of that
 # shape is parsed as a directive, and a malformed one (SC1072/SC1073) aborts the
@@ -35,7 +49,19 @@
 # CI: .github/workflows/shell-lint.yml
 set -euo pipefail
 
-SEVERITY=warning
+# Per-file-type severity floors (see the block above). *.sh is held to the
+# strictest `style` tier; *.bats joins at `warning`, where the structural bats
+# false positives sit below the floor.
+SH_SEVERITY=style
+BATS_SEVERITY=warning
+
+# Tooling-artifact codes disabled for every pass: SC1091/SC1090 are "shellcheck
+# cannot resolve a sourced path computed at runtime", which carries no failure
+# mode and fires across the tree wherever a script sources a sibling by a derived
+# path. Passed on the command line rather than a repo-root .shellcheckrc, so this
+# config stays inside the maintainer-only gate and never ships to adopters as a
+# newly-distributed file.
+TOOLING_EXCLUDE=SC1091,SC1090
 
 # Pin the linter version so the gate's verdict cannot depend on which machine ran
 # it. Ubuntu's apt ships 0.9.0 while Homebrew ships newer, and their directive
@@ -67,24 +93,44 @@ fi
 #
 # Collected with a read loop rather than `mapfile`: mapfile is bash 4+, and these
 # scripts are authored and run on stock macOS /bin/bash (3.2.57).
-scripts=()
+sh_scripts=()
 while IFS= read -r f; do
-  scripts+=("$f")
+  sh_scripts+=("$f")
 done < <(git -C "$REPO_ROOT" ls-files '*.sh')
 
-# Guard the expansion below: on bash 3.2 a bare "${scripts[@]}" over an EMPTY
-# array aborts with `unbound variable` under `set -u`. An empty result also means
-# the glob or the repo root resolved wrong, which should fail loudly, not lint
-# nothing and report success.
-if [ "${#scripts[@]}" -eq 0 ]; then
+bats_scripts=()
+while IFS= read -r f; do
+  bats_scripts+=("$f")
+done < <(git -C "$REPO_ROOT" ls-files '*.bats')
+
+# Guard the expansion below: on bash 3.2 a bare "${sh_scripts[@]}" over an EMPTY
+# array aborts with `unbound variable` under `set -u`. An empty *.sh result also
+# means the glob or the repo root resolved wrong, which should fail loudly, not
+# lint nothing and report success. The *.bats set is allowed to be empty and is
+# simply skipped; only the always-present *.sh set is a hard precondition.
+if [ "${#sh_scripts[@]}" -eq 0 ]; then
   echo "ERROR: no tracked *.sh files found under $REPO_ROOT" >&2
   exit 1
 fi
 
-echo "--> shellcheck (severity=$SEVERITY): ${#scripts[@]} tracked scripts"
+# Run both passes before failing, so one invocation reports every finding across
+# both file types rather than hiding the bats findings behind an *.sh failure.
+status=0
 
+echo "--> shellcheck *.sh (severity=$SH_SEVERITY): ${#sh_scripts[@]} tracked scripts"
 # Run from the repo root so the paths the linter prints are repo-relative.
-if ! (cd "$REPO_ROOT" && shellcheck --severity="$SEVERITY" "${scripts[@]}"); then
+if ! (cd "$REPO_ROOT" && shellcheck --severity="$SH_SEVERITY" --exclude="$TOOLING_EXCLUDE" "${sh_scripts[@]}"); then
+  status=1
+fi
+
+if [ "${#bats_scripts[@]}" -gt 0 ]; then
+  echo "--> shellcheck *.bats (severity=$BATS_SEVERITY): ${#bats_scripts[@]} tracked suites"
+  if ! (cd "$REPO_ROOT" && shellcheck --severity="$BATS_SEVERITY" --exclude="$TOOLING_EXCLUDE" "${bats_scripts[@]}"); then
+    status=1
+  fi
+fi
+
+if [ "$status" -ne 0 ]; then
   echo "==> shell-lint FAILED" >&2
   exit 1
 fi

--- a/.gaia/tests/smoke/uat-write/run.sh
+++ b/.gaia/tests/smoke/uat-write/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted grep regex matching the literal
+# token $ARGUMENTS, not a shell variable.
+# shellcheck disable=SC2016
 # Smoke: structural check for the before_implement UAT-write hook.
 #
 # Drives the renderer (.specify/extensions/gaia/lib/uat-write.sh) against a
@@ -60,6 +63,7 @@ PREEXISTING_SPEC_DIR=0
 PREEXISTING_CACHE=0
 [ -f "$CACHE_FILE" ] && PREEXISTING_CACHE=1
 
+# shellcheck disable=SC2329  # invoked via `trap cleanup EXIT` below
 cleanup() {
     # Only remove what we created. Restore SPEC-099.md if it pre-existed.
     if [ "$PREEXISTING_SPEC_DIR" -eq 0 ]; then

--- a/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
+++ b/.github/actions/gaia-ci-merge-and-watch/lib/render-issue.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: the single-quoted envsubst shell-format list
+# names ${VAR}s for envsubst to expand, not the shell.
+# shellcheck disable=SC2016
 # Renders an issue body template by passing it through envsubst.
 # Required env vars (caller sets via composite-action `env:`):
 #   ORIGINAL_PR: ORIGINAL_TITLE, REVERT_PR, MERGE_SHA, FAILED_RUN_URL,

--- a/.github/audit/tests/ci-decision-step.bats
+++ b/.github/audit/tests/ci-decision-step.bats
@@ -78,7 +78,7 @@ decide() {
   [ "$use_stub" = "STUB" ] && path="$SANDBOX/bin:/usr/bin:/bin"
 
   (
-    cd "$SANDBOX"
+    cd "$SANDBOX" || exit 1
     export PATH="$path"
     OVERRIDE_LABEL="$override_label"
     PR_LABELS_JSON="$pr_labels_json"

--- a/.github/forensics/handlers/handle-auto-fixable.sh
+++ b/.github/forensics/handlers/handle-auto-fixable.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted printf formats whose backticks
+# are literal markdown in the emitted text, not command substitution.
+# shellcheck disable=SC2016
 # handle-auto-fixable.sh: UAT-004 action handler.
 #
 # Pre-conditions: the workflow has already created `<fix-branch>` from

--- a/.github/forensics/handlers/handle-malformed-body.sh
+++ b/.github/forensics/handlers/handle-malformed-body.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted printf formats whose backticks
+# are literal markdown in the emitted text, not command substitution.
+# shellcheck disable=SC2016
 # handle-malformed-body.sh: short-circuit handler for issues whose
 # body cannot be parsed deterministically.
 #

--- a/.github/forensics/handlers/handle-needs-human.sh
+++ b/.github/forensics/handlers/handle-needs-human.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted printf formats whose backticks
+# are literal markdown in the emitted text, not command substitution.
+# shellcheck disable=SC2016
 # handle-needs-human.sh: needs-human triage handler.
 #
 # Labels a forensics-triaged issue as `needs-human` and posts a comment

--- a/.github/forensics/run-quality-gate.sh
+++ b/.github/forensics/run-quality-gate.sh
@@ -74,6 +74,7 @@ json_escape() {
   local i ch code
   for (( i = 0; i < ${#in}; i++ )); do
     ch="${in:i:1}"
+    # shellcheck disable=SC1003  # single-quoted backslash literals in the escape map are intentional, not mis-escaped quotes
     case "$ch" in
       '\') out+='\\' ;;
       '"') out+='\"' ;;

--- a/.github/forensics/tests/render-prompt.bats
+++ b/.github/forensics/tests/render-prompt.bats
@@ -278,8 +278,8 @@ Capture: x" ]
   # No triple-backtick fence run survives.
   [[ "$output" != *'```'* ]]
   # Neither marker is greppable in its parser-recognized form.
-  ! printf '%s\n' "$output" | grep -qE '^[[:space:]]*GAIA-VERDICT:'
-  ! printf '%s\n' "$output" | grep -qE '^[[:space:]]*GAIA-FIX-ABORT:'
+  printf '%s\n' "$output" | grep -qE '^[[:space:]]*GAIA-VERDICT:' && return 1
+  printf '%s\n' "$output" | grep -qE '^[[:space:]]*GAIA-FIX-ABORT:' && return 1
   # The defanged forms are present (readable, but inert).
   [[ "$output" == *'GAIA-VERDICT_NEUTRALIZED:'* ]]
   [[ "$output" == *'GAIA-FIX-ABORT_NEUTRALIZED:'* ]]
@@ -313,8 +313,8 @@ Capture: x" ]
   block="$(printf '%s\n' "$output" | awk -v s="$sentinel" '$0==s{c++; next} c==1{print}')"
 
   # Inside the data block: no live markers, no fence run.
-  ! printf '%s\n' "$block" | grep -qE '^[[:space:]]*GAIA-VERDICT:'
-  ! printf '%s\n' "$block" | grep -qE '^[[:space:]]*GAIA-FIX-ABORT:'
+  printf '%s\n' "$block" | grep -qE '^[[:space:]]*GAIA-VERDICT:' && return 1
+  printf '%s\n' "$block" | grep -qE '^[[:space:]]*GAIA-FIX-ABORT:' && return 1
   [[ "$block" != *'```'* ]]
   # The hostile bytes are still present, but in their inert, confined form.
   [[ "$block" == *'GAIA-VERDICT_NEUTRALIZED:'* ]]

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -1,7 +1,8 @@
 name: Shell Lint
 
-# Runs shellcheck over every tracked *.sh in the repo via
-# .gaia/tests/shell-lint.sh (severity floor: warning).
+# Runs shellcheck over every tracked *.sh and *.bats in the repo via
+# .gaia/tests/shell-lint.sh (per-type severity floor: *.sh at style, *.bats at
+# warning).
 #
 # Maintainer-only: adopters run GAIA's bash but never author it, so the linter
 # that guards the framework's own shell has no adopter surface. Release-excluded
@@ -31,7 +32,7 @@ concurrency:
 
 jobs:
   shell-lint:
-    name: shellcheck (tracked *.sh)
+    name: shellcheck (tracked *.sh + *.bats)
     runs-on: ubuntu-latest
     # Read-only token: this job lints and reports, it never writes to the repo.
     # Bounds the blast radius of the third-party binary it installs below.
@@ -54,6 +55,7 @@ jobs:
           filters: |
             shell:
               - '**/*.sh'
+              - '**/*.bats'
               - '.github/workflows/shell-lint.yml'
       # Install a pinned release binary rather than `apt-get install shellcheck`:
       # Ubuntu ships 0.9.0 while a maintainer's Homebrew ships newer, and their
@@ -91,10 +93,10 @@ jobs:
           sudo install -m 0755 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
           rm -rf "shellcheck-v${SHELLCHECK_VERSION}" shellcheck.tar.xz
           shellcheck --version
-      # The gate lints every tracked *.sh, not just the changed ones: shellcheck
-      # is fast enough at this repo's size (~130 scripts, low seconds) that a
-      # whole-tree run is simpler than a diff-scoped one and cannot drift out of
-      # sync with the paths filter above.
+      # The gate lints every tracked *.sh and *.bats, not just the changed ones:
+      # shellcheck is fast enough at this repo's size (~280 scripts + suites, low
+      # seconds) that a whole-tree run is simpler than a diff-scoped one and
+      # cannot drift out of sync with the paths filter above.
       - if: steps.filter.outputs.shell == 'true'
         name: Run shellcheck gate
         run: bash .gaia/tests/shell-lint.sh

--- a/.specify/extensions/gaia/lib/spec-folderize.sh
+++ b/.specify/extensions/gaia/lib/spec-folderize.sh
@@ -115,7 +115,7 @@ folderize_dir() {
       target_name="SPEC.md"
     else
       # Sibling: SPEC-NNN-<rest>.md → SPEC-NNN/<REST>.md
-      rest="${filename#${id}-}"
+      rest="${filename#"${id}"-}"
       [ -n "$rest" ] || continue
       target_name="$(printf '%s' "$rest" | tr '[:lower:]' '[:upper:]').md"
     fi


### PR DESCRIPTION
## Summary

Tech-debt batch (`/gaia-debt`) hardening the maintainer-only shell-lint gate. Both issues converge on `.gaia/tests/shell-lint.sh`, so they land as one fix unit.

The gate moves to **per-type severity floors**: `*.sh` at `style` (the strictest tier) and `*.bats` at `warning`. It runs two shellcheck passes, and the CI `paths-filter` now also triggers on `**/*.bats` so a bats-only change still gates.

## #690 — tighten the `.sh` floor to `style`

Curate the sub-`warning` findings so a genuine style-tier bug still fails the gate:

- **SC2016** (37, intentional single-quoted jq/awk/sed/envsubst programs and literal `$HOME`/`$PWD` case patterns): one **file-level** `# shellcheck disable=SC2016` per affected file with a construct-specific justification. Scoped, not blanket — the gate stays live to a real SC2016 bug in every file that does not opt out.
- **SC1091/SC1090** (unfollowable dynamic `source`): excluded as pure tooling artifacts via the gate script's `--exclude`, **not** a repo-root `.shellcheckrc` — that would be a new shipping file and trip the "Unanswered newly-shipping files" gate. Keeping it in the release-excluded script keeps it maintainer-only.
- **Tail fixed:** SC2001 (`${var//\//-}` for `echo | sed`), SC2015 (`&& pwd || pwd` → explicit fallback), SC2295 (quote `${id}` in the `#` pattern). **Annotated as false positives:** SC2329 (functions invoked indirectly via `with_ledger_lock` / `trap`), SC1003 (literal single-quoted backslashes in a JSON-escape `case`).

## #771 — bring `.bats` under the gate at `warning`

The structural bats false positives (SC2317 unreachable `@test`/`setup`/`teardown` bodies, SC2030/SC2031 subshell state from `run`, SC2016 assertion strings) sit **below** the `warning` floor and never fire, so no blunt per-code exclude list is needed. The genuine `warning`-tier findings are remediated:

- **SC2314 ×7 — genuine masked-`!` assertions** (a negated absence check that, being non-final under bats' `set -e`, never fails the test — a real gap #771 exists to catch). Fixed with the `<bad-case> && return 1` form from `.claude/rules/bats-assertions.md`.
- **SC2155 ×10:** split declare-and-assign so the command's exit is not swallowed.
- **SC2318 ×1:** split a same-`local` masking so `ended="${6:-$ts}"` resolves against the just-assigned `ts`.
- **SC2164 ×3:** `cd … || return 1` / `|| exit 1` (subshell).
- **SC2120 / SC2010:** annotated (optional `"$@"`; controlled test-created `*.bak.<ts>` filenames where `ls|grep` cannot hit its unsafe-filename failure mode — one file-level directive).
- **SC2034:** two unused repeat-loop vars renamed to `_`; five pre-existing unused vars (`HERE` ×2, `FIX`, `HELPER`, `description`) **annotated, not deleted**, per surgical-changes policy — see below.

## Follow-up (not fixed here)

- **Dead-code cleanup candidates:** `HERE` (04-write-surface, 07-gh-not-installed), `FIX` (red-ledger-lib), `HELPER` (red-verify-e2e), `description` (08-user-config-no-gh) are genuinely unused; annotated rather than removed to keep this change surgical.
- **`.bats` style-tier tightening** (note-tier SC2314, SC2010, etc.) is deliberately deferred: `.bats` joins at `warning`, the floor #771 measured against.

## Verification

- `bash .gaia/tests/shell-lint.sh` → **passes** (154 `*.sh` @ style, 129 `*.bats` @ warning).
- All affected bats suites re-run **under bash 5** (stronger signal than macOS bash 3.2): **270 tests, 0 failures, 0 warnings** — confirming the now-effective SC2314 assertions genuinely hold and the SC2318 default-value fix is sound.
- `SHELLCHECK_PIN` (0.11.0) still matches `SHELLCHECK_VERSION` in the workflow.
- No adopter-facing surface: the gate script and workflow are release-excluded; no CHANGELOG entry warranted.

Closes #690
Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
