### PR TITLE
docs(gaia): fix two false doc-correctness claims

### DIFF
--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -41,7 +41,7 @@ The rest of the skill, write-surface allowlist, no-machine-local-memory rule, wo
    - `.specify/**`
    - `.gaia/local/cache/**`
    - `.gaia/local/telemetry/**`
-     Never edit source files (`app/**`, `src/**`, repo root configs, etc.). The `after_specify` lint command audits this; you enforce it at the agent-instruction level.
+     Never edit source files (`app/**`, `src/**`, repo root configs, etc.). No automated backstop enforces this allowlist today: the `after_specify` lint checks only the saved SPEC artifact's immutability, not which paths a session wrote. You self-police it at the agent-instruction level.
 3. **One question at a time.** No multi-question forms. Closed-set questions go through `AskUserQuestion` with options ordered: recommended FIRST, then alternatives, then `Other` (free text), then `Discuss this` (escape to plain Q&A). Open-ended questions use a plain prompt with no enumerated options.
 4. **Two-gate ceremony.** Confirm intent + UATs in plain English BEFORE authoring the artifact. Confirm the rendered artifact BEFORE saving to disk. No silent advances between gates.
 5. **Coach tone, not interrogator.** Mirror back, name trade-offs, propose candidates when the human is stuck. Never punt research to the human.

--- a/.gaia/cli/src/wiki/orphans.ts
+++ b/.gaia/cli/src/wiki/orphans.ts
@@ -6,7 +6,9 @@
  * to `wc -l` or similar. With `--json`, each orphan is enriched with its
  * `title` and `domain` (both already derived by the page-index walk).
  *
- * Replaces the prose subject-orphan pass in `wiki/consolidate.md` Step 2d.
+ * Backs the enumeration half of `wiki/consolidate.md` Step 2d's subject-orphan
+ * pass: it lists zero-inbound-link pages. The step's title-substring and
+ * 90-day-staleness refine over that list stays in the prose.
  */
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';


### PR DESCRIPTION
Two doc-correctness fixes from the determinism-hardening worklist (S1-2a, S4-3a). Both correct statements that are false as written; no behavior change.

## S1-2a — `.claude/skills/gaia/references/spec.md` hard-constraint 2
The write-surface allowlist claimed "The `after_specify` lint command audits this." It does not: `.specify/extensions/gaia/lib/lint.sh` is a pure-function immutability lint of the saved SPEC artifact (frontmatter, immutability, UAT structure). It never inspects which paths a session wrote. Corrected to state there is no automated backstop for the allowlist today; it is self-policed at the agent-instruction level.

## S4-3a — `.gaia/cli/src/wiki/orphans.ts` header comment
The header claimed it "Replaces the prose subject-orphan pass in `wiki/consolidate.md` Step 2d." It only enumerates zero-inbound-link pages; Step 2d's title-substring + 90-day-staleness refine over that list stays in prose. Corrected to say it backs the enumeration half.

## Quality Gate
`.gaia/cli` change is comment-only. CLI typecheck, lint, and test suite all pass (1516 passed, 2 skipped). App surface untouched.

## CHANGELOG
No entry: pure doc/comment accuracy, no behavior/flag/action change for adopters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)