### PR TITLE
chore(hooks): drop an inert trim from the .env.example arm, name what a test pins

### DIFF
--- a/.claude/hooks/block-secrets-write.sh
+++ b/.claude/hooks/block-secrets-write.sh
@@ -97,9 +97,7 @@ fi
 # close. `typeset` is bash's synonym for `declare` and belongs with the others.
 name_re='^[[:space:]]*((export|declare|typeset|local|readonly)[[:space:]]+(-[A-Za-z-]+[[:space:]]+)*)?[A-Za-z_][A-Za-z0-9_]*(_TOKEN|_SECRET|_KEY|_PASSWORD)[[:space:]]*='
 
-# Strip surrounding whitespace, then surrounding quotes: the double- and
-# single-quote strips run in sequence over the same value, so a doubly-wrapped
-# one loses both pairs.
+# Strip surrounding whitespace, then surrounding quotes.
 trim_value() {
   sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/' <<<"$1"
 }

--- a/.claude/hooks/block-secrets-write.sh
+++ b/.claude/hooks/block-secrets-write.sh
@@ -236,7 +236,13 @@ value_allowed() {
 # because a path may begin with a dash, matching `block-env-read.sh`.
 if [ "$(basename -- "${file_path:-}")" = ".env.example" ]; then
   while IFS= read -r line; do
-    if secret_shaped "$(trim_value "$(sed -E 's/^[^=]*=//' <<<"$line")")"; then
+    # No `trim_value` here, unlike the general path below, and the asymmetry is
+    # deliberate rather than an oversight. Shape reads `[A-Za-z0-9]{13,}` runs,
+    # while trimming removes only surrounding whitespace and one matched quote
+    # pair: all non-alphanumeric, and all at the ends. So it can neither lengthen
+    # a run nor merge two, and it cannot change this verdict. The general path
+    # needs it because the allowlist's arms anchor on the whole value.
+    if secret_shaped "$(sed -E 's/^[^=]*=//' <<<"$line")"; then
       deny "BLOCKED: write assigns secret-shaped material in .env.example: '$line'. That file carries placeholders; keep the real value in a gitignored .env."
     fi
   done < <(grep -E "$name_re" <<<"$content" || true)

--- a/.claude/hooks/block-secrets-write.sh
+++ b/.claude/hooks/block-secrets-write.sh
@@ -97,7 +97,9 @@ fi
 # close. `typeset` is bash's synonym for `declare` and belongs with the others.
 name_re='^[[:space:]]*((export|declare|typeset|local|readonly)[[:space:]]+(-[A-Za-z-]+[[:space:]]+)*)?[A-Za-z_][A-Za-z0-9_]*(_TOKEN|_SECRET|_KEY|_PASSWORD)[[:space:]]*='
 
-# Strip surrounding whitespace, then one matched pair of surrounding quotes.
+# Strip surrounding whitespace, then surrounding quotes: the double- and
+# single-quote strips run in sequence over the same value, so a doubly-wrapped
+# one loses both pairs.
 trim_value() {
   sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/' <<<"$1"
 }
@@ -238,10 +240,12 @@ if [ "$(basename -- "${file_path:-}")" = ".env.example" ]; then
   while IFS= read -r line; do
     # No `trim_value` here, unlike the general path below, and the asymmetry is
     # deliberate rather than an oversight. Shape reads `[A-Za-z0-9]{13,}` runs,
-    # while trimming removes only surrounding whitespace and one matched quote
-    # pair: all non-alphanumeric, and all at the ends. So it can neither lengthen
-    # a run nor merge two, and it cannot change this verdict. The general path
-    # needs it because the allowlist's arms anchor on the whole value.
+    # while trimming removes only surrounding whitespace and surrounding quotes:
+    # all non-alphanumeric, and all at the ends. So it can neither lengthen a run
+    # nor merge two, and it cannot change this verdict. What carries that is the
+    # removals being non-alphanumeric and at the ends, not how many come off. The
+    # general path needs it because the allowlist's arms anchor on the whole
+    # value.
     if secret_shaped "$(sed -E 's/^[^=]*=//' <<<"$line")"; then
       deny "BLOCKED: write assigns secret-shaped material in .env.example: '$line'. That file carries placeholders; keep the real value in a gitignored .env."
     fi

--- a/.gaia/tests/hooks/block-secrets-write.bats
+++ b/.gaia/tests/hooks/block-secrets-write.bats
@@ -735,7 +735,7 @@ assert_allowed() {
   assert_allowed
 }
 
-@test "a quoted short value in .env.example is allowed" {
+@test "a short value in .env.example is allowed through Edit too" {
   run_hook_edit_path '.env.example' "$(printf 'SESSION_SECRET=%s\n' '"local"')"
   assert_allowed
 }


### PR DESCRIPTION
Two hygiene findings from PR #1070's round-5 audit that shipped unaddressed. Neither affects behavior. Both live on `code-audit-maintainer-shell`-owned paths, so taking them together pays that member's re-dispatch and the hooks bats run once instead of twice.

## 1. An inert `trim_value` on the `.env.example` arm

The exemption arm passed its value through `trim_value` before the shape test. Trimming removes only surrounding whitespace and one matched quote pair, all non-alphanumeric and all at the ends, while `secret_shaped` reads `[A-Za-z0-9]{13,}` runs. The call can neither lengthen a run nor merge two, so it cannot change the verdict.

Verified two ways before the edit: at the function level from the two definitions, and by a differential probe over 34 quoted, whitespace-padded, mismatched-quote, and boundary-length values, which reports no verdict difference between the trimmed and untrimmed forms.

The call goes. A comment records why this arm does not trim where the general path must, so the asymmetry does not read as an oversight worth "fixing" later. The general-path call is untouched.

## 2. A test whose name does not describe what it pins

The Edit-path coverage for that arm was named "a quoted short value in .env.example is allowed". It calls `run_hook_edit_path`, so its real coverage is the Edit tool, not the quoting. The quoting kills no mutant, and the allowlist-vs-shape content duplicates the preceding test, so the name invited a future reader to trim an apparent duplicate and silently retire the Edit path.

Renamed to match the phrasing its siblings already use. Rename only; the body is unchanged.

The recurring defect class across all five of #1070's audit rounds was tests that pass for a different reason than their name gives. This is one more instance.

## Gates

- `pnpm typecheck`, `pnpm lint`: clean
- `bash .gaia/scripts/bats5.sh .gaia/tests/hooks/`: **1205 ok, 0 not ok**, unchanged from `main`, so the rename retired nothing
- `bash .gaia/tests/concurrency/meter-gate.sh`: 23 / 23, every scenario matches
- `bash .gaia/tests/shell-lint.sh`: passed

`check-hook-scope-manifest.sh` is not owed; the diff does not touch `.gaia/hook-scopes.json`.

No CHANGELOG entry: a comment-only edit plus a test-only rename in release-excluded `.gaia/tests/`, with no adopter-visible behavior change.
