### PR TITLE
build(cli): rebundle the gaia binary after the is_oracle tally change

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -16968,6 +16968,10 @@ var splitPrefix = (value) => {
   };
 };
 var isOraclePrefix = (prefix) => ORACLE_PREFIXES.includes(prefix);
+var isOracleFindingClass = (findingClass) => {
+  const parts = splitPrefix(findingClass);
+  return parts !== void 0 && isOraclePrefix(parts.prefix);
+};
 var isValidFindingClass = (value) => {
   const parts = splitPrefix(value);
   if (parts === void 0) return false;
@@ -17052,6 +17056,7 @@ var computeTally = ({
         area_tags: aggregate.areaTags,
         distinct_pr_count: distinctPrCount,
         finding_class: findingClass,
+        is_oracle: isOracleFindingClass(findingClass),
         pr_numbers: aggregate.prNumbers,
         severity_max: aggregate.severityMax
       });


### PR DESCRIPTION
Fix-forward for main. PR #875 (S2-6, `is_oracle` on `harden-tally`) edited `.gaia/cli/src/**` but did not rebuild the committed `.gaia/cli/gaia` bundle, so the CLI reproducibility gate (rebuild-from-src, `cmp` against committed) now fails on every PR.

This runs `pnpm -C .gaia/cli bundle` and commits the result, so the committed binary matches its source again. Verified locally: after this commit, the rebuild-and-compare self-check passes for both `gaia` and `gaia-maintainer` (the latter was already byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)