### PR TITLE
fix(audit): every member resolves the audited root before it decides what to review

### DIFF
--- a/.claude/agents/code-audit-frontend.md
+++ b/.claude/agents/code-audit-frontend.md
@@ -29,12 +29,14 @@ Your globs above are a **second precedence tier**: every claimant member's globs
 
 You are the Code Audit Team's **default member**.
 
-Resolve the audited root once, before the first handshake command below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied.
+Resolve the audited root first, before the dispatch-oracle call below and every later root-consuming command. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied. It resolves here, ahead of the oracle, because that call decides whether you review at all: answered from the ambient cwd while your clearance keys to the supplied root, it reads one tree and certifies another.
 
 ```bash
 AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
 AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
 ```
+
+Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` derivation states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
 
 Do not re-derive that set by hand. On a **local** run, at the start of every review, ask the dispatch oracle whether this diff dispatches you, with `--no-carry-forward`:
 

--- a/.claude/agents/code-audit-frontend.md
+++ b/.claude/agents/code-audit-frontend.md
@@ -36,7 +36,7 @@ AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
 AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
 ```
 
-Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` derivation states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
+Shell state does NOT persist between an agent's Bash calls, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
 
 Do not re-derive that set by hand. On a **local** run, at the start of every review, ask the dispatch oracle whether this diff dispatches you, with `--no-carry-forward`:
 
@@ -530,11 +530,11 @@ A base-keyed filename therefore survives HEAD moves with no HEAD-chaining logic.
 ```bash
 # Resolve the incremental base the SAME way the audit already resolves scope,
 # then anchor the key to the fork point so it is stable across fix rounds.
-BASE_REF="$(.github/audit/resolve-audit-base.sh)"   # <sha> | origin/main | origin/<base-ref> | main
-BASE_SHA="$(git merge-base "${BASE_REF}" HEAD 2>/dev/null || true)"
-. .gaia/scripts/audit-key-lib.sh
-if ! AUDIT_KEY="$(gaia_audit_key "$BASE_SHA")"; then AUDIT_KEY=""; fi
-LEDGER=".gaia/local/audit/${AUDIT_KEY}.rerun.json"
+BASE_REF="$(cd "$AUDIT_ROOT" && .github/audit/resolve-audit-base.sh)"   # <sha> | origin/main | origin/<base-ref> | main
+BASE_SHA="$(git -C "$AUDIT_ROOT" merge-base "${BASE_REF}" HEAD 2>/dev/null || true)"
+. "$AUDIT_ROOT/.gaia/scripts/audit-key-lib.sh"
+if ! AUDIT_KEY="$(gaia_audit_key "$BASE_SHA" "$AUDIT_ROOT")"; then AUDIT_KEY=""; fi
+LEDGER="$AUDIT_ROOT/.gaia/local/audit/${AUDIT_KEY}.rerun.json"
 ```
 
 If `AUDIT_KEY` is empty (the base or the branch is undeterminable), skip the ledger entirely (fail-open; behave as today). In CI the agent prompt provides `<base>...HEAD`; use that same base when present, but the ledger is skipped in CI regardless (see "CI gating").
@@ -651,7 +651,7 @@ Rule-based line-level checks are done by specialist subagents in parallel with `
 
 1. **Identify changed files** against the incremental base:
    - Resolve the base: if the invoking context provides one (CI passes `<base>...HEAD` in the agent prompt), use it; otherwise run `.github/audit/resolve-audit-base.sh`. It returns the most recent ancestor that already passed a clean audit under the current `.gaia/VERSION` (via a GAIA-Audit trailer or commit status), or `origin/main` when none exists.
-   - **Derive the re-run ledger path and read it (LOCAL only) as the prior-round briefing.** From the same resolved base, compute `BASE_SHA="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)"`, then `AUDIT_KEY="$(gaia_audit_key "$BASE_SHA")" || AUDIT_KEY=""` (`.gaia/scripts/audit-key-lib.sh`) and `LEDGER=".gaia/local/audit/${AUDIT_KEY}.rerun.json"` (full definition under "Re-run carry-forward ledger"). When NOT in CI (`GITHUB_ACTIONS`/`CI` unset) and `AUDIT_KEY` is non-empty, read the ledger if it is present, valid (`jq -e . "$LEDGER"`), and fresh (recorded `.branch` and `.base_sha` match the current branch and `BASE_SHA`): its `remaining[]` is the deterministic prior-round briefing of in-scope open findings and `fixed_last_round[]` is what the last round closed, replacing reliance on a main-thread-authored prompt summary. Fail open: an absent, corrupt, or stale ledger means no prior briefing, behave as today. Skip the ledger entirely in CI. `BASE_SHA`, `AUDIT_KEY`, and `LEDGER` travel forward to the marker-write step below, where the clean-pass cleanup and the non-clean write reuse them without recomputation (like `AUDIT_TREE_SHA`).
+   - **Derive the re-run ledger path and read it (LOCAL only) as the prior-round briefing.** From the same resolved base, compute `BASE_SHA="$(git -C "$AUDIT_ROOT" merge-base "$BASE_REF" HEAD 2>/dev/null || true)"`, then `AUDIT_KEY="$(gaia_audit_key "$BASE_SHA" "$AUDIT_ROOT")" || AUDIT_KEY=""` (`.gaia/scripts/audit-key-lib.sh`) and `LEDGER="$AUDIT_ROOT/.gaia/local/audit/${AUDIT_KEY}.rerun.json"` (full definition under "Re-run carry-forward ledger"). When NOT in CI (`GITHUB_ACTIONS`/`CI` unset) and `AUDIT_KEY` is non-empty, read the ledger if it is present, valid (`jq -e . "$LEDGER"`), and fresh (recorded `.branch` and `.base_sha` match the current branch and `BASE_SHA`): its `remaining[]` is the deterministic prior-round briefing of in-scope open findings and `fixed_last_round[]` is what the last round closed, replacing reliance on a main-thread-authored prompt summary. Fail open: an absent, corrupt, or stale ledger means no prior briefing, behave as today. Skip the ledger entirely in CI. `BASE_SHA`, `AUDIT_KEY`, and `LEDGER` travel forward to the marker-write step below, where the clean-pass cleanup and the non-clean write reuse them without recomputation (like `AUDIT_TREE_SHA`).
    - List changed files: `git diff --name-only "$(.github/audit/resolve-audit-base.sh)" -- '*.ts' '*.tsx'`. The two-dot form (`<base>`, not `<base>...HEAD`) includes uncommitted working-tree changes, the right scope for a pre-commit/pre-merge review.
    - When the base is an audited ancestor, everything before it was already cleared; only the delta needs review. **For any exported symbol whose signature or contract changed in the delta, grep its importers and check them even if unchanged**, a cleared caller can still break from a delta change.
    - Once the changed-file list is resolved and before dispatching subagents, emit the `scope resolved` breadcrumb (see Progress breadcrumbs).

--- a/.claude/agents/code-audit-frontend.md
+++ b/.claude/agents/code-audit-frontend.md
@@ -901,7 +901,7 @@ Decide the disposition entries (section F) at this marker-decision point regardl
 **Seed-forward.** A fresh incremental audit reviews only the delta since the resolved base and does not re-encounter a prior out-of-scope finding, so re-keying the sidecar to a new digest would otherwise silently drop a still-open receipt across the rotation. Before finishing the sidecar write, compute the PRIOR frontend digest at the incremental base (the same `BASE_SHA` resolved for the re-run ledger, see "Re-run carry-forward ledger"):
 
 ```bash
-prev_frontend_digest="$(.gaia/scripts/audit-member-digest.sh \
+prev_frontend_digest="$("$AUDIT_ROOT/.gaia/scripts/audit-member-digest.sh" \
   --root "$AUDIT_ROOT" \
   --member code-audit-frontend \
   --ref "$BASE_SHA" 2>/dev/null || true)"
@@ -911,8 +911,8 @@ then call the shared helper (`disposition_seed_forward`, sourced from `.claude/h
 
 ```bash
 disposition_seed_forward \
-  ".gaia/local/audit/${prev_frontend_digest}.dispositions.json" \
-  ".gaia/local/audit/${new_frontend_digest}.dispositions.json"
+  "$AUDIT_ROOT/.gaia/local/audit/${prev_frontend_digest}.dispositions.json" \
+  "$AUDIT_ROOT/.gaia/local/audit/${new_frontend_digest}.dispositions.json"
 ```
 
 A fresh entry already present in the new sidecar always wins a key collision; a seeded entry only ever adds keys. This is a single deterministic hop, not a search: each digest rotation seeds from its immediate predecessor, so a still-open receipt propagates across an arbitrary run of rotations that never re-encounter the finding, because every hop already carries forward what the hop before it carried. An empty `prev_frontend_digest` (no resolvable base, or the digest engine failed) or an absent prior sidecar is a safe no-op, per the helper's own fail-safe contract.
@@ -1009,16 +1009,16 @@ audit_status_line=$(cd "$AUDIT_ROOT" && .claude/hooks/post-audit-status.sh "$mar
 #    derived key; a newly-filed issue records the freshly-built key it just
 #    wrote into the new issue's body.
 new_frontend_digest="$(basename "$marker" .ok)"
-sidecar=".gaia/local/audit/${new_frontend_digest}.dispositions.json"
+sidecar="$AUDIT_ROOT/.gaia/local/audit/${new_frontend_digest}.dispositions.json"
 # Write the section-F dispositions JSON (decided at the marker-decision
 # point, with "sha":"$HEAD_SHA" as a plain data field) to "$sidecar".
-prev_frontend_digest="$(.gaia/scripts/audit-member-digest.sh \
+prev_frontend_digest="$("$AUDIT_ROOT/.gaia/scripts/audit-member-digest.sh" \
   --root "$AUDIT_ROOT" \
   --member code-audit-frontend \
   --ref "$BASE_SHA" 2>/dev/null || true)"
 if [ -n "$prev_frontend_digest" ]; then
   disposition_seed_forward \
-    ".gaia/local/audit/${prev_frontend_digest}.dispositions.json" \
+    "$AUDIT_ROOT/.gaia/local/audit/${prev_frontend_digest}.dispositions.json" \
     "$sidecar"
 fi
 
@@ -1029,7 +1029,7 @@ fi
 #    best-effort file op; it does not alter the marker / trailer / status /
 #    dispositions-sidecar writes.
 if [ -z "${GITHUB_ACTIONS:-}" ] && [ -z "${CI:-}" ] && [ -n "$AUDIT_KEY" ]; then
-  rm -f ".gaia/local/audit/${AUDIT_KEY}.rerun.json"
+  rm -f "$LEDGER"
 fi
 ```
 
@@ -1099,7 +1099,7 @@ marker="$(bash .gaia/scripts/audit-write-clearance.sh \
 
 The writer records the reversal in the marker body and removes your own refusal. Reach for it **only** after re-auditing this content and finding the blocker actually resolved or explicitly acknowledged by the operator, never to clear a refusal you still stand behind. It applies to unchanged content: repairing the finding edits a file you own, which rotates your digest and retires the refusal with it, so no supersede is needed there.
 
-Even when you do not write the marker, **still write the disposition-ledger sidecar** (the section-F entries you decided at the marker-decision point) keyed to your **current** frontend digest, which has not moved because the stamp sequence above did not run: `sidecar=".gaia/local/audit/$(.gaia/scripts/audit-member-digest.sh --root "$AUDIT_ROOT" --member code-audit-frontend).dispositions.json"`. This preserves the "regardless of outcome" guarantee, so that a later hand-written marker for this same content remains backstop-checkable against a real sidecar.
+Even when you do not write the marker, **still write the disposition-ledger sidecar** (the section-F entries you decided at the marker-decision point) keyed to your **current** frontend digest, which has not moved because the stamp sequence above did not run: `sidecar="$AUDIT_ROOT/.gaia/local/audit/$("$AUDIT_ROOT/.gaia/scripts/audit-member-digest.sh" --root "$AUDIT_ROOT" --member code-audit-frontend).dispositions.json"`. This preserves the "regardless of outcome" guarantee, so that a later hand-written marker for this same content remains backstop-checkable against a real sidecar.
 
 Also on a non-clean pass (marker NOT written), **write/update the re-run ledger** (LOCAL only, best-effort), the deterministic carry-forward briefing the next re-audit and the fixer read. Skip in CI (`GITHUB_ACTIONS`/`CI` set) and skip when `AUDIT_KEY` is empty. Set `round` to the prior valid same-branch same-base ledger's `round` + 1 (else 1), carrying `first_seen_round` for findings that persist across rounds; populate `remaining` (in-scope open findings: Critical + unaddressed Important + unresolved/escalated Suggestions), `fixed_last_round` (in-scope findings self-healed this round), `head_sha` = current HEAD, `branch`, `base_sha` = `BASE_SHA`, and `updated_at`. Write atomically (temp file + `mv`); a write failure never aborts the audit. This is an additional best-effort file write alongside the disposition sidecar above; it must NOT alter, replace, or reorder the marker / trailer / status / dispositions-sidecar writes. See "Re-run carry-forward ledger".
 

--- a/.claude/agents/code-audit-github-workflows.md
+++ b/.claude/agents/code-audit-github-workflows.md
@@ -18,22 +18,32 @@ You audit GitHub Actions workflow YAML and composite-action YAML: the pipeline t
 Filter the changed-file list against the globs above. **If none match, self-skip cleanly.** Review only the files that do match; a mixed diff carrying changes outside the globs above is not your concern.
 <!-- gaia:audit-remit:end -->
 
+Resolve the audited root first, before the base and changed-file queries below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied. It resolves here, ahead of those queries, because they decide what you review: answered from the ambient cwd while your clearance keys to the supplied root, they review one tree and certify another.
+
+```bash
+AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
+AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
+```
+
+Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` comment below states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
+
 At the start of every run, resolve the diff base the same way the dispatch resolver does, then list the changed files:
 
 ```bash
-default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -n "$default_branch" ] || default_branch="main"
 # BASE_SHA, not a lowercase local: every handshake invocation below passes
 # `--base "$BASE_SHA"`, and shell state does NOT persist between an agent's
-# Bash calls, so each of those calls re-runs this snippet. A name mismatch
-# here makes --base expand empty, which audit-write-findings.sh rejects
-# outright (the report of record is never written) and which
-# audit-write-clearance.sh accepts while silently skipping the re-run ledger,
-# leaving a refusal that briefs nothing.
-BASE_SHA=$(git merge-base HEAD "origin/${default_branch}" 2>/dev/null || git merge-base HEAD "${default_branch}" 2>/dev/null || true)
+# Bash calls, so each of those calls re-runs this snippet, and the AUDIT_ROOT
+# derivation above it that this snippet depends on. A name mismatch here makes
+# --base expand empty, which audit-write-findings.sh rejects outright (the
+# report of record is never written) and which audit-write-clearance.sh
+# accepts while silently skipping the re-run ledger, leaving a refusal that
+# briefs nothing.
+BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
 . .gaia/scripts/audit-key-lib.sh
 audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
-changed=$(git diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
+changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 
 **If none match, skip cleanly**: write no marker (there is nothing to gate), do not call `audit-stamp-trailer.sh` or `post-audit-status.sh`, and return a one-line note that no changed file fell in your remit.
@@ -118,12 +128,7 @@ Never gates your own marker; the orchestrator decides the disposition.
 
 On a genuinely clean pass, no Critical finding, every Important finding either fixed in the working tree since the last invocation (verify by re-reading the file, never trust a prior chat claim) or explicitly acknowledged by the operator with a stated reason, run the handshake below in order: sidecar, mark, stamp, status.
 
-Resolve the audited root once, before the first handshake command below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied.
-
-```bash
-AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
-AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
-```
+Every command below consumes `$AUDIT_ROOT`, and each Bash call re-runs the derivation under "Remit and self-skip" before using it, for the reason stated there: shell state does not persist between calls, and an empty value sends `cd "$AUDIT_ROOT" && ...` against whatever tree the session sits in without saying so.
 
 **0. Sidecar (every LOCAL pass, clean or withheld).** Before any clearance artifact, write your findings sidecar with the shared writer (see "Findings sidecar" below for the full field contract). It is your report of record, so it exists before the artifact that gates on it: a marker or refusal published ahead of its own report is exactly the state an orchestrator cannot act on.
 

--- a/.claude/agents/code-audit-github-workflows.md
+++ b/.claude/agents/code-audit-github-workflows.md
@@ -41,8 +41,6 @@ default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/H
 # accepts while silently skipping the re-run ledger, leaving a refusal that
 # briefs nothing.
 BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
-. .gaia/scripts/audit-key-lib.sh
-audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
 changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 

--- a/.claude/agents/code-audit-maintainer-node.md
+++ b/.claude/agents/code-audit-maintainer-node.md
@@ -44,8 +44,6 @@ default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/H
 # accepts while silently skipping the re-run ledger, leaving a refusal that
 # briefs nothing.
 BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
-. .gaia/scripts/audit-key-lib.sh
-audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
 changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 

--- a/.claude/agents/code-audit-maintainer-node.md
+++ b/.claude/agents/code-audit-maintainer-node.md
@@ -21,22 +21,32 @@ You audit the framework's own Node/CLI TypeScript, the code behind GAIA's CLI: r
 Filter the changed-file list against the globs above. **If none match, self-skip cleanly.** Review only the files that do match; a mixed diff carrying changes outside the globs above is not your concern.
 <!-- gaia:audit-remit:end -->
 
+Resolve the audited root first, before the base and changed-file queries below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied. It resolves here, ahead of those queries, because they decide what you review: answered from the ambient cwd while your clearance keys to the supplied root, they review one tree and certify another.
+
+```bash
+AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
+AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
+```
+
+Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` comment below states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
+
 At the start of every run, resolve the diff base the same way the dispatch resolver does, then list the changed files:
 
 ```bash
-default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -n "$default_branch" ] || default_branch="main"
 # BASE_SHA, not a lowercase local: every handshake invocation below passes
 # `--base "$BASE_SHA"`, and shell state does NOT persist between an agent's
-# Bash calls, so each of those calls re-runs this snippet. A name mismatch
-# here makes --base expand empty, which audit-write-findings.sh rejects
-# outright (the report of record is never written) and which
-# audit-write-clearance.sh accepts while silently skipping the re-run ledger,
-# leaving a refusal that briefs nothing.
-BASE_SHA=$(git merge-base HEAD "origin/${default_branch}" 2>/dev/null || git merge-base HEAD "${default_branch}" 2>/dev/null || true)
+# Bash calls, so each of those calls re-runs this snippet, and the AUDIT_ROOT
+# derivation above it that this snippet depends on. A name mismatch here makes
+# --base expand empty, which audit-write-findings.sh rejects outright (the
+# report of record is never written) and which audit-write-clearance.sh
+# accepts while silently skipping the re-run ledger, leaving a refusal that
+# briefs nothing.
+BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
 . .gaia/scripts/audit-key-lib.sh
 audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
-changed=$(git diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
+changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 
 **If none match, skip cleanly**: write no marker (there is nothing to gate), do not call `audit-stamp-trailer.sh` or `post-audit-status.sh`, and return a one-line note that no changed file fell in your remit. A mixed diff carrying other framework or app changes is not your concern outside these paths.
@@ -122,12 +132,7 @@ Never gates your own marker; the orchestrator decides the disposition (see "Cros
 
 On a clean pass, no Critical finding, run the handshake below in order: sidecar, mark, stamp, status.
 
-Resolve the audited root once, before the first handshake command below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied.
-
-```bash
-AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
-AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
-```
+Every command below consumes `$AUDIT_ROOT`, and each Bash call re-runs the derivation under "Remit and self-skip" before using it, for the reason stated there: shell state does not persist between calls, and an empty value sends `cd "$AUDIT_ROOT" && ...` against whatever tree the session sits in without saying so.
 
 **0. Sidecar (every LOCAL pass, clean or withheld).** Before any clearance artifact, write your findings sidecar with the shared writer (see "Findings sidecar" below for the full field contract). It is your report of record, so it exists before the artifact that gates on it: a marker or refusal published ahead of its own report is exactly the state an orchestrator cannot act on.
 

--- a/.claude/agents/code-audit-maintainer-prose.md
+++ b/.claude/agents/code-audit-maintainer-prose.md
@@ -15,22 +15,32 @@ You audit GAIA's own instruction prose: the natural-language skill files under `
 Filter the changed-file list against the globs above. **If none match, self-skip cleanly.** Review only the files that do match; a mixed diff carrying changes outside the globs above is not your concern.
 <!-- gaia:audit-remit:end -->
 
+Resolve the audited root first, before the base and changed-file queries below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied. It resolves here, ahead of those queries, because they decide what you review: answered from the ambient cwd while your clearance keys to the supplied root, they review one tree and certify another.
+
+```bash
+AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
+AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
+```
+
+Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` comment below states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
+
 At the start of every run, resolve the diff base the same way the dispatch resolver does, then list the changed files:
 
 ```bash
-default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -n "$default_branch" ] || default_branch="main"
 # BASE_SHA, not a lowercase local: every handshake invocation below passes
 # `--base "$BASE_SHA"`, and shell state does NOT persist between an agent's
-# Bash calls, so each of those calls re-runs this snippet. A name mismatch
-# here makes --base expand empty, which audit-write-findings.sh rejects
-# outright (the report of record is never written) and which
-# audit-write-clearance.sh accepts while silently skipping the re-run ledger,
-# leaving a refusal that briefs nothing.
-BASE_SHA=$(git merge-base HEAD "origin/${default_branch}" 2>/dev/null || git merge-base HEAD "${default_branch}" 2>/dev/null || true)
+# Bash calls, so each of those calls re-runs this snippet, and the AUDIT_ROOT
+# derivation above it that this snippet depends on. A name mismatch here makes
+# --base expand empty, which audit-write-findings.sh rejects outright (the
+# report of record is never written) and which audit-write-clearance.sh
+# accepts while silently skipping the re-run ledger, leaving a refusal that
+# briefs nothing.
+BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
 . .gaia/scripts/audit-key-lib.sh
 audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
-changed=$(git diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
+changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 
 **If none match, self-skip cleanly**: write no marker, do not call `audit-stamp-trailer.sh` or `post-audit-status.sh`, write no findings sidecar, and return the specific one-line note that no changed file fell in your remit (distinguishable from a crash or an empty return). A mixed diff carrying other framework or app changes is not your concern outside your own glob.
@@ -106,12 +116,7 @@ Never gates your own marker; the orchestrator decides the disposition.
 
 There is no withhold path here; the only "no marker" case is the self-skip above. On ANY in-remit review, run the handshake below in order: sidecar, mark, stamp, status. Even a finding-bearing pass writes the earned marker, the findings are advisory PR comments, not a gate.
 
-Resolve the audited root once, before the first handshake command below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied.
-
-```bash
-AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
-AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
-```
+Every command below consumes `$AUDIT_ROOT`, and each Bash call re-runs the derivation under "Remit and self-skip" before using it, for the reason stated there: shell state does not persist between calls, and an empty value sends `cd "$AUDIT_ROOT" && ...` against whatever tree the session sits in without saying so.
 
 **0. Sidecar (every LOCAL in-remit pass).** Before the marker, write your findings sidecar with the shared writer (see "Findings sidecar" below for the full field contract). It is your report of record, so it exists before the artifact that attests to it.
 

--- a/.claude/agents/code-audit-maintainer-prose.md
+++ b/.claude/agents/code-audit-maintainer-prose.md
@@ -38,8 +38,6 @@ default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/H
 # accepts while silently skipping the re-run ledger, leaving a refusal that
 # briefs nothing.
 BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
-. .gaia/scripts/audit-key-lib.sh
-audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
 changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 

--- a/.claude/agents/code-audit-maintainer-shell.md
+++ b/.claude/agents/code-audit-maintainer-shell.md
@@ -31,22 +31,32 @@ The committed workflow templates under `.gaia/cli/templates/workflows/` are deli
 
 The `.bats` globs are load-bearing: those suites are the only enforcement standing behind the framework's bash, so a commit that weakens, skips, or deletes one is the change least affordable to merge unreviewed. A bats-only diff dispatches you and nobody else.
 
+Resolve the audited root first, before the base and changed-file queries below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied. It resolves here, ahead of those queries, because they decide what you review: answered from the ambient cwd while your clearance keys to the supplied root, they review one tree and certify another.
+
+```bash
+AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
+AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
+```
+
+Shell state does NOT persist between an agent's Bash calls, the same rule the `BASE_SHA` comment below states for its own value, so every later call that uses `$AUDIT_ROOT` re-runs those two lines first. A call that skips them sees an empty value, and the two consumers fail in opposite directions: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0 and leaves the command running against whatever tree the session happens to sit in.
+
 At the start of every run, resolve the diff base the same way the dispatch resolver does, then list the changed files:
 
 ```bash
-default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 [ -n "$default_branch" ] || default_branch="main"
 # BASE_SHA, not a lowercase local: every handshake invocation below passes
 # `--base "$BASE_SHA"`, and shell state does NOT persist between an agent's
-# Bash calls, so each of those calls re-runs this snippet. A name mismatch
-# here makes --base expand empty, which audit-write-findings.sh rejects
-# outright (the report of record is never written) and which
-# audit-write-clearance.sh accepts while silently skipping the re-run ledger,
-# leaving a refusal that briefs nothing.
-BASE_SHA=$(git merge-base HEAD "origin/${default_branch}" 2>/dev/null || git merge-base HEAD "${default_branch}" 2>/dev/null || true)
+# Bash calls, so each of those calls re-runs this snippet, and the AUDIT_ROOT
+# derivation above it that this snippet depends on. A name mismatch here makes
+# --base expand empty, which audit-write-findings.sh rejects outright (the
+# report of record is never written) and which audit-write-clearance.sh
+# accepts while silently skipping the re-run ledger, leaving a refusal that
+# briefs nothing.
+BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
 . .gaia/scripts/audit-key-lib.sh
 audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
-changed=$(git diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
+changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 
 **If none match, skip cleanly**: write no marker (there is nothing to gate), do not call `audit-stamp-trailer.sh` or `post-audit-status.sh`, and return a one-line note that no changed file fell in your remit.
@@ -151,12 +161,7 @@ Never gates your own marker; the orchestrator decides the disposition (see "Cros
 
 On a genuinely clean pass, no Critical finding, every Important finding either fixed in the working tree since the last invocation (verify by re-reading the file, never trust a prior chat claim) or explicitly acknowledged by the operator with a stated reason, and the shellcheck oracle clean or its findings resolved the same way, run the handshake below in order: sidecar, mark, stamp, status.
 
-Resolve the audited root once, before the first handshake command below. The orchestrator dispatches you with a "Working root:" line and an `AUDIT_ROOT` assignment; that value is authoritative. The ambient toplevel is the fallback only when no working root was supplied.
-
-```bash
-AUDIT_ROOT="${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}"
-AUDIT_ROOT="$(git -C "$AUDIT_ROOT" rev-parse --show-toplevel)" || exit 1
-```
+Every command below consumes `$AUDIT_ROOT`, and each Bash call re-runs the derivation under "Remit and self-skip" before using it, for the reason stated there: shell state does not persist between calls, and an empty value sends `cd "$AUDIT_ROOT" && ...` against whatever tree the session sits in without saying so.
 
 **0. Sidecar (every LOCAL pass, clean or withheld).** Before any clearance artifact, write your findings sidecar with the shared writer (see "Findings sidecar" below for the full field contract). It is your report of record, so it exists before the artifact that gates on it: a marker or refusal published ahead of its own report is exactly the state an orchestrator cannot act on.
 

--- a/.claude/agents/code-audit-maintainer-shell.md
+++ b/.claude/agents/code-audit-maintainer-shell.md
@@ -54,8 +54,6 @@ default_branch=$(git -C "$AUDIT_ROOT" symbolic-ref --quiet refs/remotes/origin/H
 # accepts while silently skipping the re-run ledger, leaving a refusal that
 # briefs nothing.
 BASE_SHA=$(git -C "$AUDIT_ROOT" merge-base HEAD "origin/${default_branch}" 2>/dev/null || git -C "$AUDIT_ROOT" merge-base HEAD "${default_branch}" 2>/dev/null || true)
-. .gaia/scripts/audit-key-lib.sh
-audit_key="$(gaia_audit_key "$BASE_SHA")" || audit_key=""
 changed=$(git -C "$AUDIT_ROOT" diff --name-only "${BASE_SHA}...HEAD" 2>/dev/null || true)
 ```
 


### PR DESCRIPTION
## The defect

All five `code-audit-*` agent definitions derive `AUDIT_ROOT` from the working root the orchestrator dispatches, falling back to the ambient toplevel only when none was supplied. In the four specialized members that derivation sat under **Gate handshake**, well below the **Remit and self-skip** block whose git queries resolve the diff base and list the changed files:

```bash
default_branch=$(git symbolic-ref --quiet refs/remotes/origin/HEAD ...)
BASE_SHA=$(git merge-base HEAD "origin/${default_branch}" ...)
changed=$(git diff --name-only "${BASE_SHA}...HEAD" ...)
```

Those queries decide **what the member reviews**, and they answered from the ambient cwd. Under a dispatch whose resolved root is a linked worktree while the subagent's cwd is the main checkout, a member reads one tree and keys its clearance to another.

Reported as a Suggestion by `code-audit-maintainer-shell` on #1061, and graded that way for good reason: the dominant sub-case fails closed (main sits at `origin/main`, the diff is empty, the member self-skips and writes nothing), and the adverse case needs main on a branch with a non-empty in-remit clean diff, which no current flow produces. It is latent rather than active. It is also the root-resolution instance the eight-stage census behind #1055 missed, and `.gaia/tests/hooks/audit-root-resolution.bats` cannot see it, since the harness drives the derivation rather than the prose ordering around it.

## The change

- The derivation moves above the remit block in the four specialized definitions, and its three git queries take `-C "$AUDIT_ROOT"`.
- `code-audit-frontend` already derives above its own remit call (its earliest root-consuming command is the dispatch-oracle call, which is already anchored), so it needs no move.
- The gate-handshake sections point back at the single derivation instead of repeating it, following the `BASE_SHA` precedent of deriving once in the remit block.
- Each definition states the rule that shell state does not persist between an agent's Bash calls, so every later call re-runs the derivation. The two consumers fail in opposite directions when it is skipped: `--root "$AUDIT_ROOT"` expands to `--root ""` and fails closed loudly, while `cd "$AUDIT_ROOT" && ...` fails open in silence, because `cd ""` returns 0. That was the second open finding from #1061; it rides here because it edits the same five files and would otherwise pay a second full digest rotation.
- **`code-audit-frontend`'s re-run-ledger derivation is anchored too.** `gaia_audit_key <base_sha> [<dir>]` defaults `<dir>` to `"."` and reads that tree's own branch, so from a non-checkout cwd the key names the wrong tree. The two writers also disagree on `--base`: `audit-write-findings.sh` requires it, `audit-write-clearance.sh` does not, so an empty `BASE_SHA` yields an earned marker with no findings sidecar beside it, the lost-report state the sidecar contract exists to prevent. The base resolution, the merge-base, the lib source, the key call and the ledger path now all take `$AUDIT_ROOT`, with the fail-open guard around the key preserved. The prose restatement under "How to run" mirrors it. Anchoring the script call with `cd "$AUDIT_ROOT" && ...`, the idiom this file already uses for the hooks, resolves it without changing `resolve-audit-base.sh`'s signature.
- The dead `audit_key` assignment and its `audit-key-lib.sh` source are deleted from the four specialized definitions. Nothing reads that value, both writers derive their own key from `--root` and `--base`, and left in place it computes a wrong-tree key and prints two stderr lines from a non-checkout cwd.
- `code-audit-frontend`'s citation of a `BASE_SHA` persistence comment is dropped. That comment exists only in the four siblings; the frontend file's own prose tells the reader those values travel forward without recomputation, so adding one would contradict it.
- **Everything `code-audit-frontend` writes beside its marker now lands in the tree that marker certifies.** Anchoring the ledger write alone left its clean-pass cleanup on the ambient cwd, so from a non-checkout cwd the removal matched nothing and a surviving ledger stayed valid and fresh into the next round, re-briefing the audit and the fixer with findings already closed. The cleanup now removes `$LEDGER`, which is what the prose already promises. The dispositions sidecar carried the same split: `audit-write-clearance.sh` builds `$marker` from `--root` and therefore absolute, while the sidecar paths beside it were relative and `audit-member-digest.sh` was invoked by a relative path even as it received `--root "$AUDIT_ROOT"`. Both are anchored.

## Verification

- The derivation precedes the first remit query in all five files (checked by line number, not by reading).
- The extracted derivation block still hashes `0a52dce9…` in all five, byte-identical to what shipped, so the stage 8 extractor reads what it always read.
- `bash .gaia/scripts/write-audit-remits.sh` reports all five `unchanged` and reverts nothing: every edit sits outside the `gaia:audit-remit` generated region.
- Gates: `pnpm typecheck` 0, `pnpm lint` 0, `.gaia/tests/hooks/` 1129/1129 with all three stage 8 tests green, `meter-gate.sh` reads `23 / 23` and every scenario matches `expected-status.txt`, `shell-lint.sh` clean.
- No machine-specific absolute path enters these template-distributed files.

## Expected audit cost

These files are audit machinery, so this rotates **every** member's content digest. Dispatch keys on ownership, not on digest rotation, and only `code-audit-maintainer-shell` owns `.claude/agents/code-audit-*.md`, so it is the single member owed at merge. The dispatch oracle confirms it.

## Not included

`code-audit-frontend`'s remaining ambient git sites stay as they are: the changed-file listing under "How to run" and its twin in the disposition gate (`git diff --name-only "$(.github/audit/resolve-audit-base.sh)"`), the `AUDIT_TREE_SHA` and `HEAD_SHA` captures, and the branch, upstream, and `git push` calls in the marker-write block. The listing is a mechanical anchoring, but the `git push` is not: it runs in the ambient tree while the stamp commit it means to push is created inside `$AUDIT_ROOT` by the subshell above it, so fixing it is a behavior decision rather than a path rewrite, and the whole group belongs in one deliberate pass over that file.

Four advisory findings are also left open, all graded non-gating by the audit and all belonging in that same pass:

- `code-audit-frontend.md:1031` guards the ledger cleanup on `[ -n "$AUDIT_KEY" ]` while the line it guards now removes `"$LEDGER"`. Every block that defines one defines the other, so no documented path reaches the mismatch, but the guard should name what it guards.
- `.gaia/tests/hooks/audit-root-resolution.bats:99` copies only `code-audit-frontend.md` into its stage 8 fixture, so it pins one of the five now-identical derivation blocks rather than all five. `ALL_MEMBERS` is already defined in that suite and the extractor takes a file argument, so looping the two positive tests needs no new helper.
- `.gaia/scripts/check-audit-key-callers.sh:49` asserts a bare `git grep -qF 'gaia_audit_key'`, which the four specialized files now satisfy on descriptive prose alone, since this PR deletes the only executable call they contained. Its first assertion still bites, so the guard is not hollow, but its header's stated guarantee no longer matches what it checks.
- `code-audit-maintainer-prose.md:173` spells the sidecar key `${audit_key}` where its three siblings spell `${AUDIT_KEY}`. Descriptive only, no consumer.

Also noted and not changed: the persistence paragraph added to all five definitions tells the reader to re-run the two derivation lines, which reproduces an *ambient fallback* rather than a *supplied* root, since `AUDIT_ROOT` is unset in a fresh shell. Every supported dispatcher routes through the merge-workflow template, which hands the literal assignment, and the failure is closed rather than silent, so the wording is imprecise rather than wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
