### PR TITLE
test(hooks): cover the foreign-repo exemption and the tail-truncation trade

### DIFF
--- a/.gaia/tests/hooks/distribution-preflight-check.bats
+++ b/.gaia/tests/hooks/distribution-preflight-check.bats
@@ -309,8 +309,8 @@ assert_allow() {
 @test "KNOWN RESIDUAL: a --base inside this invocation's own --body is parsed" {
   # Documented in the hook header. Within the tail this is a regex, not an
   # argument parse, so body prose that reads like a flag is taken as one. The
-  # third of the three accepted trades, pinned like the other two so it cannot
-  # drift into looking like a bug.
+  # An accepted trade, pinned like its siblings so it cannot drift into looking
+  # like a bug.
   install_maintainer_mock
   run_hook 'gh pr create --body "use --base develop next time"'
   assert_allow
@@ -331,7 +331,7 @@ assert_allow() {
   # Documented in the hook header. The tail bound is textual, so the `;` inside
   # --body ends the tail there and this invocation's own `--base develop` never
   # reaches the base parser; the base falls back to main and shipped.txt is
-  # caught. The fourth accepted trade, pinned like the other three.
+  # caught. An accepted trade, pinned like its siblings.
   #
   # Asserting DENY is what gives it teeth. A quote-aware or unbounded tail would
   # resolve develop, whose changed set excludes shipped.txt, and ALLOW.

--- a/.gaia/tests/hooks/distribution-preflight-check.bats
+++ b/.gaia/tests/hooks/distribution-preflight-check.bats
@@ -50,6 +50,13 @@ setup() {
   git -C "$FIXTURE" config user.email "test@example.com"
   git -C "$FIXTURE" config user.name "Test"
 
+  # The hook sources the repo-scope helper relative to cwd; give the fixture a
+  # real copy so the foreign-repo exemption resolves. Without it that exemption
+  # is unreachable and no test in this file can observe it.
+  mkdir -p "$FIXTURE/.claude/hooks/lib"
+  cp "$REPO_ROOT/.claude/hooks/lib/repo-scope.sh" \
+    "$FIXTURE/.claude/hooks/lib/repo-scope.sh"
+
   printf 'base\n' > "$FIXTURE/base.txt"
   git -C "$FIXTURE" add base.txt
   git -C "$FIXTURE" commit --quiet -m "base"
@@ -206,6 +213,23 @@ assert_allow() {
   assert_deny
 }
 
+# ---- repo scope --------------------------------------------------------
+
+@test "allows a gh pr create aimed at a different repo" {
+  # A PR against another repo has no bearing on this repo's distribution
+  # boundary, so the repo-scope exemption allows it before any manifest work.
+  # `--repo other/elsewhere` is the helper's authoritative form: gh ignores cwd
+  # when it is given, and the repo basename differs from the fixture's, so the
+  # helper resolves it as foreign.
+  #
+  # The mock is installed deliberately. Without it the hook would allow via the
+  # adopter-inertness guard instead, and this test would still pass with the
+  # exemption deleted. With it, the only path to ALLOW is the exemption itself.
+  install_maintainer_mock
+  run_hook "gh pr create --repo other/elsewhere --title x"
+  assert_allow
+}
+
 # ---- base-ref resolution -----------------------------------------------
 
 @test "with no base flag, falls back to the default branch and denies" {
@@ -301,6 +325,19 @@ assert_allow() {
   install_maintainer_mock
   run_hook 'echo "x; gh pr create --base develop" && gh pr create --fill'
   assert_allow
+}
+
+@test "KNOWN RESIDUAL: a quoted separator truncates this invocation's tail" {
+  # Documented in the hook header. The tail bound is textual, so the `;` inside
+  # --body ends the tail there and this invocation's own `--base develop` never
+  # reaches the base parser; the base falls back to main and shipped.txt is
+  # caught. The fourth accepted trade, pinned like the other three.
+  #
+  # Asserting DENY is what gives it teeth. A quote-aware or unbounded tail would
+  # resolve develop, whose changed set excludes shipped.txt, and ALLOW.
+  install_maintainer_mock
+  run_hook 'gh pr create --title x --body "fix; then ship" --base develop'
+  assert_deny
 }
 
 @test "does not treat --base-ref as the base flag" {

--- a/.gaia/tests/hooks/distribution-preflight-check.bats
+++ b/.gaia/tests/hooks/distribution-preflight-check.bats
@@ -308,7 +308,7 @@ assert_allow() {
 
 @test "KNOWN RESIDUAL: a --base inside this invocation's own --body is parsed" {
   # Documented in the hook header. Within the tail this is a regex, not an
-  # argument parse, so body prose that reads like a flag is taken as one. The
+  # argument parse, so body prose that reads like a flag is taken as one.
   # An accepted trade, pinned like its siblings so it cannot drift into looking
   # like a bug.
   install_maintainer_mock


### PR DESCRIPTION
## What

Closes two coverage gaps in `.gaia/tests/hooks/distribution-preflight-check.bats`.

**Gap (a): the foreign-repo exemption was untested.** `setup()` never copied `.claude/hooks/lib/repo-scope.sh` into the fixture. The hook sources it behind `[ -f .claude/hooks/lib/repo-scope.sh ]`, so with no helper present the source was skipped silently and `cmd_targets_foreign_repo` never existed. The exemption was unreachable in all 35 tests: deleting it left the suite fully green. Six sibling suites already copy the helper in and each has a foreign-repo test; this matches that precedent (`block-no-verify.bats:37`).

**Gap (b): one accepted trade was unpinned.** The hook header records four accepted trades; only three had KNOWN RESIDUAL tests. The tail-truncation trade is now pinned: a quoted `;` inside `--body` ends the tail parse there, so this invocation's own `--base develop` never reaches the base parser.

## Mutation testing

Both new tests were verified to die under mutation, and each dies **exclusively**:

| Mutation | Result |
|---|---|
| Delete the repo-scope source + exemption | `not ok 12` (repo-scope test) only. 36 ok / 1 not ok. |
| Make the tail bound quote-parity aware | `not ok 21` (truncation test) only. 36 ok / 1 not ok. |

The blunter mutation `tail_re` -> `(.*)` also kills the truncation test but co-kills the existing trailing-donate test, since both pin the same textual bound. The quote-parity mutation was built to isolate the new test.

Test (a) installs the maintainer mock deliberately. Without it the hook allows via the adopter-inertness guard instead, so the test would pass with the exemption deleted, hollow in exactly the way this suite has been bitten by before. The mock is what makes the exemption the only path to ALLOW; both explanatory comments are in the test so the next reader does not remove it.

The hook itself is untouched and byte-identical to `main`; all mutations were applied temporarily and reverted via `git checkout`.

## Verification

37/37 (35 pre-existing + 2 new), zero failures, run explicitly under each shell binary:

- `/bin/bash` 3.2.57
- `/opt/homebrew/bin/bash` 5.3.15

No pre-existing test changed behavior under the new `setup()` line.

## Notes

- Quality Gate: skipped per `wiki/decisions/Quality Gate.md:54`. No staged file matches the source/config pattern (`.bats` only).
- CHANGELOG: no entry. Test-only, alters no shipped behavior, and `.gaia/tests/**` is release-excluded so nothing reaches an adopter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)