### PR TITLE
fix(ci): harden audit-ci-tests.yml token scope and pin YAML parser

### DIFF
--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -23,10 +23,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# The job only checks out and runs bats; it needs no write scopes, so pin
-# GITHUB_TOKEN to least privilege instead of inheriting the repo-default scope.
+# The job checks out, resolves changed files via dorny/paths-filter, and runs
+# bats; it needs no write scopes, so pin GITHUB_TOKEN to least privilege instead
+# of inheriting the repo-default scope. `pull-requests: read` is load-bearing,
+# not decoration: naming any scope here sets every unlisted one to `none`, and
+# dorny/paths-filter resolves a PR's changed files through the API, which needs
+# it. Omitting it works only while this repo is public; the day it went private,
+# every run would 403 with "Resource not accessible by integration". Mirrors
+# shell-lint.yml, which runs the same action on the same trigger.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   audit-ci-tests:

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -23,6 +23,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The job only checks out and runs bats; it needs no write scopes, so pin
+# GITHUB_TOKEN to least privilege instead of inheriting the repo-default scope.
+permissions:
+  contents: read
+
 jobs:
   audit-ci-tests:
     name: bats (.github/audit)
@@ -101,9 +106,12 @@ jobs:
               # trigger on both the test dir and the script it guards.
               - '.gaia/statusline/**'
               - '.gaia/tests/statusline/**'
+      # python3-yaml pins the parser lint-yaml.bats' require_yaml_parser needs
+      # (python3+pyyaml), so its parser-backed negative tests run explicitly
+      # rather than resting on whatever the runner image happens to preinstall.
       - if: steps.filter.outputs.code == 'true'
-        name: Install bats
-        run: sudo apt-get update && sudo apt-get install -y bats
+        name: Install bats and YAML parser
+        run: sudo apt-get update && sudo apt-get install -y bats python3-yaml
       - if: steps.filter.outputs.code == 'true'
         name: Run .github/audit bats suites
         run: bats .github/audit/tests/


### PR DESCRIPTION
Batch tech-debt fix for two same-file findings in `.github/workflows/audit-ci-tests.yml` (both `severity:suggestion`, both `Handler: prompt`).

## #858 — no `permissions:` block (GITHUB_TOKEN inherits default scope)
Adds a top-level `permissions: { contents: read }` block. The job only checks out and runs bats, so it needs no write scopes; pinning least privilege replaces the repo-default inherited scope. Defense-in-depth hardening flagged by the github-workflows auditor.

## #857 — no YAML parser installed, so `lint-yaml.bats` parser tests can silently skip
Pins `python3-yaml` in the install step. `lint-yaml.bats`'s `require_yaml_parser` needs python3+pyyaml (or yq) and `skip`s otherwise; installing it explicitly makes the parser-backed negative tests image-independent instead of resting on whatever `ubuntu-latest` happens to preinstall. The step is renamed `Install bats and YAML parser` to match.

Both edits are confined to the one release-excluded maintainer-only workflow; no adopter-facing surface changes.

Closes #857
Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)