### PR TITLE
fix(hooks): deny writes that newly break YAML plain scalars in frontmatter and .yaml files

### DIFF
--- a/.claude/hooks/block-invalid-yaml-write.sh
+++ b/.claude/hooks/block-invalid-yaml-write.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# PreToolUse Edit/Write/MultiEdit hook: deny a YAML-bearing write (a
+# .yml/.yaml file, or Markdown --- frontmatter) that newly breaks the YAML
+# region it targets, valid before this call, invalid after.
+#
+# tech-debt #867: Claude repeatedly authors invalid YAML plain scalars, most
+# often a mid-sentence ": " (read as a mapping-key separator) or a stray " #"
+# (read as a comment, silently truncating the value), and only discovers it
+# when a downstream parser or lint fails, sometimes on an already-saved
+# immutable artifact. .specify/extensions/gaia/lib/lint.sh catches the same
+# class in SPEC frontmatter, but only at save-time, after the round trip this
+# hook exists to prevent, and only for one surface; this hook is structural
+# (any .yml/.yaml, any .md carrying --- frontmatter) rather than a directory
+# allowlist, since the highest-frequency case (frontmatter inside .md) is
+# exactly what a naive extension-only scope misses.
+#
+# Regression-only, never a blanket validity gate: this hook compares the
+# region's state before and after the call and denies only a valid -> invalid
+# transition this call itself causes. A repo scan while authoring this hook
+# found pre-existing broken frontmatter already sitting in several tracked
+# files; a "the resulting file must be valid" rule would have permanently
+# locked out any further, unrelated edit to those files. Regression-only
+# means the hook never blocks a file already broken by prior debt.
+#
+# Detect and pinpoint only, never auto-heal: a malformed scalar's intended
+# form (quote it vs. it was meant to be a mapping key) is not provable from
+# the parse failure alone, so the agent repairs it; this hook only says where
+# and why.
+#
+# Fail-open, matching the other block-*.sh guards: no python3+pyyaml, an
+# Edit/MultiEdit target that doesn't exist yet, or an old_string this hook
+# can't locate in the current file all allow the call rather than blocking a
+# legitimate edit on a heuristic miss.
+set -euo pipefail
+
+payload=$(cat)
+tool_name=$(jq -r '.tool_name // empty' <<<"$payload")
+
+case "$tool_name" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+file_path=$(jq -r '.tool_input.file_path // empty' <<<"$payload")
+[[ -n "$file_path" ]] || exit 0
+
+case "$file_path" in
+  *.yml | *.yaml | *.md) ;;
+  *) exit 0 ;;
+esac
+
+command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1 || exit 0
+
+deny() {
+  jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Reconstructs the file's content before and after this call (Write's content
+# is already the full "after"; Edit/MultiEdit apply their old_string ->
+# new_string replacement(s) against the current on-disk "before", mirroring
+# what the real tool is about to do), extracts each side's YAML region, and
+# compares. Prints a message and exits 1 only on a valid -> invalid
+# transition; exits 0 (silently) otherwise, including when the region was
+# already invalid before this call (see the regression-only note above).
+PY_SCRIPT=$(cat <<'PYEOF'
+import json
+import re
+import sys
+
+import yaml
+
+
+def apply_edit(current, old, new, replace_all):
+    if old not in current:
+        return None
+    if replace_all:
+        return current.replace(old, new)
+    return current.replace(old, new, 1)
+
+
+def yaml_region(file_path, text):
+    if file_path.endswith((".yml", ".yaml")):
+        return text
+    if file_path.endswith(".md"):
+        m = re.match(r"^---\r?\n(.*?\r?\n)---\r?\n", text, re.DOTALL)
+        return m.group(1) if m else None
+    return None
+
+
+# A YAML comment must be preceded by whitespace, so `key: value #trailing`
+# parses cleanly and yaml.safe_load never raises: it just silently drops
+# everything from the ` #` onward. This is the second footgun tech-debt #867
+# names ("sweep #9" -> "sweep"), and a successful parse can't surface it, so
+# it needs its own scan rather than living inside the try/except below.
+# Skips quoted/flow/block-scalar values (already immune by construction) and
+# tracks block-scalar bodies by indentation so literal `#` characters inside
+# a `|`/`>` block never false-positive.
+KEY_LINE_RE = re.compile(r"^(?P<indent>[ \t]*)(?:-\s+)?[\w.\-]+:[ \t]+(?P<value>.+?)\s*$")
+BLOCK_START_RE = re.compile(r":[ \t]*[|>][+-]?\d*[ \t]*$")
+
+
+def find_space_hash_truncations(region):
+    problems = []
+    block_indent = None
+    for line in region.split("\n"):
+        if block_indent is not None:
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip(" \t"))
+            if stripped == "" or indent > block_indent:
+                continue
+            block_indent = None
+        if BLOCK_START_RE.search(line):
+            block_indent = len(line) - len(line.lstrip(" \t"))
+            continue
+        m = KEY_LINE_RE.match(line)
+        if not m:
+            continue
+        value = m.group("value")
+        if value[:1] in ('"', "'", "[", "{", "|", ">"):
+            continue
+        if " #" in value:
+            problems.append(line.strip())
+    return problems
+
+
+def check_region(region):
+    """(parse_ok, parse_err, set-of-truncation-lines). A missing region
+    (no frontmatter yet, or the file didn't exist) counts as valid: there is
+    nothing prior to regress from."""
+    if region is None:
+        return True, "", set()
+    try:
+        yaml.safe_load(region)
+        parse_ok, parse_err = True, ""
+    except yaml.YAMLError as exc:
+        parse_ok, parse_err = False, str(exc).replace("\n", " ")
+    return parse_ok, parse_err, set(find_space_hash_truncations(region))
+
+
+payload = json.load(sys.stdin)
+tool_name = payload.get("tool_name", "")
+tool_input = payload.get("tool_input", {})
+file_path = tool_input.get("file_path", "")
+
+if tool_name == "Write":
+    after_text = tool_input.get("content", "")
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            before_text = fh.read()
+    except OSError:
+        before_text = None
+elif tool_name in ("Edit", "MultiEdit"):
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            before_text = fh.read()
+    except OSError:
+        sys.exit(0)
+    after_text = before_text
+    edits = [tool_input] if tool_name == "Edit" else tool_input.get("edits", [])
+    for edit in edits:
+        nxt = apply_edit(
+            after_text,
+            edit.get("old_string", ""),
+            edit.get("new_string", ""),
+            bool(edit.get("replace_all", False)),
+        )
+        if nxt is None:
+            sys.exit(0)
+        after_text = nxt
+else:
+    sys.exit(0)
+
+after_region = yaml_region(file_path, after_text)
+if after_region is None:
+    sys.exit(0)
+
+before_region = yaml_region(file_path, before_text) if before_text is not None else None
+
+before_ok, _before_err, before_trunc = check_region(before_region)
+after_ok, after_err, after_trunc = check_region(after_region)
+
+if before_ok and not after_ok:
+    print(after_err)
+    sys.exit(1)
+
+new_trunc = after_trunc - before_trunc
+if new_trunc:
+    example = sorted(new_trunc)[0]
+    print(f"unquoted ' #' in a plain scalar silently truncates the value as a comment: \"{example}\"")
+    sys.exit(1)
+PYEOF
+)
+
+yaml_err=""
+yaml_parse_failed=0
+if ! yaml_err=$(printf '%s' "$payload" | python3 -c "$PY_SCRIPT" 2>&1); then
+  yaml_parse_failed=1
+fi
+
+if [[ "$yaml_parse_failed" -eq 1 ]]; then
+  deny "BLOCKED: '$file_path' would newly produce broken YAML: $yaml_err. This is the plain-scalar footgun from tech-debt #867: a bare ': ' or ' #' inside prose, or a value starting with a YAML indicator character, reads as structural YAML, not text (the ' #' case parses fine and silently drops everything after it). Quote the value, or use a block scalar (| or >-), then re-check."
+fi
+
+exit 0

--- a/.claude/hooks/block-invalid-yaml-write.sh
+++ b/.claude/hooks/block-invalid-yaml-write.sh
@@ -144,56 +144,73 @@ def check_region(region):
     return parse_ok, parse_err, set(find_space_hash_truncations(region))
 
 
-payload = json.load(sys.stdin)
-tool_name = payload.get("tool_name", "")
-tool_input = payload.get("tool_input", {})
-file_path = tool_input.get("file_path", "")
+# Returns a deny message on a genuine, newly-introduced regression, or None
+# to allow. Any exception escaping here (not just a missing file: a
+# non-UTF-8 read is UnicodeDecodeError, a ValueError subclass, not OSError)
+# is caught by the top-level call below and treated as None, matching the
+# hook's own fail-open contract: an internal bug must never turn into a
+# surprise deny.
+def main():
+    payload = json.load(sys.stdin)
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
 
-if tool_name == "Write":
-    after_text = tool_input.get("content", "")
-    try:
-        with open(file_path, "r", encoding="utf-8") as fh:
-            before_text = fh.read()
-    except OSError:
-        before_text = None
-elif tool_name in ("Edit", "MultiEdit"):
-    try:
-        with open(file_path, "r", encoding="utf-8") as fh:
-            before_text = fh.read()
-    except OSError:
-        sys.exit(0)
-    after_text = before_text
-    edits = [tool_input] if tool_name == "Edit" else tool_input.get("edits", [])
-    for edit in edits:
-        nxt = apply_edit(
-            after_text,
-            edit.get("old_string", ""),
-            edit.get("new_string", ""),
-            bool(edit.get("replace_all", False)),
-        )
-        if nxt is None:
-            sys.exit(0)
-        after_text = nxt
-else:
-    sys.exit(0)
+    if tool_name == "Write":
+        after_text = tool_input.get("content", "")
+        try:
+            with open(file_path, "r", encoding="utf-8") as fh:
+                before_text = fh.read()
+        except OSError:
+            before_text = None
+    elif tool_name in ("Edit", "MultiEdit"):
+        try:
+            with open(file_path, "r", encoding="utf-8") as fh:
+                before_text = fh.read()
+        except OSError:
+            return None
+        after_text = before_text
+        edits = [tool_input] if tool_name == "Edit" else tool_input.get("edits", [])
+        for edit in edits:
+            nxt = apply_edit(
+                after_text,
+                edit.get("old_string", ""),
+                edit.get("new_string", ""),
+                bool(edit.get("replace_all", False)),
+            )
+            if nxt is None:
+                return None
+            after_text = nxt
+    else:
+        return None
 
-after_region = yaml_region(file_path, after_text)
-if after_region is None:
-    sys.exit(0)
+    after_region = yaml_region(file_path, after_text)
+    if after_region is None:
+        return None
 
-before_region = yaml_region(file_path, before_text) if before_text is not None else None
+    before_region = yaml_region(file_path, before_text) if before_text is not None else None
 
-before_ok, _before_err, before_trunc = check_region(before_region)
-after_ok, after_err, after_trunc = check_region(after_region)
+    before_ok, _before_err, before_trunc = check_region(before_region)
+    after_ok, after_err, after_trunc = check_region(after_region)
 
-if before_ok and not after_ok:
-    print(after_err)
-    sys.exit(1)
+    if before_ok and not after_ok:
+        return after_err
 
-new_trunc = after_trunc - before_trunc
-if new_trunc:
-    example = sorted(new_trunc)[0]
-    print(f"unquoted ' #' in a plain scalar silently truncates the value as a comment: \"{example}\"")
+    new_trunc = after_trunc - before_trunc
+    if new_trunc:
+        example = sorted(new_trunc)[0]
+        return f"unquoted ' #' in a plain scalar silently truncates the value as a comment: \"{example}\""
+
+    return None
+
+
+try:
+    deny_reason = main()
+except Exception:
+    deny_reason = None
+
+if deny_reason is not None:
+    print(deny_reason)
     sys.exit(1)
 PYEOF
 )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -147,6 +147,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/block-worktree-path-mismatch.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-invalid-yaml-write.sh"
           }
         ]
       },

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -24,6 +24,7 @@
     ".claude/hooks/block-env-read.sh": "owned",
     ".claude/hooks/block-env-write.sh": "owned",
     ".claude/hooks/block-eslint-config-edit.sh": "owned",
+    ".claude/hooks/block-invalid-yaml-write.sh": "owned",
     ".claude/hooks/block-lockfile-edit.sh": "owned",
     ".claude/hooks/block-main-destructive-git.sh": "owned",
     ".claude/hooks/block-manifest-write.sh": "owned",
@@ -611,6 +612,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-07-19T09:40:38.984Z",
+  "generated": "2026-07-19T10:44:01.524Z",
   "version": "1.6.1"
 }

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+# Tests for .claude/hooks/block-invalid-yaml-write.sh.
+#
+# Regression coverage for tech-debt #867: Claude repeatedly authors invalid
+# YAML plain scalars (a mid-sentence ": " read as a mapping-key separator, or
+# a stray " #" read as a comment that silently truncates the value) and only
+# discovers it when a downstream parser or lint fails, sometimes on an
+# already-saved artifact. This guard reconstructs the resulting content for
+# an Edit/Write/MultiEdit call, extracts the YAML region (the whole file for
+# .yml/.yaml, or the --- frontmatter block for .md), and denies the call on
+# a real parse failure. It fails open on anything it cannot resolve: no
+# python3+pyyaml, a target that doesn't exist yet, or an old_string it can't
+# locate in the current file.
+#
+# Assertion style note: per .claude/rules/bats-assertions.md, non-final
+# absence checks use a positive match for the bad case plus an explicit
+# `return 1`, never `!`-negation.
+
+setup() {
+  HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
+  HOOK_ABS="$HOOKS_SRC/block-invalid-yaml-write.sh"
+  SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
+  if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import yaml' >/dev/null 2>&1; then
+    skip "python3 with pyyaml not available"
+  fi
+}
+
+teardown() {
+  [ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"
+  return 0
+}
+
+make_workdir() {
+  WORKDIR=$(mktemp -d -t gaia-yaml-write-XXXXXX)
+}
+
+# Quote-safe delivery (mandatory, mirrors block-worktree-path-mismatch.bats):
+# pass $json and $HOOK_ABS as positional args to an inner bash -c rather than
+# re-wrapping in an outer single-quoted string, so embedded quotes/newlines in
+# a payload never terminate the wrapper early.
+run_hook_write() {
+  local path="$1" content="$2"
+  local json
+  json=$(jq -n --arg p "$path" --arg c "$content" '{tool_name: "Write", tool_input: {file_path: $p, content: $c}}')
+  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+}
+
+run_hook_edit() {
+  local path="$1" old="$2" new="$3"
+  local json
+  json=$(jq -n --arg p "$path" --arg o "$old" --arg n "$new" '{tool_name: "Edit", tool_input: {file_path: $p, old_string: $o, new_string: $n}}')
+  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+}
+
+run_hook_multiedit() {
+  local path="$1" edits_json="$2"
+  local json
+  json=$(jq -n --arg p "$path" --argjson e "$edits_json" '{tool_name: "MultiEdit", tool_input: {file_path: $p, edits: $e}}')
+  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+}
+
+assert_denied() {
+  [ "$status" -eq 0 ]
+  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
+}
+
+assert_allowed() {
+  [ "$status" -eq 0 ]
+  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
+  return 0
+}
+
+# --- denied: Write with a genuine YAML parse error ---
+
+@test "Write of a .yaml file with a mid-sentence colon-space plain scalar is denied" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.yaml" $'title: fix this: it breaks\n'
+  assert_denied
+}
+
+@test "Write of a .md file whose frontmatter has an unquoted colon-space value is denied" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.md" $'---\ndescription: works in isolation: its guarantees hold\n---\nbody\n'
+  assert_denied
+}
+
+# --- allowed: Write with valid YAML ---
+
+@test "Write of a .yaml file with a properly quoted colon-space value is allowed" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.yaml" $'title: "fix this: it breaks"\n'
+  assert_allowed
+}
+
+@test "Write of a .md file with valid frontmatter is allowed" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.md" $'---\nname: foo\ndescription: a normal description\n---\nbody\n'
+  assert_allowed
+}
+
+@test "Write of a .md file with no frontmatter at all is allowed" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.md" $'# Just a heading\n\nSome prose: with a colon.\n'
+  assert_allowed
+}
+
+@test "Write of a non-YAML, non-Markdown file is allowed (out of scope)" {
+  make_workdir
+  run_hook_write "$WORKDIR/foo.ts" $'const x: number = 1;\n'
+  assert_allowed
+}
+
+# --- regression-only: pre-existing brokenness never locks out a file ---
+
+@test "Write that overwrites an already-broken file with still-broken frontmatter is allowed" {
+  make_workdir
+  printf '%s' $'---\ndescription: works in isolation: its guarantees hold\n---\nold body\n' >"$WORKDIR/foo.md"
+  run_hook_write "$WORKDIR/foo.md" $'---\ndescription: works in isolation: its guarantees hold\n---\nnew body\n'
+  assert_allowed
+}
+
+@test "Edit to the body of a file whose frontmatter is already broken is allowed" {
+  make_workdir
+  printf '%s' $'---\ndescription: works in isolation: its guarantees hold\n---\nold body\n' >"$WORKDIR/foo.md"
+  run_hook_edit "$WORKDIR/foo.md" "old body" "new body, unrelated to the frontmatter"
+  assert_allowed
+}
+
+# --- Edit: reconstructs resulting content from the on-disk file ---
+
+@test "Edit that introduces an invalid colon-space scalar into frontmatter is denied" {
+  make_workdir
+  printf '%s' $'---\ndescription: fine\n---\nbody\n' >"$WORKDIR/foo.md"
+  run_hook_edit "$WORKDIR/foo.md" "description: fine" "description: works in isolation: its guarantees hold"
+  assert_denied
+}
+
+@test "Edit that keeps frontmatter valid is allowed" {
+  make_workdir
+  printf '%s' $'---\ndescription: fine\n---\nbody\n' >"$WORKDIR/foo.md"
+  run_hook_edit "$WORKDIR/foo.md" "description: fine" "description: still fine"
+  assert_allowed
+}
+
+@test "Edit introducing a space-hash comment truncation into a .yaml value is denied" {
+  make_workdir
+  printf '%s' $'title: sweep\n' >"$WORKDIR/foo.yaml"
+  run_hook_edit "$WORKDIR/foo.yaml" "title: sweep" "title: sweep #9"
+  assert_denied
+}
+
+@test "Edit on a file that does not exist yet fails open (allowed)" {
+  make_workdir
+  run_hook_edit "$WORKDIR/nope.yaml" "a" "b"
+  assert_allowed
+}
+
+@test "Edit whose old_string is not found in the current file fails open (allowed)" {
+  make_workdir
+  printf '%s' $'title: fine\n' >"$WORKDIR/foo.yaml"
+  run_hook_edit "$WORKDIR/foo.yaml" "not-present-anywhere" "title: broken: value"
+  assert_allowed
+}
+
+# --- MultiEdit ---
+
+@test "MultiEdit that introduces an invalid scalar is denied" {
+  make_workdir
+  printf '%s' $'---\ndescription: fine\nother: ok\n---\nbody\n' >"$WORKDIR/foo.md"
+  edits='[{"old_string":"description: fine","new_string":"description: fine"},{"old_string":"other: ok","new_string":"other: works in isolation: its guarantees hold"}]'
+  run_hook_multiedit "$WORKDIR/foo.md" "$edits"
+  assert_denied
+}
+
+@test "MultiEdit that keeps content valid is allowed" {
+  make_workdir
+  printf '%s' $'---\ndescription: fine\nother: ok\n---\nbody\n' >"$WORKDIR/foo.md"
+  edits='[{"old_string":"description: fine","new_string":"description: still fine"},{"old_string":"other: ok","new_string":"other: still ok"}]'
+  run_hook_multiedit "$WORKDIR/foo.md" "$edits"
+  assert_allowed
+}
+
+# --- ignored: not our matcher ---
+
+@test "a Read tool call is ignored" {
+  make_workdir
+  local json
+  json=$(jq -n --arg p "$WORKDIR/foo.yaml" '{tool_name: "Read", tool_input: {file_path: $p}}')
+  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  assert_allowed
+}
+
+# --- structural ---
+
+@test "block-invalid-yaml-write.sh is executable" {
+  [ -x "$HOOK_ABS" ]
+}
+
+@test "settings.json is valid JSON" {
+  run jq empty "$SETTINGS_ABS"
+  [ "$status" -eq 0 ]
+}
+
+@test "settings.json registers the hook under the Edit|Write|MultiEdit matcher" {
+  run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write|MultiEdit") | .hooks[] | select(.command == ".claude/hooks/block-invalid-yaml-write.sh")' "$SETTINGS_ABS"
+  [ "$status" -eq 0 ]
+}

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -111,6 +111,15 @@ assert_allowed() {
   assert_allowed
 }
 
+# --- fail-open: an internal error never turns into a surprise deny ---
+
+@test "Write overwriting a file containing non-UTF-8 bytes is allowed, not a crash-to-deny" {
+  make_workdir
+  printf 'title: caf\xe9 time\n' >"$WORKDIR/foo.yaml"
+  run_hook_write "$WORKDIR/foo.yaml" $'title: valid\n'
+  assert_allowed
+}
+
 # --- regression-only: pre-existing brokenness never locks out a file ---
 
 @test "Write that overwrites an already-broken file with still-broken frontmatter is allowed" {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ### Added
 
+- a `PreToolUse` guard (`.claude/hooks/block-invalid-yaml-write.sh`) that denies an Edit/Write/MultiEdit call that newly breaks a YAML region, a `.yml`/`.yaml` file or a Markdown `---` frontmatter block, closing the recurring footgun where a mid-sentence `: ` or a stray ` #` in an unquoted scalar reads as structural YAML instead of prose and is only caught later by a downstream parser or lint, sometimes on an already-saved artifact. The check is regression-only, so a file whose frontmatter was already broken before the edit never gets locked out (#867)
 - a `PreToolUse` guard (`.claude/hooks/block-worktree-path-mismatch.sh`) that denies an Edit/Write/MultiEdit call whose target resolves to a different git worktree than the session's current one, closing a silent-wrong-write footgun where a stale pre-switch absolute path applied to the wrong checkout with no error signal. `isolation.md`'s `RESOLVED_ROOT` guidance now explicitly covers Edit/Write/Read alongside Bash and sub-agent dispatch (#842)
 
 - New wiki concept page, Registering a Code Audit Team Member, documenting how to add a roster member (agent def, roster and builtin-fallback lockstep, machinery wiring, `finding_class` bucket, and recurrence-tally integration) and the required local-gate checklist a member add must run locally. (#817)


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` guard (`.claude/hooks/block-invalid-yaml-write.sh`) that reconstructs the resulting content of an Edit/Write/MultiEdit call, extracts the targeted YAML region (a whole `.yml`/`.yaml` file, or a Markdown `---` frontmatter block), and denies the call only on a valid → invalid transition it itself introduces.
- Catches both known footguns: a mid-sentence `: ` (throws a real YAML parse error) and a stray ` #` (parses fine but silently truncates the value as a comment, so it needs its own scan).
- Regression-only by design: a repo scan while building this turned up 12 pre-existing files with already-broken frontmatter; a blanket "resulting file must be valid" rule would have permanently locked out any further edit to those files. The hook compares before/after state and only blocks a fresh regression.
- Adds a CHANGELOG entry (adopter-facing new hook).

Closes #867

## Test plan
- [x] New bats suite `.gaia/tests/hooks/block-invalid-yaml-write.bats` (19 tests): denied/allowed Write, Edit, and MultiEdit cases, both footgun classes, regression-only behavior, fail-open edge cases, and structural checks (executable bit, settings.json registration).
- [x] Manually verified against real repo files: an unrelated edit to an already-broken file (`wiki/modules/Testing.md`) is allowed; introducing a fresh colon-space break into a previously-valid file (`.claude/agents/code-audit-frontend.md`) is denied with a clear message.
- [x] `shellcheck -S style` on the hook and `-S warning` on the bats suite: both clean.
- [x] Quality Gate: skipped (no staged file matches its trigger patterns — only `.claude/hooks/**`, `.claude/settings.json`, `.gaia/tests/**`, `CHANGELOG.md` touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)