### PR TITLE
fix(hooks): require the payload cwd to be absolute

### DIFF
--- a/.claude/hooks/block-worktree-path-mismatch.sh
+++ b/.claude/hooks/block-worktree-path-mismatch.sh
@@ -92,9 +92,15 @@ payload_cwd=$(jq -r '.cwd // empty' <<<"$payload")
 # own two-branch derivation above guarantees, and unlike a `--` terminator it
 # behaves identically on bash 3.2 and bash 5. An empty value falls through to
 # the `-n` guard below and routes to the process cwd, same as an absent field.
-# `dirname --` and `CDPATH=''` below are belt-and-braces once this holds: with
-# an absolute payload_cwd neither a dash-leading operand nor a CDPATH lookup is
-# reachable, and they stay as defense in depth.
+# `dirname --` and `CDPATH=''` on the payload_main_root line below are
+# belt-and-braces once this holds: with an absolute payload_cwd neither a
+# dash-leading operand nor a CDPATH lookup is reachable there, so they stay only
+# as defense in depth. That covers those two, and nothing else. The
+# identically-shaped guards further down operate on file_path, which no
+# invariant constrains, and they are load-bearing: dropping the CDPATH guard
+# there turns a deny into an allow, because cd resolves a relative file_path
+# through CDPATH into the exempt shared-state tree while git still resolves the
+# write to the main checkout.
 case "$payload_cwd" in
   /*) ;;
   *) payload_cwd="" ;;

--- a/.claude/hooks/block-worktree-path-mismatch.sh
+++ b/.claude/hooks/block-worktree-path-mismatch.sh
@@ -28,8 +28,10 @@
 # inferred to stand in for one. Reading only the process cwd would let the guard
 # go silently inert if a harness version ever stopped aligning the two. The
 # payload cwd is honored only when it is absolute and resolves to a checkout of
-# this repo; anything else routes to the process cwd. That absolute-path
-# requirement is load-bearing, not cosmetic, and is argued where it is enforced.
+# this repo; anything else routes to the process cwd. The absolute requirement
+# is load-bearing, because the value reaches a bare `cd` that would otherwise
+# option-parse a leading dash and silently succeed into $HOME. The full case
+# analysis sits with the `case` below that enforces it.
 #
 # Scope, and why it stops there: the guard adjudicates "does this target resolve
 # to the main checkout", which is #841's own case. `main_root` derives from

--- a/.claude/hooks/block-worktree-path-mismatch.sh
+++ b/.claude/hooks/block-worktree-path-mismatch.sh
@@ -26,7 +26,10 @@
 # nothing about per-agent versus shared scoping. It is preferred because it is a
 # declared input describing this call, where the process cwd is ambient state
 # inferred to stand in for one. Reading only the process cwd would let the guard
-# go silently inert if a harness version ever stopped aligning the two.
+# go silently inert if a harness version ever stopped aligning the two. The
+# payload cwd is honored only when it is absolute and resolves to a checkout of
+# this repo; anything else routes to the process cwd. That absolute-path
+# requirement is load-bearing, not cosmetic, and is argued where it is enforced.
 #
 # Scope, and why it stops there: the guard adjudicates "does this target resolve
 # to the main checkout", which is #841's own case. `main_root` derives from
@@ -70,13 +73,30 @@ esac
 main_root="$(cd "$(dirname "$abs_common_dir")" 2>/dev/null && pwd -P)" || exit 0
 # The calling agent's working directory comes from the payload's `cwd`, the
 # value Claude Code reports for the agent that issued this call. It is honored
-# only when it resolves to a checkout of THIS repo (same common git dir as
-# main_root); a cwd naming an unrelated repository would arm the gate on a
-# comparison between two different repositories and deny a legitimate edit. The
-# hook's own process cwd is the fallback for an absent, unresolvable, or
-# foreign-repo payload cwd.
+# only when it is absolute AND resolves to a checkout of THIS repo (same common
+# git dir as main_root); a cwd naming an unrelated repository would arm the gate
+# on a comparison between two different repositories and deny a legitimate edit.
+# The hook's own process cwd is the fallback for an absent, relative,
+# unresolvable, or foreign-repo payload cwd.
 current_root=""
 payload_cwd=$(jq -r '.cwd // empty' <<<"$payload")
+# Absolute-cwd invariant, established once so every consumer below inherits it:
+# payload_cwd flows into `git -C`, into string-concatenation, and into `cd`, and
+# each option-parses its own operand. `cd` is the sharp edge: `cd -P`, `cd -L`,
+# and `cd -e` parse as an option with NO operand, so cd lands in $HOME and
+# succeeds rather than failing into the `|| payload_main_root=""` fallback, and
+# `cd -` moves to $OLDPWD and prints it. Requiring a leading slash makes every
+# downstream operand provably absolute, which is the same property main_root's
+# own two-branch derivation above guarantees, and unlike a `--` terminator it
+# behaves identically on bash 3.2 and bash 5. An empty value falls through to
+# the `-n` guard below and routes to the process cwd, same as an absent field.
+# `dirname --` and `CDPATH=''` below are belt-and-braces once this holds: with
+# an absolute payload_cwd neither a dash-leading operand nor a CDPATH lookup is
+# reachable, and they stay as defense in depth.
+case "$payload_cwd" in
+  /*) ;;
+  *) payload_cwd="" ;;
+esac
 if [[ -n "$payload_cwd" ]]; then
   payload_common_dir="$(git -C "$payload_cwd" rev-parse --git-common-dir 2>/dev/null)" || payload_common_dir=""
   case "$payload_common_dir" in

--- a/.gaia/tests/hooks/block-worktree-path-mismatch.bats
+++ b/.gaia/tests/hooks/block-worktree-path-mismatch.bats
@@ -426,6 +426,61 @@ assert_allowed() {
   assert_allowed
 }
 
+# The payload cwd is honored only when absolute. Every consumer downstream of it
+# option-parses its own operand: `dirname --` stops dirname there, but the value
+# dirname returns still reaches a bare `cd`, which reads a leading dash as its
+# own options. `cd -P`, `cd -L`, and `cd -e` all parse as an option with no
+# operand, so cd succeeds into $HOME instead of firing the `|| payload_main_root=""`
+# fallback, and `cd -` moves to $OLDPWD and prints it. A payload cwd of exactly
+# `-P` naming a real directory would therefore set payload_main_root to $HOME;
+# were that to equal main_root, the same-repo check would pass spuriously and a
+# legitimate main-checkout edit would be denied off a foreign cwd. Requiring an
+# absolute path shuts every one of those doors at the source, and is the same
+# property the neighbouring main_root derivation already relies on.
+#
+# A relative cwd resolving to the main checkout is the observable case: honored,
+# it would read the agent as sitting in the main checkout and allow the target;
+# ignored, the worktree process cwd stays in charge and denies.
+@test "a relative payload cwd is ignored in favour of the process cwd" {
+  make_repo
+  make_worktree "debt/28-foo" "debt/28-foo"
+  ln -s "$REPO" "$WT/linkdir"
+  cd "$WT"
+  run_hook_edit_cwd "Edit" "$REPO/f" "linkdir"
+  assert_denied
+}
+
+# The mirror of the load-bearing deny case above, and the one case reading the
+# cwd from the payload deliberately loosens: when the payload says the agent is
+# in the MAIN checkout, a main-checkout target is that agent's own correct
+# write, even though the hook's process cwd sits in a worktree. Adjudicating off
+# the process cwd alone denies it.
+@test "a payload cwd in the main checkout allows a main-checkout target from a worktree process cwd" {
+  make_repo
+  make_worktree "debt/29-foo" "debt/29-foo"
+  cd "$WT"
+  run_hook_edit_cwd "Edit" "$REPO/f" "$REPO"
+  assert_allowed
+}
+
+# --git-common-dir answers relative to the directory it is asked about: `.git`
+# from a checkout root, `../.git` from a subdirectory. A payload cwd below the
+# main checkout's root therefore takes the `*)` branch, which resolves that
+# `..` against payload_cwd for `cd` + `pwd -P` to collapse. (A linked worktree
+# reports an absolute common dir from root and subdirectories alike, so the main
+# checkout is the only source of the relative form.) This pins the collapse:
+# string-stripping the trailing /.git instead of resolving it leaves
+# `$REPO/sub/..`, which fails the same-repo check and falls back to the process
+# cwd, denying a correct write.
+@test "a payload cwd in a main-checkout subdirectory resolves its relative common dir" {
+  make_repo
+  make_worktree "debt/30-foo" "debt/30-foo"
+  mkdir -p "$REPO/sub"
+  cd "$WT"
+  run_hook_edit_cwd "Edit" "$REPO/f" "$REPO/sub"
+  assert_allowed
+}
+
 # --- structural ---
 
 @test "block-worktree-path-mismatch.sh is executable" {


### PR DESCRIPTION
Follow-up to #938, closing findings its own shell audit raised after that PR merged. Hardening only: no adopter-visible behavior change, and no reachable path differs under a harness that sends an absolute cwd.

## The gap

#938 added `dirname --` to stop `dirname` option-parsing its operand. That was incomplete: the value `dirname` returns still reaches a bare `cd`, which option-parses it in turn.

Measured with `HOME=/tmp/fakehome`:

| Operand | Behavior |
|---|---|
| `cd "-P"`, `cd "-L"` | parse as an option with **no operand**, so `cd` lands in `$HOME` and **exits 0** |
| `cd "-e"` | same on bash 5 (bash 3.2's `cd` has no `-e`, so it falls back there) |
| `cd "-"` | moves to `$OLDPWD` **and prints it**, producing a two-line capture. `cd -- "-"` does not fix this |

So a payload cwd of exactly `-P` naming a real directory inside a repo sets `payload_main_root` to `$HOME` instead of firing the `|| payload_main_root=""` fallback. Where that equals `main_root`, the same-repo check passes spuriously, `current_root` is taken from a foreign cwd, and a legitimate main-checkout edit is denied. Same class as the bug #938 fixed, through a different door.

## The fix

Establish the invariant once, before any consumer reads the value:

```bash
case "$payload_cwd" in
  /*) ;;
  *) payload_cwd="" ;;
esac
```

This makes every downstream operand provably absolute, the same property `main_root`'s own two-branch derivation already guarantees. Fixing the operand beats patching each consumer, since the consumers are `git -C`, string concatenation, and `cd`, each with its own parsing rules.

Unlike a `--` terminator, it behaves identically on bash 3.2 and bash 5, so a gate can catch its removal. Worth stating plainly: **no gate protected the `--`**. CI and `bats5.sh` both run bash 5, where the unguarded path is invisible, so removing `--` would have been green everywhere.

`dirname --` and `CDPATH=''` stay as defense in depth. With an absolute cwd neither a dash-leading operand nor a CDPATH lookup is reachable, so they are belt-and-braces rather than load-bearing; removing them would churn just-merged code for no gain.

## Correcting the record

#938's commit message claimed the invariant was "now local rather than inherited from a caller contract the file never states." That described the intent, not the code. It holds now.

## Tests

34/34 green under bash 5. Three new cases, each mutation-verified against the mutant it is meant to kill:

| Test | Kills | Pre-change |
|---|---|---|
| a relative payload cwd is ignored in favour of the process cwd | removing the `case` guard | **red** |
| a payload cwd in the main checkout allows a main-checkout target from a worktree process cwd | reverting the payload-cwd read (not uniquely, see below) | green (coverage gap) |
| a payload cwd in a main-checkout subdirectory resolves its relative common dir | string-stripping `/.git` instead of resolving it | green (coverage gap) |

The first supersedes a CDPATH-specific test the audit proposed. That test depended on a **relative** payload cwd, which this change now blanks, so it no longer discriminates the `CDPATH=''` mutant. Pinning the invariant covers the same ground at its source. Recording that explicitly rather than letting CDPATH coverage look dropped.

The second is the mirror of #938's load-bearing deny case, and the one case reading the cwd from the payload deliberately loosens. The third exercises the `..`-bearing common-dir form only a main-checkout subdirectory produces; every prior test passed a checkout root.

## Gate

Quality Gate not applicable: no staged file is inspectable by typecheck, lint, tests, or build (bash and bats only), verified with the gate's own staged-file grep. The real gate: `shell-lint.sh` clean, `bats5.sh` 34/34 under bash 5, and the absolute-cwd `case` verified to behave identically on bash 3.2.57 and 5.3.15.

No CHANGELOG entry: the behavior an adopter sees is unchanged, and the existing `## [Unreleased]` line already covers the payload-cwd change this refines.

## Not in scope

Two findings from the same audit are filed separately rather than folded in: the guard still goes inert when the hook's own process cwd leaves the repo (`main_root` never consults the payload), and audit member reports are lost when returned as plain output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Audit outcome

`code-audit-maintainer-shell` cleared the branch, built all seven mutants itself rather than taking my pairings on trust, and raised three Suggestions.

**S1, fixed.** My comment claimed `dirname --` and `CDPATH=''` "below" are belt-and-braces once the invariant holds. True of the two guards on the `payload_main_root` line; **false** of the identically-shaped pair further down, which operate on `file_path`. No invariant constrains `file_path`, and those guards are load-bearing: the audit proved that dropping the `CDPATH` one turns a **deny into an allow**, because `cd` resolves a relative `file_path` through `CDPATH` into the exempt shared-state tree while `git` still resolves the write to the main checkout. As written, the comment invited a reader to delete a guard and reintroduce a live bypass. Now scoped explicitly, and it names the hazard rather than only narrowing the claim, since line-number pointers drift.

**S2, filed as debt.** The `file_path` guards have no test coverage: two mutants against them survive the full suite. Pre-existing, and the fix is a new test against code this branch does not touch, so it gets its own issue rather than a scope-stretch here. S1 removes the invitation to delete those guards; the follow-up removes the consequence.

**S3, accepted, correcting my own claim above.** Test 30 is not tautological, but its kill-set is a strict subset of test 31's: test 31 is test 30 plus a subdirectory, and both payloads take the same relative-common-dir branch, so nothing kills 30 without also killing 31. It stays as documentation of the primary allow case; it should not be counted as independent discrimination. The table above is corrected accordingly.

Confirmed by the audit's own mutation matrix: test 29 is the **unique** killer of removing the `case` guard, and test 31 the **unique** killer of string-stripping `/.git`. Removing `CDPATH=''` from the payload chain survives the suite, which is the empirical proof that the invariant makes it unreachable, and therefore that dropping the CDPATH-specific test lost nothing.
