### PR TITLE
debt(ci): two more bats setup() gates fail closed on CI (#1095)

### DIFF
--- a/.gaia/scripts/tests/retrigger-reachability.bats
+++ b/.gaia/scripts/tests/retrigger-reachability.bats
@@ -43,6 +43,39 @@
 # second, malformed directive (SC1073) and fails the lint outright.
 # shellcheck disable=SC2030,SC2031
 
+# require_repo_path <test-flag> <path> <label>
+#
+# The three paths this suite reads are preconditions on CI, not maybes: the job
+# that runs it checks the repo out whole, so an absent path there means one of
+# them was renamed and this guard silently stopped guarding, or the job is
+# misconfigured. So the CI branch FAILS instead of skipping, for the same reason
+# `require_yaml_parser` below does: a skip reports `ok ... # skip` and greens the
+# job, which would retire every test in this file including the section-0 gate
+# that exists to stop exactly that. Only one of the three has a backstop that
+# reds loudly on its own (verify-required-checks.yml invokes
+# verify-required-checks.sh by path); this arm is what covers the other two.
+# Off CI the skip stands: a checkout that legitimately lacks these paths is not
+# the environment the guard is making a claim about. Section 0 proves the CI
+# branch fires.
+require_repo_path() {
+  local flag="$1" path="$2" label="$3"
+  # `test` rather than `[ ]`: shellcheck parses a bracket test's operator
+  # statically and rejects one held in a variable (SC1073/SC1072), while the
+  # `test` builtin it does not try to parse resolves the flag at runtime, which
+  # is what lets one helper serve both the -d and the -f preconditions.
+  if test "$flag" "$path"; then
+    return 0
+  fi
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # No `::error::` prefix: bats prints a test's stderr prefixed with `# `, and
+    # Actions parses a workflow command only at column 0, so the annotation that
+    # spelling promises would never render. The `return 1` is what gates.
+    echo "$label not present on a CI runner; every test here would skip to green. If it moved, update this suite's paths in setup()." >&2
+    return 1
+  fi
+  skip "$label not present"
+}
+
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
@@ -58,9 +91,12 @@ setup() {
   # per run would price a two-job chain the same as a single job and leave the
   # second hop's wait uncovered.
   POLLER_MARGIN_MIN=5
-  [ -d "$WORKFLOWS_DIR" ] || skip ".github/workflows not present"
-  [ -f "$VERIFY" ] || skip "verify-required-checks.sh not present"
-  [ -f "$READ_CONFIG" ] || skip "read-audit-ci-config.sh not present"
+  # `|| return 1` on each: only the last of the three is setup()'s final command,
+  # so the first two would otherwise lean on `set -e` to propagate. The skip arm
+  # exits 0 from inside the helper, so this only ever forwards the CI failure.
+  require_repo_path -d "$WORKFLOWS_DIR" ".github/workflows" || return 1
+  require_repo_path -f "$VERIFY" "verify-required-checks.sh" || return 1
+  require_repo_path -f "$READ_CONFIG" "read-audit-ci-config.sh" || return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -471,18 +507,21 @@ poller_window_minutes() {
 }
 
 # ---------------------------------------------------------------------------
-# 0. The parser gate itself. Every parsing test below routes through
-#    `require_yaml_parser`, which makes that one function the single point where
-#    all 15 of them can be turned off at once. On a CI runner it has to FAIL
-#    rather than skip, and nothing else in this file would notice if it stopped:
-#    weakening it back to a skip would red nothing, and a runner that lost its
-#    python3-yaml install would report `ok ... # skip` fifteen times and green
-#    the job. This test is what makes that weakening red. It is deliberately not
-#    parser-gated itself.
+# 0. This suite's own two gates. Each is a single point where a whole population
+#    of tests below can be turned off at once, and on a CI runner each has to
+#    FAIL rather than skip. Nothing else in this file would notice if either
+#    stopped: weakening one back to a bare `skip` would red nothing, and the
+#    affected tests would report `ok ... # skip` and green the job. These two
+#    tests are what make that weakening red. Neither is parser-gated itself.
+#
+#    `require_yaml_parser` gates the 15 parsing tests; `require_repo_path` gates
+#    setup(), so every test in the file. That second one covers a gate its own
+#    test cannot escape, since setup() runs first here as it does everywhere: what
+#    the test catches is the weakening, not the condition.
 # ---------------------------------------------------------------------------
 
 @test "the parser gate fails on a CI runner and still skips off CI" {
-  local shim="$BATS_TMPDIR/retrigger-no-parser" rc
+  local shim="$BATS_TEST_TMPDIR/retrigger-no-parser" rc
   mkdir -p "$shim"
   # python3 present, but its `import yaml` fails: the shape a runner takes when
   # python3-yaml is dropped from the apt line, not one where python3 is missing
@@ -508,6 +547,45 @@ poller_window_minutes() {
     echo "the gate failed off CI, where a missing parser must still skip" >&2
     return 1
   }
+}
+
+# Both arms of the gate for one (flag, path) that must not satisfy it. Calling the
+# gate in a subshell is what keeps its `skip` arm from marking the caller skipped --
+# bats' `skip` exits 0, so the subshell's status is exactly the discriminator wanted
+# here: non-zero is the CI failure, 0 is the off-CI skip.
+assert_repo_path_gate() {
+  local flag="$1" path="$2" rc
+
+  rc=0
+  ( GITHUB_ACTIONS=true; require_repo_path "$flag" "$path" "a renamed path" ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner for '$flag $path'; every test here would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( unset GITHUB_ACTIONS; require_repo_path "$flag" "$path" "a renamed path" ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI for '$flag $path', where an unsatisfied precondition must still skip" >&2
+    return 1
+  }
+}
+
+@test "the path precondition gate fails on a CI runner and still skips off CI" {
+  mkdir -p "$BATS_TEST_TMPDIR/a-dir"
+  : > "$BATS_TEST_TMPDIR/a-file"
+
+  # Absent by construction: $BATS_TEST_TMPDIR is created empty for this test and
+  # nothing puts `renamed-away` in it. Both flags, because setup() gates a
+  # directory with -d and two scripts with -f.
+  assert_repo_path_gate -d "$BATS_TEST_TMPDIR/renamed-away" || return 1
+  assert_repo_path_gate -f "$BATS_TEST_TMPDIR/renamed-away" || return 1
+
+  # Present but the wrong type. This pair is what pins the runtime flag: a gate
+  # that ignored it and asked only whether the path exists would pass both of
+  # these and prove nothing about the -d/-f distinction setup() relies on.
+  assert_repo_path_gate -f "$BATS_TEST_TMPDIR/a-dir" || return 1
+  assert_repo_path_gate -d "$BATS_TEST_TMPDIR/a-file"
 }
 
 # ---------------------------------------------------------------------------

--- a/.gaia/scripts/tests/retrigger-reachability.bats
+++ b/.gaia/scripts/tests/retrigger-reachability.bats
@@ -514,10 +514,15 @@ poller_window_minutes() {
 #    affected tests would report `ok ... # skip` and green the job. These two
 #    tests are what make that weakening red. Neither is parser-gated itself.
 #
-#    `require_yaml_parser` gates the 15 parsing tests; `require_repo_path` gates
-#    setup(), so every test in the file. That second one covers a gate its own
+#    `require_yaml_parser` gates the 15 parsing tests. `require_repo_path` gates
+#    setup(), so every test in the file, and the five tests that additionally read
+#    code-review-audit.yml call it again for that path. It covers a gate its own
 #    test cannot escape, since setup() runs first here as it does everywhere: what
 #    the test catches is the weakening, not the condition.
+#
+#    Between them these two are the only place this file stands a test down. A
+#    bare `skip` anywhere else would be a third gate reporting `ok ... # skip`
+#    with nothing watching it.
 # ---------------------------------------------------------------------------
 
 @test "the parser gate fails on a CI runner and still skips off CI" {
@@ -824,7 +829,7 @@ workflow_timeout_gaps() {
   local window names wf gaps
 
   require_yaml_parser
-  [ -f "$AUDIT_WORKFLOW" ] || skip "code-review-audit.yml not present"
+  require_repo_path -f "$AUDIT_WORKFLOW" "code-review-audit.yml" || return 1
 
   window="$(poller_window_minutes "$AUDIT_WORKFLOW")"
   [ -n "$window" ] || {
@@ -1103,7 +1108,7 @@ YAML
   local window ceiling subject cap
 
   require_yaml_parser
-  [ -f "$AUDIT_WORKFLOW" ] || skip "code-review-audit.yml not present"
+  require_repo_path -f "$AUDIT_WORKFLOW" "code-review-audit.yml" || return 1
   mkdir -p "$sb"
   cp "$WORKFLOWS_DIR"/*.yml "$sb/"
 
@@ -1338,7 +1343,7 @@ write_chain_fixture() {
   local spelling subject path minutes hops window ceiling
 
   require_yaml_parser
-  [ -f "$AUDIT_WORKFLOW" ] || skip "code-review-audit.yml not present"
+  require_repo_path -f "$AUDIT_WORKFLOW" "code-review-audit.yml" || return 1
   mkdir -p "$sb"
 
   window="$(poller_window_minutes "$AUDIT_WORKFLOW")"
@@ -1387,7 +1392,7 @@ write_chain_fixture() {
   local subject path minutes hops window flat ceiling
 
   require_yaml_parser
-  [ -f "$AUDIT_WORKFLOW" ] || skip "code-review-audit.yml not present"
+  require_repo_path -f "$AUDIT_WORKFLOW" "code-review-audit.yml" || return 1
   mkdir -p "$sb"
 
   window="$(poller_window_minutes "$AUDIT_WORKFLOW")"
@@ -1465,7 +1470,7 @@ YAML
   local subject path minutes hops window ceiling
 
   require_yaml_parser
-  [ -f "$AUDIT_WORKFLOW" ] || skip "code-review-audit.yml not present"
+  require_repo_path -f "$AUDIT_WORKFLOW" "code-review-audit.yml" || return 1
   mkdir -p "$sb"
 
   window="$(poller_window_minutes "$AUDIT_WORKFLOW")"

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -17,13 +17,37 @@
 # absence checks use a positive match for the bad case plus an explicit
 # `return 1`, never `!`-negation.
 
+# The hook parses YAML with python3 + PyYAML and fails open without it, so every
+# assertion in this file depends on the parser being present. On CI that parser is
+# a precondition rather than a maybe: audit-ci-tests.yml installs python3-yaml in
+# the same job that runs this suite. So the CI branch FAILS instead of skipping. A
+# skip reports `ok ... # skip` and greens the job, so a runner that lost that
+# install would retire every test in this file in silence, the hollow guard this
+# suite exists to prevent on the hook, turned on the suite itself. The gate test in
+# the first section below proves this branch fires. Matches the same-shaped gates in
+# .gaia/scripts/tests/retrigger-reachability.bats and .gaia/tests/lib/lint-yaml.bats.
+require_yaml_parser() {
+  if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # No `::error::` prefix: bats prints a test's stderr prefixed with `# `, and
+    # Actions parses a workflow command only at column 0, so the annotation that
+    # spelling promises would never render. The `return 1` is what gates.
+    echo "no YAML parser (python3 + PyYAML) on a CI runner; every test here would skip to green. Check the apt install in .github/workflows/audit-ci-tests.yml." >&2
+    return 1
+  fi
+  skip "python3 with pyyaml not available"
+}
+
+# `require_yaml_parser` is setup()'s last command, so its status is setup()'s: the
+# CI branch's `return 1` fails each test individually and attaches its message,
+# rather than aborting the run.
 setup() {
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-invalid-yaml-write.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
-  if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import yaml' >/dev/null 2>&1; then
-    skip "python3 with pyyaml not available"
-  fi
+  require_yaml_parser
 }
 
 teardown() {
@@ -69,6 +93,46 @@ assert_allowed() {
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
   return 0
+}
+
+# --- the parser gate itself ---
+#
+# setup() routes every test in this file through `require_yaml_parser`, which makes
+# that one function the single point where all of them can be turned off at once. On
+# a CI runner it has to FAIL rather than skip, and nothing else here would notice if
+# it stopped: weakening it back to a bare `skip` would red nothing, and a runner that
+# lost its python3-yaml install would report `ok ... # skip` for every test and green
+# the job. This test is what makes that weakening red. It runs through setup() like
+# every other test here, so it cannot escape the gate it covers: what it catches is
+# the weakening, not the condition.
+
+@test "the parser gate fails on a CI runner and still skips off CI" {
+  local shim="$BATS_TEST_TMPDIR/yaml-write-no-parser" rc
+  mkdir -p "$shim"
+  # python3 present, but its `import yaml` fails: the shape a runner takes when
+  # python3-yaml is dropped from the apt line, not one where python3 is missing
+  # outright. The shebang is absolute so the stripped PATH below cannot affect it.
+  printf '#!/bin/sh\nexit 1\n' > "$shim/python3"
+  chmod +x "$shim/python3"
+
+  # The shim ALONE is a sufficient PATH: the gate runs no command other than
+  # `command -v python3` and that python3. Calling the gate in a subshell is what
+  # keeps its `skip` arm from marking this test skipped -- bats' `skip` exits 0,
+  # so the subshell's status is exactly the discriminator wanted here: non-zero
+  # is the CI failure, 0 is the off-CI skip.
+  rc=0
+  ( PATH="$shim" GITHUB_ACTIONS=true; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner with no YAML parser; every test here would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( PATH="$shim"; unset GITHUB_ACTIONS; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI, where a missing parser must still skip" >&2
+    return 1
+  }
 }
 
 # --- denied: Write with a genuine YAML parse error ---

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -347,15 +347,18 @@ jobs:
               - '**/*.yml'
               - '**/*.yaml'
       # python3-yaml pins the parser (python3+pyyaml) that every
-      # `require_yaml_parser` gate on this runner needs. Two suites carry one:
-      # retrigger-reachability.bats, which gates 15 of its 22 tests behind it and
-      # has no fallback, and lint-yaml.bats, whose gate also accepts `yq`, so on a
-      # runner carrying yq that suite still parses. Both gates FAIL rather than
-      # `skip` when GITHUB_ACTIONS is set, precisely so dropping this package reds
-      # the run here instead of retiring the whole self-heal reachability
-      # invariant behind `ok ... # skip`. Those two gates are what enforce this
-      # line; this comment only explains it. Pin the package here rather than
-      # resting on whatever the runner image happens to preinstall.
+      # `require_yaml_parser` gate on this runner needs. Three suites carry one:
+      # block-invalid-yaml-write.bats, whose gate sits in setup() and so covers
+      # all of its tests with no fallback; retrigger-reachability.bats, which
+      # gates 15 of its tests behind it, also with no fallback; and
+      # lint-yaml.bats, whose gate also accepts `yq`, so on a runner carrying yq
+      # that suite still parses. All three FAIL rather than `skip` when
+      # GITHUB_ACTIONS is set, precisely so dropping this package reds the run
+      # here instead of retiring the whole self-heal reachability invariant, and
+      # the YAML-write hook's coverage, behind `ok ... # skip`. Those gates are
+      # what enforce this line; this comment only explains it. Pin the package
+      # here rather than resting on whatever the runner image happens to
+      # preinstall.
       # Admits `sandbox` as well as `code`, so a PR that arms only that output
       # still gets bats on the box. This is what puts bats there deterministically:
       # ubuntu-latest does not preinstall it. run-all.sh does carry an


### PR DESCRIPTION
Closes #1095

A bats `skip` reports `ok ... # skip`, so a suite whose `setup()` skips retires every one of its tests while the required check stays green. Two gates still took that shape; both now fail on a CI runner and still skip off it.

## What changed

**`.gaia/tests/hooks/block-invalid-yaml-write.bats`** skipped all 20 tests when python3 + PyYAML was absent, in the same job and behind the same `python3-yaml` apt package as the suites already hardened. The gate moves into `require_yaml_parser` (the shape already merged in `retrigger-reachability.bats` and `lint-yaml.bats`) so a test can drive it, and `setup()` calls it as its last command, which makes the CI arm's `return 1` setup()'s own status.

**`.gaia/scripts/tests/retrigger-reachability.bats`** skipped all 22 tests when any of `.github/workflows`, `verify-required-checks.sh`, or `read-audit-ci-config.sh` was renamed, including the section-0 gate that exists to stop this file being switched off silently. The three preconditions move into `require_repo_path`.

**The decision the issue carries** was fail-close on CI versus document the backstop. Fail-close, for two reasons. Only one of the three paths has the loud backstop (`verify-required-checks.yml` invokes `verify-required-checks.sh` by path); the other two have none, so a comment would document a guarantee that covers one case in three. And the suite argues against skip-to-green everywhere else in the file, so leaving its own preconditions on that shape is the inconsistency, not the fix.

**Item 3**, one line: the parser-gate shim moves to the per-test-private `$BATS_TEST_TMPDIR`, the convention this file's other 16 temp paths already follow. Per the issue, `lint-yaml.bats:64` is deliberately left alone: `$BATS_TMPDIR` is that file's own convention for all five of its temp paths.

## Proving the gates

Each gate gets a section-0 test, and each was mutated on its own before dispatch. Every mutant below reds its test; all restored.

| Mutant | Result |
| --- | --- |
| yaml gate: CI arm deleted (falls through to `skip`) | red |
| yaml gate: off-CI `skip` turned into `return 1` | red |
| yaml gate: `import yaml` term dropped from the formula | red |
| path gate: CI arm deleted | red |
| path gate: off-CI `skip` turned into `return 1` | red |
| path gate: runtime flag ignored (`test -e` instead of `test "$flag"`) | red |
| path gate: precondition always satisfied (`if true`) | red |

The `test -e` mutant survived the first version of the path-gate test, which only exercised absent paths. The test now also asserts a present-but-wrong-type path (`-f` on a directory, `-d` on a file), which is what pins the runtime flag.

End-to-end, on the real wiring rather than the helper alone:

- `retrigger-reachability.bats` copied into a tree with no `.github/workflows`: `GITHUB_ACTIONS=true` gives 23 not ok / 0 skipped; off CI gives 23 skipped.
- `block-invalid-yaml-write.bats` under a PATH shim whose `python3 -c 'import yaml'` exits 1: `GITHUB_ACTIONS=true` gives 21 not ok / 0 skipped; off CI gives 21 skipped.

## Verification

Green after the last edit, prose included:

- `.gaia/scripts/tests/` 1149 ok, 0 not ok (the one skip is a pre-existing `flock not installed` case)
- `.gaia/tests/hooks/` 1236 ok, 0 not ok
- `.gaia/tests/lib/` 361 ok, 0 not ok (untouched)
- `.gaia/tests/shell-lint.sh` passed
- `.gaia/tests/distribution/run-all.sh` 17/17

`require_repo_path` uses the `test` builtin rather than `[ ]`: shellcheck parses a bracket test's operator statically and rejects one held in a variable (SC1073/SC1072), which is what shell-lint caught on the first version.

Quality Gate does not apply, the staged set is two `.bats` files (pre-commit confirmed `No changed files -- skipping lint-staged`).

## Noted, not changed

The last three tests in `block-invalid-yaml-write.bats` are structural (hook is executable, `settings.json` is valid JSON, the matcher is registered) and need no YAML parser, but `setup()` gates them along with everything else. Narrowing the gate to the tests that parse would touch all 20 and is outside what this issue asks for.

## Audit rounds

Three rounds, all clean, no Critical or Important at any point.

1. `code-audit-maintainer-shell` on the two bats files. Clean, plus one Suggestion: five in-test `[ -f "$AUDIT_WORKFLOW" ] || skip` guards in `retrigger-reachability.bats` kept the old shape. **Applied**, same class and same file as the issue, and routing them through the helper is what makes the section-0 header's claim about the file's gates true.
2. `code-audit-maintainer-shell` on the widened change. Clean, plus a cross-remit finding: `audit-ci-tests.yml`'s comment justifying the `python3-yaml` pin enumerated two dependent suites and this PR makes it three. **Applied**, since this PR is what made the comment wrong.
3. `code-audit-github-workflows` on the workflow comment. Clean.

Two Suggestions **declined**, both cosmetic with no failure mode, and both would buy a full member re-dispatch on already-marked content:

- `require_repo_path`'s single message says "every test here", exact for the three `setup()` calls and overstated at the five in-test ones. The actionable clause is correct at all eight sites, and one shared message beats a fourth parameter. The reporting auditor said the same.
- Dropping the literal `15` from the `audit-ci-tests.yml` comment as a count that can go stale. Fair, but pre-existing rather than introduced here, and the pin's rationale holds whatever the count is.