### PR TITLE
debt(lint): lint .playwright and .storybook, and fix what surfaced

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,9 +95,13 @@ jobs:
       # linted, and Chromatic's Vite build strips types instead of checking
       # them, so it is not a substitute. The `*.config.*` alternation names
       # every root config for the same reason, not only the four whose tools
-      # this job runs; each one is in the tsconfig program, is linted, and
-      # `react-router.config.` additionally feeds the typegen step that runs
-      # before `tsc`.
+      # this job runs: each one is linted, the `.ts` ones are also in the
+      # tsconfig program (the `.mjs` ones are not, since `include` lists no
+      # `.mjs` glob and `allowJs` is off), and `react-router.config.` feeds the
+      # typegen step that runs before `tsc`. `pnpm-workspace.yaml` and `.npmrc`
+      # are here because pnpm 11 reads install behavior from them that the
+      # lockfile's own `settings:` block does not carry, so a change to either
+      # can break `--frozen-lockfile` for the next unrelated PR.
       - name: Detect test-relevant changes in the incremental delta
         id: filter
         if: steps.chore-deps.outputs.skip == 'false'
@@ -106,7 +110,7 @@ jobs:
         run: |
           set -eu
           changed=$(git diff --name-only "${CHECK_BASE}...HEAD")
-          pattern='^(app|test)/|^\.playwright/|^\.storybook/|^(package\.json|pnpm-lock\.yaml|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint|react-router|doctor|knip|prettier|stylelint)\.config\.|^\.github/workflows/tests\.yml$'
+          pattern='^(app|test)/|^\.playwright/|^\.storybook/|^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.npmrc|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint|react-router|doctor|knip|prettier|stylelint)\.config\.|^\.github/workflows/tests\.yml$'
           if printf '%s\n' "$changed" | grep -qE "$pattern"; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,11 @@ jobs:
       # here too even when it carries no tests: `.storybook/` holds neither
       # tests nor stories, but it is inside the tsconfig `include` and is
       # linted, and Chromatic's Vite build strips types instead of checking
-      # them, so it is not a substitute.
+      # them, so it is not a substitute. The `*.config.*` alternation names
+      # every root config for the same reason, not only the four whose tools
+      # this job runs; each one is in the tsconfig program, is linted, and
+      # `react-router.config.` additionally feeds the typegen step that runs
+      # before `tsc`.
       - name: Detect test-relevant changes in the incremental delta
         id: filter
         if: steps.chore-deps.outputs.skip == 'false'
@@ -102,7 +106,7 @@ jobs:
         run: |
           set -eu
           changed=$(git diff --name-only "${CHECK_BASE}...HEAD")
-          pattern='^(app|test)/|^\.playwright/|^\.storybook/|^(package\.json|pnpm-lock\.yaml|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint)\.config\.|^\.github/workflows/tests\.yml$'
+          pattern='^(app|test)/|^\.playwright/|^\.storybook/|^(package\.json|pnpm-lock\.yaml|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint|react-router|doctor|knip|prettier|stylelint)\.config\.|^\.github/workflows/tests\.yml$'
           if printf '%s\n' "$changed" | grep -qE "$pattern"; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,11 @@ jobs:
       # required check green without running, so a path that carries tests
       # must appear here: `.playwright/` holds the e2e specs and their
       # helpers, which `playwright.config.` alone does not cover.
+      # This job also runs typecheck and lint, so a path those cover belongs
+      # here too even when it carries no tests: `.storybook/` holds neither
+      # tests nor stories, but it is inside the tsconfig `include` and is
+      # linted, and Chromatic's Vite build strips types instead of checking
+      # them, so it is not a substitute.
       - name: Detect test-relevant changes in the incremental delta
         id: filter
         if: steps.chore-deps.outputs.skip == 'false'
@@ -97,7 +102,7 @@ jobs:
         run: |
           set -eu
           changed=$(git diff --name-only "${CHECK_BASE}...HEAD")
-          pattern='^(app|test)/|^\.playwright/|^(package\.json|pnpm-lock\.yaml|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint)\.config\.|^\.github/workflows/tests\.yml$'
+          pattern='^(app|test)/|^\.playwright/|^\.storybook/|^(package\.json|pnpm-lock\.yaml|\.node-version)$|^tsconfig[^/]*\.json$|^(vite|vitest|playwright|eslint)\.config\.|^\.github/workflows/tests\.yml$'
           if printf '%s\n' "$changed" | grep -qE "$pattern"; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -3,7 +3,10 @@
     "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint",
     "prettier --write"
   ],
-  "{.storybook,.playwright}/**/*.{ts,tsx}": ["prettier --write"],
+  "{.storybook,.playwright}/**/*.{ts,tsx}": [
+    "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint",
+    "prettier --write"
+  ],
   "app/**/*.css": ["stylelint --fix", "prettier --write"],
   "app/**/*.json": ["prettier --write"]
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -4,7 +4,7 @@
     "prettier --write"
   ],
   "{.storybook,.playwright}/**/*.{ts,tsx}": [
-    "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint",
+    "eslint --fix --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint-tooling",
     "prettier --write"
   ],
   "app/**/*.css": ["stylelint --fix", "prettier --write"],

--- a/.playwright/e2e/home-a11y.spec.ts
+++ b/.playwright/e2e/home-a11y.spec.ts
@@ -2,7 +2,6 @@ import {expectNoSeriousA11yViolations} from '../a11y';
 import {expect, test} from '../fixtures';
 import {hydration} from '../utils';
 
-// eslint-disable-next-line playwright/expect-expect -- expectNoSeriousA11yViolations is the assertion
 test('home page has no serious a11y violations', async ({page}, testInfo) => {
   await page.goto('/');
   await hydration(page);
@@ -36,9 +35,9 @@ test('home dark mode has no serious a11y violations', async ({
 });
 
 test('home page landmarks and headings pass best-practice rules', async ({
-  page,
   makeAxeBuilder,
-}, testInfo) => {
+  page,
+}) => {
   await page.goto('/');
   await hydration(page);
 
@@ -47,24 +46,18 @@ test('home page landmarks and headings pass best-practice rules', async ({
   const {violations} = await axe.analyze();
 
   const targetRules = new Set([
-    'region',
-    'landmark-one-main',
     'heading-order',
+    'landmark-one-main',
     'page-has-heading-one',
+    'region',
   ]);
-  const relevant = violations.filter((v) => targetRules.has(v.id));
+  // Project each violation to its triage fields: a failure names the rule, its
+  // impact, and how many nodes tripped it, without dumping serialized axe nodes.
+  const relevant = violations
+    .filter((v) => targetRules.has(v.id))
+    .map((v) => ({id: v.id, impact: v.impact, nodes: v.nodes.length}));
 
-  if (relevant.length > 0) {
-    await testInfo.attach('axe-landmark-violations.json', {
-      body: JSON.stringify(relevant, null, 2),
-      contentType: 'application/json',
-    });
-    throw new Error(
-      `Found ${relevant.length} landmark/heading violations: ${relevant
-        .map((v) => `${v.id} (${v.impact})`)
-        .join(', ')}`
-    );
-  }
+  expect(relevant).toEqual([]);
 
   // Structural invariants: exactly one <main> (Layout-owned) and one <h1>.
   await expect(page.locator('main')).toHaveCount(1);

--- a/.playwright/e2e/language-switch-a11y.spec.ts
+++ b/.playwright/e2e/language-switch-a11y.spec.ts
@@ -2,7 +2,6 @@ import {expectNoSeriousA11yViolations} from '../a11y';
 import {test} from '../fixtures';
 import {hydration} from '../utils';
 
-// eslint-disable-next-line playwright/expect-expect -- expectNoSeriousA11yViolations is the assertion
 test('language switcher has no serious a11y violations', async ({
   page,
 }, testInfo) => {

--- a/.playwright/e2e/legal-a11y.spec.ts
+++ b/.playwright/e2e/legal-a11y.spec.ts
@@ -7,7 +7,7 @@ const LEGAL_ROUTES = [
   {h1: 'Terms of Service', path: '/terms'},
 ] as const;
 
-for (const {path, h1} of LEGAL_ROUTES) {
+for (const {h1, path} of LEGAL_ROUTES) {
   test(`${path} renders and has no serious a11y violations`, async ({
     page,
   }, testInfo) => {

--- a/.playwright/e2e/react-perf-smoke.spec.ts
+++ b/.playwright/e2e/react-perf-smoke.spec.ts
@@ -1,6 +1,6 @@
-import {readFileSync} from 'node:fs';
 import {expect, test} from '@playwright/test';
 import type {Page} from '@playwright/test';
+import {readFileSync} from 'node:fs';
 import {collectRenderDump, installRenderCapture} from '../react-perf/capture';
 import type {RawDump} from '../react-perf/types';
 import {hydration} from '../utils';
@@ -72,6 +72,7 @@ test('captures bippy renders: active, canary resolves name + memo + timing', asy
   // §6 #2 + #6: records carry phase + a numeric fiberId; update records exist.
   const updates = dump.all.filter((record) => record.phase === 'update');
   expect(updates.length).toBeGreaterThan(0);
+
   for (const record of dump.all) {
     expect(typeof record.phase).toBe('string');
     expect(Number.isFinite(record.fiberId)).toBe(true);
@@ -84,6 +85,7 @@ test('captures bippy renders: active, canary resolves name + memo + timing', asy
       ...record.stateChanged,
       ...record.contextChanged,
     ];
+
     for (const change of changes) {
       expect(typeof change.prev).toBe('string');
       expect(typeof change.next).toBe('string');
@@ -101,14 +103,14 @@ test('captures bippy renders: active, canary resolves name + memo + timing', asy
   expect(
     canaryRecords.every((record) => record.componentName !== 'Unknown')
   ).toBe(true);
-  expect(canaryRecords.every((record) => record.isMemo === false)).toBe(true);
+  expect(canaryRecords.every((record) => !record.isMemo)).toBe(true);
   expect(canaryRecords.some((record) => record.totalTime > 0)).toBe(true);
   expect(canaryRecords.some((record) => record.phase === 'update')).toBe(true);
 });
 
 test('noStrict bypass disables StrictMode (render-time inflation collapses)', async ({
-  browser,
   baseURL,
+  browser,
 }) => {
   const load = async (isStrictModeDisabled: boolean) => {
     const context = await browser.newContext({baseURL});
@@ -119,6 +121,7 @@ test('noStrict bypass disables StrictMode (render-time inflation collapses)', as
     const result = await collectRenderDump(page);
     const dump = readDump(result.rawPath);
     await context.close();
+
     return {meta: result.meta, total: totalRenderTime(dump)};
   };
 

--- a/.playwright/react-perf/capture.ts
+++ b/.playwright/react-perf/capture.ts
@@ -4,28 +4,33 @@
 // RawDump to .gaia/local/cache/<run>/renders.json (gitignored, auto-deleted on
 // process exit unless kept). The raw dump must never enter the model context;
 // the reduce CLI (Phase 2) produces the small summary the skill reads.
-import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
-import {dirname, join, resolve} from 'node:path';
-import {fileURLToPath} from 'node:url';
+
+/* eslint-disable no-underscore-dangle -- window.__renders / __bippyMeta /
+   __PERF_NO_STRICT are the harness wire contract; the names are fixed by
+   harness-entry.ts and app/entry.client.tsx, not chosen here. */
+import type {Page} from '@playwright/test';
 import {build} from 'esbuild';
 import {nanoid} from 'nanoid';
-import type {Page} from '@playwright/test';
+import {mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import type {BippyMeta, RawDump, RawDumpMeta, RenderRecord} from './types';
 
-const CURRENT_MODULE_DIR = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(CURRENT_MODULE_DIR, '..', '..');
-const CACHE_ROOT = join(REPO_ROOT, '.gaia', 'local', 'cache');
-const HARNESS_ENTRY = join(CURRENT_MODULE_DIR, 'harness-entry.ts');
+const CURRENT_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(CURRENT_MODULE_DIR, '..', '..');
+const CACHE_ROOT = path.join(REPO_ROOT, '.gaia', 'local', 'cache');
+const HARNESS_ENTRY = path.join(CURRENT_MODULE_DIR, 'harness-entry.ts');
 
 export type CaptureResult = {
-  rawPath: string; // absolute path to the written renders.json
   meta: RawDump['meta'];
+  rawPath: string; // absolute path to the written renders.json
   recordCount: number;
 };
 
 // Bundle the bippy harness to a browser IIFE once per process (bippy stays
 // version-pinned in package.json; no generated bundle is committed).
 let harnessIifePromise: Promise<string> | undefined;
+
 const buildHarnessIife = async (): Promise<string> => {
   harnessIifePromise ??= build({
     bundle: true,
@@ -36,12 +41,15 @@ const buildHarnessIife = async (): Promise<string> => {
     target: 'es2022',
     write: false,
   }).then((result) => {
-    const [output] = result.outputFiles;
+    const output = result.outputFiles.at(0);
+
     if (!output) {
       throw new Error('react-perf: esbuild produced no output for the harness');
     }
+
     return output.text;
   });
+
   return harnessIifePromise;
 };
 
@@ -52,14 +60,15 @@ const captureOptions = new WeakMap<Page, {isStrictModeDisabled: boolean}>();
 // Run dirs to remove on process exit (auto-delete unless the caller keeps them).
 const pendingCleanup = new Set<string>();
 let cleanupHooked = false;
-const scheduleCleanup = (dir: string): void => {
-  pendingCleanup.add(dir);
+
+const scheduleCleanup = (directory: string): void => {
+  pendingCleanup.add(directory);
   if (cleanupHooked) return;
   cleanupHooked = true;
   process.on('exit', () => {
-    for (const dir of pendingCleanup) {
+    for (const pending of pendingCleanup) {
       try {
-        rmSync(dir, {force: true, recursive: true});
+        rmSync(pending, {force: true, recursive: true});
       } catch {
         // best-effort cleanup on exit
       }
@@ -88,7 +97,7 @@ export const installRenderCapture = async (
 
 export const collectRenderDump = async (
   page: Page,
-  options: {runId?: string; keep?: boolean} = {}
+  options: {keep?: boolean; runId?: string} = {}
 ): Promise<CaptureResult> => {
   const runId = options.runId ?? `${Date.now()}-${nanoid()}`;
   const keep = options.keep ?? false;
@@ -125,7 +134,8 @@ export const collectRenderDump = async (
 
   const browserMeta: BippyMeta = browser.meta;
   const renders: RenderRecord[] = browser.renders;
-  const isStrictModeDisabled = captureOptions.get(page)?.isStrictModeDisabled ?? false;
+  const isStrictModeDisabled =
+    captureOptions.get(page)?.isStrictModeDisabled ?? false;
 
   const meta: RawDumpMeta = {
     bippyVersion: browserMeta.bippyVersion,
@@ -139,12 +149,12 @@ export const collectRenderDump = async (
 
   const dump: RawDump = {all: renders, meta, total: renders.length};
 
-  const runDir = join(CACHE_ROOT, runId);
-  mkdirSync(runDir, {recursive: true});
-  const rawPath = join(runDir, 'renders.json');
+  const runDirectory = path.join(CACHE_ROOT, runId);
+  mkdirSync(runDirectory, {recursive: true});
+  const rawPath = path.join(runDirectory, 'renders.json');
   writeFileSync(rawPath, JSON.stringify(dump, null, 2));
 
-  if (!keep) scheduleCleanup(runDir);
+  if (!keep) scheduleCleanup(runDirectory);
 
   return {meta, rawPath, recordCount: dump.total};
 };

--- a/.playwright/react-perf/harness-entry.ts
+++ b/.playwright/react-perf/harness-entry.ts
@@ -10,6 +10,9 @@
 // (never injectProfilingHooks/lite); it gates real renders via didFiberRender
 // (traverseRenderedFibers) and keys cross-commit identity by getFiberId; it
 // retains no fibers, DOM nodes, or fiber.type objects.
+
+/* eslint-disable no-underscore-dangle -- window.__renders / __bippyMeta are the
+   harness wire contract this file publishes for capture.ts to read. */
 import {
   ClassComponentTag,
   detectReactBuildType,
@@ -60,6 +63,7 @@ const getTypeLabel = (value: unknown): string => {
   if (value === null) return 'null';
   if (value === undefined) return 'undefined';
   if (Array.isArray(value)) return `array(${value.length})`;
+
   return typeof value;
 };
 
@@ -85,6 +89,7 @@ const getFiberKindLabel = (tag: number): string => {
   if (tag === ForwardRefTag) return 'ForwardRef';
   if (tag === ClassComponentTag) return 'Class';
   if (tag === FunctionComponentTag) return 'Function';
+
   return `tag(${tag})`;
 };
 
@@ -101,7 +106,7 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
     const {selfTime, totalTime} = getTimings(fiber);
     if (totalTime > 0 || selfTime > 0) meta.profilingAvailable = true;
 
-    const tag = fiber.tag;
+    const {tag} = fiber;
     const isMemo =
       tag === MemoComponentTag ||
       tag === SimpleMemoComponentTag ||
@@ -127,6 +132,7 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
       traverseState(fiber, (next, prev) => {
         const nextValue = next?.memoizedState;
         const prevValue = prev?.memoizedState;
+
         if (!isEffectState(nextValue) && !Object.is(prevValue, nextValue)) {
           stateChanged.push({
             index: stateIndex,
@@ -141,6 +147,7 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
       traverseContexts(fiber, (next, prev) => {
         const nextValue = next?.memoizedValue;
         const prevValue = prev?.memoizedValue;
+
         if (!Object.is(prevValue, nextValue)) {
           contextChanged.push({
             next: getTypeLabel(nextValue),
@@ -150,6 +157,9 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
         }
       });
     }
+
+    const seq = renderSequenceNumber;
+    renderSequenceNumber += 1;
 
     const record: RenderRecord = {
       changedTotal:
@@ -164,7 +174,7 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
       phase,
       propsChanged,
       selfTime,
-      seq: renderSequenceNumber++,
+      seq,
       stateChanged,
       tag,
       totalTime,
@@ -181,8 +191,10 @@ const onRender = (fiber: Fiber, phase: RenderPhase): void => {
 const inspectRenderers = (): void => {
   try {
     const hook = getRDTHook();
+
     for (const renderer of hook.renderers.values()) {
       meta.rendererVersion ??= renderer.version;
+
       if (detectReactBuildType(renderer) === 'production') {
         meta.productionDetected = true;
         meta.errors.push(
@@ -199,12 +211,13 @@ instrument(
   secure(
     {
       name: 'gaia-react-perf',
-      onActive() {
+      onActive: () => {
         meta.installed = true;
         inspectRenderers();
       },
-      onCommitFiberRoot(_rendererID, root) {
+      onCommitFiberRoot: (_rendererID, root) => {
         meta.commits += 1;
+
         try {
           traverseRenderedFibers(root, onRender);
         } catch (error) {

--- a/.playwright/react-perf/types.ts
+++ b/.playwright/react-perf/types.ts
@@ -3,72 +3,73 @@
 // fiber, DOM node, or fiber.type. Change entries carry TYPE LABELS, never raw
 // values (privacy + size).
 
-// One change entry inside propsChanged / stateChanged / contextChanged.
-export type ChangeEntry = {
-  name?: string; // props: the prop name. Omitted for state/context.
-  index?: number; // state: the hook index. Omitted for props/context.
-  prev: string; // type label only: 'object' | 'function' | 'number' | ...
-  next: string; // type label
-  unstable: boolean; // both refs are object/function and !Object.is(prev, next)
-};
-
-// One rendered fiber, serialized to primitives.
-export type RenderRecord = {
-  seq: number; // monotonic capture order
-  fiberId: number; // getFiberId(fiber) — stable cross-commit identity
-  componentName: string; // getDisplayName(getType(fiber.type)) ?? 'Unknown'
-  phase: string; // 'mount' | 'update' | 'unmount' (bippy phase)
-  kind: string; // 'Memo' | 'ForwardRef' | 'Class' | 'Function' | 'tag(N)'
-  tag: number; // fiber.tag
-  isMemo: boolean; // tag ∈ {MemoComponentTag, SimpleMemoComponentTag} or hasMemoCache
-  selfTime: number; // getTimings(fiber).selfTime
-  totalTime: number; // getTimings(fiber).totalTime (subtree-inclusive)
-  didCommit: boolean; // didFiberCommit(fiber)
-  didRender: boolean; // didFiberRender(fiber)
-  changedTotal: number; // propsChanged + stateChanged + contextChanged lengths
-  propsChanged: ChangeEntry[];
-  stateChanged: ChangeEntry[];
-  contextChanged: ChangeEntry[];
-};
-
-// The `meta` envelope written to the raw dump.
-export type RawDumpMeta = {
-  installed: boolean; // instrumentation went active
-  commits: number; // # onCommitFiberRoot calls observed
-  errors: string[]; // swallowed per-fiber / onError messages
-  strictMode: boolean; // true ⇒ capture ran with <StrictMode> on (timings ~2x)
-  rendererVersion: string | null; // renderer.version (self-describing results)
-  profilingAvailable: boolean; // a known render had non-zero actualDuration
-  bippyVersion: string; // pinned bippy version (e.g. '0.5.42')
-};
-
-// The on-disk raw dump written to .gaia/local/cache/<run>/renders.json.
-export type RawDump = {
-  meta: RawDumpMeta;
-  total: number; // all.length
-  all: RenderRecord[];
-};
-
 // In-browser diagnostics channel the harness writes and the capture helper
 // reads. It carries the browser-derived subset of RawDumpMeta plus an internal
 // production-abort signal that is NOT written to the dump. strictMode is stamped
 // capture-side from the noStrict option, so it is absent here.
 export type BippyMeta = {
-  installed: boolean;
+  bippyVersion: string;
   commits: number;
   errors: string[];
-  rendererVersion: string | null;
-  profilingAvailable: boolean;
-  bippyVersion: string;
+  installed: boolean;
   productionDetected: boolean;
+  profilingAvailable: boolean;
+  rendererVersion: null | string;
+};
+
+// One change entry inside propsChanged / stateChanged / contextChanged.
+export type ChangeEntry = {
+  index?: number; // state: the hook index. Omitted for props/context.
+  name?: string; // props: the prop name. Omitted for state/context.
+  next: string; // type label
+  prev: string; // type label only: 'object' | 'function' | 'number' | ...
+  unstable: boolean; // both refs are object/function and !Object.is(prev, next)
+};
+
+// The on-disk raw dump written to .gaia/local/cache/<run>/renders.json.
+export type RawDump = {
+  all: RenderRecord[];
+  meta: RawDumpMeta;
+  total: number; // all.length
+};
+
+// The `meta` envelope written to the raw dump.
+export type RawDumpMeta = {
+  bippyVersion: string; // pinned bippy version (e.g. '0.5.42')
+  commits: number; // # onCommitFiberRoot calls observed
+  errors: string[]; // swallowed per-fiber / onError messages
+  installed: boolean; // instrumentation went active
+  profilingAvailable: boolean; // a known render had non-zero actualDuration
+  rendererVersion: null | string; // renderer.version (self-describing results)
+  strictMode: boolean; // true ⇒ capture ran with <StrictMode> on (timings ~2x)
+};
+
+// One rendered fiber, serialized to primitives.
+export type RenderRecord = {
+  changedTotal: number; // propsChanged + stateChanged + contextChanged lengths
+  componentName: string; // getDisplayName(getType(fiber.type)) ?? 'Unknown'
+  contextChanged: ChangeEntry[];
+  didCommit: boolean; // didFiberCommit(fiber)
+  didRender: boolean; // didFiberRender(fiber)
+  fiberId: number; // getFiberId(fiber) — stable cross-commit identity
+  isMemo: boolean; // tag ∈ {MemoComponentTag, SimpleMemoComponentTag} or hasMemoCache
+  kind: string; // 'Memo' | 'ForwardRef' | 'Class' | 'Function' | 'tag(N)'
+  phase: string; // 'mount' | 'update' | 'unmount' (bippy phase)
+  propsChanged: ChangeEntry[];
+  selfTime: number; // getTimings(fiber).selfTime
+  seq: number; // monotonic capture order
+  stateChanged: ChangeEntry[];
+  tag: number; // fiber.tag
+  totalTime: number; // getTimings(fiber).totalTime (subtree-inclusive)
 };
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- augmenting the global Window needs declaration merging, which only an interface does
   interface Window {
-    __renders?: RenderRecord[];
     __bippyMeta?: BippyMeta;
     // Set by the capture helper (addInitScript) for honest non-StrictMode timing
     // runs; read by app/entry.client.tsx to skip the <StrictMode> wrapper.
     __PERF_NO_STRICT?: boolean;
+    __renders?: RenderRecord[];
   }
 }

--- a/.playwright/utils.ts
+++ b/.playwright/utils.ts
@@ -16,7 +16,7 @@ export const hydration = async (page: Page): Promise<boolean> => {
   // dependencies mid-flight, which fails the dynamic import of entry.client.tsx
   // so the page never hydrates and the meta never appears.
   const isHydrated = await meta
-    .waitFor({state: 'attached', timeout: 5_000})
+    .waitFor({state: 'attached', timeout: 5000})
     .then(() => true)
     .catch(() => false);
 

--- a/.storybook/chromatic/decorator.tsx
+++ b/.storybook/chromatic/decorator.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable better-tailwindcss/no-unregistered-classes */
 import type {ReactRenderer} from '@storybook/react-vite';
 import type {DecoratorFunction} from 'storybook/internal/types';
 

--- a/.storybook/chromatic/index.ts
+++ b/.storybook/chromatic/index.ts
@@ -13,7 +13,6 @@ export const isChromaticSnapshot =
     [...(window?.location.ancestorOrigins ?? {length: 0})].some((origin) =>
       origin.includes('www.chromatic.com')
     )
-    // @ts-ignore
   : false);
 
 if (!isChromaticSnapshot) {
@@ -25,12 +24,10 @@ if (!isChromaticSnapshot) {
 
     if (isDark) {
       document.documentElement.classList.add('dark');
-      docsStory?.classList.add('bg-gray-900');
-      docsStory?.classList.add('text-white');
+      docsStory?.classList.add('bg-gray-900', 'text-white');
     } else {
       document.documentElement.classList.remove('dark');
-      docsStory?.classList.remove('bg-gray-900');
-      docsStory?.classList.remove('text-white');
+      docsStory?.classList.remove('bg-gray-900', 'text-white');
     }
   });
 }

--- a/.storybook/env.ts
+++ b/.storybook/env.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-// @ts-ignore
 window.process.env = {
   API_URL: import.meta.env.API_URL,
   COMMIT_SHA: import.meta.env.COMMIT_SHA,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ## [Unreleased]
 
+### Changed
+
+- ESLint now checks `.playwright/` and `.storybook/`. The lint preset ignored both by default, which silently disabled the very rules it configured for them, so every e2e spec, Playwright helper, and Storybook config file went unchecked while `pnpm lint` reported a clean tree. `@gaia-react/lint` 1.11.0 stops ignoring them, and the 78 findings that surfaced in GAIA's own tree are fixed here. **Action required:** run `pnpm lint` after updating. Most of what surfaces in your own e2e and Storybook code auto-fixes; what remains is real (#980)
+
 ### Added
 
 - the PR Merge Workflow now tells the operator to verify an audit Suggestion's technical claims before applying it. The existing guidance prices the re-audit a fix costs but assumes the Suggestion is right, and a member can assert a mechanism it inferred rather than verified; implementing such a claim verbatim turns a reviewer's error into documented guidance that reads as reviewed. The content digest still forces a re-review of the applied fix, so this buys one round rather than closing a hole (#986)

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",
     "@faker-js/faker": "10.5.0",
-    "@gaia-react/lint": "1.10.0",
+    "@gaia-react/lint": "1.11.0",
     "@msw/data": "1.1.7",
     "@playwright-testing-library/test": "4.5.0",
     "@playwright/test": "1.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 10.5.0
         version: 10.5.0
       '@gaia-react/lint':
-        specifier: 1.10.0
-        version: 1.10.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.5)(storybook@10.5.0(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.14.0(typescript@6.0.3))(tailwindcss@4.3.2)(typescript@6.0.3)(vitest@4.1.10)
+        specifier: 1.11.0
+        version: 1.11.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.5)(storybook@10.5.0(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.14.0(typescript@6.0.3))(tailwindcss@4.3.2)(typescript@6.0.3)(vitest@4.1.10)
       '@msw/data':
         specifier: 1.1.7
         version: 1.1.7
@@ -763,8 +763,8 @@ packages:
     resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
-  '@gaia-react/lint@1.10.0':
-    resolution: {integrity: sha512-T6OuWvbw9yVt9AlmiBOS8w5SMlMcfpfHnYp2bEtibB6vHJFUemHIVA2D1Y7lMCw8EHyQciodKK0q+jPAqQvsPQ==}
+  '@gaia-react/lint@1.11.0':
+    resolution: {integrity: sha512-3sU/qKJQBeTZ5NRw83/u6X+XSDN/+yy02geO/2viC1AGWChytTt0f9nrvA3Ftgj/hObyu5v6+Xuteqo6fgWsCQ==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       eslint: ^9.0.0
@@ -5958,7 +5958,7 @@ snapshots:
 
   '@faker-js/faker@10.5.0': {}
 
-  '@gaia-react/lint@1.10.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.5)(storybook@10.5.0(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.14.0(typescript@6.0.3))(tailwindcss@4.3.2)(typescript@6.0.3)(vitest@4.1.10)':
+  '@gaia-react/lint@1.11.0(@testing-library/dom@10.4.1)(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.2(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.5)(storybook@10.5.0(@types/react@19.2.17)(prettier@3.9.5)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(stylelint@17.14.0(typescript@6.0.3))(tailwindcss@4.3.2)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@9.39.5(jiti@2.7.0))
       '@eslint/config-helpers': 0.6.0

--- a/wiki/dependencies/gaia-lint.md
+++ b/wiki/dependencies/gaia-lint.md
@@ -2,10 +2,10 @@
 type: dependency
 status: active
 package: '@gaia-react/lint'
-version: 1.9.0
+version: 1.11.0
 role: lint-config
 created: 2026-04-27
-updated: 2026-07-04
+updated: 2026-07-22
 tags: [dependency, lint, eslint]
 ---
 
@@ -63,6 +63,8 @@ export default defineConfig([
 | `base` | Standard TS/JS hygiene | — |
 | `react` | React-specific rules including `no-null-render` (autofix: converts `return null` in render context to `return undefined`; does not touch loaders, actions, or utilities) | `no-null-render` added in 1.8.0 |
 | `testing` | D-8 test-honesty: `vitest/prefer-called-with`, `no-restricted-imports` (blocks `*.server` / internals from consumer tests) | Added in 1.6.0 |
+| `storybook` | `eslint-plugin-storybook` recommended, scoped to `*.stories.*` and `.storybook/main.*` | `.storybook/` half reaches files from 1.11.0 |
+| `playwright` | `eslint-plugin-playwright` recommended, scoped to `.playwright/**`; `expect-expect` counts `expect*()` helpers as the assertion, `no-skipped-test` allows the conditional `test.skip(condition, reason)` form | block reaches files from 1.11.0; `allowConditional` added there |
 | `guardrails` | `no-enum`, `no-switch`, `no-jsx-iife`, `no-zod-enum` (errors on `z.enum([...])`; use `z.literal([...])` for string unions) custom plugins; `gaia/no-restricted-syntax` selectors ban `cond ? <JSX/> : null` and `cond ? null : <JSX/>` (flag-only, no autofix) and flag `.length && <JSX/>` numeric-0 leaks (report-only) | `.length` selector added in 1.8.0; `no-zod-enum` added in 1.9.0 |
 | `styleHygiene` | `import-x/no-restricted-paths` with carve-outs: `resources+/` and `actions+/` routes are exempt for UI layers | Carve-out added in 1.6.0 |
 | `betterTailwind` | Tailwind class ordering and hygiene | — |


### PR DESCRIPTION
Closes #980

## Problem

`.playwright` and `.storybook` were bare entries in the lint preset's default ignore list. A config object carrying only `ignores` is a **global** ignore in ESLint flat config, and a global ignore beats any later block's `files`, so the two blocks written to lint those directories were shadowed by the defaults they ship alongside:

- the `playwright` block scopes itself to `.playwright/**/*.ts?(x)` and never matched a file, taking its hand-tuned `expect-expect` options with it
- the `storybook` block kept its `*.stories.*` rules (those files live elsewhere) but lost its `.storybook/main.*` half

Every e2e spec, Playwright helper, and Storybook config file went unchecked while `pnpm lint` reported a clean tree and CI stayed green.

## Fix

Root cause is fixed upstream in [`@gaia-react/lint` 1.11.0](https://github.com/gaia-react/lint/pull/40), which drops both entries and adds an `ignores` suite that asks ESLint itself which paths survive the defaults, so a future directory-level entry that shadows a scoped block fails a test instead of shipping. This bumps to it and fixes the 78 findings that surfaced here: 59 by `eslint --fix`, 19 by hand.

Two of those findings were coverage, not style:

- `playwright/expect-expect` counts the project's `expect*()` a11y helpers as assertions, retiring two hand-written disable comments that never suppressed anything
- `playwright/no-conditional-in-test` caught a hand-rolled `if (relevant.length > 0) { attach; throw }` in the landmark spec, now an assertion over a projection of the violating rules

Upstream also gained `playwright/no-skipped-test`'s `allowConditional`, so the template's own runtime-conditional skip (a language switcher that single-language projects do not render) stays legal while a bare `test.skip()` stays flagged.

The react-perf harness files take a file-level `no-underscore-dangle` disable: `window.__renders` / `__bippyMeta` / `__PERF_NO_STRICT` are the wire contract between the injected harness and the capture helper, not a naming choice, and `app/entry.client.tsx` already carries the same disable for the same reason.

A second commit closes the same gap one layer down: `.lintstagedrc.json` gave those directories a prettier-only entry (because running eslint on an ignored file only warns), so a lint error in an e2e spec would have passed the pre-commit gate and surfaced in CI.

## Verification

| Step | Result |
| --- | --- |
| Simplify | 4 angles reviewed; reuse / simplification / efficiency clean, altitude raised 3 doc findings, all applied or trimmed |
| Localization | n/a, no user-facing strings touched |
| Typecheck | pass |
| Lint | pass, zero warnings, real config against published 1.11.0 |
| Unit tests | 155 passed, 1 skipped, zero console warnings |
| E2E | 8 passed, 1 skipped (the conditional language-switch skip) |
| Dev server | `/` and `/privacy` both 200 |
| Build | pass |

The e2e run is the load-bearing one: `capture.ts` and `harness-entry.ts` carry real edits (a `path` default import, `outputFiles.at(0)`, the `seq` counter extraction, handler methods to arrow properties), and `react-perf-smoke.spec.ts` exercises all of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)