### PR TITLE
refactor(harden): emit is_oracle from harden-tally, drop hand-synced prefix list

### DIFF
--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -41,13 +41,14 @@ It prints JSON to stdout:
       "distinct_pr_count": 4,
       "pr_numbers": [311, 314, 318, 320],
       "area_tags": ["app/components"],
-      "severity_max": "warning"
+      "severity_max": "warning",
+      "is_oracle": false
     }
   ]
 }
 ```
 
-Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. Coverage detection is class-level and scope-blind in v1: a promoted rule suppresses its `finding_class` regardless of the rule's `paths:` glob, because coverage keys only on the provenance marker's `finding_class`, not on scope. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error, and it always exits 0. The emitted JSON carries a `gh_ok` boolean that separates a real all-clear from a failed window read. When `gh_ok` is `false`, the merged-PR window could not be read (a `gh`/network outage), which is NOT an all-clear: report "could not read the merged-PR window; this is not an all-clear, re-run when `gh` is available" and stop, never claim no findings. (Run ends here; see `## Cost record (run end)`.) When `gh_ok` is `true` and `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop. (Run ends here; see `## Cost record (run end)`.)
+Bind to these fields per candidate: `finding_class`, `distinct_pr_count`, `pr_numbers`, `area_tags`, `severity_max`, `is_oracle`. The tally already drops classes a promoted rule covers and classes the decline ledger suppresses, so every entry it returns is an open candidate. Coverage detection is class-level and scope-blind in v1: a promoted rule suppresses its `finding_class` regardless of the rule's `paths:` glob, because coverage keys only on the provenance marker's `finding_class`, not on scope. `harden-tally` is network-dependent and non-fatal: a `gh` failure yields an empty candidate list rather than an error, and it always exits 0. The emitted JSON carries a `gh_ok` boolean that separates a real all-clear from a failed window read. When `gh_ok` is `false`, the merged-PR window could not be read (a `gh`/network outage), which is NOT an all-clear: report "could not read the merged-PR window; this is not an all-clear, re-run when `gh` is available" and stop, never claim no findings. (Run ends here; see `## Cost record (run end)`.) When `gh_ok` is `true` and `candidate_count` is `0`, report "no recurring findings crossed the threshold in the last 90 days" and stop. (Run ends here; see `## Cost record (run end)`.)
 
 ## Judge-the-form logic (the heart of the command)
 
@@ -65,13 +66,9 @@ Also check whether the quality gate (`wiki/decisions/Quality Gate.md`) already l
 
 ### Axis 2, which form (lowest context weight that fits)
 
-Inspect the `finding_class` prefix and the pattern's nature:
+Inspect the candidate's `is_oracle` flag and the pattern's nature:
 
-- **Oracle-class finding** (the `finding_class` is a tool id: it starts with `react-doctor/`, `axe/`, `knip/`, or `cve/`).
-
-  <!-- gaia:maintainer-only:start -->
-  This prefix list mirrors `ORACLE_PREFIXES` in `.gaia/cli/src/schemas/finding-class.ts`; keep the two in sync, a prefix added to the code but not here is misclassified as holistic/rule and mis-routed.
-  <!-- gaia:maintainer-only:end -->
+- **Oracle-class finding** (if `harden-tally` flags the candidate's `is_oracle` true, its `finding_class` is a tool id owned by a deterministic tool).
 
   A deterministic check already exists for it. Recommend making that check BLOCKING or adding it to the quality gate, an enforcement edit, NOT a new prose rule. Point at `wiki/decisions/Quality Gate.md` and the tool's wiring (`.claude/rules/knip.md`, `.claude/rules/dep-audit.md`, the `code-audit-frontend` agent, or the relevant CI workflow). A `knip/*` class is the exception to the quality-gate route: the developer Quality Gate intentionally omits knip (see `.claude/rules/knip.md`), so route knip enforcement to the `code-audit-frontend` agent or CI, never the dev gate. Never draft prose for an oracle class.
 

--- a/.gaia/cli/src/harden/__tests__/compute-tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/compute-tally.test.ts
@@ -52,6 +52,26 @@ describe('computeTally', () => {
     expect(candidate.severity_max).toBe('warning');
     expect(candidate.pr_numbers).toEqual([1201, 1188, 1175]);
     expect(candidate.area_tags).toEqual(['app/components', 'app/hooks']);
+    expect(candidate.is_oracle).toBe(true);
+  });
+
+  test('sets is_oracle false for a closed-vocabulary (non-oracle) class', () => {
+    const result = computeTally({
+      coveredClass: noCover,
+      prs: [3, 2, 1].map((n) =>
+        pr(n, [
+          {
+            area_tags: [],
+            finding_class: 'rule/switch-statement',
+            severity: 'warning',
+          },
+        ])
+      ),
+      suppressedClass: noSuppress,
+      windowDays: 90,
+    });
+
+    expect(result.candidates[0]?.is_oracle).toBe(false);
   });
 
   test('does not surface a class on only 2 distinct PRs', () => {

--- a/.gaia/cli/src/harden/__tests__/tally.test.ts
+++ b/.gaia/cli/src/harden/__tests__/tally.test.ts
@@ -157,6 +157,7 @@ describe('harden-tally run', () => {
       'react-doctor/no-generic-handler-names'
     );
     expect(candidates[0]?.distinct_pr_count).toBe(3);
+    expect(candidates[0]?.is_oracle).toBe(true);
   });
 
   test('CI+local findings for the same class across distinct PRs combine into one candidate', () => {
@@ -201,6 +202,7 @@ describe('harden-tally run', () => {
     expect(printed.candidate_count).toBe(1);
     const candidates = printed.candidates as Record<string, unknown>[];
     expect(candidates[0]?.severity_max).toBe('error');
+    expect(candidates[0]?.is_oracle).toBe(false);
   });
 
   test('two different auditors posting on the same PR both count (#731 regression)', () => {

--- a/.gaia/cli/src/harden/compute-tally.ts
+++ b/.gaia/cli/src/harden/compute-tally.ts
@@ -13,7 +13,10 @@
  * decline ledger. Suggestion-severity findings and findings repeated within a
  * single PR never qualify.
  */
-import {isValidFindingClass} from '../schemas/finding-class.js';
+import {
+  isOracleFindingClass,
+  isValidFindingClass,
+} from '../schemas/finding-class.js';
 
 export const RECURRENCE_THRESHOLD = 3;
 
@@ -32,6 +35,7 @@ export type TallyCandidate = {
   area_tags: string[];
   distinct_pr_count: number;
   finding_class: string;
+  is_oracle: boolean;
   pr_numbers: number[];
   severity_max: CountableSeverity;
 };
@@ -189,6 +193,7 @@ export const computeTally = ({
         area_tags: aggregate.areaTags,
         distinct_pr_count: distinctPrCount,
         finding_class: findingClass,
+        is_oracle: isOracleFindingClass(findingClass),
         pr_numbers: aggregate.prNumbers,
         severity_max: aggregate.severityMax,
       });

--- a/.gaia/cli/src/schemas/__tests__/finding-class.test.ts
+++ b/.gaia/cli/src/schemas/__tests__/finding-class.test.ts
@@ -3,6 +3,7 @@ import {
   FINDING_CLASS_PREFIXES,
   FindingClassSchema,
   HOLISTIC_FINDING_CLASSES,
+  isOracleFindingClass,
   isValidFindingClass,
   OUT_OF_SCOPE_FALLBACK_FINDING_CLASS,
   PROSE_FINDING_CLASSES,
@@ -113,6 +114,28 @@ describe('schemas/finding-class', () => {
           'workflow',
         ])
       );
+    });
+  });
+
+  describe('isOracleFindingClass (harden-tally is_oracle source)', () => {
+    test.each([
+      'react-doctor/no-generic-handler-names',
+      'axe/color-contrast',
+      'knip/exports',
+      'cve/1098765',
+    ])('true for an oracle-prefixed class: %s', (value) => {
+      expect(isOracleFindingClass(value)).toBe(true);
+    });
+
+    test.each([
+      'holistic/hardcoded-string',
+      'rule/switch-statement',
+      'workflow/unpinned-action',
+      'prose/excessive-length',
+      'not-a-real-prefix/x',
+      '',
+    ])('false for a non-oracle class: %j', (value) => {
+      expect(isOracleFindingClass(value)).toBe(false);
     });
   });
 

--- a/.gaia/cli/src/schemas/finding-class.ts
+++ b/.gaia/cli/src/schemas/finding-class.ts
@@ -153,6 +153,19 @@ const isOraclePrefix = (prefix: string): prefix is FindingClassPrefix =>
   (ORACLE_PREFIXES as readonly string[]).includes(prefix);
 
 /**
+ * True when `findingClass` carries a known oracle prefix (`react-doctor/`,
+ * `axe/`, `knip/`, `cve/`), the deterministic-tool buckets. Reuses the same
+ * `ORACLE_PREFIXES` membership check as `isValidFindingClass` so callers never
+ * need to re-list the prefixes; `harden-tally` uses this to emit `is_oracle`
+ * per candidate.
+ */
+export const isOracleFindingClass = (findingClass: string): boolean => {
+  const parts = splitPrefix(findingClass);
+
+  return parts !== undefined && isOraclePrefix(parts.prefix);
+};
+
+/**
  * True when `value` matches the per-bucket convention: a well-formed oracle id
  * (open id space after a known oracle prefix) or a seeded closed-vocabulary
  * member (holistic, rule, workflow, or prose). Everything else (free text,


### PR DESCRIPTION
## Summary

- `harden-tally` now emits an `is_oracle` boolean per candidate, computed by a new `isOracleFindingClass` helper in `.gaia/cli/src/schemas/finding-class.ts` that reuses the existing `ORACLE_PREFIXES` membership check (no new prefix list).
- `harden.md`'s Axis 2 oracle-detection prose now routes on the emitted `is_oracle` flag instead of eyeballing a hardcoded 4-prefix list.
- **Removed the drift hazard**: the prose 4-prefix list (`react-doctor/`, `axe/`, `knip/`, `cve/`) and the maintainer-only comment that admitted it was "hand-synced" with `ORACLE_PREFIXES` in `finding-class.ts` are both deleted from `harden.md`. `ORACLE_PREFIXES` remains the single source of truth; nothing duplicates it anymore.
- Additive change only: `TallyCandidate` gains `is_oracle: boolean`. No existing consumer of `harden-tally`'s JSON output reads a shape that breaks (checked `.gaia/scripts/check-updates.sh`, the only other consumer, which only reads `candidate_count` / `gh_ok`).

## Verification

- `pnpm -C .gaia/cli typecheck` — clean
- `pnpm -C .gaia/cli lint` — clean (0 warnings)
- `pnpm -C .gaia/cli test` — 120 test files, 1527 tests passed, 2 pre-existing skips
- Extended `compute-tally.test.ts`, `tally.test.ts` (the harden-tally CLI test), and `finding-class.test.ts` with cases asserting `is_oracle`/`isOracleFindingClass` is `true` for oracle-prefixed classes and `false` for holistic/rule/workflow/prose classes.
- `git grep` for hardcoded machine paths and unbalanced `gaia:maintainer-only` markers in the touched files: clean.

## Test plan

- [x] `pnpm -C .gaia/cli typecheck`
- [x] `pnpm -C .gaia/cli lint`
- [x] `pnpm -C .gaia/cli test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
