### PR TITLE
docs(audit): the merge-path dispatch template supplies AUDIT_ROOT

### DIFF
--- a/wiki/concepts/PR Merge Workflow.md
+++ b/wiki/concepts/PR Merge Workflow.md
@@ -96,7 +96,7 @@ It prints one member (agent) name per line, deduped and sorted, and always exits
   Agent(
     subagent_type: "<member-name>",
     run_in_background: false,
-    prompt: "Working root: <RESOLVED_ROOT>, the absolute path of the checkout under review; the orchestrator substitutes the value it resolved from the isolation reference at dispatch time. Expected HEAD tree: <EXPECTED_TREE>, the tree captured immediately before this dispatch wave.
+    prompt: "Working root: <RESOLVED_ROOT>, the absolute path of the checkout under review; the orchestrator substitutes the value it resolved from the isolation reference at dispatch time. Before running any handshake command, set AUDIT_ROOT=<RESOLVED_ROOT>. Expected HEAD tree: <EXPECTED_TREE>, the tree captured immediately before this dispatch wave.
     MANDATORY FIRST ACTION, before any review: run `git -C <RESOLVED_ROOT> rev-parse HEAD^{tree}` and compare it to <EXPECTED_TREE>. If that command errors (missing path, git unavailable) OR the value does not match exactly, STOP, do not review, do not write a marker, and return only the mismatch or error as your entire output.
     Only on an exact match, review all changes in <RESOLVED_ROOT>'s current branch compared to main, scoping every git command to `git -C <RESOLVED_ROOT>`. Identify security vulnerabilities, performance issues, code smells, anti-patterns, and refactoring opportunities."
   )


### PR DESCRIPTION
## What

Adds one sentence to the Code Audit Team dispatch template in `wiki/concepts/PR Merge Workflow.md`:

> Before running any handshake command, set `AUDIT_ROOT=<RESOLVED_ROOT>`.

Copied verbatim from the sibling template at `.claude/skills/gaia/references/plan.md:204`, in the same position, so the two read identically.

## Why

The five Code Audit Team agent definitions resolve the audited root from the `AUDIT_ROOT` the orchestrator supplies:

```bash
AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
```

The ambient toplevel is the fallback, meant for when no working root was supplied. Two templates produce that value, and only the plan-path one set it. The merge-path template, the one `.claude/rules/pr-merge.md` routes an orchestrator to before `gh pr merge`, supplied a working root and an expected tree but never `AUDIT_ROOT`, so every member dispatched on that path took the fallback and the anchoring shipped in #1061 was exercised on the plan path alone. Harmless while the orchestrator's cwd is the audited root, wrong-tree the moment it is not, which is the condition #1055 exists to close.

Reported as a cross-remit finding by `code-audit-maintainer-shell` during #1061's pre-merge gate. No roster entry in `.gaia/audit-ci.yml` claims `wiki/**`, so no member owns the file.

## Scope

One line. `git grep "Working root:"` confirms exactly two dispatch templates exist repo-wide; no third carries the same gap.

The surrounding prose needs no companion change: the plan-path template explains nothing about `AUDIT_ROOT` outside its own prompt string either, and all five agent definitions already state that the dispatch carries the assignment and that the value is authoritative.

## Verification

- `git grep "set AUDIT_ROOT="` returns both templates, with the clause byte-identical between them.
- The wiki-style historical-phrasing audit returns clean on the edited file.
- The Quality Gate has nothing to check: no `.ts|tsx|js|jsx|mjs|cjs|css` and no gate-affecting config in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)