### PR TITLE
debt(spec-md): collapse redundant auto-mode-acquire sentence

### DIFF
--- a/.claude/skills/gaia/references/spec.md
+++ b/.claude/skills/gaia/references/spec.md
@@ -413,7 +413,7 @@ Acquire the session lock, right alongside the cache-init block above:
 bash .specify/extensions/gaia/lib/spec-session-lock.sh acquire "$PWD" "$SPEC_ID" || true
 ```
 
-This site has no auto-mode exception, it runs identically in interactive and auto mode. Both interactive and auto mode acquire at fresh allocation, satisfying auto-mode acquire.
+Both interactive and auto mode acquire at fresh allocation, satisfying auto-mode acquire.
 
 ### 4. Gate 1, shape confirmation
 


### PR DESCRIPTION
## Summary
- Line 416 of `.claude/skills/gaia/references/spec.md` doubled the same assertion already made by the Session-lock Acquire-points note at line 126. Collapses to one sentence, keeping the pinned load-bearing clause.

Closes #891

## Test plan
- [x] Doc-grep-pinned literal (`Both interactive and auto mode acquire at fresh allocation`, `.gaia/tests/lib/spec-session-lock-docs.bats` test 13) preserved exactly.
- Pure markdown change under `.claude/`; Quality Gate skips per `wiki/decisions/Quality Gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)