### PR TITLE
refactor(bats): extract the bash-5 pre-flight guard to .gaia/scripts/bats5.sh

### DIFF
--- a/.claude/rules/bats-assertions.md
+++ b/.claude/rules/bats-assertions.md
@@ -13,33 +13,7 @@ Repro (bats runs each `@test` body under `set -e`, so mirror it with a plainly-c
 
 A bash-3.2 local `bats` run is a **weaker signal than CI** (ubuntu bash 5), and the gap is not limited to the `[[ ]]` skip documented below. A second, independent gap is BSD-vs-GNU CLI divergence: a macOS-only green misses commands that only exist in one flavor. The concrete case is `date -v` (BSD) versus `date -d` (GNU): the losing form exits non-zero on Linux, and under bats' `set -e` that aborts the test before any fallback runs.
 
-Run bats through this guard instead of calling `bats` directly. It prefers a Homebrew bash 5 when one is installed (Apple Silicon: `/opt/homebrew/bin/bash`, Intel: `/usr/local/bin/bash`) and warns loudly on stderr when the bash bats will actually use resolves to major version < 4, so the warning fires only where the gap is real (silent on any bash 5 host, macOS or Linux):
-
-```bash
-bats5() {
-  for d in /opt/homebrew/bin /usr/local/bin; do
-    if [ -x "$d/bash" ]; then
-      PATH="$d:$PATH"
-      export PATH
-      break
-    fi
-  done
-  resolved_bash=$(command -v bash)
-  major=$("$resolved_bash" -c 'echo "${BASH_VERSINFO[0]}"')
-  if [ "$major" -lt 4 ]; then
-    echo "############################################################" >&2
-    echo "# WARNING: bats will run under bash $major ($resolved_bash)." >&2
-    echo "# This local green is a WEAKER signal than CI (ubuntu bash 5):" >&2
-    echo "# a false bare [[ ]] can pass silently, and BSD-only commands" >&2
-    echo "# (e.g. 'date -v') that fail on Linux won't be caught here." >&2
-    echo "# brew install bash, then re-run before trusting this pass count." >&2
-    echo "############################################################" >&2
-  fi
-  bats "$@"
-}
-```
-
-Source it (or paste it into the shell), then call `bats5` wherever the rest of this page says `bats`.
+Run bats through the guard in `.gaia/scripts/bats5.sh` instead of calling `bats` directly: `source .gaia/scripts/bats5.sh`, then call `bats5` wherever the rest of this page says `bats` (or run `.gaia/scripts/bats5.sh <args>` directly). It prefers a Homebrew bash 5 when one is installed (Apple Silicon: `/opt/homebrew/bin/bash`, Intel: `/usr/local/bin/bash`) and warns loudly on stderr when the bash bats will actually use resolves to major version < 4, so the warning fires only where the gap is real (silent on any bash 5 host, macOS or Linux).
 
 <!-- gaia:maintainer-only:start -->
 A deterministic lint over `.bats` files and shipped `*.sh` for `date -v` / `date -d` usage would catch the BSD/GNU class statically; that belongs in the shell-lint gate (`.gaia/tests/shell-lint.sh`), outside this rule's scope.

--- a/.gaia/manifest.json
+++ b/.gaia/manifest.json
@@ -196,6 +196,7 @@
     ".gaia/scripts/audit-noop-detect.sh": "owned",
     ".gaia/scripts/audit-window-lib.sh": "owned",
     ".gaia/scripts/audit-write-clearance.sh": "owned",
+    ".gaia/scripts/bats5.sh": "owned",
     ".gaia/scripts/check-updates.sh": "owned",
     ".gaia/scripts/classifier/classify-determinism.mjs": "owned",
     ".gaia/scripts/cost-backfill.sh": "owned",
@@ -612,6 +613,6 @@
     "wiki/overview.md": "wiki-owned",
     "wiki/README.md": "wiki-owned"
   },
-  "generated": "2026-07-19T10:44:01.524Z",
+  "generated": "2026-07-19T11:28:29.943Z",
   "version": "1.6.1"
 }

--- a/.gaia/scripts/bats5.sh
+++ b/.gaia/scripts/bats5.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# bats5.sh - Run bats under bash 5 when one is available (pre-flight guard).
+#
+# macOS ships bash 3.2 as /bin/bash, which is what bats-core resolves to by
+# default. A bash-3.2 local `bats` run is a weaker signal than CI (ubuntu bash
+# 5): a false bare `[[ ]]` can pass silently, and BSD-only commands (e.g.
+# `date -v`) that fail on Linux go uncaught. This prefers a Homebrew bash 5 on
+# PATH (Apple Silicon: /opt/homebrew/bin, Intel: /usr/local/bin) and warns
+# loudly on stderr when the bash bats will actually use resolves to major
+# version < 4, so the warning fires only where the gap is real (silent on any
+# bash 5 host, macOS or Linux). See .claude/rules/bats-assertions.md.
+#
+# Usage:
+#   source .gaia/scripts/bats5.sh   # then call `bats5` wherever a page says `bats`
+#   .gaia/scripts/bats5.sh <args>   # run directly; forwards <args> to bats under the guard
+
+bats5() {
+  # The helper vars are locals so sourcing this file into a shell does not
+  # leak them; PATH is exported on purpose, that export is the whole point.
+  local d resolved_bash major
+  for d in /opt/homebrew/bin /usr/local/bin; do
+    if [ -x "$d/bash" ]; then
+      PATH="$d:$PATH"
+      export PATH
+      break
+    fi
+  done
+  resolved_bash=$(command -v bash)
+  # SC2016: single quotes are intentional. BASH_VERSINFO must expand inside the
+  # resolved bash ("$resolved_bash" -c ...), not in this shell.
+  # shellcheck disable=SC2016
+  major=$("$resolved_bash" -c 'echo "${BASH_VERSINFO[0]}"')
+  if [ "$major" -lt 4 ]; then
+    echo "############################################################" >&2
+    echo "# WARNING: bats will run under bash $major ($resolved_bash)." >&2
+    echo "# This local green is a WEAKER signal than CI (ubuntu bash 5):" >&2
+    echo "# a false bare [[ ]] can pass silently, and BSD-only commands" >&2
+    echo "# (e.g. 'date -v') that fail on Linux won't be caught here." >&2
+    echo "# brew install bash, then re-run before trusting this pass count." >&2
+    echo "############################################################" >&2
+  fi
+  bats "$@"
+}
+
+# When executed directly (not sourced), run the guard immediately.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  bats5 "$@"
+fi

--- a/.gaia/scripts/tests/bats5.bats
+++ b/.gaia/scripts/tests/bats5.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Tests for .gaia/scripts/bats5.sh, the bash-5 pre-flight guard for bats.
+# Assertions use bash-3.2-safe forms (POSIX [ ], explicit failure) per
+# .claude/rules/bats-assertions.md.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../bats5.sh"
+}
+
+@test "sourcing defines the bats5 function" {
+  # shellcheck disable=SC1090
+  source "$SCRIPT"
+  [ -n "$(declare -F bats5)" ]
+}
+
+@test "sourcing does not auto-invoke bats" {
+  marker="${BATS_TEST_TMPDIR}/called"
+  bats() { echo called >>"$marker"; }
+  # shellcheck disable=SC1090
+  source "$SCRIPT"
+  [ ! -f "$marker" ]
+}
+
+@test "bats5 forwards its arguments to bats" {
+  recorded="${BATS_TEST_TMPDIR}/args"
+  bats() { printf '%s\n' "$*" >"$recorded"; }
+  # shellcheck disable=SC1090
+  source "$SCRIPT"
+  bats5 one two three
+  grep -qxF 'one two three' "$recorded"
+}
+
+@test "bats5 does not leak its helper locals into the caller" {
+  bats() { :; }
+  # shellcheck disable=SC1090
+  source "$SCRIPT"
+  bats5 noop
+  [ -z "${d+set}" ]
+  [ -z "${resolved_bash+set}" ]
+  [ -z "${major+set}" ]
+}


### PR DESCRIPTION
Determinism-hardening worklist item **S10-2**.

The ~25-line `bats5()` wrapper lived inline in the `**/*.bats`-scoped `.claude/rules/bats-assertions.md` body, so it reloaded into context on every bats edit. This extracts it to a dual-use `.gaia/scripts/bats5.sh` and shrinks the rule to a one-line pointer.

## What changed
- **New** `.gaia/scripts/bats5.sh`: the same guard, now `source`-able (`source .gaia/scripts/bats5.sh`, then call `bats5`) **or** runnable directly (`.gaia/scripts/bats5.sh <args>`). The function declares its helpers `local` so sourcing does not leak `d`/`resolved_bash`/`major` into the caller's shell (the inline version leaked them). A `# shellcheck disable=SC2016` documents the deliberate single-quoted `${BASH_VERSINFO[0]}` that must expand in the *resolved* child bash.
- **Shrunk** `.claude/rules/bats-assertions.md`: the inline function block becomes a one-paragraph pointer. Pure context win, identical behavior.
- **New** `.gaia/scripts/tests/bats5.bats`: 4 tests (function defined on source, no auto-invoke on source, arg forwarding, local hygiene), written in the bash-3.2-safe style the rule itself prescribes.
- **Manifest**: `bats5.sh` answered as `owned` (shipping) via `release manifest --ship` — the shipped rule references it, so it must ship.

## Verification
- `shellcheck .gaia/scripts/bats5.sh` — clean.
- `.gaia/scripts/bats5.sh .gaia/scripts/tests/bats5.bats` — 4/4 pass (dogfooded: the new test runs *through* the new script).
- Quality Gate skips (no `.ts/.js`/gate-config staged).

## CHANGELOG
No entry: pure extraction refactor, identical guard behavior, matches the no-entry precedent for recent `debt`/`refactor` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)