### PR TITLE
debt(chore-deps-audit-stamp): move module JSDoc above imports

### DIFF
--- a/.gaia/cli/src/automation/__tests__/chore-deps-audit-stamp.test.ts
+++ b/.gaia/cli/src/automation/__tests__/chore-deps-audit-stamp.test.ts
@@ -1,12 +1,3 @@
-import yaml from 'js-yaml';
-import {describe, expect, test} from 'vitest';
-import {readFileSync} from 'node:fs';
-import {workflowAuditTemplatePath} from '../paths.js';
-
-type AuditWorkflow = {
-  jobs: {'code-review-audit': {steps: WorkflowStep[]}};
-};
-
 /**
  * Regression guard for the chore(deps) merge-gate gap.
  *
@@ -22,6 +13,15 @@ type AuditWorkflow = {
  * the whole file is release-excluded on an adopter clone), matching the
  * findings-block contract guard in audit-template-dogfood.test.ts.
  */
+import yaml from 'js-yaml';
+import {describe, expect, test} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {workflowAuditTemplatePath} from '../paths.js';
+
+type AuditWorkflow = {
+  jobs: {'code-review-audit': {steps: WorkflowStep[]}};
+};
+
 type WorkflowStep = {
   env?: Record<string, string>;
   id?: string;


### PR DESCRIPTION
## Summary

ESLint's import-hoist autofix left the module-purpose JSDoc block between the two type aliases in `chore-deps-audit-stamp.test.ts`, so it read as documenting the local `WorkflowStep` alias instead of the module/suite it was written for. Cosmetic/legibility only, no behavioral impact.

## What changed

Moves the JSDoc block to a leading module comment above the imports and keeps both type aliases together beneath it.

Closes #884

## Test plan

- `pnpm -C .gaia/cli typecheck` clean
- `pnpm -C .gaia/cli lint` clean
- `pnpm --dir .gaia/cli exec vitest run` — 121 files, 1530 tests pass
- Root `pnpm typecheck && pnpm lint && pnpm test --run && pnpm build` clean (change is isolated to `.gaia/cli`, which root lint/typecheck exclude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)