### PR TITLE
debt(ci): the PyYAML precondition is a guard, not a comment (#1093)

### DIFF
--- a/.gaia/scripts/tests/retrigger-reachability.bats
+++ b/.gaia/scripts/tests/retrigger-reachability.bats
@@ -158,20 +158,34 @@ workflow_for_context() {
 # that makes the parser worth it everywhere else. `workflow_for_context` matches
 # a job's `    name: <ctx>` at exactly four spaces; `workflow_for_name` and the
 # retrigger-listing test read a workflow's top-level `name:` with sed; and the
-# dispatch-trigger test greps `^  workflow_dispatch:`. A quoted, inline-list, or
-# differently-indented spelling defeats each of them. All four fail CLOSED: the
-# read comes back empty or unmatched and its caller reports a named gap rather
-# than skipping the workflow, so a narrow scrape costs a false alarm here, never
-# the false green a silent drop-out would cost. Parsing buys nothing these four
-# do not already have.
+# dispatch-trigger test greps `^  workflow_dispatch:`. A quoted or
+# differently-indented spelling defeats the three `name:` reads, whose value is a
+# scalar in every legal YAML shape, so no flow sequence reaches them; an inline
+# `on: [push, workflow_dispatch]` is what defeats the trigger grep. All four fail
+# CLOSED: the read comes back empty or unmatched, and the context is named as a
+# gap by the test that owns that report. For `workflow_for_context` that is the
+# dispatch-trigger test in section 1 below; its other three loops `continue` past
+# an unresolved context precisely because section 1 already reports it. So a
+# narrow scrape costs a false alarm here, never the false green a silent drop-out
+# would cost. Parsing buys nothing these four do not already have.
 # ---------------------------------------------------------------------------
 
 # Gate only the tests that parse YAML, so the REQUIRED_CONTEXTS tests still run
-# where PyYAML is absent. CI installs python3-yaml (audit-ci-tests.yml), so the
-# authoritative gate always parses. Matches .gaia/tests/lib/lint-yaml.bats.
+# where PyYAML is absent. On CI the parser is a precondition rather than a maybe:
+# audit-ci-tests.yml installs python3-yaml in the same job that runs this suite.
+# So the CI branch FAILS instead of skipping. A skip reports `ok ... # skip` and
+# greens the job, so a runner that lost that install would retire the 15
+# parser-gated tests below in silence -- the hollow-guard failure the rest of
+# this file exists to catch, turned on the file itself. Section 0 below proves
+# this branch fires. Matches .gaia/tests/lib/lint-yaml.bats, whose own gate also
+# accepts a `yq` fallback this one has no equivalent of.
 require_yaml_parser() {
   if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
     return 0
+  fi
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::error::no YAML parser (python3 + PyYAML) on a CI runner; the parser-gated tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
+    return 1
   fi
   skip "no YAML parser available (python3 + PyYAML)"
 }
@@ -451,6 +465,46 @@ poller_window_minutes() {
       exit
     }
   ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 0. The parser gate itself. Every parsing test below routes through
+#    `require_yaml_parser`, which makes that one function the single point where
+#    all 15 of them can be turned off at once. On a CI runner it has to FAIL
+#    rather than skip, and nothing else in this file would notice if it stopped:
+#    weakening it back to a skip would red nothing, and a runner that lost its
+#    python3-yaml install would report `ok ... # skip` fifteen times and green
+#    the job. This test is what makes that weakening red. It is deliberately not
+#    parser-gated itself.
+# ---------------------------------------------------------------------------
+
+@test "the parser gate fails on a CI runner and still skips off CI" {
+  local shim="$BATS_TMPDIR/retrigger-no-parser" rc
+  mkdir -p "$shim"
+  # python3 present, but its `import yaml` fails: the shape a runner takes when
+  # python3-yaml is dropped from the apt line, not one where python3 is missing
+  # outright. The shebang is absolute so the stripped PATH below cannot affect it.
+  printf '#!/bin/sh\nexit 1\n' > "$shim/python3"
+  chmod +x "$shim/python3"
+
+  # The shim ALONE is a sufficient PATH: the gate runs no command other than
+  # `command -v python3` and that python3. Calling the gate in a subshell is what
+  # keeps its `skip` arm from marking this test skipped -- bats' `skip` exits 0,
+  # so the subshell's status is exactly the discriminator wanted here: non-zero
+  # is the CI failure, 0 is the off-CI skip.
+  rc=0
+  ( PATH="$shim" GITHUB_ACTIONS=true; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner with no YAML parser; 15 tests would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( PATH="$shim"; unset GITHUB_ACTIONS; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI, where a missing parser must still skip" >&2
+    return 1
+  }
 }
 
 # ---------------------------------------------------------------------------

--- a/.gaia/scripts/tests/retrigger-reachability.bats
+++ b/.gaia/scripts/tests/retrigger-reachability.bats
@@ -184,7 +184,10 @@ require_yaml_parser() {
     return 0
   fi
   if [ -n "${GITHUB_ACTIONS:-}" ]; then
-    echo "::error::no YAML parser (python3 + PyYAML) on a CI runner; the parser-gated tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
+    # No `::error::` prefix: bats prints a test's stderr prefixed with `# `, and
+    # Actions parses a workflow command only at column 0, so the annotation that
+    # spelling promises would never render. The `return 1` is what gates.
+    echo "no YAML parser (python3 + PyYAML) on a CI runner; the parser-gated tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
     return 1
   fi
   skip "no YAML parser available (python3 + PyYAML)"

--- a/.gaia/tests/lib/lint-yaml.bats
+++ b/.gaia/tests/lib/lint-yaml.bats
@@ -48,7 +48,10 @@ require_yaml_parser() {
     return 0
   fi
   if [ -n "${GITHUB_ACTIONS:-}" ]; then
-    echo "::error::no YAML parser (python3+pyyaml or yq) on a CI runner; the parse-fail tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
+    # No `::error::` prefix: bats prints a test's stderr prefixed with `# `, and
+    # Actions parses a workflow command only at column 0, so the annotation that
+    # spelling promises would never render. The `return 1` is what gates.
+    echo "no YAML parser (python3+pyyaml or yq) on a CI runner; the parse-fail tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
     return 1
   fi
   skip "no YAML parser available (python3+pyyaml or yq); lint.sh skips the parse check"

--- a/.gaia/tests/lib/lint-yaml.bats
+++ b/.gaia/tests/lib/lint-yaml.bats
@@ -33,6 +33,13 @@ assert_all_required_keys_present() {
 # check is best-effort: with neither python3+pyyaml nor yq present it skips
 # the check silently, so the hazard fixtures below lint clean and would fail
 # these tests spuriously. Detection mirrors lint.sh (python3+pyyaml, then yq).
+#
+# On CI the parser is a precondition rather than a maybe: audit-ci-tests.yml
+# installs python3-yaml in the same job that runs this suite. So the CI branch
+# FAILS instead of skipping. A skip reports `ok ... # skip` and greens the job,
+# which would retire every parse-fail test below in silence. The test directly
+# after this one proves that branch fires. Matches the same-named gate in
+# .gaia/scripts/tests/retrigger-reachability.bats, which has no yq fallback.
 require_yaml_parser() {
   if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
     return 0
@@ -40,7 +47,45 @@ require_yaml_parser() {
   if command -v yq >/dev/null 2>&1; then
     return 0
   fi
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::error::no YAML parser (python3+pyyaml or yq) on a CI runner; the parse-fail tests here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
+    return 1
+  fi
   skip "no YAML parser available (python3+pyyaml or yq); lint.sh skips the parse check"
+}
+
+# The gate above is the single point where every parse-fail test below can be
+# turned off at once, and nothing else in this file would notice if it started
+# skipping on CI. This is what makes that weakening red. Not itself gated.
+@test "the parser gate fails on a CI runner and still skips off CI" {
+  local shim="$BATS_TMPDIR/lint-yaml-no-parser" rc
+  mkdir -p "$shim"
+  # python3 present, but its `import yaml` fails: the shape a runner takes when
+  # python3-yaml is dropped from the apt line, not one where python3 is missing
+  # outright. The shebang is absolute so the stripped PATH below cannot affect it.
+  printf '#!/bin/sh\nexit 1\n' > "$shim/python3"
+  chmod +x "$shim/python3"
+
+  # The shim ALONE is a sufficient PATH, and here it is also load-bearing: the
+  # gate runs no command other than `command -v python3`, that python3, and
+  # `command -v yq`, so a PATH holding only the shim is what puts the yq fallback
+  # out of reach on a host that has yq installed. Calling the gate in a subshell
+  # keeps its `skip` arm from marking this test skipped -- bats' `skip` exits 0,
+  # so the subshell's status is the discriminator: non-zero is the CI failure,
+  # 0 is the off-CI skip.
+  rc=0
+  ( PATH="$shim" GITHUB_ACTIONS=true; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner with no YAML parser; the parse-fail tests would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( PATH="$shim"; unset GITHUB_ACTIONS; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI, where a missing parser must still skip" >&2
+    return 1
+  }
 }
 
 @test "valid GAIA frontmatter lints clean, no yaml_parse_error" {

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -348,12 +348,14 @@ jobs:
               - '**/*.yaml'
       # python3-yaml pins the parser (python3+pyyaml) that every
       # `require_yaml_parser` gate on this runner needs. Two suites carry one:
-      # lint-yaml.bats, and retrigger-reachability.bats, which gates 15 of its 21
-      # tests behind it. Both gates `skip`, and a skip reports GREEN, so dropping
-      # this package reds nothing; it silently retires every parser-backed
-      # assertion in both suites, including the whole self-heal reachability
-      # invariant. Pin it here rather than resting on whatever the runner image
-      # happens to preinstall.
+      # retrigger-reachability.bats, which gates 15 of its 22 tests behind it and
+      # has no fallback, and lint-yaml.bats, whose gate also accepts `yq`, so on a
+      # runner carrying yq that suite still parses. Both gates FAIL rather than
+      # `skip` when GITHUB_ACTIONS is set, precisely so dropping this package reds
+      # the run here instead of retiring the whole self-heal reachability
+      # invariant behind `ok ... # skip`. Those two gates are what enforce this
+      # line; this comment only explains it. Pin the package here rather than
+      # resting on whatever the runner image happens to preinstall.
       # Admits `sandbox` as well as `code`, so a PR that arms only that output
       # still gets bats on the box. This is what puts bats there deterministically:
       # ubuntu-latest does not preinstall it. run-all.sh does carry an


### PR DESCRIPTION
`audit-ci-tests.yml` installs `python3-yaml`, and nothing asserted it was there. Both bats suites that parse YAML gate those tests behind a `require_yaml_parser` that calls `skip`, and a skip reports **GREEN**: `retrigger-reachability.bats` gated 15 of its tests that way, including the entire self-heal re-trigger reachability invariant. Trimming the package from the apt line would have red nothing while silently retiring all 15. A comment on that line was the only thing standing between that edit and the loss.

Issue #1093 offered two fixes and asked for a pick. This takes the **stronger** one.

## Why the stronger form

1. **The narrow one cannot be proven to fire.** It is a line in a workflow no bats suite exercises, so it could not be mutated and watched go red, which `.claude/rules/pr-merge.md` requires of any guard added here.
2. **It closes the class, not the instance.** The narrow assertion fires only for a trim of that one apt token; this also fires when a *new* job or workflow runs these suites without a parser, which is the same hollow-guard failure one level up.
3. It lives with the thing being hollowed.

## What changed

Both gates now **fail** rather than skip when `GITHUB_ACTIONS` is set. Off CI they still skip, so a local run without a parser is unchanged.

Each gate carries a test driving it through **both** branches behind a stripped `PATH` and a `python3` whose `import yaml` fails. In `lint-yaml.bats` the stripped `PATH` is load-bearing rather than incidental: it is what puts that gate's `yq` fallback out of reach on a host that has `yq`.

Also corrects the three comment inaccuracies the issue bundles (items 2-4): the claim that both gates skip, the fail-closed rationale (stated per-caller, true at one of four `workflow_for_context` call sites), and which spelling defeats which line-oriented read.

## Safety

The install step's `if:` (`code || sandbox || workflow_dispatch`) is a strict superset of every suite step's (`code || workflow_dispatch`), so the new failure branch can only fire when the parser is genuinely absent, never on a job that legitimately skipped the install. `cli-tests.yml` runs only `region-marker-conformance.bats`, which reaches neither gate.

## Verification

Every check below ran after the last edit, prose included.

| Check | Result | Baseline |
|---|---|---|
| `retrigger-reachability.bats` | 22 ok, 0 fail | 21 |
| `.gaia/scripts/tests/` | 1148 ok, 0 fail | 1147 |
| `.gaia/tests/hooks/` | 1235 ok, 0 fail | 1235 |
| `.gaia/tests/lib/` | 361 ok, 0 fail | 360 |
| `shell-lint.sh` | passed | passed |
| `distribution/run-all.sh` | 17/17 | 17/17 |

**Mutation proofs** (guard's own logic mutated, one mechanism at a time, each restored):

- `retrigger` gate, CI branch back to `skip` -> red, "the gate skipped on a CI runner..."
- `retrigger` gate, `GITHUB_ACTIONS` condition dropped -> red, "the gate failed off CI..."
- `lint-yaml` gate, same two -> red, same two messages
- `lint-yaml` test, stripped `PATH` -> inherited `PATH`, with a `yq` supplied -> red, proving the `yq` fallback is genuinely out of reach

No CHANGELOG entry: all three files are release-excluded (`.gaia/release-exclude` lines 88, 89, 195), so nothing adopter-facing changes.

Closes #1093