### PR TITLE
docs(deps): record why bippy stays at 0.5.42

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,14 @@ minimumReleaseAgeExclude:
   # release-age window is already satisfied for it. Scoped to the exact pinned
   # version; the package.json pin (no caret) keeps the exception inert for any
   # other release.
+  #
+  # Do not bump to 0.6.0: it drops the `secure` export the harness wraps its
+  # instrumentation in (.playwright/react-perf/harness-entry.ts), taking the
+  # production gate, install-check timeout, and non-throwing onError with it.
+  # 0.6.0 removes 13 exports with no changelog entry while its README still
+  # documents `secure`, so the removal may be unintentional; upstream question
+  # is https://github.com/aidenybai/bippy/issues/75. A bump also has to update
+  # the exact-version assertion in .playwright/e2e/react-perf-smoke.spec.ts.
   - 'bippy@0.5.42'
 
 # Resolution settings. pnpm 11 reads these from pnpm-workspace.yaml, not from


### PR DESCRIPTION
Comment-only change to `pnpm-workspace.yaml`. No dependency moves, no code changes.

## Why

`bippy` was the one package the last dependency-update run ([#973](https://github.com/gaia-react/gaia/pull/973)) attempted and reverted, and working out *why* took a full investigation: diffing `dist/index.d.ts` between 0.5.42 and 0.6.0, tracing the harness's import to its single call site, and checking upstream source and changelog. None of that was written down anywhere, so the next run would have paid for it again.

The pin (`package.json`, no caret) and the release-age exclusion already existed and are unchanged. This records only the reason a bump is blocked:

- 0.6.0 drops the `secure` export that `.playwright/react-perf/harness-entry.ts` wraps its instrumentation in, taking the production gate, install-check timeout, and non-throwing `onError` with it.
- 0.6.0 removes 13 exports with no changelog entry, while its README still documents `secure` as the primary usage pattern, so the removal may be unintentional. Upstream question: https://github.com/aidenybai/bippy/issues/75
- A bump also has to move the exact-version assertion in `.playwright/e2e/react-perf-smoke.spec.ts`.

## Verification

Quality Gate skips: `pnpm-workspace.yaml` is neither a source extension nor on the gate-affecting config list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
