### PR TITLE
debt(release): scan past an unbalanced fence in the excluded-titles leak-check

### DIFF
--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -23060,11 +23060,19 @@ var isFenceDelimiter = (line) => {
 var stripSkippedSpans = (line) => line.replaceAll(WIKILINK_SPAN, "").replaceAll(INLINE_CODE_SPAN, "");
 var findTitleLeaksInFile = (file2, matchers, lineAllowlist) => {
   const leaks = [];
-  let insideFence = false;
-  for (const [index, line] of file2.content.split("\n").entries()) {
-    if (isFenceDelimiter(line)) {
-      insideFence = !insideFence;
-    } else if (!insideFence && !lineAllowlist.some((rx) => rx.test(line))) {
+  const lines = file2.content.split("\n");
+  const fenceIndices = lines.flatMap(
+    (line, index) => isFenceDelimiter(line) ? [index] : []
+  );
+  const insideClosedFence = /* @__PURE__ */ new Set();
+  for (let pair = 0; pair + 1 < fenceIndices.length; pair += 2) {
+    for (let index = fenceIndices[pair]; index <= fenceIndices[pair + 1]; index += 1) {
+      insideClosedFence.add(index);
+    }
+  }
+  for (const [index, line] of lines.entries()) {
+    const scannable = !insideClosedFence.has(index) && !lineAllowlist.some((rx) => rx.test(line));
+    if (scannable) {
       const residue = stripSkippedSpans(line);
       for (const { regex, title } of matchers) {
         if (regex.test(residue)) {

--- a/.gaia/cli/src/release/scrub.test.ts
+++ b/.gaia/cli/src/release/scrub.test.ts
@@ -1761,6 +1761,47 @@ describe('excluded-titles derived check', () => {
     expect(exit).toBe(0);
   });
 
+  test('flags a bare title after an unbalanced (unclosed) fence while still skipping a closed fence', () => {
+    // Fence delimiters bound a code block only when they PAIR. An odd delimiter
+    // count leaves a trailing unclosed fence: a naive per-line toggle stays
+    // stuck `inside` after it and swallows the rest of the file, so a real title
+    // leaking after the unclosed fence goes unreported (fail-open). The closed
+    // pair above it must still be skipped.
+    sandbox = setupSandbox({config: TITLE_DERIVED_CONFIG});
+    seedTitleSource(sandbox);
+    sandbox.writeStaged(
+      'wiki/concepts/Foo.md',
+      [
+        '# Foo',
+        '',
+        '```',
+        'Bundle-time Scrub inside a closed block.',
+        '```',
+        '',
+        '```',
+        'code with no closing fence',
+        '',
+        'The Forensics Triage Workflow leaks after the unclosed fence.',
+        '',
+      ].join('\n')
+    );
+
+    const exit = run([sandbox.stagingDir, '--json'], {cwd: sandbox.rootDir});
+    expect(exit).toBe(1);
+
+    const report = JSON.parse(stdio.outputs.join('')) as {
+      leaks: {check: string; file: string; line: number; match: string}[];
+    };
+    expect(report.leaks).toEqual([
+      {
+        check: 'excluded-titles',
+        file: 'wiki/concepts/Foo.md',
+        line: 10,
+        match: 'Forensics Triage Workflow',
+      },
+    ]);
+  });
+
   test('does not flag a bare title inside a stripped maintainer-only block', () => {
     // marker-strip runs before leak-check and re-reads the file fresh, so the
     // wrapped mention is gone before the title check ever sees the line.

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -981,10 +981,17 @@ type TitleMatcher = {regex: RegExp; title: string};
 
 /**
  * Scan one post-strip staging file for bare-title leaks with its OWN full
- * line-stream walk (not `scanForLeaks`), tracking fenced-code-block state per
- * file. Every line is observed so a fence delimiter always toggles state, even
- * a line-allowlisted one; routing this through `scanForLeaks` would drop
- * allowlisted lines before the walk and desync the fence counter.
+ * line-stream walk (not `scanForLeaks`), tracking fenced-code-block spans per
+ * file. Spans are derived from the raw line stream up front, independent of the
+ * line-allowlist, so an allowlisted line inside a fence can never desync
+ * detection; routing this through `scanForLeaks` would drop allowlisted lines
+ * before the walk and cause exactly that desync.
+ *
+ * Fence delimiters bound a code block only when they PAIR. An unbalanced (odd)
+ * delimiter count leaves a trailing unclosed fence whose lone opener closes
+ * nothing, so every line from it to EOF is scanned as prose rather than
+ * silently swallowed. Otherwise a bare excluded-title mention after an unclosed
+ * fence would go unreported (fail-open).
  */
 const findTitleLeaksInFile = (
   file: {content: string; id: string; path: string},
@@ -992,12 +999,32 @@ const findTitleLeaksInFile = (
   lineAllowlist: readonly RegExp[]
 ): Leak[] => {
   const leaks: Leak[] = [];
-  let insideFence = false;
+  const lines = file.content.split('\n');
 
-  for (const [index, line] of file.content.split('\n').entries()) {
-    if (isFenceDelimiter(line)) {
-      insideFence = !insideFence;
-    } else if (!insideFence && !lineAllowlist.some((rx) => rx.test(line))) {
+  // Line indices inside a CLOSED fence pair. Delimiters pair left-to-right; a
+  // final lone (odd) delimiter closes nothing and is deliberately left out, so
+  // it and every line after it stays scannable.
+  const fenceIndices = lines.flatMap((line, index) =>
+    isFenceDelimiter(line) ? [index] : []
+  );
+  const insideClosedFence = new Set<number>();
+
+  for (let pair = 0; pair + 1 < fenceIndices.length; pair += 2) {
+    for (
+      let index = fenceIndices[pair];
+      index <= fenceIndices[pair + 1];
+      index += 1
+    ) {
+      insideClosedFence.add(index);
+    }
+  }
+
+  for (const [index, line] of lines.entries()) {
+    const scannable =
+      !insideClosedFence.has(index) &&
+      !lineAllowlist.some((rx) => rx.test(line));
+
+    if (scannable) {
       const residue = stripSkippedSpans(line);
 
       for (const {regex, title} of matchers) {


### PR DESCRIPTION
## What

The `excluded-titles` release leak-check (`gaia-maintainer release scrub`) tracked fenced-code-block state with a per-line `insideFence` toggle. An **odd (unbalanced) fence-delimiter count** left the toggle stuck `true` through end-of-file, so every line after the unclosed fence was silently skipped. A bare Title-Case mention of a release-excluded wiki page appearing *after* such a fence went unreported.

This is **fail-open**: the release build passes when it should fail, and a dangling reference to a page the adopter's clone never received could ship. Maintainer-only, release-excluded tooling, so no adopter clone is affected today, and the introducing check (#911) is still unreleased.

## Fix

Derive fenced-code-block spans from delimiter **pairs** instead of a running toggle. Delimiters pair left-to-right; a trailing lone (odd) delimiter closes nothing, so it and every line after it stay scannable, restoring the fail-closed posture the sibling checks hold. Balanced fences behave exactly as before.

## Test

Adds a `scrub.test.ts` case: a page with a closed fence pair followed by an **unclosed** fence and a bare excluded-title mention after it. The mention must be flagged (it was swallowed before), while the closed pair above it is still skipped. Fails on the old toggle, passes on the fix.

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)