### PR TITLE
docs(harden): use aggregate term for the unclassified signal in Guardrails

### DIFF
--- a/.claude/skills/gaia/references/harden.md
+++ b/.claude/skills/gaia/references/harden.md
@@ -304,4 +304,4 @@ Apply the shared tally machinery in `.claude/skills/gaia/references/cost-record.
 - Recommend exactly one form per candidate, with rationale; check edit-vs-new first; bias to the lowest-context-weight form. Never reflexively author a prose rule.
 - Factor the efficacy lens (Axis 3) into the recommendation and rationale: a recurring finding proves the problem, not the fix. When the recommended form is prose and no cheap evidence shows it would change behavior, surface that as a defer/decline signal for the human, never as an auto-decline.
 - This loop keys only on `finding_class` recurrence from the PR window.
-- `holistic/unclassified` is never a draftable candidate and is never auto-drafted: it carries no approve/decline/defer/redirect action and authors no artifact. It re-surfaces every tally until a class is seeded or its findings age out of the 90-day window.
+- The `unclassified` signal is never a draftable candidate and is never auto-drafted: it carries no approve/decline/defer/redirect action and authors no artifact. It re-surfaces every tally until a class is seeded or its findings age out of the 90-day window.


### PR DESCRIPTION
## What

Resolves the one open non-blocking Suggestion from the SPEC-051 (#881) pre-merge prose audit.

The last `## Guardrails` bullet in `.claude/skills/gaia/references/harden.md` was the only place in the file naming the underlying finding class `holistic/unclassified`. Everywhere else (the field binding at the top, the `## Unclassified recurrence signal` section, the list/why handlers) uses the aggregate field name `unclassified`, and one handler explicitly states the signal "carries no `finding_class`." Leading that bullet with the class name read as a contradiction.

## Change

Swap the bullet's leading `holistic/unclassified` for the aggregate term the rest of the doc uses:

> The `unclassified` signal is never a draftable candidate and is never auto-drafted: ...

Wording-only. No behavior or surface change; not CHANGELOG-worthy.

## Verification

- `git grep -nF "holistic/unclassified" -- .claude/skills/gaia/references/harden.md` now returns nothing.
- The three doc-grep-pinned strings are untouched (different bullet).
- Both pinned bats suites green:
  - `.gaia/tests/statusline/harden-unclassified-segment.bats` (8/8)
  - `.gaia/tests/prose-audit/spec051-countability-prose.bats` (12/12)
- `.claude/**` markdown-only change → Quality Gate skips (no source/config staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)