### PR TITLE
debt(ci): pass Storybook a literal placeholder, not the real SESSION_SECRET

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -93,5 +93,8 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           MSW_ENABLED: ${{ secrets.MSW_ENABLED || 'true' }}
           npm_package_version: ${{ steps.package-version.outputs.current-version}}
-          SESSION_SECRET: ${{ secrets.SESSION_SECRET || 'ci-placeholder-session-secret-not-real' }}
+          # Storybook never signs a cookie, so this only has to satisfy the
+          # required z.string() in app/env.server.ts. Keep it a literal: the real
+          # secret has no reason to enter a build that publishes a public artifact.
+          SESSION_SECRET: 'storybook-placeholder-not-used-for-signing'
           SITE_URL: ${{ secrets.SITE_URL || 'http://localhost:3000' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ### Changed
 
+- the Chromatic workflow no longer passes the repository's real `SESSION_SECRET` into the Storybook build. Storybook never signs a cookie, so the variable only ever had to satisfy a required environment schema, and it now receives a literal placeholder instead. Nothing reached the published static build before either, but that depended on a bundler optimization rather than on the secret never being there (#996)
 - ESLint now checks `.playwright/` and `.storybook/`. The lint preset ignored both by default, which silently disabled the very rules it configured for them, so every e2e spec, Playwright helper, and Storybook config file went unchecked while `pnpm lint` reported a clean tree. `@gaia-react/lint` 1.11.0 stops ignoring them, and the 78 findings that surfaced in GAIA's own tree are fixed here. **Action required:** run `pnpm lint` after updating. Most of what surfaces in your own e2e and Storybook code auto-fixes; what remains is real (#980)
 
 ### Added


### PR DESCRIPTION
The Chromatic job handed the repository's real `SESSION_SECRET` to a Storybook build that never uses it for its purpose. The secret signs cookies, and both consumers are server-only paths Storybook does not execute: `app/entry.server.tsx` and `app/sessions.server/language.ts`.

The variable only has to be *present*. `app/env.server.ts` parses the environment at module scope and declares the field as a required `z.string()`, and `app/root.tsx` imports that module, so the parse can run in the browser under `storybook dev`, which is why `.storybook/env.ts` shims the value. Any non-empty string satisfies it, and the existing `|| 'ci-placeholder-session-secret-not-real'` fallback already proved a literal works, since the job passes when the secret is absent.

Nothing reached the published artifact before this either: `.storybook/env.ts` exports nothing and `package.json` declares `"sideEffects": false`, so the module is tree-shaken out of the preview bundle. That left a bundler optimization as the only thing standing between a real secret and a build that publishes a public artifact, with no test asserting the property. Passing a literal removes the dependence rather than continuing to rely on it.

## Verification

- `SESSION_SECRET: z.string()` in `app/env.server.ts` carries no length or format constraint, so the placeholder satisfies the parse.
- The workflow YAML parses and the step's `env` map resolves as intended.

## Scope

`SITE_URL` on the adjacent line is deliberately left alone, per the issue: a deployed site URL is public by definition, and `new URL(...)` throws on a non-URL string, so its existing `|| 'http://localhost:3000'` fallback is already the right shape.

`.github/workflows/tests.yml` carries the same `secrets.SESSION_SECRET || <literal>` shape and is also left alone. It publishes no artifact, and its Playwright run exercises the real cookie-signing path, so a real value there is coherent in a way it is not for a Storybook build. Noted rather than folded in.

Closes #996
