### PR TITLE
refactor(tests): remove 4 dead SC2034-annotated vars across bats suites (#862)

### DIFF
--- a/.gaia/tests/forensics/04-write-surface.bats
+++ b/.gaia/tests/forensics/04-write-surface.bats
@@ -5,9 +5,6 @@
 # of the runbook branch and, where used, the `lib/*.sh` mirrors, never the shipped
 # skill body. Real end-to-end guard: integration.md "Local skill end-to-end" diff.
 
-# shellcheck disable=SC2034  # unused test-dir anchor; pre-existing dead code, kept (not deleted) per surgical-changes policy
-HERE="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
-
 setup() {
   # The temp repos below run `git commit`. CI runners have no ambient git
   # identity (`user.name`/`user.email`) and cannot derive one, so the commit

--- a/.gaia/tests/forensics/07-gh-not-installed.bats
+++ b/.gaia/tests/forensics/07-gh-not-installed.bats
@@ -6,9 +6,6 @@
 # of the runbook branch and, where used, the `lib/*.sh` mirrors, never the shipped
 # skill body. Real end-to-end guard: integration.md "Local skill end-to-end" diff.
 
-# shellcheck disable=SC2034  # unused test-dir anchor; pre-existing dead code, kept (not deleted) per surgical-changes policy
-HERE="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
-
 # ---------------------------------------------------------------------------
 # No-gh surrogate
 #

--- a/.gaia/tests/hooks/red-ledger-lib.bats
+++ b/.gaia/tests/hooks/red-ledger-lib.bats
@@ -18,8 +18,6 @@ setup() {
   [ -d "$REPO_ROOT/node_modules/typescript" ] || skip "typescript not installed (node-dependent RED suite)"
   HELPER="$REPO_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LIB="$REPO_ROOT/.claude/hooks/lib/red-ledger.sh"
-  # shellcheck disable=SC2034  # unused fixture-path var; pre-existing dead code, kept (not deleted) per surgical-changes policy
-  FIX="$BATS_TEST_DIRNAME/fixtures/red-ledger"
 
   # Repo-relative fixture paths (helper + lib expect repo-relative input run
   # from the repo root).

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -35,8 +35,6 @@ setup() {
   CAPTURE_HOOK="$HOME_ROOT/.claude/hooks/capture-red-observations.sh"
   CHECK_HOOK="$HOME_ROOT/.claude/hooks/red-verify-commit-check.sh"
   BARE_TEST_HOOK="$HOME_ROOT/.claude/hooks/block-bare-test.sh"
-  # shellcheck disable=SC2034  # unused helper-path var; pre-existing dead code, kept (not deleted) per surgical-changes policy
-  HELPER="$HOME_ROOT/.gaia/scripts/red-ledger/extract-test-signals.mjs"
   LEDGER_REL=".gaia/local/red-ledger/observations.jsonl"
 
   REPO=$(mktemp -d -t red-e2e-XXXXXX)


### PR DESCRIPTION
## What

Removes the four confirmed-dead, `# shellcheck disable=SC2034`-annotated variables that PR #860 surfaced when it brought `.bats` under the shell-lint gate. Each was silenced with a disable directive rather than deleted (surgically, to keep #860 focused); this is the follow-up cleanup that removes the dead assignment **and** its directive.

Removed (each confirmed dead by a whole-file grep returning a single reference, the assignment itself):

- `.gaia/tests/forensics/04-write-surface.bats` — `HERE` (test-dir anchor)
- `.gaia/tests/forensics/07-gh-not-installed.bats` — `HERE` (test-dir anchor)
- `.gaia/tests/hooks/red-ledger-lib.bats` — `FIX` (fixture-dir path)
- `.gaia/tests/hooks/red-verify-e2e.bats` — `HELPER` (helper-script path)

## Kept (per-var judgment)

`.gaia/tests/forensics/08-user-config-no-gh.bats` — `local description="$1"` in `diagnose_branch` is **kept** with its annotation. It documents the helper's call signature (all four call sites pass a human-readable label as `$1`), its annotation already reads as intentionally-unused-for-documentation rather than misleading, and removing it would leave `local node_version="${2:-}"` starting confusingly at positional 2. This is the "defensible to keep, decide per-var" case the issue explicitly carves out.

## Verification

- `bash .gaia/tests/shell-lint.sh` — passes (removing the vars removes the SC2034 findings, so no annotation is needed).
- The five affected suites pass under bash 5.

Closes #862