### PR TITLE
test(red-verify): make `! denied` absence assertions position-safe (#861)

### DIFF
--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -118,6 +118,13 @@ run_commit_hook() {
 
 denied() { [[ "$output" == *'"permissionDecision": "deny"'* ]]; }
 
+# Absence assertion: fail the test when the hook denied. A bare `! denied` only
+# works as a test's final line -- `set -e` exempts a `!`-negated command from
+# aborting, so the moment a later line is appended it silently goes inert. This
+# form fails in any position (returns 1 when denied) and stays green as a final
+# line when allowed (the completed `if` exits 0). See .claude/rules/bats-assertions.md.
+refute_denied() { if denied; then return 1; fi; }
+
 PASSING_TEST='import {expect, test} from "vitest";
 test("adds two numbers", () => {
   expect(1 + 1).toBe(2);
@@ -150,7 +157,7 @@ test("adds two numbers", () => {
   seed_matching_red "app/utils/x/index.test.ts" "adds two numbers"
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 # --- prose-only claim does not satisfy the gate ---
@@ -191,7 +198,7 @@ test("adds two numbers", () => {
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "denies a brand-new test added to a file that already exists at HEAD" {
@@ -222,7 +229,7 @@ test("brand new test", () => {
   stage_file "app/x/index.ts" 'export const x = 1;'
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "allows when 'git commit' appears only inside a quoted message string" {
@@ -230,14 +237,14 @@ test("brand new test", () => {
   # No real git commit invocation: the words are inside an echo string.
   run_commit_hook 'echo "remember to git commit later"'
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "ignores commands that are not git commit" {
   stage_file "app/utils/x/index.test.ts" "$PASSING_TEST"
   run_commit_hook "git status"
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 # --- Foreign-repo commit -> out of scope ---
@@ -267,7 +274,7 @@ test("never closes", () => {
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 # --- Dynamic-title test -> exempt (no computable signal, never in scope) ---
@@ -285,7 +292,7 @@ test(`dynamic ${n}`, () => {
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 # --- Type-only tests -> exempt (no runtime assertion; tsc is the enforcer) ---
@@ -310,14 +317,14 @@ test("rejects a bad arg", () => {
   stage_file "app/utils/x/index.test.ts" "$TYPE_ONLY_EXPECTTYPEOF"
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "allows a new type-only test (@ts-expect-error proof, no runtime assertion)" {
   stage_file "app/utils/x/index.test.ts" "$TYPE_ONLY_TS_EXPECT_ERROR"
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "exempts the type-only sibling but still denies the runtime sibling" {
@@ -414,7 +421,7 @@ test("renders something", () => { expect(true).toBe(true); });
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "carve-out: a new a11y-helper test (.ts) commits without a RED" {
@@ -431,7 +438,7 @@ test("has no a11y violations", async () => {
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "carve-out: a new test whose own body reads the clock commits without a RED" {
@@ -445,7 +452,7 @@ test("uses wall-clock time", () => {
 '
   run_commit_hook
   [ "$status" -eq 0 ]
-  ! denied
+  refute_denied
 }
 
 @test "carve-out: the deterministic surface STILL demands a RED" {


### PR DESCRIPTION
## What

Migrate the 12 final-position `! denied` absence assertions in `.gaia/tests/hooks/red-verify-commit-check.bats` (lines 153, 194, 225, 233, 240, 270, 288, 313, 320, 417, 434, 448) to a position-safe `refute_denied` helper.

## Why

A bare `! denied` fails a test **only** as its final line. POSIX `set -e` (which bats runs every `@test` body under) explicitly exempts a `!`-negated command from aborting, so the moment one stops being the last line, an appended assertion, a reorder, a cleanup step, the assertion silently goes inert and always "passes" even when the hook wrongly denied. These twelve are currently correct because they sit last, but are one edit away from becoming no-ops. This is the SC2314 masked-assertion class; it sits at shellcheck's `style` tier, below the shell-lint `.bats` `warning` floor, so the deterministic gate cannot catch it. Same class PR #860 fixed at line 256.

## Deviation from the issue's suggested fix (please note)

The issue recommended `denied && return 1` "for uniformity with line 256." **That form is subtly wrong for these twelve**, because they are final-position with nothing after them. `denied()` returns non-zero when the hook did *not* deny, so on an "allows" test `denied && return 1` as the last line leaves `denied`'s non-zero status as the test result, failing the test. It only works at line 256 because a `rm -rf` cleanup line follows it (non-final). Applying the literal suggestion turned all 12 tests red.

Instead I used a documented `refute_denied()` helper wrapping `if denied; then return 1; fi`, which satisfies the issue's actual goal ("a form that fails correctly regardless of position"): it returns 1 when denied in any position, and the completed `if` exits 0 as a final line when allowed. This follows the repo's existing `refute_*` helper convention noted in `.claude/rules/bats-assertions.md`. Line 256 is left untouched (out of scope; correct as-is because it is non-final).

## Verification

- Full suite green under bash 5 (Homebrew): 25/25 before and after, confirming no pass/fail behavior change.
- `refute_denied` proven position-safe: fails when denied in both final and non-final position; passes when allowed as a final line.
- `shellcheck` clean (SC2314 gone); `bash .gaia/tests/shell-lint.sh` passes.
- Quality Gate skipped (only a `.bats` file staged, no source or gate-affecting config).

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)