### PR TITLE
feat(audit): measure the audit re-spawn before re-keying the marker

### DIFF
--- a/.claude/hooks/wiki-session-start.sh
+++ b/.claude/hooks/wiki-session-start.sh
@@ -13,4 +13,10 @@ git rev-parse HEAD > "$GIT_DIR/claude-session-start" 2>/dev/null || true
 # blocks the session. See local-janitor.sh for the provable-death contract.
 [ -f .claude/hooks/local-janitor.sh ] && bash .claude/hooks/local-janitor.sh || true
 
+# Bounded prune of the Code Audit Team re-spawn breadcrumb ledger: age-drops
+# records past the retention window and caps the file's line count. Side-effect
+# only; never blocks the session. Absent on a clone that does not carry the
+# spawn oracle, where the guard makes it a no-op.
+[ -f .gaia/scripts/audit-respawn-prune.sh ] && bash .gaia/scripts/audit-respawn-prune.sh || true
+
 exit 0

--- a/.claude/hooks/wiki-session-start.sh
+++ b/.claude/hooks/wiki-session-start.sh
@@ -13,10 +13,13 @@ git rev-parse HEAD > "$GIT_DIR/claude-session-start" 2>/dev/null || true
 # blocks the session. See local-janitor.sh for the provable-death contract.
 [ -f .claude/hooks/local-janitor.sh ] && bash .claude/hooks/local-janitor.sh || true
 
+# gaia:maintainer-only:start
 # Bounded prune of the Code Audit Team re-spawn breadcrumb ledger: age-drops
 # records past the retention window and caps the file's line count. Side-effect
-# only; never blocks the session. Absent on a clone that does not carry the
-# spawn oracle, where the guard makes it a no-op.
+# only; never blocks the session. The prune script is release-excluded, so this
+# block is maintainer-only and the scrub strips it from the shipped hook; the
+# guard keeps it inert on a maintainer clone that does not carry the script.
 [ -f .gaia/scripts/audit-respawn-prune.sh ] && bash .gaia/scripts/audit-respawn-prune.sh || true
+# gaia:maintainer-only:end
 
 exit 0

--- a/.gaia/hook-scopes.json
+++ b/.gaia/hook-scopes.json
@@ -239,7 +239,7 @@
       "hook": ".claude/hooks/wiki-session-start.sh",
       "scope": "any",
       "state": [],
-      "why": "Records HEAD under the per-worktree git-dir (git rev-parse --git-dir, correct by construction, oracle G) and delegates to the already-converted local-janitor.sh; touches no .gaia/local state itself."
+      "why": "Records HEAD under the per-worktree git-dir (git rev-parse --git-dir, correct by construction, oracle G) and delegates to the already-converted local-janitor.sh and to audit-respawn-prune.sh (release-excluded, guarded on [ -f ... ] so a clone without it is a no-op); touches no .gaia/local state itself."
     },
     {
       "hook": ".claude/hooks/wiki-session-stop.sh",

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -37,6 +37,14 @@
 .claude/commands/distribution-audit.md
 # Maintainer-only Code Audit Team spawn-list optimization; adopters resolve required members via resolve-audit-members.sh and the frontend self-skip is fail-closed on its absence.
 .gaia/scripts/resolve-audit-spawn.sh
+# The re-spawn measurement instrument exists only to serve the maintainer-only
+# spawn oracle above: the shared ledger lib it writes through, the session-start
+# prune that bounds the ledger, and the attribution query that reads it. An
+# adopter clone never runs the oracle, so it never has a ledger for any of the
+# three to act on.
+.gaia/scripts/audit-respawn-lib.sh
+.gaia/scripts/audit-respawn-prune.sh
+.gaia/scripts/audit-respawn-report.sh
 # verify-required-checks.sh declares the required_status_checks the GAIA team's own
 # branch ruleset must enforce (job names like "Audit CI Tests" that only exist
 # on maintainer-only, release-excluded workflows); an adopter clone has no such

--- a/.gaia/scripts/audit-respawn-lib.sh
+++ b/.gaia/scripts/audit-respawn-lib.sh
@@ -53,12 +53,17 @@
 #   <branch>, <head>, <merge_base>, and <digest> may each be empty; an empty
 #   value emits an empty JSON string ("") -- never a placeholder.
 #
-#   Escaping: <branch> is the only free-form field. Git ref names cannot
-#   contain a backslash or an ASCII control character, so `"` is the single
-#   JSON-significant character git permits in one, escaped via bash
-#   parameter substitution. No `jq` is required to build a line, and none may
-#   be assumed: the oracle's digest-marker filter can run on a machine with
-#   no `jq`.
+#   Escaping: two fields are free-form, <branch> and <member>, and they are
+#   not escaped alike. Git ref names cannot contain a backslash or an ASCII
+#   control character, so `"` is the single JSON-significant character git
+#   permits in a <branch>. <member> comes from the hand-authored roster, which
+#   constrains no charset, so it takes a backslash pass FIRST and then the
+#   quote pass; reversing that order would re-escape the backslashes the quote
+#   pass just introduced. Do not add a second pass over either field: they are
+#   already fully escaped where the record is built, and escaping twice would
+#   double every backslash. Both use bash parameter substitution, so no `jq` is
+#   required to build a line, and none may be assumed: the oracle's
+#   digest-marker filter can run on a machine with no `jq`.
 #
 #   One `printf` produces the whole line, appended with `>>`: a single small
 #   write() under O_APPEND is what keeps concurrent appends from different

--- a/.gaia/scripts/audit-respawn-lib.sh
+++ b/.gaia/scripts/audit-respawn-lib.sh
@@ -1,0 +1,177 @@
+# shellcheck shell=bash
+#
+# GAIA shared audit re-spawn ledger helper (single-sourced).
+#
+# The Code Audit Team's spawn oracle (.gaia/scripts/resolve-audit-spawn.sh)
+# re-dispatches a member whenever its valid current-digest earned marker is
+# missing, and one cause of a missing marker is not a content change at all:
+# absorbing main rotates a member's content digest without touching the
+# three-dot diff the member actually reviews. This file is the one
+# definition of the ledger path, the record shape, and the retention knobs
+# that instrument how often that happens, shared by three consumers: the
+# writer inside the oracle, the retention sweep, and the attribution query.
+# It records what the oracle saw; it classifies nothing.
+#
+# Sourced, never executed. No side effects at source time: defines two
+# constants and functions only. Bash 3.2 compatible (macOS default: no
+# associative arrays, no `mapfile`, no `${var^^}`). Never `cd`s (per
+# .claude/rules/shell-cwd.md).
+#
+# GAIA_RESPAWN_LEDGER_REL
+#   The ledger's path relative to `<root>/.gaia/local/`.
+# GAIA_RESPAWN_SCHEMA
+#   The `schema` field's literal value on every record this file writes.
+#
+# gaia_respawn_ledger_path <root>
+#   Prints "<root>/.gaia/local/<GAIA_RESPAWN_LEDGER_REL>" and returns 0.
+#   Prints nothing and returns 1 when <root> is empty or unset. Resolves
+#   nothing and derives no root itself: <root> is the caller's already
+#   resolved repo root. A linked worktree's `.gaia/local` is one wholesale
+#   symlink to the main checkout's (.gaia/scripts/link-worktree.sh), so this
+#   reaches the single shared copy from every tree, exactly as the clearance
+#   reader (.claude/hooks/lib/audit-clearance.sh) already does for marker
+#   paths.
+#
+# gaia_respawn_record <ledger> <ts> <branch> <head> <merge_base> <member> <digest> <cleared>
+#   Appends exactly one JSON-Lines record to <ledger>, creating the parent
+#   directory if needed, keys in exactly this order:
+#     {"schema":1,"ts":"...","branch":"...","head":"...","merge_base":"...",
+#      "member":"...","digest":"...","cleared":true}
+#   ALWAYS returns 0, on every path, and ALWAYS writes nothing to stdout or
+#   stderr: the oracle's stdout is its contract, and its stderr carries
+#   advisories only, so a breadcrumb diagnostic on either would be a
+#   behavior change the oracle must not make. Its callers run under
+#   `set -euo pipefail` and must not be disturbed.
+#
+#   Silent no-op (still exit 0) when <ledger> is empty, <member> is empty,
+#   the parent directory cannot be created, or the append itself fails (an
+#   unwritable file, a <ledger> that names an existing directory).
+#
+#   <cleared> is normalized: exactly the string "true" emits the JSON
+#   boolean `true`; every other value, including empty, emits `false`.
+#
+#   <branch>, <head>, <merge_base>, and <digest> may each be empty; an empty
+#   value emits an empty JSON string ("") -- never a placeholder.
+#
+#   Escaping: <branch> is the only free-form field. Git ref names cannot
+#   contain a backslash or an ASCII control character, so `"` is the single
+#   JSON-significant character git permits in one, escaped via bash
+#   parameter substitution. No `jq` is required to build a line, and none may
+#   be assumed: the oracle's digest-marker filter can run on a machine with
+#   no `jq`.
+#
+#   One `printf` produces the whole line, appended with `>>`: a single small
+#   write() under O_APPEND is what keeps concurrent appends from different
+#   trees from interleaving mid-record. There is deliberately no lock.
+#
+# gaia_respawn_retention_days
+#   Prints the retention window in days, default-then-floor (see below):
+#   90 when $GAIA_AUDIT_RESPAWN_RETENTION_DAYS is unset, empty, or not a bare
+#   run of digits; otherwise the override, raised to 45 when below 45.
+#   Always exits 0. The 45-day floor is load-bearing: the SPEC's reopen
+#   condition is measured over at least one month of accumulated
+#   breadcrumbs, and the registry entry's `reaped_by` promises a sweep whose
+#   retention outlasts that window, so no override may shorten it below one
+#   month. Floor-clamping mirrors the janitor's existing knobs
+#   (GAIA_AUDIT_FINDINGS_RETENTION_HOURS, GAIA_CACHE_ARTIFACT_RETENTION_DAYS).
+#
+# gaia_respawn_max_records
+#   Prints the line cap, default-then-floor, same rule: 20000 when
+#   $GAIA_AUDIT_RESPAWN_MAX_RECORDS is unset, empty, or not a bare run of
+#   digits; otherwise the override, raised to 1000 when below 1000. Always
+#   exits 0. THE CAP IS SUBORDINATE TO THE AGE WINDOW: this function only
+#   reports a number, the prune sweep that consumes it may apply the cap
+#   ONLY to records already outside the age window. A cap that dropped
+#   in-window records would silently shorten retention below the observation
+#   window the reaper exists to guarantee; on a repository whose oracle runs
+#   hot enough to exceed the cap inside the window, the ledger grows past the
+#   cap rather than losing the measurement. Do not read this function as a
+#   hard file-size bound; it is not one.
+#
+# Default-then-floor, the rule both knobs above follow, in this order:
+#   1. Validate. Unset, empty, or anything that is not a bare run of digits
+#      (abc, -5, 12.5, 1e3, " 30 ") is not an override at all; the knob takes
+#      its default.
+#   2. Floor. A valid numeric override below the floor is raised to the
+#      floor.
+#   The floor only ever raises a number the caller actually supplied; it is
+#   NOT a fallback for garbage, which already resolved to the default in
+#   step 1 and is already above the floor. So
+#   GAIA_AUDIT_RESPAWN_RETENTION_DAYS=abc prints 90, not 45, and
+#   GAIA_AUDIT_RESPAWN_RETENTION_DAYS=10 prints 45.
+#
+# Usage (sourced):
+#   . .gaia/scripts/audit-respawn-lib.sh
+#   ledger="$(gaia_respawn_ledger_path "$repo_root")" || ledger=""
+#   gaia_respawn_record "$ledger" "$ts" "$branch" "$head" "$merge_base" "$member" "$digest" "$cleared"
+#   days="$(gaia_respawn_retention_days)"
+#   cap="$(gaia_respawn_max_records)"
+
+GAIA_RESPAWN_LEDGER_REL="telemetry/audit-respawn.jsonl"
+GAIA_RESPAWN_SCHEMA=1
+
+# gaia_respawn_ledger_path <root>
+gaia_respawn_ledger_path() {
+  local root="${1-}"
+  [ -n "$root" ] || return 1
+  printf '%s/.gaia/local/%s\n' "$root" "$GAIA_RESPAWN_LEDGER_REL"
+  return 0
+}
+
+# gaia_respawn_record <ledger> <ts> <branch> <head> <merge_base> <member> <digest> <cleared>
+# See the contract above. Fail-open and silent on every path.
+gaia_respawn_record() {
+  local ledger="${1-}" ts="${2-}" branch="${3-}" head="${4-}" merge_base="${5-}"
+  local member="${6-}" digest="${7-}" cleared_arg="${8-}"
+  [ -n "$ledger" ] || return 0
+  [ -n "$member" ] || return 0
+
+  local cleared="false"
+  [ "$cleared_arg" = "true" ] && cleared="true"
+
+  local dir
+  dir="$(dirname -- "$ledger" 2>/dev/null)" || return 0
+  mkdir -p -- "$dir" 2>/dev/null || return 0
+
+  # `branch` is the only free-form field; escape the one JSON-significant
+  # character git ref names can carry.
+  branch="${branch//\"/\\\"}"
+
+  # Grouped so the group's OWN `2>/dev/null` is established before the
+  # inner `>>` redirect is attempted: bash evaluates a simple command's
+  # redirections left to right, so a bare `printf ... >>"$ledger" 2>/dev/null`
+  # would still leak a failed-redirect diagnostic to the shell's stderr (the
+  # trailing `2>/dev/null` is never reached). The group's redirection applies
+  # first and catches it.
+  {
+    printf '{"schema":%s,"ts":"%s","branch":"%s","head":"%s","merge_base":"%s","member":"%s","digest":"%s","cleared":%s}\n' \
+      "$GAIA_RESPAWN_SCHEMA" "$ts" "$branch" "$head" "$merge_base" "$member" "$digest" "$cleared" >>"$ledger"
+  } 2>/dev/null || return 0
+
+  return 0
+}
+
+# _gaia_respawn_default_then_floor <value> <default> <floor>
+# The one shared implementation of the two-step rule both public knobs
+# below follow. Always exits 0.
+_gaia_respawn_default_then_floor() {
+  local v="${1-}" default="$2" floor="$3"
+  case "$v" in
+    '' | *[!0-9]*) v="$default" ;;
+  esac
+  [ "$v" -lt "$floor" ] && v="$floor"
+  printf '%s\n' "$v"
+  return 0
+}
+
+# gaia_respawn_retention_days
+gaia_respawn_retention_days() {
+  _gaia_respawn_default_then_floor "${GAIA_AUDIT_RESPAWN_RETENTION_DAYS-}" 90 45
+  return 0
+}
+
+# gaia_respawn_max_records
+gaia_respawn_max_records() {
+  _gaia_respawn_default_then_floor "${GAIA_AUDIT_RESPAWN_MAX_RECORDS-}" 20000 1000
+  return 0
+}

--- a/.gaia/scripts/audit-respawn-lib.sh
+++ b/.gaia/scripts/audit-respawn-lib.sh
@@ -142,6 +142,11 @@ gaia_respawn_record() {
   # cannot classify, so a single malformed record would live in the ledger
   # forever, defeating the one bound the sweep exists to enforce.
   branch="${branch//\"/\\\"}"
+  # Backslash first, then quote: escaping in the other order would re-escape
+  # the backslashes this line just introduced. `branch` needs no backslash pass
+  # because git ref names cannot carry one; `member` can, since the roster
+  # parser preserves whatever the file holds.
+  member="${member//\\/\\\\}"
   member="${member//\"/\\\"}"
 
   # Grouped so the group's OWN `2>/dev/null` is established before the
@@ -166,6 +171,15 @@ _gaia_respawn_default_then_floor() {
   case "$v" in
     '' | *[!0-9]*) v="$default" ;;
   esac
+  # Normalize the base before anything reads the number. `test` parses base 10
+  # while `$(( ))` reads a leading zero as octal, so an override like `050`
+  # would clear the floor compare below as 50 and then reach a consumer's
+  # arithmetic as 40, shortening the window under the floor the header promises
+  # no override can shorten. `08` and `09` are not octal at all and abort the
+  # consumer outright. `10#` settles it once, here, so the check and every
+  # caller share one base. Safe unconditionally: the case arm above has already
+  # guaranteed a non-empty bare run of digits.
+  v=$((10#$v))
   [ "$v" -lt "$floor" ] && v="$floor"
   printf '%s\n' "$v"
   return 0

--- a/.gaia/scripts/audit-respawn-lib.sh
+++ b/.gaia/scripts/audit-respawn-lib.sh
@@ -133,9 +133,16 @@ gaia_respawn_record() {
   dir="$(dirname -- "$ledger" 2>/dev/null)" || return 0
   mkdir -p -- "$dir" 2>/dev/null || return 0
 
-  # `branch` is the only free-form field; escape the one JSON-significant
-  # character git ref names can carry.
+  # Escape the one JSON-significant character these fields can carry. Git ref
+  # names cannot hold a backslash or a control character, so `"` is all that
+  # `branch` needs. `member` is not ref-shaped at all: it comes from the
+  # hand-authored roster in `.gaia/audit-ci.yml`, which no charset guard
+  # constrains, so it gets the same treatment. An unescaped quote there would
+  # emit a line no JSON reader can parse, and the prune sweep keeps what it
+  # cannot classify, so a single malformed record would live in the ledger
+  # forever, defeating the one bound the sweep exists to enforce.
   branch="${branch//\"/\\\"}"
+  member="${member//\"/\\\"}"
 
   # Grouped so the group's OWN `2>/dev/null` is established before the
   # inner `>>` redirect is attempted: bash evaluates a simple command's

--- a/.gaia/scripts/audit-respawn-prune.sh
+++ b/.gaia/scripts/audit-respawn-prune.sh
@@ -113,18 +113,31 @@ tab="$(printf '\t')"
 # ledger byte-identical, never reconstructed from parsed JSON:
 #   "<n>\tK"          in-window (or unparseable): always survives the age arm
 #   "<n>\tD\t<epoch>" out-of-window: a cap-arm candidate, epoch for sorting
-classified="$(jq -R -r --argjson cutoff "$cutoff" '
-  . as $line
-  | (input_line_number) as $n
-  | ((try (fromjson | .ts) catch null) // null) as $ts
+#
+# awk supplies the line number, and the selection pass below re-reads the
+# ledger with the same awk numbering, so exactly ONE scheme decides which
+# record is which. jq's own `input_line_number` is deliberately not used: on a
+# ledger whose final line carries no trailing newline it reports the same
+# number for the last two lines, while awk's FNR counts them separately. The
+# two schemes then disagree by one from that point on, and the age arm inverts,
+# dropping a live in-window record and keeping an expired one. No writer here
+# produces an unterminated ledger, but a short or interrupted append does, and
+# that is exactly when the sweep must not corrupt the measurement.
+classified="$(awk -v OFS="$tab" '{ print FNR, $0 }' "$ledger" \
+  | jq -R -r --argjson cutoff "$cutoff" '
+  . as $row
+  | ($row | index("\t")) as $i
+  | ($row[:$i]) as $n
+  | ($row[($i + 1):]) as $line
+  | ((try ($line | fromjson | .ts) catch null) // null) as $ts
   | (if $ts == null then null
      else (try ($ts | fromdateiso8601) catch null) end) as $epoch
   | if ($epoch == null or $epoch >= $cutoff) then
-      ($n | tostring) + "\tK"
+      $n + "\tK"
     else
-      ($n | tostring) + "\tD\t" + ($epoch | tostring)
+      $n + "\tD\t" + ($epoch | tostring)
     end
-' "$ledger")"
+')"
 jq_status=$?
 [ "$jq_status" -eq 0 ] || exit 0
 
@@ -164,6 +177,10 @@ keep_nums="$(
 )"
 
 tmp="$(mktemp "${ledger}.XXXXXX" 2>/dev/null)" || exit 0
+# Nothing else reaps a stray sibling: the janitor's outlier sweep never enters
+# telemetry/, and the ledger's registry entry matches an exact path. An
+# interrupt between here and the mv would otherwise leave one behind for good.
+trap 'rm -f -- "$tmp"' EXIT INT TERM
 
 write_status=0
 if [ -n "$keep_nums" ]; then

--- a/.gaia/scripts/audit-respawn-prune.sh
+++ b/.gaia/scripts/audit-respawn-prune.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# SC2016 is intentional file-wide: single-quoted jq filters where $line, $ts,
+# $epoch, $cutoff, $n are jq bindings, not shell variables.
+# shellcheck disable=SC2016
+#
+# audit-respawn-prune.sh: the audit re-spawn ledger prune sweep -- the reaper
+# the registry entry `audit-respawn-ledger` (.gaia/state-registry.json)
+# promises via its `reaped_by` field. This script's literal name for itself
+# is the string that field carries verbatim:
+#
+#   audit re-spawn ledger prune sweep
+#
+# Bounds .gaia/local/telemetry/audit-respawn.jsonl, the Code Audit Team spawn
+# oracle's re-spawn breadcrumb ledger (.gaia/scripts/audit-respawn-lib.sh),
+# which nothing else bounds. Two trim arms, and they are not peers:
+#
+#   Age arm  drops every record whose `ts` parses and is older than the
+#            retention window (gaia_respawn_retention_days, floor-clamped).
+#            A record that does not parse as JSON, or whose `ts` is missing
+#            or unparseable, is always kept: the sweep never deletes what it
+#            cannot classify.
+#   Cap arm  subordinate to the age arm. It may only trim records the age arm
+#            has ALREADY decided are out-of-window; it never removes a record
+#            still inside the window, even when the in-window set alone
+#            exceeds the cap (gaia_respawn_max_records, floor-clamped). A
+#            repository whose oracle runs hot enough to exceed the cap inside
+#            the window grows its ledger past the cap rather than losing the
+#            measurement -- the SPEC's reopen condition needs the full
+#            observation window, and a cap that dropped in-window records
+#            would silently shorten it.
+#
+#            The cap arm engages ONLY when the ledger's total record count
+#            (before this run) exceeds the cap; below that, the ledger is not
+#            under size pressure at all and the age arm's own unconditional
+#            drop stands untouched -- an idle repository never sees an
+#            out-of-window record survive just because the cap has room. Once
+#            engaged, the newest out-of-window records fill the smaller of
+#            (a) the room left under the cap after every in-window record is
+#            kept, and (b) how far over the cap the full pre-prune ledger
+#            actually was, so the reprieve never manufactures headroom that
+#            was not already being spent. Both bounds floor at zero.
+#
+# Every surviving line is written back byte-identical to its input (this
+# script never re-serializes a record through jq); this is enforced by
+# selecting survivors by original line number rather than reconstructing JSON.
+#
+# Concurrency: no lock. A record appended between this sweep's read and its
+# atomic replace is lost. Accepted: the sweep runs once at session start, the
+# ledger is a breadcrumb store whose own writer already tolerates a missing
+# record (gaia_respawn_record fails open and silent), and no clearance
+# decision depends on this ledger.
+#
+# Fail-safe and fail-silent by construction: an unresolvable root, a missing
+# sibling lib, an absent or empty ledger, or a missing jq are each a silent
+# no-op that leaves the ledger untouched. Always exits 0, so it can never
+# block a session start, the same contract .claude/hooks/local-janitor.sh
+# carries. No stdout in normal operation; `--help` prints usage and exits 0.
+#
+# Usage:
+#   audit-respawn-prune.sh [<root>] [--help|-h]
+#
+# <root> defaults to the current tree's own toplevel (git rev-parse
+# --show-toplevel) when omitted -- the same call the janitor uses for its own
+# .gaia/local walks. A linked worktree's .gaia/local is one wholesale symlink
+# to the main checkout's (.gaia/scripts/link-worktree.sh), so this reaches
+# the single shared ledger from every tree without a separate main-root
+# derivation.
+
+set -uo pipefail
+
+for _arg in "$@"; do
+  case "$_arg" in
+    --help | -h)
+      printf 'Usage: audit-respawn-prune.sh [<root>] [--help|-h]\n'
+      printf 'Prunes .gaia/local/telemetry/audit-respawn.jsonl: drops records past\n'
+      printf 'the retention window, then caps the out-of-window remainder. The cap\n'
+      printf 'never trims a record still inside the window. See\n'
+      printf '.gaia/scripts/audit-respawn-lib.sh for the retention knobs.\n'
+      exit 0
+      ;;
+  esac
+done
+
+root="${1:-}"
+if [ -z "$root" ]; then
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+fi
+[ -n "$root" ] || exit 0
+
+lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+[ -n "$lib_dir" ] || exit 0
+lib="$lib_dir/audit-respawn-lib.sh"
+[ -f "$lib" ] || exit 0
+# shellcheck source=/dev/null
+. "$lib" || exit 0
+
+ledger="$(gaia_respawn_ledger_path "$root" 2>/dev/null)" || exit 0
+[ -n "$ledger" ] || exit 0
+[ -f "$ledger" ] || exit 0
+[ -s "$ledger" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+days="$(gaia_respawn_retention_days)"
+cap="$(gaia_respawn_max_records)"
+now_epoch="$(date -u +%s 2>/dev/null)" || exit 0
+cutoff=$((now_epoch - days * 86400))
+
+tab="$(printf '\t')"
+
+# One jq pass classifies every line by the AGE ARM alone, tagging each with
+# its original line number so survivors can later be re-selected from the
+# ledger byte-identical, never reconstructed from parsed JSON:
+#   "<n>\tK"          in-window (or unparseable): always survives the age arm
+#   "<n>\tD\t<epoch>" out-of-window: a cap-arm candidate, epoch for sorting
+classified="$(jq -R -r --argjson cutoff "$cutoff" '
+  . as $line
+  | (input_line_number) as $n
+  | ((try (fromjson | .ts) catch null) // null) as $ts
+  | (if $ts == null then null
+     else (try ($ts | fromdateiso8601) catch null) end) as $epoch
+  | if ($epoch == null or $epoch >= $cutoff) then
+      ($n | tostring) + "\tK"
+    else
+      ($n | tostring) + "\tD\t" + ($epoch | tostring)
+    end
+' "$ledger")"
+jq_status=$?
+[ "$jq_status" -eq 0 ] || exit 0
+
+inwindow_count="$(awk -F"$tab" '$2 == "K" { c++ } END { print c + 0 }' <<<"$classified")"
+total_records="$(awk -F"$tab" 'END { print NR + 0 }' <<<"$classified")"
+
+# budget = max(0, min(room left under the cap after in-window, how far over
+# the cap the full pre-prune ledger was)). The second term is the gate: when
+# the ledger was never over the cap to begin with (total_records <= cap),
+# room_under_cap alone would be a large positive number for any ordinary
+# repository (the default cap is 20000) and would wrongly resurrect
+# out-of-window records the age arm already dropped. Bounding by the actual
+# overage keeps the cap arm inert until the ledger is genuinely under
+# pressure.
+room_under_cap=$((cap - inwindow_count))
+overage=$((total_records - cap))
+budget=$room_under_cap
+[ "$overage" -lt "$budget" ] && budget=$overage
+[ "$budget" -lt 0 ] && budget=0
+
+# Cap arm: the newest out-of-window candidates, up to $budget, chosen by
+# sorting on the epoch field then trimming; their original line numbers are
+# recovered afterward so the final selection can be restored to file order.
+keep_out_nums=""
+if [ "$budget" -gt 0 ]; then
+  keep_out_nums="$(awk -F"$tab" '$2 == "D" { print $3 "\t" $1 }' <<<"$classified" \
+    | sort -t "$tab" -k1,1nr \
+    | head -n "$budget" \
+    | cut -d "$tab" -f2)"
+fi
+
+keep_nums="$(
+  {
+    awk -F"$tab" '$2 == "K" { print $1 }' <<<"$classified"
+    [ -n "$keep_out_nums" ] && printf '%s\n' "$keep_out_nums"
+  } | sort -n -u
+)"
+
+tmp="$(mktemp "${ledger}.XXXXXX" 2>/dev/null)" || exit 0
+
+write_status=0
+if [ -n "$keep_nums" ]; then
+  awk 'NR == FNR { keep[$1] = 1; next } (FNR in keep)' \
+    <(printf '%s\n' "$keep_nums") "$ledger" > "$tmp" || write_status=1
+fi
+if [ "$write_status" -ne 0 ]; then
+  rm -f -- "$tmp"
+  exit 0
+fi
+
+mv -- "$tmp" "$ledger" || { rm -f -- "$tmp"; exit 0; }
+
+exit 0

--- a/.gaia/scripts/audit-respawn-report.sh
+++ b/.gaia/scripts/audit-respawn-report.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# audit-respawn-report.sh: the Code Audit Team re-spawn attribution query.
+#
+# .gaia/scripts/resolve-audit-spawn.sh appends one breadcrumb per considered
+# member to .gaia/local/telemetry/audit-respawn.jsonl every time its digest-
+# marker-presence filter runs: the member, its content digest, whether it was
+# cleared, the branch, HEAD, and the merge-base of HEAD and origin/main. It
+# records what it saw and classifies nothing.
+#
+# This script is the judgement, as a query over the accumulated records: over
+# a caller-given time window, how many member re-spawns are attributable to a
+# peer's merge landing under an already-audited branch, rather than to the
+# branch's own content changing?
+#
+# The attribution rule. Group every record by [branch, member]; order each
+# group by ts ascending. For each consecutive pair (p, c) within a group:
+#   rotated         := c.digest != p.digest, and both are non-empty
+#   base_moved      := c.merge_base != p.merge_base, and both are non-empty
+#   lost_clearance  := p.cleared == true and c.cleared == false
+# Pairs are formed over the WHOLE ledger, before any window filter; a pair is
+# in window when c.ts >= since. That ordering is deliberate: filtering first
+# would silently drop every transition whose earlier half fell just outside
+# the window, which is exactly the transition most likely to matter at a
+# window boundary.
+#
+# Reported counts, all over in-window pairs:
+#   records                      records whose own ts >= since
+#   transitions                  in-window consecutive pairs
+#   peer_merge_respawns          rotated and base_moved and lost_clearance
+#   own_change_respawns          rotated and (not base_moved) and lost_clearance
+#   peer_merge_rotations_upper   rotated and base_moved
+# peer_merge_respawns is the single quantity this instrument exists to
+# produce. The other four are context that keeps it honest.
+#
+# Three caveats travel with the number wherever it is reported (also printed
+# below in the text report):
+#   1. A run that both absorbs main and lands its own edits classifies as
+#      peer-merge, so within its own class the count is an upper bound.
+#   2. The pairing needs an observation taken while the member was cleared, so
+#      the count is a lower bound on total incidence.
+#   3. Attribution is a query over recorded facts, never a judgement the
+#      resolver makes; refining the rule needs no ledger migration.
+#
+# Usage:
+#   audit-respawn-report.sh [--since <days>] [--json] [--root <path>] [--help|-h]
+#     --since <days>  Window in days, default 30. Non-empty run of digits.
+#     --json          Emit one JSON object instead of the text report.
+#     --root <path>   Repo root override, default `git rev-parse --show-toplevel`.
+#     --help | -h     Usage, exit 0.
+#
+# Exit codes. Unlike the oracle and the retention sweep, this is a human-
+# facing query tool, so it reports its inability to answer rather than
+# swallowing it:
+#   0  a report was produced. Includes the absent-ledger case (all counts
+#      zero), which is a real answer, not an error.
+#   1  the question cannot be answered: jq missing, an unresolvable root, an
+#      unparseable --since, or an unknown flag. Diagnostic on stderr, nothing
+#      on stdout.
+#
+# A malformed (non-JSON) ledger line is skipped, not fatal: a lost record is
+# not a reason to refuse the whole report.
+#
+# Bash 3.2 compatible (macOS default): no associative arrays, no `mapfile`,
+# no `${var^^}`. Never `date -v` (BSD-only) or `date -d` (GNU-only); epoch
+# arithmetic is shell `date -u +%s` plus jq's `todateiso8601` /
+# `fromdateiso8601` on both platforms.
+#
+# gaia:maintainer-only:start
+# Sibling bats suite: .gaia/scripts/tests/audit-respawn-report.bats.
+# gaia:maintainer-only:end
+
+set -uo pipefail
+
+print_usage() {
+  cat <<'USAGE'
+Usage: audit-respawn-report.sh [--since <days>] [--json] [--root <path>] [--help|-h]
+  Reports how many Code Audit Team re-spawns, over the last <days> (default
+  30), are attributable to a peer's merge landing under an already-audited
+  branch versus the branch's own content changing. Reads
+  .gaia/local/telemetry/audit-respawn.jsonl. Exit 0 on a produced report
+  (including the absent-ledger, all-zero case); exit 1 when the question
+  cannot be answered (jq missing, an unresolvable root, an unparseable
+  --since, or an unknown flag).
+USAGE
+}
+
+SINCE_DAYS="30"
+JSON_OUT=0
+ROOT_OVERRIDE=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --since)
+      if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+        echo "audit-respawn-report: --since requires a <days> argument" >&2
+        exit 1
+      fi
+      SINCE_DAYS="$2"
+      shift 2
+      ;;
+    --json)
+      JSON_OUT=1
+      shift
+      ;;
+    --root)
+      if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+        echo "audit-respawn-report: --root requires a <path> argument" >&2
+        exit 1
+      fi
+      ROOT_OVERRIDE="$2"
+      shift 2
+      ;;
+    --help | -h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "audit-respawn-report: unrecognized argument '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$SINCE_DAYS" in
+  '' | *[!0-9]*)
+    echo "audit-respawn-report: --since must be a non-empty run of digits, got '$SINCE_DAYS'" >&2
+    exit 1
+    ;;
+esac
+# Base-10 forced: strips a leading zero and guards bash arithmetic below from
+# ever reading a digit run as octal.
+SINCE_DAYS_NUM=$((10#$SINCE_DAYS))
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "audit-respawn-report: jq is required" >&2
+  exit 1
+fi
+
+if [ -n "$ROOT_OVERRIDE" ]; then
+  repo_root="$ROOT_OVERRIDE"
+else
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [ -z "$repo_root" ]; then
+  echo "audit-respawn-report: could not resolve a repo root (pass --root)" >&2
+  exit 1
+fi
+
+_lib="$(dirname "${BASH_SOURCE[0]}")/audit-respawn-lib.sh"
+if [ ! -f "$_lib" ]; then
+  echo "audit-respawn-report: cannot find audit-respawn-lib.sh beside this script" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$_lib"
+
+ledger="$(gaia_respawn_ledger_path "$repo_root" 2>/dev/null)" || ledger=""
+if [ -z "$ledger" ]; then
+  echo "audit-respawn-report: could not resolve the ledger path" >&2
+  exit 1
+fi
+
+cutoff=$(($(date -u +%s) - SINCE_DAYS_NUM * 86400))
+since="$(jq -rn --argjson e "$cutoff" '$e | todateiso8601' 2>/dev/null)" || since=""
+if [ -z "$since" ]; then
+  echo "audit-respawn-report: could not compute the window start" >&2
+  exit 1
+fi
+
+content=""
+[ -f "$ledger" ] && content="$(cat "$ledger" 2>/dev/null || true)"
+
+# The jq program. Reads the raw ledger text as one string (-R -s), splits on
+# newline, drops blank lines, and parses each survivor with `fromjson? //
+# empty` so one malformed line is skipped rather than aborting the report.
+#
+# Pairing happens over the WHOLE parsed set, grouped by [branch, member] and
+# sorted by ts within each group, before the window filter is applied to the
+# pair's LATER record only -- see the header comment above for why that
+# order matters. `records` is independently the count of records whose own
+# ts falls in window.
+#
+# ts -> epoch is fromdateiso8601, wrapped in try/catch: an unparseable ts
+# sorts and pairs on its raw string but never counts as in-window, for either
+# `records` or a pair. sort_by(.ts) on the writer's fixed-width ISO-8601 UTC
+# string is a correct chronological sort.
+# shellcheck disable=SC2016 # single-quoted on purpose: these are jq $-vars, fed via --argjson/--arg, never bash-interpolated.
+JQ_PROGRAM='
+def epoch_of: try (.ts | fromdateiso8601) catch null;
+def in_window($e): ($e != null) and ($e >= $cutoff);
+
+[ split("\n")[] | select(length > 0) | (fromjson? // empty) ] as $recs
+| ( $recs | map(select(in_window(epoch_of))) | length ) as $records
+| ( $recs
+    | group_by([(.branch // ""), (.member // "")])
+    | map(
+        sort_by(.ts)
+        | . as $g
+        | [ range(1; ($g | length)) | { p: $g[. - 1], c: $g[.] } ]
+      )
+    | add // []
+  ) as $pairs
+| ( $pairs | map(select(in_window(.c | epoch_of))) ) as $inwin
+| ( $inwin
+    | map(
+        (((.p.digest // "") != "") and ((.c.digest // "") != "") and ((.p.digest) != (.c.digest))) as $rotated
+        | (((.p.merge_base // "") != "") and ((.c.merge_base // "") != "") and ((.p.merge_base) != (.c.merge_base))) as $base_moved
+        | (((.p.cleared // false) == true) and ((.c.cleared // false) == false)) as $lost_clearance
+        | { rotated: $rotated, base_moved: $base_moved, lost_clearance: $lost_clearance }
+      )
+  ) as $flags
+| {
+    schema: 1,
+    window_days: $window_days,
+    since: $since,
+    ledger: $ledger,
+    records: $records,
+    transitions: ($inwin | length),
+    peer_merge_respawns: ($flags | map(select(.rotated and .base_moved and .lost_clearance)) | length),
+    own_change_respawns: ($flags | map(select(.rotated and (.base_moved | not) and .lost_clearance)) | length),
+    peer_merge_rotations_upper: ($flags | map(select(.rotated and .base_moved)) | length)
+  }
+'
+
+report_json="$(printf '%s' "$content" | jq -R -s -c \
+  --argjson cutoff "$cutoff" \
+  --argjson window_days "$SINCE_DAYS_NUM" \
+  --arg since "$since" \
+  --arg ledger "$ledger" \
+  "$JQ_PROGRAM" 2>/dev/null)" || report_json=""
+
+if [ -z "$report_json" ] || ! jq -e 'type == "object" and has("peer_merge_respawns")' >/dev/null 2>&1 <<<"$report_json"; then
+  echo "audit-respawn-report: could not build the report" >&2
+  exit 1
+fi
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  printf '%s\n' "$report_json"
+  exit 0
+fi
+
+records="$(jq -r '.records' <<<"$report_json")"
+transitions="$(jq -r '.transitions' <<<"$report_json")"
+peer_merge="$(jq -r '.peer_merge_respawns' <<<"$report_json")"
+own_change="$(jq -r '.own_change_respawns' <<<"$report_json")"
+rotations_upper="$(jq -r '.peer_merge_rotations_upper' <<<"$report_json")"
+
+printf 'audit re-spawn attribution\n'
+printf 'window:                        last %s days (since %s)\n' "$SINCE_DAYS_NUM" "$since"
+printf 'ledger:                        %s\n' "$ledger"
+printf '\n'
+printf 'records in window:             %s\n' "$records"
+printf 'observed transitions:          %s\n' "$transitions"
+printf 'peer-merge re-spawns:          %s   <- the reopen-condition quantity\n' "$peer_merge"
+printf 'own-change re-spawns:          %s\n' "$own_change"
+printf 'peer-merge rotations (upper):  %s\n' "$rotations_upper"
+printf '\n'
+printf 'Caveats:\n'
+printf '  - a run that both absorbs main and lands its own edits counts as peer-merge,\n'
+printf '    so within its class this is an upper bound\n'
+printf '  - the pairing needs an observation taken while the member was cleared, so it\n'
+printf '    is a lower bound on total incidence\n'
+printf '  - attribution is a query over recorded facts, not a judgement the resolver\n'
+printf '    makes\n'
+
+exit 0

--- a/.gaia/scripts/check-registry-completeness.sh
+++ b/.gaia/scripts/check-registry-completeness.sh
@@ -48,6 +48,7 @@ GAIA_REGISTRY_COMPLETENESS_ENTRY_IDS='
 audit-clearance-markers
 audit-findings-rerun-sidecars
 audit-progress-log
+audit-respawn-ledger
 audit-security-notes
 audit-window-breadcrumb
 audit-worthiness-ledger

--- a/.gaia/scripts/resolve-audit-spawn.sh
+++ b/.gaia/scripts/resolve-audit-spawn.sh
@@ -279,8 +279,18 @@ fi
 # loaded or redefined lib can never make the oracle abort.
 _respawn_lib="$(dirname "${BASH_SOURCE[0]}")/audit-respawn-lib.sh"
 if [ -f "$_respawn_lib" ]; then
+  # `set -u` is relaxed for the source alone. An unset-variable reference at
+  # the lib's top level aborts the shell where it stands, so neither the
+  # trailing `|| true` nor any guard below would ever be reached. Restored on
+  # the next line, so the oracle's own body still runs under -u.
+  # Source-time output goes nowhere either. The lib is contracted to have no
+  # side effects at source time, and this script's stdout IS its answer, so a
+  # stray print there would corrupt the spawn set itself rather than merely
+  # log noise.
+  set +u
   # shellcheck source=/dev/null
-  . "$_respawn_lib" 2>/dev/null || true
+  . "$_respawn_lib" >/dev/null 2>&1 || true
+  set -u
 fi
 
 # --- Digest batch (parallel arrays; bash 3.2 has no associative arrays) ----

--- a/.gaia/scripts/resolve-audit-spawn.sh
+++ b/.gaia/scripts/resolve-audit-spawn.sh
@@ -32,6 +32,14 @@
 #   spawn). The script writes no clearance artifact on any path (mints
 #   nothing).
 #
+#   Separately, on the digest-marker-presence filter's active path, the
+#   filter appends one re-spawn breadcrumb per considered member to
+#   .gaia/local/telemetry/audit-respawn.jsonl. A breadcrumb is not a
+#   clearance artifact (only an audit member's own review ever writes one of
+#   those), and the append never affects stdout or the exit status: it is
+#   fail-open and silent on every path, exactly like the mints-nothing
+#   guarantee above.
+#
 #   stderr carries advisories only, never part of the answer: the fail-closed
 #   warnings below, the freshness advisory below, and the dispatch resolver's
 #   own diagnostics passed through.
@@ -262,6 +270,19 @@ if [ -n "$_lib_dir" ] && [ -f "$_lib_dir/audit-clearance.sh" ]; then
   . "$_lib_dir/audit-clearance.sh"
 fi
 
+# The re-spawn breadcrumb ledger's shared writer. This one lives BESIDE this
+# script, not under .claude/hooks/lib/ with the digest recipe above, so it is
+# resolved from this script's own on-disk location directly rather than via
+# $_lib_dir. Absent, unsourceable, or defective -> the breadcrumb is disabled
+# and nothing else about the oracle changes; every call against it below is
+# additionally guarded on `command -v gaia_respawn_record`, so a partially
+# loaded or redefined lib can never make the oracle abort.
+_respawn_lib="$(dirname "${BASH_SOURCE[0]}")/audit-respawn-lib.sh"
+if [ -f "$_respawn_lib" ]; then
+  # shellcheck source=/dev/null
+  . "$_respawn_lib" 2>/dev/null || true
+fi
+
 # --- Digest batch (parallel arrays; bash 3.2 has no associative arrays) ----
 
 _DIGEST_MEMBER=()
@@ -301,6 +322,23 @@ _member_digest() {
   return 1
 }
 
+# _respawn_breadcrumb <member> <digest> <cleared>
+#
+# Appends one re-spawn breadcrumb for MEMBER to the ledger. The per-run
+# context (ledger path, ts, branch, head, merge_base) is NOT re-derived here:
+# it reads the plain variables of the same name that digest_marker_filter,
+# its only caller, already resolved once above its member loop -- ordinary
+# bash dynamic scoping, not a second computation. `command -v
+# gaia_respawn_record` guards the write: an absent, unsourceable, or
+# defective ledger lib disables the breadcrumb and changes nothing else.
+# ALWAYS returns 0. The call site still wraps every call in `|| true` so a
+# future edit here can never trip `set -euo pipefail`.
+_respawn_breadcrumb() {
+  command -v gaia_respawn_record >/dev/null 2>&1 || return 0
+  gaia_respawn_record "$ledger" "$ts" "$branch" "$head" "$merge_base" "$1" "$2" "$3" || true
+  return 0
+}
+
 # --- The digest-marker-presence filter (mints nothing) ---------------------
 #
 # Reads a newline-separated member list on $1, prints the members whose valid
@@ -314,17 +352,62 @@ _member_digest() {
 # unchanged, degrading to today's spawn-everyone behavior; matches the old
 # jq-absent degrade the deleted carry-forward filter used.
 digest_marker_filter() {
-  local members="$1" m out="" digest
+  local members="$1" m out="" digest cleared ledger ts branch head merge_base
 
   if ! command -v clearance_member_cleared >/dev/null 2>&1 || ! _load_member_digests; then
     printf '%s' "$members"
     return 0
   fi
 
+  # --- Re-spawn breadcrumb: per-run context, computed once ------------------
+  #
+  # What is recorded, once per considered member below: the member's name,
+  # its content digest from the batch already loaded above, and whether a
+  # valid current-digest earned marker cleared it -- the two facts this
+  # filter already computes to decide whether to spawn the member, not a
+  # second derivation. Alongside them, resolved ONCE here rather than per
+  # member: a UTC timestamp, the branch, HEAD, and the merge-base of HEAD and
+  # origin/main.
+  #
+  # The resolver never classifies. It does not decide whether a re-spawn came
+  # from the branch's own edits or from absorbing a peer's merge; that
+  # question is a query over the accumulated records (comparing merge_base
+  # and digest across consecutive rows for the same branch and member),
+  # answerable later without touching this write path.
+  #
+  # The write sits ONLY here, inside the branch this filter is already
+  # active on, after both `command -v clearance_member_cleared` and
+  # `_load_member_digests` have already succeeded above. Every other path
+  # through this script -- the fail-closed answers, the ownerless probe,
+  # `--no-carry-forward`, and this filter's own degrade branch just above --
+  # writes nothing, because none of them derives a digest and none of them
+  # has anything to record.
+  #
+  # Fail open and silent. Each lookup below is `2>/dev/null || true`-guarded:
+  # a detached HEAD yields an empty branch, an unresolvable origin/main
+  # yields an empty merge_base, and neither disables the breadcrumb.
+  # `merge_base` reads refs/remotes/origin/main literally (matching the
+  # freshness advisory above), never the ownerless probe's origin/HEAD
+  # default-branch resolution, so the field has one meaning wherever it is
+  # read. No `git fetch`: the oracle runs before every dispatch wave and must
+  # stay fast and offline-safe. Nothing here may print to stdout or stderr,
+  # change the member set, or trip `set -euo pipefail`; `_respawn_breadcrumb`
+  # below is called with `|| true` for exactly that reason.
+  ledger="$(gaia_respawn_ledger_path "$repo_root" 2>/dev/null || true)"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  branch="$(git -C "$repo_root" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  head="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || true)"
+  merge_base="$(git -C "$repo_root" merge-base HEAD refs/remotes/origin/main 2>/dev/null || true)"
+
   while IFS= read -r m; do
     [ -n "$m" ] || continue
     digest="$(_member_digest "$m")" || digest=""
+    cleared=false
     if [ -n "$digest" ] && clearance_member_cleared "$repo_root" "$digest" "$m"; then
+      cleared=true
+    fi
+    _respawn_breadcrumb "$m" "$digest" "$cleared" || true
+    if [ "$cleared" = true ]; then
       continue
     fi
     out="${out}${m}

--- a/.gaia/scripts/tests/audit-respawn-lib.bats
+++ b/.gaia/scripts/tests/audit-respawn-lib.bats
@@ -1,0 +1,256 @@
+#!/usr/bin/env bats
+#
+# Conformance suite for .gaia/scripts/audit-respawn-lib.sh: the shared
+# ledger helper for the audit re-spawn measurement instrument. Three
+# consumers depend on this file (the oracle's breadcrumb writer, the
+# retention sweep, and the attribution query), so this suite is the one
+# place their shared contract is proven.
+#
+# What it proves, in the section order below:
+#   1. source-time purity, no side effects
+#   2. gaia_respawn_ledger_path, the path join and the empty-root refusal
+#   3. gaia_respawn_record: creates the parent dir, appends, newline-terminated
+#   4. the record's JSON shape and exact key order
+#   5. `cleared` normalization, a JSON boolean on every input
+#   6. double-quote escaping in the free-form `branch` field
+#   7. a slash in `branch` round-trips unchanged, no transformation
+#   8. empty fields round-trip as "", never a placeholder
+#   9. fail-open silence: no stdout/stderr on any failure path
+#   10. fail-open under `set -euo pipefail`: the caller's next command still runs
+#   11. gaia_respawn_retention_days: default-then-floor
+#   12. gaia_respawn_max_records: default-then-floor
+#
+# Run under bash 5 (bash 3.2's `[[ ]]` skip-under-set-e gap is real; see
+# .claude/rules/bats-assertions.md): `source .gaia/scripts/bats5.sh && bats5
+# .gaia/scripts/tests/audit-respawn-lib.bats`.
+#
+# Assertion style note: per .claude/rules/bats-assertions.md, non-final
+# absence checks use a positive match for the bad case plus an explicit
+# `return 1`, never `!`-negation; equality/numeric/empty checks use POSIX
+# `[ ... ]`, which fails correctly on every bash version. Every expected
+# value below is written as a literal: an assertion that recomputes the
+# derivation in its own body would be testing its own arithmetic.
+
+setup() {
+  LIB="$(cd "$BATS_TEST_DIRNAME/.." && pwd)/audit-respawn-lib.sh"
+  # shellcheck disable=SC1090
+  source "$LIB"
+  command -v jq >/dev/null 2>&1 || skip "jq required"
+}
+
+# a_record [cleared]: appends one record with fixed, distinguishable field
+# values to a fresh "$BATS_TEST_TMPDIR/l.jsonl" and prints the path.
+a_record() {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl"
+  gaia_respawn_record "$ledger" "2026-08-01T12:34:56Z" "spec-063-foo" \
+    "1111111111111111111111111111111111111111" \
+    "2222222222222222222222222222222222222222" \
+    "code-audit-frontend" \
+    "3333333333333333333333333333333333333333333333333333333333333333" \
+    "${1:-true}"
+  printf '%s' "$ledger"
+}
+
+# ========== 1. source-time purity ==========
+
+@test "criterion 1: sourcing the lib is silent at source time and creates no file" {
+  local scratch="$BATS_TEST_TMPDIR/purity"
+  mkdir -p "$scratch"
+  run bash -c "cd '$scratch' && . '$LIB' && echo ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+  [ -z "$(ls -A "$scratch")" ]
+}
+
+@test "structural: sourcing the lib defines the four public functions" {
+  run bash -c '
+    # shellcheck disable=SC1090
+    source "$1"
+    type gaia_respawn_ledger_path >/dev/null
+    type gaia_respawn_record >/dev/null
+    type gaia_respawn_retention_days >/dev/null
+    type gaia_respawn_max_records >/dev/null
+    echo OK
+  ' _ "$LIB"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}
+
+# ========== 2. gaia_respawn_ledger_path ==========
+
+@test "criterion 2: the ledger path joins root, .gaia/local, and the relative constant" {
+  run gaia_respawn_ledger_path /tmp/x
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/x/.gaia/local/telemetry/audit-respawn.jsonl" ]
+}
+
+@test "criterion 2: an empty root prints nothing and returns 1" {
+  run gaia_respawn_ledger_path ""
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+# ========== 3. gaia_respawn_record: creation, append, newline termination ==========
+
+@test "criterion 3: a fresh call creates the parent directory and writes exactly one line" {
+  local ledger="$BATS_TEST_TMPDIR/fresh/nested/l.jsonl"
+  [ ! -e "$BATS_TEST_TMPDIR/fresh" ]
+  gaia_respawn_record "$ledger" ts br h m mem dig true
+  [ -f "$ledger" ]
+  [ "$(wc -l <"$ledger" | tr -d ' ')" = "1" ]
+}
+
+@test "criterion 3: a second call appends a second line" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl"
+  gaia_respawn_record "$ledger" ts1 br h m mem dig1 true
+  gaia_respawn_record "$ledger" ts2 br h m mem dig2 false
+  [ "$(wc -l <"$ledger" | tr -d ' ')" = "2" ]
+  grep -qF '"digest":"dig1"' "$ledger" || return 1
+  grep -qF '"digest":"dig2"' "$ledger" || return 1
+}
+
+@test "criterion 3: the file ends with a newline and has no blank lines" {
+  local ledger
+  ledger="$(a_record)"
+  gaia_respawn_record "$ledger" ts2 br h m mem dig2 false
+  [ "$(tail -c1 "$ledger" | od -An -tx1 | tr -d ' ')" = "0a" ]
+  grep -q '^$' "$ledger" && return 1
+  return 0
+}
+
+# ========== 4. JSON shape and exact key order ==========
+
+@test "criterion 4: the written line parses under jq and its keys are in the contracted order" {
+  local ledger line
+  ledger="$(a_record)"
+  line="$(head -n1 "$ledger")"
+  echo "$line" | jq -e . >/dev/null
+  [ "$(echo "$line" | jq -r 'keys_unsorted | join(",")')" = "schema,ts,branch,head,merge_base,member,digest,cleared" ]
+}
+
+# ========== 5. cleared normalization ==========
+
+@test "criterion 5: cleared true emits the JSON boolean true" {
+  local ledger line
+  ledger="$(a_record true)"
+  line="$(head -n1 "$ledger")"
+  [ "$(echo "$line" | jq -r '.cleared')" = "true" ]
+}
+
+@test "criterion 5: cleared false, empty, and TRUE all emit the JSON boolean false" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line v
+  gaia_respawn_record "$ledger" ts br h m mem dig false
+  gaia_respawn_record "$ledger" ts br h m mem dig ""
+  gaia_respawn_record "$ledger" ts br h m mem dig TRUE
+  while IFS= read -r line; do
+    v="$(echo "$line" | jq -r '.cleared')"
+    [ "$v" = "false" ] || return 1
+  done <"$ledger"
+}
+
+# ========== 6. double-quote escaping ==========
+
+@test "criterion 6: a branch containing a double quote still parses and round-trips" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line
+  gaia_respawn_record "$ledger" ts 'a"b' h m mem dig true
+  line="$(head -n1 "$ledger")"
+  echo "$line" | jq -e . >/dev/null
+  [ "$(echo "$line" | jq -r '.branch')" = 'a"b' ]
+}
+
+# ========== 7. slash round-trip ==========
+
+@test "criterion 7: a branch containing a slash round-trips unchanged" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line
+  gaia_respawn_record "$ledger" ts 'feat/x' h m mem dig true
+  line="$(head -n1 "$ledger")"
+  [ "$(echo "$line" | jq -r '.branch')" = "feat/x" ]
+}
+
+# ========== 8. empty fields round-trip as "" ==========
+
+@test "criterion 8: empty branch, head, merge_base, and digest round-trip as empty strings" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line
+  gaia_respawn_record "$ledger" ts "" "" "" mem "" true
+  line="$(head -n1 "$ledger")"
+  echo "$line" | jq -e . >/dev/null
+  [ "$(echo "$line" | jq -r '.branch')" = "" ]
+  [ "$(echo "$line" | jq -r '.head')" = "" ]
+  [ "$(echo "$line" | jq -r '.merge_base')" = "" ]
+  [ "$(echo "$line" | jq -r '.digest')" = "" ]
+}
+
+# ========== 9. fail-open silence ==========
+
+@test "criterion 9: an empty ledger path returns 0 and writes nothing to stdout or stderr" {
+  run gaia_respawn_record "" ts br h m mem dig true
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "criterion 9: an empty member returns 0, writes nothing, and creates no file" {
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl"
+  run gaia_respawn_record "$ledger" ts br h m "" dig true
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ ! -e "$ledger" ]
+}
+
+@test "criterion 9: an uncreatable parent directory returns 0 and writes nothing" {
+  local blocker="$BATS_TEST_TMPDIR/blocker"
+  touch "$blocker"
+  run gaia_respawn_record "$blocker/sub/l.jsonl" ts br h m mem dig true
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ========== 10. fail-open under set -euo pipefail ==========
+
+@test "criterion 10: none of the three failure cases abort a caller running set -euo pipefail" {
+  local blocker="$BATS_TEST_TMPDIR/blocker"
+  touch "$blocker"
+  run bash -c "
+    set -euo pipefail
+    . '$LIB'
+    gaia_respawn_record '' ts br h m mem dig true
+    echo after-empty-ledger
+    gaia_respawn_record '$BATS_TEST_TMPDIR/l.jsonl' ts br h m '' dig true
+    echo after-empty-member
+    gaia_respawn_record '$blocker/sub/l.jsonl' ts br h m mem dig true
+    echo after-mkdir-fail
+  "
+  [ "$status" -eq 0 ]
+  grep -qF "after-empty-ledger" <<<"$output" || return 1
+  grep -qF "after-empty-member" <<<"$output" || return 1
+  grep -qF "after-mkdir-fail" <<<"$output" || return 1
+}
+
+# ========== 11. gaia_respawn_retention_days: default-then-floor ==========
+
+@test "criterion 11: unset, an override above the floor, and an override below the floor" {
+  [ "$(gaia_respawn_retention_days)" = "90" ]
+  [ "$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS=120 bash -c ". '$LIB'; gaia_respawn_retention_days")" = "120" ]
+  [ "$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS=10 bash -c ". '$LIB'; gaia_respawn_retention_days")" = "45" ]
+}
+
+@test "criterion 11: invalid overrides fall through to the default 90, never the floor" {
+  local v
+  for v in abc "" -5 12.5; do
+    [ "$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS="$v" bash -c ". '$LIB'; gaia_respawn_retention_days")" = "90" ] || return 1
+  done
+}
+
+# ========== 12. gaia_respawn_max_records: default-then-floor ==========
+
+@test "criterion 12: unset, an override above the floor, and an override below the floor" {
+  [ "$(gaia_respawn_max_records)" = "20000" ]
+  [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS=50000 bash -c ". '$LIB'; gaia_respawn_max_records")" = "50000" ]
+  [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS=10 bash -c ". '$LIB'; gaia_respawn_max_records")" = "1000" ]
+}
+
+@test "criterion 12: invalid overrides fall through to the default 20000, never the floor" {
+  local v
+  for v in abc ""; do
+    [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS="$v" bash -c ". '$LIB'; gaia_respawn_max_records")" = "20000" ] || return 1
+  done
+}

--- a/.gaia/scripts/tests/audit-respawn-lib.bats
+++ b/.gaia/scripts/tests/audit-respawn-lib.bats
@@ -158,6 +158,18 @@ a_record() {
   [ "$(echo "$line" | jq -r '.branch')" = 'a"b' ]
 }
 
+@test "criterion 6b: a member containing a double quote still parses and round-trips" {
+  # `member` comes from the hand-authored roster, which no charset guard
+  # constrains. An unescaped quote would emit a line no JSON reader can parse,
+  # and the prune sweep keeps what it cannot classify, so one malformed record
+  # would outlive every retention bound the sweep exists to enforce.
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line
+  gaia_respawn_record "$ledger" ts br h m 'a"b' dig true
+  line="$(head -n1 "$ledger")"
+  echo "$line" | jq -e . >/dev/null
+  [ "$(echo "$line" | jq -r '.member')" = 'a"b' ]
+}
+
 # ========== 7. slash round-trip ==========
 
 @test "criterion 7: a branch containing a slash round-trips unchanged" {

--- a/.gaia/scripts/tests/audit-respawn-lib.bats
+++ b/.gaia/scripts/tests/audit-respawn-lib.bats
@@ -158,6 +158,17 @@ a_record() {
   [ "$(echo "$line" | jq -r '.branch')" = 'a"b' ]
 }
 
+@test "criterion 6c: a member containing a backslash still parses and round-trips" {
+  # The roster parser preserves a backslash, and a trailing one would escape
+  # the closing quote, emitting a line no reader can parse. The sweep keeps
+  # what it cannot classify, so that record would never be reaped.
+  local ledger="$BATS_TEST_TMPDIR/l.jsonl" line
+  gaia_respawn_record "$ledger" ts br h m 'code-audit-x\' dig true
+  line="$(head -n1 "$ledger")"
+  echo "$line" | jq -e . >/dev/null
+  [ "$(echo "$line" | jq -r '.member')" = 'code-audit-x\' ]
+}
+
 @test "criterion 6b: a member containing a double quote still parses and round-trips" {
   # `member` comes from the hand-authored roster, which no charset guard
   # constrains. An unescaped quote would emit a line no JSON reader can parse,
@@ -258,6 +269,20 @@ a_record() {
   [ "$(gaia_respawn_max_records)" = "20000" ]
   [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS=50000 bash -c ". '$LIB'; gaia_respawn_max_records")" = "50000" ]
   [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS=10 bash -c ". '$LIB'; gaia_respawn_max_records")" = "1000" ]
+}
+
+@test "criterion 11b: a leading-zero override is read in base 10 by the knob and by its consumers" {
+  # `test` parses base 10 and `$(( ))` reads a leading zero as octal, so an
+  # un-normalized `050` clears the 45-day floor compare as 50 and then reaches
+  # a consumer's arithmetic as 40, shortening the window below the floor. `08`
+  # and `09` are not octal at all and abort the consumer outright.
+  [ "$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS=050 bash -c ". '$LIB'; gaia_respawn_retention_days")" = "50" ]
+  [ "$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS=008 bash -c ". '$LIB'; gaia_respawn_retention_days")" = "45" ]
+  [ "$(GAIA_AUDIT_RESPAWN_MAX_RECORDS=08000 bash -c ". '$LIB'; gaia_respawn_max_records")" = "8000" ]
+  # The printed value must survive a consumer's arithmetic unchanged.
+  local days
+  days="$(GAIA_AUDIT_RESPAWN_RETENTION_DAYS=050 bash -c ". '$LIB'; gaia_respawn_retention_days")"
+  [ "$(bash -c "echo \$(($days * 1))")" = "50" ]
 }
 
 @test "criterion 12: invalid overrides fall through to the default 20000, never the floor" {

--- a/.gaia/scripts/tests/audit-respawn-prune.bats
+++ b/.gaia/scripts/tests/audit-respawn-prune.bats
@@ -171,6 +171,24 @@ mutant_script() {
   return 0
 }
 
+@test "4b: a final line with no trailing newline is judged by its own age, not its predecessor's" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-first"
+  append_record "$ledger" "$(epoch_ts 200)" "out-middle"
+  # Deliberately unterminated: what a short or interrupted append leaves
+  # behind. Line-numbering schemes disagree on exactly this shape, so the
+  # last record is where an off-by-one shows up.
+  printf '{"schema":1,"ts":"%s","branch":"in-last","head":"aaaa","merge_base":"bbbb","member":"code-audit-frontend","digest":"cccc","cleared":false}' \
+    "$(epoch_ts 2)" >> "$ledger"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  local survivors; survivors="$(branches_in "$ledger")"
+  [ "$survivors" = "$(printf 'in-first\nin-last')" ]
+  grep -qF '"branch":"out-middle"' "$ledger" && return 1
+  return 0
+}
+
 @test "5: every record out of window leaves a zero-byte file" {
   local root ledger
   root="$(make_root)"; ledger="$(ledger_for "$root")"
@@ -416,6 +434,23 @@ make_hook_sandbox() {
   [ "$status" -eq 0 ]
 }
 
+@test "15e: the hook's prune delegation sits inside maintainer-only markers" {
+  # The prune script is release-excluded, so a shipped hook referencing it
+  # outside the markers is a runtime-dependency leak that fails the release
+  # build long after this PR merges. `release runtime-deps` strips
+  # marker-delimited blocks before extracting path references, so the wrap is
+  # what keeps the reference invisible to the scan.
+  local delegation_line start_line end_line
+  delegation_line="$(grep -n 'bash .gaia/scripts/audit-respawn-prune.sh' "$HOOK_ABS" | head -1 | cut -d: -f1)"
+  [ -n "$delegation_line" ]
+  start_line="$(awk -v n="$delegation_line" 'NR < n && /gaia:maintainer-only:start/ { l = NR } END { print l + 0 }' "$HOOK_ABS")"
+  end_line="$(awk -v n="$delegation_line" 'NR > n && /gaia:maintainer-only:end/ { print NR; exit }' "$HOOK_ABS")"
+  [ "$start_line" -gt 0 ]
+  [ -n "$end_line" ]
+  [ "$start_line" -lt "$delegation_line" ]
+  [ "$end_line" -gt "$delegation_line" ]
+}
+
 @test "15c: the reaped_by literal joins the registry entry to this script" {
   grep -qF 'audit re-spawn ledger prune sweep' "$SCRIPT" || return 1
   local reaped_by
@@ -505,6 +540,28 @@ make_hook_sandbox() {
   # epoch as out-of-window, and with a tiny default-cap fixture the cap arm's
   # budget is 0, so both are dropped.
   [ ! -s "$ledger" ]
+}
+
+@test "mutation: taking the line number from jq's input_line_number turns test 4b red" {
+  local root ledger mutant
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-first"
+  append_record "$ledger" "$(epoch_ts 200)" "out-middle"
+  printf '{"schema":1,"ts":"%s","branch":"in-last","head":"aaaa","merge_base":"bbbb","member":"code-audit-frontend","digest":"cccc","cleared":false}' \
+    "$(epoch_ts 2)" >> "$ledger"
+  # Restore the second numbering scheme wholesale: jq reads the ledger
+  # directly and numbers the rows itself, while the selection pass counts with
+  # awk's FNR. Removing the awk pass is what makes the mutation bite, since
+  # that pass also re-terminates the final line; leaving it in place would hand
+  # jq an already-normalized stream where its own counter is correct.
+  mutant="$(mutant_script 's#awk -v OFS="\$tab" .{ print FNR, \$0 }. "\$ledger"#cat "$ledger"#; s#(\$row\[:\$i\]) as \$n#(input_line_number | tostring) as $n#; s#(\$row\[(\$i + 1):\]) as \$line#$row as $line#')"
+  run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  # Correct behavior (test 4b) keeps in-first and in-last and drops
+  # out-middle. The mutant must NOT reproduce that.
+  local survivors; survivors="$(branches_in "$ledger")"
+  [ "$survivors" = "$(printf 'in-first\nin-last')" ] && return 1
+  return 0
 }
 
 @test "mutation: removing the retention floor clamp (raw env var) turns test 8b red" {

--- a/.gaia/scripts/tests/audit-respawn-prune.bats
+++ b/.gaia/scripts/tests/audit-respawn-prune.bats
@@ -259,6 +259,29 @@ mutant_script() {
 
 # ========== 9: cap arm, subordinate to the window ==========
 
+@test "8d: a leading-zero override (050) keeps a 47-day record, it does not read as octal 40" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 47)" "aged-47"
+  GAIA_AUDIT_RESPAWN_RETENTION_DAYS=050 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  # Read as octal the window is 40 days and this record is dropped, silently
+  # shortening retention below the 45-day floor no override may cross.
+  grep -qF "aged-47" "$ledger" || return 1
+}
+
+@test "8e: a leading-zero cap override does not abort the sweep" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  # 08 and 09 are not valid octal, so an un-normalized value reaches the
+  # arithmetic as an error, leaves its target unset, and trips `set -u`.
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=08000 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  grep -qF "in-1" "$ledger" || return 1
+}
+
 @test "9a: 1200 all-in-window records under cap=1000 all survive, byte-identical (cap does not fire)" {
   local root ledger ts before after
   root="$(make_root)"; ledger="$(ledger_for "$root")"

--- a/.gaia/scripts/tests/audit-respawn-prune.bats
+++ b/.gaia/scripts/tests/audit-respawn-prune.bats
@@ -1,0 +1,520 @@
+#!/usr/bin/env bats
+#
+# Tests for `.gaia/scripts/audit-respawn-prune.sh` -- the audit re-spawn
+# ledger prune sweep, the reaper the `audit-respawn-ledger` registry entry's
+# `reaped_by` field names. Bounds .gaia/local/telemetry/audit-respawn.jsonl
+# with two arms: an age window (gaia_respawn_retention_days) and a record cap
+# (gaia_respawn_max_records) strictly subordinate to it -- the cap never
+# trims an in-window record, and it never resurrects an out-of-window one
+# unless the ledger's own pre-prune total was already over the cap (see the
+# script's own header for why that gate is load-bearing: without it, the
+# default 20000 cap would resurrect every out-of-window record in any
+# ordinarily-sized ledger, which criteria 4 and 5 below rule out).
+#
+# Every fixture writes ledger lines directly (never depends on the spawn
+# oracle running) and sources audit-respawn-lib.sh for the ledger-path helper
+# and the retention/cap knobs, so the suite and the script under test cannot
+# drift on either.
+#
+# Timestamps are built portably, per .claude/rules/bats-assertions.md: an
+# epoch via `date -u +%s` arithmetic, formatted with `jq -rn --argjson e "$e"
+# '$e | todateiso8601'` -- never `date -v` (BSD-only) or `date -d` (GNU-only).
+# A bulk fixture (hundreds to low thousands of records) computes ITS ONE
+# shared timestamp once and loops with plain printf, not one jq fork per
+# line: the difference between this suite finishing in under a second and
+# taking the better part of a minute.
+#
+# Assertion style (bash-3.2 safe, .claude/rules/bats-assertions.md):
+# equality/status/emptiness/file checks use POSIX `[ ... ]`; substring checks
+# use `grep -qF -- "needle" <<<"$output" || return 1`; a `!`-negated command
+# is used only as a test's final line.
+#
+# Run under bash 5 (bash 3.2's `[[ ]]` skip-under-set-e gap is real):
+#   source .gaia/scripts/bats5.sh && bats5 .gaia/scripts/tests/audit-respawn-prune.bats
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  SCRIPT="$THIS_DIR/../audit-respawn-prune.sh"
+  LIB="$THIS_DIR/../audit-respawn-lib.sh"
+  REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  HOOK_ABS="$REPO_ROOT/.claude/hooks/wiki-session-start.sh"
+  [ -x "$SCRIPT" ] || skip "audit-respawn-prune.sh not executable"
+  [ -f "$LIB" ] || skip "audit-respawn-lib.sh missing"
+  [ -f "$HOOK_ABS" ] || skip "wiki-session-start.sh missing"
+
+  NOW_EPOCH="$(date -u +%s)"
+}
+
+# --- fixture helpers ---------------------------------------------------
+
+# epoch_ts <days_ago>: an ISO-8601 timestamp <days_ago> days before "now".
+epoch_ts() {
+  local days_ago="$1" e
+  e=$((NOW_EPOCH - days_ago * 86400))
+  jq -rn --argjson e "$e" '$e | todateiso8601'
+}
+
+# make_root: a fresh, plain (non-git) root with .gaia/local/telemetry
+# pre-created. Prints the path.
+make_root() {
+  local d
+  d="$(mktemp -d "$BATS_TEST_TMPDIR/root-XXXXXX")"
+  mkdir -p "$d/.gaia/local/telemetry"
+  printf '%s' "$d"
+}
+
+# ledger_for <root>: the ledger path via the SAME lib call the script itself
+# uses, so the suite and the script under test cannot drift on the location.
+ledger_for() {
+  # shellcheck source=/dev/null
+  ( . "$LIB"; gaia_respawn_ledger_path "$1" )
+}
+
+# append_record <ledger> <ts> <branch>: one C2-shaped line.
+append_record() {
+  local ledger="$1" ts="$2" branch="$3"
+  printf '{"schema":1,"ts":"%s","branch":"%s","head":"aaaa","merge_base":"bbbb","member":"code-audit-frontend","digest":"cccc","cleared":false}\n' \
+    "$ts" "$branch" >> "$ledger"
+}
+
+# append_bulk <ledger> <count> <ts> <prefix>: <count> records sharing one
+# precomputed <ts>.
+append_bulk() {
+  local ledger="$1" count="$2" ts="$3" prefix="$4" i
+  for i in $(seq 1 "$count"); do
+    printf '{"schema":1,"ts":"%s","branch":"%s-%s","head":"aaaa","merge_base":"bbbb","member":"code-audit-frontend","digest":"cccc","cleared":false}\n' \
+      "$ts" "$prefix" "$i"
+  done >> "$ledger"
+}
+
+# branches_in <ledger>: every record's `.branch` field, one per line, in file
+# order -- greps the literal field rather than parsing JSON, since a
+# deliberately malformed test line may not parse at all.
+branches_in() {
+  grep -o '"branch":"[^"]*"' "$1" 2>/dev/null | sed 's/"branch":"//; s/"$//'
+}
+
+# A PATH carrying every binary the script needs EXCEPT jq (mirrors
+# resolve-audit-spawn.bats's path_without_jq).
+path_without_jq() {
+  local d="$BATS_TEST_TMPDIR/nojq-bin" b p
+  mkdir -p "$d"
+  for b in env bash sh git awk sed grep sort head tail tr cat cut wc dirname basename mktemp date rm mkdir printf test expr; do
+    p="$(command -v "$b" 2>/dev/null)" && ln -sf "$p" "$d/$b"
+  done
+  printf '%s' "$d"
+}
+
+# mutant_script <sed_expr>: a throwaway copy of $SCRIPT with <sed_expr>
+# applied, alongside an untouched copy of $LIB so the mutant's own
+# BASH_SOURCE-relative lib lookup resolves. Prints the mutant script's path.
+# The real tracked $SCRIPT is never touched, so there is nothing to restore.
+mutant_script() {
+  local sed_expr="$1" dir
+  dir="$(mktemp -d "$BATS_TEST_TMPDIR/mutant-XXXXXX")"
+  cp "$LIB" "$dir/audit-respawn-lib.sh"
+  sed "$sed_expr" "$SCRIPT" > "$dir/audit-respawn-prune.sh"
+  chmod +x "$dir/audit-respawn-prune.sh"
+  printf '%s' "$dir/audit-respawn-prune.sh"
+}
+
+# ========== 1-2: --help, ledger absent ==========
+
+@test "1: --help prints usage and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  grep -qF -- "Usage: audit-respawn-prune.sh" <<<"$output" || return 1
+}
+
+@test "1b: -h is the same as --help" {
+  run bash "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  grep -qF -- "Usage: audit-respawn-prune.sh" <<<"$output" || return 1
+}
+
+@test "2: ledger absent exits 0, prints nothing, creates nothing" {
+  local root; root="$(make_root)"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ ! -e "$(ledger_for "$root")" ]
+}
+
+# ========== 3-7: age arm ==========
+
+@test "3: every record inside the window leaves the ledger byte-identical" {
+  local root ledger before after
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "a"
+  append_record "$ledger" "$(epoch_ts 5)" "b"
+  before="$(shasum "$ledger")"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  after="$(shasum "$ledger")"
+  [ "$before" = "$after" ]
+}
+
+@test "4: a mix drops exactly the out-of-window records, in-window survive in order, byte-identical" {
+  local root ledger before_in1 before_in2
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  append_record "$ledger" "$(epoch_ts 2)" "in-2"
+  before_in1="$(sed -n '1p' "$ledger")"
+  before_in2="$(sed -n '3p' "$ledger")"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "2" ]
+  [ "$(sed -n '1p' "$ledger")" = "$before_in1" ]
+  [ "$(sed -n '2p' "$ledger")" = "$before_in2" ]
+  grep -qF "out-1" "$ledger" && return 1
+  return 0
+}
+
+@test "5: every record out of window leaves a zero-byte file" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  append_record "$ledger" "$(epoch_ts 150)" "out-2"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ -f "$ledger" ]
+  [ ! -s "$ledger" ]
+}
+
+@test "6: a malformed (non-JSON) line survives untouched regardless of position" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-before"
+  printf 'not json at all\n' >> "$ledger"
+  append_record "$ledger" "$(epoch_ts 200)" "out-after"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  grep -qxF "not json at all" "$ledger" || return 1
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+}
+
+@test "7: a record with no ts, and one with an unparseable ts, both survive" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  printf '{"schema":1,"branch":"no-ts"}\n' >> "$ledger"
+  printf '{"schema":1,"ts":"not-a-date","branch":"bad-ts"}\n' >> "$ledger"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "2" ]
+  grep -qF '"branch":"no-ts"' "$ledger" || return 1
+  grep -qF '"branch":"bad-ts"' "$ledger" || return 1
+}
+
+# ========== 8: retention-day floor ==========
+
+@test "8a: override=45 (at the floor), a 60-day record is dropped" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 60)" "aged-60"
+  GAIA_AUDIT_RESPAWN_RETENTION_DAYS=45 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ ! -s "$ledger" ]
+}
+
+@test "8b: override=10 (below the floor), a 20-day record survives via the 45-day floor" {
+  # Discriminating fixture: 20 days sits BETWEEN the override (10) and the
+  # floor (45). With the floor, 20 < 45 -> survives. Without it, 20 > 10 ->
+  # would be dropped. A 60-day record here would drop either way and prove
+  # nothing (per the task doc's own warning against that false-green shape).
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 20)" "aged-20"
+  GAIA_AUDIT_RESPAWN_RETENTION_DAYS=10 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+}
+
+@test "8c: an invalid override (abc) takes the 90-day default, not the 45-day floor" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 60)" "aged-60"
+  GAIA_AUDIT_RESPAWN_RETENTION_DAYS=abc run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+}
+
+# ========== 9: cap arm, subordinate to the window ==========
+
+@test "9a: 1200 all-in-window records under cap=1000 all survive, byte-identical (cap does not fire)" {
+  local root ledger ts before after
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  ts="$(epoch_ts 1)"
+  append_bulk "$ledger" 1200 "$ts" "in"
+  before="$(shasum "$ledger")"
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=1000 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  after="$(shasum "$ledger")"
+  [ "$before" = "$after" ]
+}
+
+@test "9b: 1200 in-window + 500 out-of-window under cap=1000: the 500 are gone, all 1200 survive" {
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_bulk "$ledger" 1200 "$(epoch_ts 1)" "in"
+  append_bulk "$ledger" 500 "$(epoch_ts 200)" "out"
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=1000 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1200" ]
+  grep -qF '"out-' "$ledger" && return 1
+  return 0
+}
+
+@test "9c: cap arm engages only once the pre-prune total exceeds the cap (default cap, small mix stays fully age-arm-governed)" {
+  # Guards the gate the script's own header documents: with the DEFAULT cap
+  # (20000) and a small ledger, in-window count is always far below cap, so a
+  # naive budget = cap - inwindow would resurrect every out-of-window record.
+  # This must not happen -- it is what tests 4 and 5 above already assert
+  # under default settings; this test states the gate explicitly.
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+  grep -qF "out-1" "$ledger" && return 1
+  return 0
+}
+
+@test "9d: once the cap arm engages, it resurrects exactly the newest out-of-window records up to budget, in original order" {
+  # inwindow=998, cap=1000 -> budget=2. 5 out-of-window candidates at
+  # distinct ages: only the 2 NEWEST (closest to the cutoff) must survive.
+  local root ledger ts
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  ts="$(epoch_ts 1)"
+  append_bulk "$ledger" 998 "$ts" "in"
+  append_record "$ledger" "$(epoch_ts 200)" "oow-200"
+  append_record "$ledger" "$(epoch_ts 180)" "oow-180"
+  append_record "$ledger" "$(epoch_ts 150)" "oow-150"
+  append_record "$ledger" "$(epoch_ts 120)" "oow-120"
+  append_record "$ledger" "$(epoch_ts 100)" "oow-100"
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=1000 run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1000" ]
+  local survivors; survivors="$(branches_in "$ledger" | grep '^oow-')"
+  [ "$survivors" = "$(printf 'oow-120\noow-100')" ]
+  # Original relative order preserved: the surviving out-of-window records
+  # still trail every in-window record, exactly as appended.
+  [ "$(tail -n 2 "$ledger" | grep -c oow)" = "2" ]
+}
+
+# ========== 10: jq absent ==========
+
+@test "10: jq absent leaves the ledger byte-identical and exits 0" {
+  local root ledger before after nojq
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  before="$(shasum "$ledger")"
+  nojq="$(path_without_jq)"
+  PATH="$nojq" run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  after="$(shasum "$ledger")"
+  [ "$before" = "$after" ]
+}
+
+# ========== 11: no temp file left behind ==========
+
+@test "11a: after a successful prune, the ledger's directory holds exactly the ledger" {
+  local root ledger dir
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  dir="$(dirname "$ledger")"
+  [ "$(ls -A "$dir")" = "$(basename "$ledger")" ]
+}
+
+@test "11b: after a jq-absent no-op, no temp file is left behind" {
+  local root ledger dir nojq
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  nojq="$(path_without_jq)"
+  PATH="$nojq" run bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  dir="$(dirname "$ledger")"
+  [ "$(ls -A "$dir")" = "$(basename "$ledger")" ]
+}
+
+# ========== 12: unwritable ledger directory ==========
+
+@test "12: an unwritable ledger directory exits 0, no crash, ledger untouched" {
+  local root ledger dir before after
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  before="$(shasum "$ledger")"
+  dir="$(dirname "$ledger")"
+  chmod 555 "$dir"
+  run bash "$SCRIPT" "$root"
+  chmod 755 "$dir"
+  [ "$status" -eq 0 ]
+  after="$(shasum "$ledger")"
+  [ "$before" = "$after" ]
+}
+
+# ========== 13: bash 3.2 ==========
+
+@test "13: runs correctly under the system bash (3.2 on macOS)" {
+  [ -x /bin/bash ] || skip "/bin/bash not present"
+  local root ledger
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  run /bin/bash "$SCRIPT" "$root"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+}
+
+# ========== 15: the SessionStart hook, sandboxed only ==========
+#
+# .claude/hooks/wiki-session-start.sh is a REAL SessionStart hook with side
+# effects on the live checkout (records HEAD, fires local-janitor.sh's nine
+# sweeps over the live .gaia/local). Every test below runs it against a
+# throwaway `git init` sandbox and never against the real repository.
+
+# make_hook_sandbox: a throwaway git repo with a copy of the real prune
+# script + its lib at the sandbox's own .gaia/scripts/, exactly where the
+# hook's relative-path [ -f ... ] guard and the script's own BASH_SOURCE
+# lookup both expect to find them. Prints the sandbox path.
+make_hook_sandbox() {
+  local d
+  d="$(mktemp -d "$BATS_TEST_TMPDIR/hooksandbox-XXXXXX")"
+  git init -q --initial-branch=main "$d"
+  git -C "$d" config user.email t@example.com
+  git -C "$d" config user.name T
+  git -C "$d" config commit.gpgsign false
+  printf 'x\n' > "$d/f"
+  git -C "$d" add f
+  git -C "$d" commit -q -m init
+  mkdir -p "$d/.gaia/scripts" "$d/.gaia/local/telemetry"
+  cp "$SCRIPT" "$d/.gaia/scripts/audit-respawn-prune.sh"
+  cp "$LIB" "$d/.gaia/scripts/audit-respawn-lib.sh"
+  chmod +x "$d/.gaia/scripts/audit-respawn-prune.sh"
+  printf '%s' "$d"
+}
+
+@test "15a: the hook exits 0 in a sandbox with the prune script present" {
+  local sandbox
+  sandbox="$(make_hook_sandbox)"
+  cd "$sandbox" || return 1
+  run bash "$HOOK_ABS"
+  [ "$status" -eq 0 ]
+}
+
+@test "15b: the hook exits 0 in a sandbox with the prune script renamed away (adopter-clone no-op)" {
+  local sandbox
+  sandbox="$(make_hook_sandbox)"
+  mv "$sandbox/.gaia/scripts/audit-respawn-prune.sh" "$sandbox/.gaia/scripts/audit-respawn-prune.sh.gone"
+  cd "$sandbox" || return 1
+  run bash "$HOOK_ABS"
+  [ "$status" -eq 0 ]
+}
+
+@test "15c: the reaped_by literal joins the registry entry to this script" {
+  grep -qF 'audit re-spawn ledger prune sweep' "$SCRIPT" || return 1
+  local reaped_by
+  reaped_by="$(jq -r '.entries[] | select(.id == "audit-respawn-ledger") | .reaped_by' "$REPO_ROOT/.gaia/state-registry.json")"
+  [ "$reaped_by" = "audit re-spawn ledger prune sweep" ]
+}
+
+@test "15d: the session-start path reaps the registered ledger path (out-of-window gone, in-window survives)" {
+  local sandbox ledger
+  sandbox="$(make_hook_sandbox)"
+  ledger="$(ledger_for "$sandbox")"
+  append_record "$ledger" "$(epoch_ts 1)" "in-1"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  cd "$sandbox" || return 1
+  run bash "$HOOK_ABS"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1" ]
+  grep -qF "in-1" "$ledger" || return 1
+  grep -qF "out-1" "$ledger" && return 1
+  return 0
+}
+
+# ========== mutation proof: each mechanism, one at a time ==========
+#
+# Every mutant is a throwaway copy (mutant_script above); the tracked $SCRIPT
+# is never touched, so there is nothing to restore afterward.
+
+@test "mutation: deleting the age filter (pass every line through) turns test 5 red" {
+  local root ledger mutant
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 200)" "out-1"
+  append_record "$ledger" "$(epoch_ts 150)" "out-2"
+  mutant="$(mutant_script 's/\$epoch == null or \$epoch >= \$cutoff/true/')"
+  run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  # Correct behavior (test 5) is a zero-byte file; the mutant must NOT
+  # produce one -- both records pass straight through.
+  [ -s "$ledger" ]
+}
+
+@test "mutation: reversing the cap's ordering (keep oldest, not newest) turns test 9d red" {
+  local root ledger ts mutant
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  ts="$(epoch_ts 1)"
+  append_bulk "$ledger" 998 "$ts" "in"
+  append_record "$ledger" "$(epoch_ts 200)" "oow-200"
+  append_record "$ledger" "$(epoch_ts 180)" "oow-180"
+  append_record "$ledger" "$(epoch_ts 150)" "oow-150"
+  append_record "$ledger" "$(epoch_ts 120)" "oow-120"
+  append_record "$ledger" "$(epoch_ts 100)" "oow-100"
+  mutant="$(mutant_script 's/-k1,1nr/-k1,1n/')"
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=1000 run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  local survivors; survivors="$(branches_in "$ledger" | grep '^oow-')"
+  # Correct behavior (test 9d) keeps oow-120 and oow-100 (the newest). The
+  # reversed mutant must keep the OLDEST pair instead.
+  [ "$survivors" = "$(printf 'oow-200\noow-180')" ]
+}
+
+@test "mutation: making the cap absolute (naive tail -n \$max over the post-age result) turns test 9a red" {
+  local root ledger ts mutant lineno
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  ts="$(epoch_ts 1)"
+  append_bulk "$ledger" 1200 "$ts" "in"
+  # The unique K-only selection line ('$2 == "K" { print $1 }' <<<"$classified",
+  # the in-window-survivors half of the final selection, i.e. the "post-age
+  # result"); appending "| tail -n \"\$cap\"" to it is the naive absolute-cap
+  # bug the contract warns against.
+  lineno="$(grep -nF '2 == "K" { print' "$SCRIPT" | head -1 | cut -d: -f1)"
+  mutant="$(mutant_script "${lineno}s/\$/ | tail -n \"\$cap\"/")"
+  GAIA_AUDIT_RESPAWN_MAX_RECORDS=1000 run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  # Correct behavior (test 9a) keeps all 1200. The absolute-cap mutant must
+  # wrongly truncate to 1000.
+  [ "$(wc -l < "$ledger" | tr -d ' ')" = "1000" ]
+}
+
+@test "mutation: dropping malformed lines instead of keeping them turns test 6/7 red" {
+  local root ledger mutant
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  printf 'not json at all\n' >> "$ledger"
+  printf '{"schema":1,"branch":"no-ts"}\n' >> "$ledger"
+  mutant="$(mutant_script 's/\$epoch == null or \$epoch >= \$cutoff/\$epoch >= \$cutoff/')"
+  run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  # Correct behavior (tests 6, 7) keeps both. The mutant reclassifies a null
+  # epoch as out-of-window, and with a tiny default-cap fixture the cap arm's
+  # budget is 0, so both are dropped.
+  [ ! -s "$ledger" ]
+}
+
+@test "mutation: removing the retention floor clamp (raw env var) turns test 8b red" {
+  local root ledger mutant
+  root="$(make_root)"; ledger="$(ledger_for "$root")"
+  append_record "$ledger" "$(epoch_ts 20)" "aged-20"
+  mutant="$(mutant_script 's/days="\$(gaia_respawn_retention_days)"/days="\${GAIA_AUDIT_RESPAWN_RETENTION_DAYS:-90}"/')"
+  GAIA_AUDIT_RESPAWN_RETENTION_DAYS=10 run bash "$mutant" "$root"
+  [ "$status" -eq 0 ]
+  # Correct behavior (test 8b) keeps the 20-day record (floored to 45).
+  # The unfloored mutant applies the raw 10-day window and drops it.
+  [ ! -s "$ledger" ]
+}

--- a/.gaia/scripts/tests/audit-respawn-report.bats
+++ b/.gaia/scripts/tests/audit-respawn-report.bats
@@ -1,0 +1,548 @@
+#!/usr/bin/env bats
+#
+# Conformance suite for .gaia/scripts/audit-respawn-report.sh: the query over
+# the audit re-spawn breadcrumb ledger that reports how many Code Audit Team
+# re-spawns are attributable to a peer's merge versus the branch's own edits.
+#
+# Criteria 1-23 (from the task plan) run on hand-written fixture ledgers,
+# built via the `rec` helper below, which is the right way to pin the
+# query's arithmetic precisely. The final test is deliberately different: it
+# rebuilds a real peer-merge fixture through the actual oracle
+# (resolve-audit-spawn.sh) in an isolated sandbox and runs this script
+# against the ledger those oracle runs actually produced, proving the writer
+# and this query agree on what "peer-merge" means.
+#
+# Run under bash 5 (bash 3.2's `[[ ]]` skip-under-set-e gap is real; see
+# .claude/rules/bats-assertions.md): `source .gaia/scripts/bats5.sh && bats5
+# .gaia/scripts/tests/audit-respawn-report.bats`.
+#
+# Assertion style note: per .claude/rules/bats-assertions.md, non-final
+# absence checks use a positive match for the bad case plus an explicit
+# `return 1`, never `!`-negation; equality/numeric/empty checks use POSIX
+# `[ ... ]`, which fails correctly on every bash version. Every expected
+# count below is a literal worked out by hand from its fixture: no test
+# recomputes the query's own predicates.
+
+setup() {
+  THIS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  SCRIPT="$THIS_DIR/../audit-respawn-report.sh"
+  LIB="$THIS_DIR/../audit-respawn-lib.sh"
+  [ -x "$SCRIPT" ] || skip "audit-respawn-report.sh not executable"
+  [ -f "$LIB" ] || skip "audit-respawn-lib.sh not found"
+  command -v jq >/dev/null 2>&1 || skip "jq required"
+  # shellcheck source=/dev/null
+  source "$LIB"
+
+  ROOT="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$ROOT"
+  LEDGER="$(gaia_respawn_ledger_path "$ROOT")"
+}
+
+# ---------------------------------------------------------------------------
+# Shared fixture + assertion helpers
+# ---------------------------------------------------------------------------
+
+# ts_ago <seconds>: an ISO-8601 UTC timestamp <seconds> in the past. Built
+# from `date -u +%s` arithmetic plus jq's `todateiso8601`, matching the
+# script's own epoch handling -- never `date -v`/`date -d`.
+ts_ago() {
+  local secs="$1"
+  jq -rn --argjson e "$(($(date -u +%s) - secs))" '$e | todateiso8601'
+}
+
+# rec <branch> <member> <ts> <digest> <merge_base> <cleared>: appends one
+# C2-shaped record to $LEDGER. `head` is a fixed placeholder: the query
+# never reads it.
+rec() {
+  local branch="$1" member="$2" ts="$3" digest="$4" merge_base="$5" cleared="$6"
+  mkdir -p "$(dirname "$LEDGER")"
+  printf '{"schema":1,"ts":"%s","branch":"%s","head":"h","merge_base":"%s","member":"%s","digest":"%s","cleared":%s}\n' \
+    "$ts" "$branch" "$merge_base" "$member" "$digest" "$cleared" >>"$LEDGER"
+}
+
+# stdout_only / stderr_only <args...>: the script's stdout or stderr alone,
+# since `run` merges both into $output.
+stdout_only() {
+  "$SCRIPT" "$@" 2>/dev/null
+}
+# SC2069: deliberate capture-stderr / discard-stdout order.
+# shellcheck disable=SC2069
+stderr_only() {
+  "$SCRIPT" "$@" 2>&1 1>/dev/null
+}
+
+# extract_num <label>: the first run of digits on the line of the global
+# $output (set by the most recent `run`) that contains LABEL. Only parses
+# the rendered text; does not recompute the query.
+extract_num() {
+  local label="$1"
+  grep -F "$label" <<<"$output" | head -1 | grep -oE '[0-9]+' | head -1
+}
+
+# A PATH whose dir carries every binary the script needs EXCEPT jq, so
+# `command -v jq` fails and the script's own jq-required guard fires.
+# Mirrors resolve-audit-spawn.bats's path_without_jq.
+path_without_jq() {
+  local d="$BATS_TEST_TMPDIR/nojq-bin" b p
+  mkdir -p "$d"
+  for b in env bash sh git awk sed grep sort head tail tr cat cut wc dirname basename mktemp date rm mkdir printf test expr; do
+    p="$(command -v "$b" 2>/dev/null)" && ln -sf "$p" "$d/$b"
+  done
+  printf '%s' "$d"
+}
+
+# ---------------------------------------------------------------------------
+# 1. --help
+# ---------------------------------------------------------------------------
+
+@test "criterion 1: --help prints usage and exits 0" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  grep -qF "Usage: audit-respawn-report.sh" <<<"$output" || return 1
+}
+
+# ---------------------------------------------------------------------------
+# 2-3. Absent / empty ledger
+# ---------------------------------------------------------------------------
+
+@test "criterion 2: absent ledger reports all-zero counts, exit 0, text names window and ledger path" {
+  run "$SCRIPT" --root "$ROOT"
+  [ "$status" -eq 0 ]
+  grep -qF "window:" <<<"$output" || return 1
+  grep -qF "$LEDGER" <<<"$output" || return 1
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.records' <<<"$output")" = "0" ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "0" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "0" ]
+  [ "$(jq -r '.peer_merge_rotations_upper' <<<"$output")" = "0" ]
+}
+
+@test "criterion 3: empty ledger file behaves the same as absent" {
+  mkdir -p "$(dirname "$LEDGER")"
+  : >"$LEDGER"
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.records' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 4-6. Unanswerable queries: exit 1, stderr diagnostic, nothing on stdout
+# ---------------------------------------------------------------------------
+
+@test "criterion 4: an unknown flag exits 1 with a stderr diagnostic and no stdout" {
+  run "$SCRIPT" --root "$ROOT" --bogus
+  [ "$status" -eq 1 ]
+  [ -z "$(stdout_only --root "$ROOT" --bogus)" ]
+  [ -n "$(stderr_only --root "$ROOT" --bogus)" ]
+}
+
+@test "criterion 5: --since abc and --since \"\" both exit 1 with no stdout" {
+  run "$SCRIPT" --root "$ROOT" --since abc
+  [ "$status" -eq 1 ]
+  [ -z "$(stdout_only --root "$ROOT" --since abc)" ]
+  [ -n "$(stderr_only --root "$ROOT" --since abc)" ]
+
+  run "$SCRIPT" --root "$ROOT" --since ""
+  [ "$status" -eq 1 ]
+  [ -z "$(stdout_only --root "$ROOT" --since "")" ]
+  [ -n "$(stderr_only --root "$ROOT" --since "")" ]
+}
+
+@test "criterion 6: jq absent from PATH exits 1, stderr diagnostic, nothing on stdout" {
+  local nojq
+  nojq="$(path_without_jq)"
+  run env PATH="$nojq" "$SCRIPT" --root "$ROOT"
+  [ "$status" -eq 1 ]
+  [ -z "$(PATH="$nojq" "$SCRIPT" --root "$ROOT" 2>/dev/null)" ]
+}
+
+# ---------------------------------------------------------------------------
+# 7. UAT-004 headline case
+# ---------------------------------------------------------------------------
+
+@test "criterion 7: two branches each carrying a peer-merge transition report peer_merge_respawns=2, text and json" {
+  rec "A" "memberX" "$(ts_ago 3600)" "d1" "m1" true
+  rec "A" "memberX" "$(ts_ago 1800)" "d2" "m2" false
+  rec "B" "memberX" "$(ts_ago 3500)" "e1" "n1" true
+  rec "B" "memberX" "$(ts_ago 1700)" "e2" "n2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "2" ]
+
+  run "$SCRIPT" --root "$ROOT"
+  [ "$status" -eq 0 ]
+  [ "$(extract_num 'peer-merge re-spawns:')" = "2" ]
+}
+
+# ---------------------------------------------------------------------------
+# 8. Own-change vs peer-merge, both directions in one fixture
+# ---------------------------------------------------------------------------
+
+@test "criterion 8: an own-change transition counts in own_change_respawns and not in peer_merge_respawns" {
+  rec "A" "memberX" "$(ts_ago 3600)" "d1" "m1" true
+  rec "A" "memberX" "$(ts_ago 1800)" "d2" "m1" false # merge_base unchanged
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "1" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 9. merge_base moves, digest doesn't: rotated is false, counts nowhere
+# ---------------------------------------------------------------------------
+
+@test "criterion 9: merge_base moves but digest is unchanged counts nowhere" {
+  rec "A" "memberX" "$(ts_ago 3600)" "dsame" "m1" true
+  rec "A" "memberX" "$(ts_ago 1800)" "dsame" "m2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "1" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "0" ]
+  [ "$(jq -r '.peer_merge_rotations_upper' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 10. Never cleared: counts in the upper bound, not the respawn count
+# ---------------------------------------------------------------------------
+
+@test "criterion 10: a member never cleared counts in peer_merge_rotations_upper but not peer_merge_respawns" {
+  rec "A" "memberX" "$(ts_ago 3600)" "d1" "m1" false
+  rec "A" "memberX" "$(ts_ago 1800)" "d2" "m2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.peer_merge_rotations_upper' <<<"$output")" = "1" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 11. Two members on the same branch pair independently
+# ---------------------------------------------------------------------------
+
+@test "criterion 11: two members on the same branch pair independently, not across each other" {
+  # Interleaved chronologically: X1, Y1, X2, Y2. Each member's OWN pair is
+  # an own-change transition (merge_base constant per member, digest
+  # rotates, clearance lost). A naive whole-file pairing that ignored
+  # `member` would instead consecutively pair (X1,Y1), (Y1,X2), (X2,Y2):
+  # the middle pair alone would spuriously satisfy rotated (different
+  # members' digests always differ) + base_moved (mX != mY) +
+  # lost_clearance (Y1 cleared true -> X2 cleared false), inflating
+  # peer_merge_respawns to 1 it must never reach.
+  rec "A" "memberX" "$(ts_ago 4000)" "dx1" "mX" true
+  rec "A" "memberY" "$(ts_ago 3500)" "dy1" "mY" true
+  rec "A" "memberX" "$(ts_ago 3000)" "dx2" "mX" false
+  rec "A" "memberY" "$(ts_ago 2500)" "dy2" "mY" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "2" ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "2" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 12. The same member on two branches pairs independently
+# ---------------------------------------------------------------------------
+
+@test "criterion 12: the same member on two branches pairs independently, not across each other" {
+  # Same shape of proof as criterion 11, with branch and member swapped:
+  # one member, two branches, interleaved chronologically.
+  rec "P" "memberZ" "$(ts_ago 4000)" "p1" "mP" true
+  rec "Q" "memberZ" "$(ts_ago 3500)" "q1" "mQ" true
+  rec "P" "memberZ" "$(ts_ago 3000)" "p2" "mP" false
+  rec "Q" "memberZ" "$(ts_ago 2500)" "q2" "mQ" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "2" ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "2" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 13. Window boundary
+# ---------------------------------------------------------------------------
+
+@test "criterion 13: a pair is counted iff its LATER record falls inside the window" {
+  # In-window pair: earlier record outside a 1-day window, later inside.
+  rec "IN" "memberX" "$(ts_ago 172800)" "d1" "m1" true  # 2 days ago
+  rec "IN" "memberX" "$(ts_ago 43200)" "d2" "m2" false  # 12 hours ago
+  # Out-of-window pair: both records fall outside the 1-day window.
+  rec "OUT" "memberX" "$(ts_ago 259200)" "e1" "n1" true # 3 days ago
+  rec "OUT" "memberX" "$(ts_ago 172800)" "e2" "n2" false # 2 days ago
+
+  run "$SCRIPT" --root "$ROOT" --json --since 1
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "1" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# 14. records is independent of transitions
+# ---------------------------------------------------------------------------
+
+@test "criterion 14: records counts records in window independently of transitions" {
+  rec "SOLO" "memberX" "$(ts_ago 1800)" "d1" "m1" true # no partner: +1 records, +0 transitions
+  rec "PAIR" "memberX" "$(ts_ago 3600)" "e1" "m1" true
+  rec "PAIR" "memberX" "$(ts_ago 1800)" "e2" "m2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.records' <<<"$output")" = "3" ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# 15. Out-of-order input sorts by ts within each group
+# ---------------------------------------------------------------------------
+
+@test "criterion 15: out-of-order input lines produce the same counts as sorted input" {
+  local l1 l2 l3 l4
+  l1="$(printf '{"schema":1,"ts":"%s","branch":"A","head":"h","merge_base":"m1","member":"memberX","digest":"d1","cleared":true}' "$(ts_ago 3600)")"
+  l2="$(printf '{"schema":1,"ts":"%s","branch":"A","head":"h","merge_base":"m2","member":"memberX","digest":"d2","cleared":false}' "$(ts_ago 1800)")"
+  l3="$(printf '{"schema":1,"ts":"%s","branch":"B","head":"h","merge_base":"n1","member":"memberX","digest":"e1","cleared":true}' "$(ts_ago 3500)")"
+  l4="$(printf '{"schema":1,"ts":"%s","branch":"B","head":"h","merge_base":"n2","member":"memberX","digest":"e2","cleared":false}' "$(ts_ago 1700)")"
+
+  mkdir -p "$(dirname "$LEDGER")"
+  # Deliberately shuffled, not chronological and not grouped by branch.
+  printf '%s\n%s\n%s\n%s\n' "$l4" "$l1" "$l3" "$l2" >"$LEDGER"
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.transitions' <<<"$output")" = "2" ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "2" ]
+}
+
+# ---------------------------------------------------------------------------
+# 16. Malformed line skipped
+# ---------------------------------------------------------------------------
+
+@test "criterion 16: a malformed line is skipped; the remaining records still produce correct counts" {
+  rec "A" "memberX" "$(ts_ago 3600)" "d1" "m1" true
+  printf 'not valid json at all\n' >>"$LEDGER"
+  rec "A" "memberX" "$(ts_ago 1800)" "d2" "m2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# 17. Empty digest / merge_base never satisfy rotated / base_moved
+# ---------------------------------------------------------------------------
+
+@test "criterion 17: an empty merge_base or digest never satisfies base_moved / rotated" {
+  # Empty merge_base on both records of the pair: base_moved stays false
+  # (empty is not "both non-empty") even though the digest rotates. That
+  # makes this a legitimate OWN-CHANGE transition, not a peer-merge one --
+  # an unresolvable origin/main must never inflate the peer-merge count.
+  rec "A" "memberX" "$(ts_ago 3600)" "d1" "" true
+  rec "A" "memberX" "$(ts_ago 1800)" "d2" "" false
+  # Empty digest on both records of the pair: rotated stays false even
+  # though merge_base changes, so this pair counts nowhere at all.
+  rec "B" "memberY" "$(ts_ago 3600)" "" "m1" true
+  rec "B" "memberY" "$(ts_ago 1800)" "" "m2" false
+
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.peer_merge_respawns' <<<"$output")" = "0" ]
+  [ "$(jq -r '.own_change_respawns' <<<"$output")" = "1" ]
+  [ "$(jq -r '.peer_merge_rotations_upper' <<<"$output")" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# 18. --json parses under jq -e . with numeric counts
+# ---------------------------------------------------------------------------
+
+@test "criterion 18: --json output parses under jq -e . and all five counts are numbers" {
+  run "$SCRIPT" --root "$ROOT" --json
+  [ "$status" -eq 0 ]
+  jq -e . >/dev/null 2>&1 <<<"$output" || return 1
+  jq -e '[.records,.transitions,.peer_merge_respawns,.own_change_respawns,.peer_merge_rotations_upper] | all(type=="number")' \
+    >/dev/null 2>&1 <<<"$output" || return 1
+}
+
+# ---------------------------------------------------------------------------
+# 19. Text output prints all three caveats
+# ---------------------------------------------------------------------------
+
+@test "criterion 19: text output prints all three caveats" {
+  run "$SCRIPT" --root "$ROOT"
+  [ "$status" -eq 0 ]
+  grep -qF "so within its class this is an upper bound" <<<"$output" || return 1
+  grep -qF "is a lower bound on total incidence" <<<"$output" || return 1
+  grep -qF "attribution is a query over recorded facts" <<<"$output" || return 1
+}
+
+# ---------------------------------------------------------------------------
+# 24. The one end-to-end join: a real oracle ledger, not a fixture.
+#
+# Every criterion above runs on a hand-written fixture. This rebuilds
+# task-breadcrumb-writer's UAT-002 peer-merge fixture against the REAL
+# oracle (resolve-audit-spawn.sh) in its own isolated sandbox -- mirroring
+# resolve-audit-spawn.bats's own setup -- then runs THIS script against the
+# ledger those oracle runs actually produced. No hand-written line appears
+# in that ledger.
+# ---------------------------------------------------------------------------
+
+e2e_write_full_roster() {
+  local sb="$1"
+  cat >"$sb/.gaia/audit-ci.yml" <<'YAML'
+auditors:
+  - name: code-audit-frontend
+    globs:
+      - "app/**"
+      - "test/**"
+      - ".storybook/**"
+    scope: adopter
+    push_fixes: true
+    default: true
+  - name: code-audit-maintainer-shell
+    globs:
+      - ".gaia/**/*.sh"
+      - ".gaia/**/*.bats"
+      - ".claude/hooks/**/*.sh"
+      - ".specify/extensions/gaia/lib/*.sh"
+      - ".github/**/*.sh"
+      - ".github/**/*.bats"
+    scope: maintainer-only
+    push_fixes: false
+  - name: code-audit-maintainer-node
+    globs:
+      - ".gaia/cli/src/**"
+    scope: maintainer-only
+    push_fixes: false
+YAML
+}
+
+e2e_stage() {
+  local sb="$1" p
+  shift
+  for p in "$@"; do
+    mkdir -p "$sb/$(dirname "$p")"
+    printf 'x\n' >"$sb/$p"
+    git -C "$sb" add "$p"
+  done
+}
+
+e2e_commit() {
+  git -C "$1" commit --quiet -m "$2"
+}
+
+e2e_member_digest_for() {
+  local sb="$1" member="$2"
+  bash -c '. "$1"; audit_member_digest "$2" "$3"' _ \
+    "$THIS_DIR/../../../.claude/hooks/lib/audit-digest.sh" "$sb" "$member"
+}
+
+e2e_write_marker() {
+  local sb="$1" member="$2" digest sha tree infix sidecar
+  digest="$(e2e_member_digest_for "$sb" "$member")"
+  sha="$(git -C "$sb" rev-parse HEAD)"
+  tree="$(git -C "$sb" rev-parse 'HEAD^{tree}')"
+  if [ "$member" = "code-audit-frontend" ]; then
+    infix=""
+    sidecar="true"
+  else
+    infix=".$member"
+    sidecar="false"
+  fi
+  mkdir -p "$sb/.gaia/local/audit"
+  printf '{"version":"1.6.1","schema":3,"member":"%s","provenance":"earned","digest":"%s","tree":"%s","sha":"%s","audited_at":"2026-07-14T10:00:00Z","sidecar":%s}\n' \
+    "$member" "$digest" "$tree" "$sha" "$sidecar" \
+    >"$sb/.gaia/local/audit/${digest}${infix}.ok"
+}
+
+e2e_sync_origin_main() {
+  local sb="$1" sha
+  sha="$(git -C "$sb" rev-parse main)"
+  git -C "$sb" update-ref refs/remotes/origin/main "$sha"
+}
+
+# Advances origin/main by one commit that actually changes PATH's content to
+# CONTENT: a real content diff, so absorbing it genuinely rotates the
+# member's digest. Built via a throwaway GIT_INDEX_FILE so the sandbox's
+# real index and checked-out working tree are untouched; only the
+# remote-tracking ref moves.
+e2e_advance_origin_main_with_change() {
+  local sb="$1" path="$2" content="$3" parent idx blob new_tree new_commit
+  parent="$(git -C "$sb" rev-parse main)"
+  idx="$BATS_TEST_TMPDIR/e2e-idx-$RANDOM"
+  GIT_INDEX_FILE="$idx" git -C "$sb" read-tree main
+  blob="$(printf '%s\n' "$content" | git -C "$sb" hash-object -w --stdin)"
+  GIT_INDEX_FILE="$idx" git -C "$sb" update-index --add --cacheinfo "100644,${blob},${path}"
+  new_tree="$(GIT_INDEX_FILE="$idx" git -C "$sb" write-tree)"
+  rm -f "$idx"
+  new_commit="$(git -C "$sb" commit-tree "$new_tree" -p "$parent" -m "origin change to $path")"
+  git -C "$sb" update-ref refs/remotes/origin/main "$new_commit"
+}
+
+e2e_run_oracle() {
+  (cd "$1" && ./.gaia/scripts/resolve-audit-spawn.sh 2>/dev/null)
+}
+
+@test "criterion 24: end-to-end join - a real oracle ledger reports peer_merge_respawns >= 1" {
+  local sb resolver_src oracle_src lib_dir
+  sb="$BATS_TEST_TMPDIR/e2e-sandbox"
+  resolver_src="$THIS_DIR/../resolve-audit-members.sh"
+  oracle_src="$THIS_DIR/../resolve-audit-spawn.sh"
+  lib_dir="$THIS_DIR/../../../.claude/hooks/lib"
+  [ -x "$resolver_src" ] || skip "resolve-audit-members.sh not executable"
+  [ -x "$oracle_src" ] || skip "resolve-audit-spawn.sh not executable"
+
+  mkdir -p "$sb/.gaia/scripts" "$sb/.claude/hooks/lib"
+  printf '1.6.1\n' >"$sb/.gaia/VERSION"
+
+  git -C "$sb" init --quiet --initial-branch=main
+  git -C "$sb" config user.email "test@example.com"
+  git -C "$sb" config user.name "Test"
+  git -C "$sb" config commit.gpgsign false
+
+  echo "# readme" >"$sb/README.md"
+  git -C "$sb" add README.md
+  git -C "$sb" commit --quiet -m "init"
+  git -C "$sb" checkout --quiet -b feature
+
+  cp "$resolver_src" "$sb/.gaia/scripts/resolve-audit-members.sh"
+  chmod +x "$sb/.gaia/scripts/resolve-audit-members.sh"
+  cp "$oracle_src" "$sb/.gaia/scripts/resolve-audit-spawn.sh"
+  chmod +x "$sb/.gaia/scripts/resolve-audit-spawn.sh"
+  cp "$LIB" "$sb/.gaia/scripts/audit-respawn-lib.sh"
+  cp "$lib_dir/audit-scope.sh" "$sb/.claude/hooks/lib/audit-scope.sh"
+  cp "$lib_dir/audit-machinery.sh" "$sb/.claude/hooks/lib/audit-machinery.sh"
+  cp "$lib_dir/audit-clearance.sh" "$sb/.claude/hooks/lib/audit-clearance.sh"
+  cp "$lib_dir/audit-digest.sh" "$sb/.claude/hooks/lib/audit-digest.sh"
+
+  e2e_write_full_roster "$sb"
+  e2e_stage "$sb" .gaia/scripts/y.sh
+  e2e_commit "$sb" "chore"
+  e2e_write_marker "$sb" code-audit-maintainer-shell
+  e2e_sync_origin_main "$sb"
+
+  e2e_run_oracle "$sb" >/dev/null
+
+  # origin/main gains a REAL content change to a file the shell member owns.
+  e2e_advance_origin_main_with_change "$sb" .gaia/scripts/peer-owned.sh "peer change"
+  git -C "$sb" merge --quiet --no-edit refs/remotes/origin/main
+
+  e2e_run_oracle "$sb" >/dev/null
+
+  run "$SCRIPT" --root "$sb" --json
+  [ "$status" -eq 0 ]
+  local peer_json
+  peer_json="$(jq -r '.peer_merge_respawns' <<<"$output")"
+  [ "$peer_json" -ge 1 ] || return 1
+
+  run "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  local peer_text
+  peer_text="$(extract_num 'peer-merge re-spawns:')"
+  [ "$peer_text" -ge 1 ] || return 1
+}

--- a/.gaia/scripts/tests/audit-respawn-report.bats
+++ b/.gaia/scripts/tests/audit-respawn-report.bats
@@ -151,6 +151,27 @@ path_without_jq() {
   [ -n "$(stderr_only --root "$ROOT" --since "")" ]
 }
 
+@test "criterion 5b: a leading-zero --since is read in base 10, not as octal" {
+  # `$(( ))` reads a leading zero as octal, so an un-normalized `030` would
+  # silently report a 24-day window while the text still echoed "030 days",
+  # and `08` is not octal at all: the arithmetic errors, leaves its target
+  # unset, and trips `set -u` with a raw bash diagnostic in place of this
+  # script's own message. The `10#` guard is what prevents both, and without
+  # this test nothing turns red if a future edit drops it.
+  local since_ts expected_ts
+  run "$SCRIPT" --root "$ROOT" --json --since 030
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.window_days' <<<"$output")" = "30" ]
+  since_ts="$(jq -r '.since' <<<"$output")"
+  expected_ts="$(jq -rn --argjson e "$(( $(date -u +%s) - 30 * 86400 ))" '$e | todateiso8601')"
+  # Same day, so a second's clock drift between the two calls cannot flake it.
+  [ "${since_ts%T*}" = "${expected_ts%T*}" ]
+
+  run "$SCRIPT" --root "$ROOT" --json --since 08
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.window_days' <<<"$output")" = "8" ]
+}
+
 @test "criterion 6: jq absent from PATH exits 1, stderr diagnostic, nothing on stdout" {
   local nojq
   nojq="$(path_without_jq)"

--- a/.gaia/scripts/tests/resolve-audit-spawn.bats
+++ b/.gaia/scripts/tests/resolve-audit-spawn.bats
@@ -204,6 +204,97 @@ pool_snapshot() {
   ( cd "$dir" && find . -type f | LC_ALL=C sort | while IFS= read -r f; do printf '%s ' "$f"; shasum "$f" 2>/dev/null; done )
 }
 
+# --- Re-spawn breadcrumb ledger fixtures ------------------------------------
+#
+# The ledger the digest-marker filter appends to on its active path
+# (.gaia/local/telemetry/audit-respawn.jsonl), and the fixtures needed to
+# exercise it: a way to control which sibling audit-respawn-lib.sh the
+# oracle sees, and a way to make a peer-merge rotation genuinely rotate a
+# digest rather than reuse main's tree.
+
+# The ledger's path under the sandbox, matching gaia_respawn_ledger_path's
+# own contract.
+ledger_path() {
+  printf '%s/.gaia/local/telemetry/audit-respawn.jsonl' "$SANDBOX"
+}
+
+# The ledger's lines, one per line; empty (prints nothing) when the ledger
+# file does not exist yet.
+ledger_lines() {
+  local f
+  f="$(ledger_path)"
+  [ -f "$f" ] || return 0
+  cat "$f"
+}
+
+# Copies the REAL oracle ($SCRIPT) into the sandbox's OWN .gaia/scripts/ and
+# runs that copy from the sandbox, so its ${BASH_SOURCE[0]}-relative sibling
+# lookups (both _lib_dir and the re-spawn lib) resolve inside the sandbox
+# instead of the real repository. Every other test in this file runs the
+# real repo's oracle via $SCRIPT / run_oracle unmodified: this helper exists
+# only for the lib-absent / lib-defective tests below, the sole cases that
+# need to control the sandbox's own sibling audit-respawn-lib.sh. Do not add
+# a setup() copy of that lib for the general suite; it would be dead weight,
+# since $SCRIPT (real repo path) never resolves siblings from the sandbox.
+run_sandbox_oracle() {
+  cp "$SCRIPT" "$SANDBOX/.gaia/scripts/resolve-audit-spawn.sh"
+  chmod +x "$SANDBOX/.gaia/scripts/resolve-audit-spawn.sh"
+  ( cd "$SANDBOX" && ./.gaia/scripts/resolve-audit-spawn.sh "$@" 2>/dev/null )
+}
+
+# stderr-capturing sibling of run_sandbox_oracle, for the lib-absent /
+# lib-defective tests that need to prove the `command -v gaia_respawn_record`
+# guard is load-bearing: without it, an absent lib makes the oracle attempt
+# to invoke a nonexistent command, which leaks a "command not found"
+# diagnostic onto real stderr even though `|| true` keeps stdout and the
+# exit status untouched. run_sandbox_oracle itself discards stderr, so it
+# cannot see this leak; this helper exists to catch exactly that.
+# SC2069: deliberate capture-stderr / discard-stdout order, mirrors
+# oracle_stderr above.
+# shellcheck disable=SC2069
+run_sandbox_oracle_stderr() {
+  cp "$SCRIPT" "$SANDBOX/.gaia/scripts/resolve-audit-spawn.sh"
+  chmod +x "$SANDBOX/.gaia/scripts/resolve-audit-spawn.sh"
+  ( cd "$SANDBOX" && ./.gaia/scripts/resolve-audit-spawn.sh 2>&1 1>/dev/null )
+}
+
+# A PATH whose dir carries every binary these scripts need EXCEPT a sha256
+# tool (both sha256sum AND shasum absent; jq stays present), so the digest
+# engine's own fail-closed guard fires and the digest batch never loads,
+# while the jq-gated clearance reader stays reachable in principle. This is
+# the "sha256-tool arm" the digest-batch-unavailable criterion needs: the
+# degrade must be reached without deleting any lib.
+path_without_sha256() {
+  local d="$BATS_TEST_TMPDIR/nosha-bin" b p
+  mkdir -p "$d"
+  for b in env bash sh git awk sed grep sort head tail tr cat cut wc dirname basename mktemp date rm mkdir printf test expr jq; do
+    p="$(command -v "$b" 2>/dev/null)" && ln -sf "$p" "$d/$b"
+  done
+  printf '%s' "$d"
+}
+
+# Advances origin/main by ONE commit that actually changes PATH's content to
+# CONTENT: a real content diff on origin/main, not `advance_origin_main`'s
+# reused main^{tree}. Built via a throwaway GIT_INDEX_FILE seeded from
+# main's tree, so the sandbox's real index and its checked-out `feature`
+# working tree are both untouched; only the remote-tracking ref moves, and
+# the caller merges it into `feature` explicitly to make the merge-base move
+# too. Needed because `advance_origin_main` alone rotates no member's
+# digest (its synthetic commits carry no content change) and so cannot, on
+# its own, produce the peer-merge signal this ledger measures.
+advance_origin_main_with_change() {
+  local path="$1" content="$2" parent idx blob new_tree new_commit
+  parent="$(git -C "$SANDBOX" rev-parse main)"
+  idx="$BATS_TEST_TMPDIR/tmp-index-$RANDOM"
+  GIT_INDEX_FILE="$idx" git -C "$SANDBOX" read-tree main
+  blob="$(printf '%s\n' "$content" | git -C "$SANDBOX" hash-object -w --stdin)"
+  GIT_INDEX_FILE="$idx" git -C "$SANDBOX" update-index --add --cacheinfo "100644,${blob},${path}"
+  new_tree="$(GIT_INDEX_FILE="$idx" git -C "$SANDBOX" write-tree)"
+  rm -f "$idx"
+  new_commit="$(git -C "$SANDBOX" commit-tree "$new_tree" -p "$parent" -m "origin change to $path")"
+  git -C "$SANDBOX" update-ref refs/remotes/origin/main "$new_commit"
+}
+
 # ---------------------------------------------------------------------------
 # 1. app-only diff -> code-audit-frontend
 # ---------------------------------------------------------------------------
@@ -760,4 +851,348 @@ code-audit-maintainer-shell"
   err="$(oracle_stderr)"
   grep -qF -- "behind origin/main" <<<"$err" && return 1
   return 0
+}
+
+# ---------------------------------------------------------------------------
+# The re-spawn breadcrumb ledger. The digest-marker filter already computes,
+# per considered member, both halves of the question this ledger measures
+# (the member's content digest and whether a valid current-digest marker
+# cleared it); these tests exercise the append it now performs alongside
+# that decision. The oracle's own dispatch decision, exit status, and stdout
+# must stay exactly as proven by every test above -- these tests add
+# coverage for the ledger's own shape and fail-open behavior, never for a
+# changed dispatch answer.
+# ---------------------------------------------------------------------------
+
+@test "UAT-001: the ledger holds exactly one line per considered member, mixing cleared and uncleared" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  write_marker code-audit-frontend
+  stage .gaia/scripts/token-tally.sh; commit "fix"
+
+  # CONTROL: the whole-branch diff dispatches both members, matching the
+  # UAT-016 fixture this reuses.
+  members="$(resolve_members)"
+  expected_count="$(printf '%s\n' "$members" | grep -c .)"
+
+  run run_oracle
+  [ "$status" -eq 0 ]
+
+  actual_count="$(ledger_lines | grep -c .)"
+  [ "$actual_count" -eq "$expected_count" ]
+
+  actual_members="$(ledger_lines | jq -r .member | LC_ALL=C sort -u)"
+  expected_members="$(printf '%s\n' "$members" | LC_ALL=C sort -u)"
+  [ "$actual_members" = "$expected_members" ]
+
+  grep -qF '"member":"code-audit-frontend"' <<<"$(ledger_lines)" || return 1
+  grep -qF '"member":"code-audit-maintainer-shell"' <<<"$(ledger_lines)" || return 1
+}
+
+@test "each ledger line parses under jq and carries exactly the frozen key order" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  write_marker code-audit-frontend
+  stage .gaia/scripts/token-tally.sh; commit "fix"
+  run run_oracle
+  [ "$status" -eq 0 ]
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf '%s' "$line" | jq -e . >/dev/null || return 1
+    keys="$(printf '%s' "$line" | jq -r 'keys_unsorted | join(",")')"
+    [ "$keys" = "schema,ts,branch,head,merge_base,member,digest,cleared" ] || return 1
+  done <<<"$(ledger_lines)"
+}
+
+@test "digest in the ledger equals the member's real digest from the digest engine" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  write_marker code-audit-frontend
+  stage .gaia/scripts/token-tally.sh; commit "fix"
+  run run_oracle
+  [ "$status" -eq 0 ]
+
+  frontend_digest="$(member_digest_for code-audit-frontend)"
+  shell_digest="$(member_digest_for code-audit-maintainer-shell)"
+
+  rec_frontend="$(ledger_lines | grep '"member":"code-audit-frontend"')"
+  rec_shell="$(ledger_lines | grep '"member":"code-audit-maintainer-shell"')"
+
+  [ "$(printf '%s' "$rec_frontend" | jq -r .digest)" = "$frontend_digest" ]
+  [ "$(printf '%s' "$rec_shell" | jq -r .digest)" = "$shell_digest" ]
+}
+
+@test "cleared is true for a member holding a valid marker, false for a malformed one" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  write_marker code-audit-frontend
+  stage .gaia/scripts/token-tally.sh; commit "fix"
+  # The shell member's marker file exists but is not writer-shaped (garbage
+  # JSON), the same malformed-marker fixture shape the dispatch tests above
+  # use.
+  shell_digest="$(member_digest_for code-audit-maintainer-shell)"
+  mkdir -p "$SANDBOX/.gaia/local/audit"
+  printf 'not json {\n' > "$SANDBOX/.gaia/local/audit/${shell_digest}.code-audit-maintainer-shell.ok"
+
+  run run_oracle
+  [ "$status" -eq 0 ]
+
+  rec_frontend="$(ledger_lines | grep '"member":"code-audit-frontend"')"
+  rec_shell="$(ledger_lines | grep '"member":"code-audit-maintainer-shell"')"
+
+  [ "$(printf '%s' "$rec_frontend" | jq -r .cleared)" = "true" ]
+  [ "$(printf '%s' "$rec_shell" | jq -r .cleared)" = "false" ]
+}
+
+@test "head and branch in the ledger match the fixture's real HEAD and branch name" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  run run_oracle
+  [ "$status" -eq 0 ]
+
+  real_head="$(git -C "$SANDBOX" rev-parse HEAD)"
+  real_branch="$(git -C "$SANDBOX" symbolic-ref --short HEAD)"
+
+  rec="$(ledger_lines | tail -1)"
+  [ "$(printf '%s' "$rec" | jq -r .head)" = "$real_head" ]
+  [ "$(printf '%s' "$rec" | jq -r .branch)" = "$real_branch" ]
+}
+
+@test "UAT-002: peer-merge rotation - merge_base moves, digest rotates, and clearance is lost across the pair" {
+  write_full_roster
+  stage .gaia/scripts/y.sh; commit "chore"
+  write_marker code-audit-maintainer-shell
+  sync_origin_main
+
+  run run_oracle
+  before="$(ledger_lines | tail -1)"
+  before_mb="$(printf '%s' "$before" | jq -r .merge_base)"
+
+  # origin/main gains a REAL content change to a file the shell member owns.
+  advance_origin_main_with_change .gaia/scripts/peer-owned.sh "peer change"
+  git -C "$SANDBOX" merge --quiet --no-edit refs/remotes/origin/main
+  after_mb_check="$(git -C "$SANDBOX" merge-base HEAD refs/remotes/origin/main)"
+  # The merge-base must have actually moved before the record is trusted.
+  [ "$after_mb_check" != "$before_mb" ] || return 1
+
+  run run_oracle
+  after="$(ledger_lines | grep '"member":"code-audit-maintainer-shell"' | tail -1)"
+
+  before_digest="$(printf '%s' "$before" | jq -r .digest)"
+  after_digest="$(printf '%s' "$after" | jq -r .digest)"
+  after_mb="$(printf '%s' "$after" | jq -r .merge_base)"
+  before_cleared="$(printf '%s' "$before" | jq -r .cleared)"
+  after_cleared="$(printf '%s' "$after" | jq -r .cleared)"
+
+  [ -n "$before_mb" ] || return 1
+  [ -n "$after_mb" ] || return 1
+  [ "$before_mb" != "$after_mb" ] || return 1
+  [ "$before_digest" != "$after_digest" ] || return 1
+  [ "$before_cleared" = "true" ] || return 1
+  [ "$after_cleared" = "false" ] || return 1
+}
+
+@test "UAT-003: own-edit rotation - merge_base stays identical while digest and head differ" {
+  write_full_roster
+  stage .gaia/scripts/y.sh; commit "chore"
+  write_marker code-audit-maintainer-shell
+  sync_origin_main
+
+  run run_oracle
+  before="$(ledger_lines | tail -1)"
+
+  # A maintainer edit to a file the shell member owns; origin/main untouched.
+  stage .gaia/scripts/z.sh; commit "more shell"
+
+  run run_oracle
+  after="$(ledger_lines | tail -1)"
+
+  before_mb="$(printf '%s' "$before" | jq -r .merge_base)"
+  after_mb="$(printf '%s' "$after" | jq -r .merge_base)"
+  before_digest="$(printf '%s' "$before" | jq -r .digest)"
+  after_digest="$(printf '%s' "$after" | jq -r .digest)"
+  before_head="$(printf '%s' "$before" | jq -r .head)"
+  after_head="$(printf '%s' "$after" | jq -r .head)"
+
+  [ -n "$before_mb" ] || return 1
+  [ "$before_mb" = "$after_mb" ] || return 1
+  [ "$before_digest" != "$after_digest" ] || return 1
+  [ "$before_head" != "$after_head" ] || return 1
+}
+
+@test "on a detached HEAD, branch is empty in the ledger and the run is otherwise unchanged" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  sha="$(commit_sha)"
+  git -C "$SANDBOX" checkout --quiet "$sha"
+  run run_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  rec="$(ledger_lines | tail -1)"
+  [ "$(printf '%s' "$rec" | jq -r .branch)" = "" ]
+}
+
+@test "with no origin/main, merge_base is empty in the ledger and the run is otherwise unchanged" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  git -C "$SANDBOX" rev-parse --verify --quiet refs/remotes/origin/main >/dev/null 2>&1 && return 1
+  run run_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  rec="$(ledger_lines | tail -1)"
+  [ "$(printf '%s' "$rec" | jq -r .merge_base)" = "" ]
+}
+
+@test "--no-carry-forward writes no ledger file at all (the filter is skipped)" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  run run_oracle --no-carry-forward
+  [ "$status" -eq 0 ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "digest batch unavailable (no sha256 tool) writes no ledger; the degrade path returns before the loop" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  nosha="$(path_without_sha256)"
+  out="$( cd "$SANDBOX" && PATH="$nosha" "$SCRIPT" 2>/dev/null )"
+  # Filter disabled entirely (digest batch never loads) -> unfiltered passthrough.
+  [ "$out" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "jq absent still writes breadcrumbs, all cleared:false" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  write_marker code-audit-frontend
+  stage .gaia/scripts/token-tally.sh; commit "fix"
+
+  nojq="$(path_without_jq)"
+  out="$( cd "$SANDBOX" && PATH="$nojq" "$SCRIPT" 2>/dev/null )"
+  grep -qxF "code-audit-frontend" <<<"$out" || return 1
+  grep -qxF "code-audit-maintainer-shell" <<<"$out" || return 1
+
+  ledger_content="$(ledger_lines)"
+  [ -n "$ledger_content" ] || return 1
+  printf '%s\n' "$ledger_content" | grep -qF '"cleared":true' && return 1
+  count="$(printf '%s\n' "$ledger_content" | grep -c .)"
+  [ "$count" -eq 2 ] || return 1
+}
+
+@test "ledger parent path blocked (a file where the directory should be): stdout, exit status, and stderr are unaffected" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+
+  mkdir -p "$SANDBOX/.gaia/local"
+  printf 'blocked\n' > "$SANDBOX/.gaia/local/telemetry"
+
+  run run_oracle
+  blocked_status="$status"
+  blocked_stdout="$output"
+  blocked_stderr="$(oracle_stderr)"
+
+  [ ! -d "$SANDBOX/.gaia/local/telemetry" ]
+  rm -f "$SANDBOX/.gaia/local/telemetry"
+
+  run run_oracle
+  unblocked_status="$status"
+  unblocked_stdout="$output"
+  unblocked_stderr="$(oracle_stderr)"
+
+  [ "$blocked_status" -eq "$unblocked_status" ]
+  [ "$blocked_stdout" = "$unblocked_stdout" ]
+  [ "$blocked_stderr" = "$unblocked_stderr" ]
+}
+
+@test "ledger file made unwritable (chmod 0444): stdout, exit status, and stderr are unaffected" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+
+  run run_oracle
+  [ -f "$(ledger_path)" ] || return 1
+  chmod 0444 "$(ledger_path)"
+  before_count="$(ledger_lines | grep -c .)"
+
+  run run_oracle
+  locked_status="$status"
+  locked_stdout="$output"
+  locked_stderr="$(oracle_stderr)"
+
+  after_count="$(ledger_lines | grep -c .)"
+  [ "$after_count" -eq "$before_count" ]
+
+  chmod 0644 "$(ledger_path)"
+  run run_oracle
+  unlocked_status="$status"
+  unlocked_stdout="$output"
+  unlocked_stderr="$(oracle_stderr)"
+
+  [ "$locked_status" -eq "$unlocked_status" ]
+  [ "$locked_stdout" = "$unlocked_stdout" ]
+  [ "$locked_stderr" = "$unlocked_stderr" ]
+}
+
+@test "criterion 18: re-spawn lib absent from the sandbox - stdout, exit status, and stderr unaffected, no ledger" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  rm -f "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+  # The guard (`command -v gaia_respawn_record`) is what keeps this silent:
+  # without it, the oracle would attempt to invoke the now-undefined
+  # function and leak a "command not found" diagnostic here.
+  [ -z "$(run_sandbox_oracle_stderr)" ]
+}
+
+@test "criterion 18: re-spawn lib present but unsourceable (syntax error) - stdout and exit status unaffected, no ledger" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  printf 'if true\n' > "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "criterion 18: re-spawn lib present but its top level returns 1 - stdout and exit status unaffected, no ledger" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  printf 'return 1\n' > "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "criterion 18: re-spawn lib sourceable but gaia_respawn_record is defective - stdout and exit status unaffected, no ledger" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  cat "$THIS_DIR/../audit-respawn-lib.sh" > "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  printf '\ngaia_respawn_record() { return 1; }\n' >> "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "the ledger lives outside the audit pool: pool_snapshot stays byte-identical while the ledger gains a line" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  before_pool="$(pool_snapshot)"
+  run run_oracle
+  [ "$status" -eq 0 ]
+  after_pool="$(pool_snapshot)"
+  [ "$before_pool" = "$after_pool" ]
+  [ -f "$(ledger_path)" ]
+}
+
+@test "the oracle runs cleanly under macOS's system /bin/bash (bash 3.2 compatibility)" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  run bash -c 'cd "$1" && /bin/bash "$2"' _ "$SANDBOX" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
 }

--- a/.gaia/scripts/tests/resolve-audit-spawn.bats
+++ b/.gaia/scripts/tests/resolve-audit-spawn.bats
@@ -1167,6 +1167,32 @@ code-audit-maintainer-shell"
   [ ! -f "$(ledger_path)" ]
 }
 
+@test "criterion 18: re-spawn lib aborts under set -u while sourcing - stdout and exit status unaffected, no ledger" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  # The fifth defective shape, and the one the `|| true` on the source line
+  # cannot absorb: an unset-variable reference at the lib's top level kills the
+  # shell where it stands, before any later statement runs. The oracle's
+  # contract has to survive it the same way it survives the other four.
+  printf ': "$GAIA_RESPAWN_NO_SUCH_VAR"\n' > "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+  [ ! -f "$(ledger_path)" ]
+}
+
+@test "criterion 18: re-spawn lib prints at source time - stdout stays the spawn set alone" {
+  write_full_roster
+  stage app/x.tsx; commit "feat"
+  # The lib is contracted to be side-effect-free at source time. This script's
+  # stdout is its answer, so a stray print would not just add noise, it would
+  # be read back as a member name.
+  printf 'echo stray-source-time-output\n' > "$SANDBOX/.gaia/scripts/audit-respawn-lib.sh"
+  run run_sandbox_oracle
+  [ "$status" -eq 0 ]
+  [ "$output" = "code-audit-frontend" ]
+}
+
 @test "criterion 18: re-spawn lib sourceable but gaia_respawn_record is defective - stdout and exit status unaffected, no ledger" {
   write_full_roster
   stage app/x.tsx; commit "feat"

--- a/.gaia/state-registry.json
+++ b/.gaia/state-registry.json
@@ -88,6 +88,18 @@
       "source": "SPEC-061 §shared"
     },
     {
+      "id": "audit-respawn-ledger",
+      "path": "telemetry/audit-respawn.jsonl",
+      "match": "exact",
+      "kind": "file",
+      "scope": "shared",
+      "keyed_by": "singleton append-only store; every row is self-identifying (branch + head + merge_base + member + digest + ts) and each record is one O_APPEND write, so rows written from different trees interleave without a lock and are separated at read time by their branch and member fields",
+      "why": "The Code Audit Team spawn oracle's re-spawn breadcrumb: one record per member considered, written where the oracle already holds every member digest and has already read the clearance store. Shared rather than per-tree because the question it answers, how often a member is re-spawned for a key rotation it did not earn, is a property of the repository's audit history across every branch and every tree, not of one working copy.",
+      "writer": "code",
+      "reaped_by": "audit re-spawn ledger prune sweep",
+      "source": "SPEC-063 §shared"
+    },
+    {
       "id": "debt-count-and-refresh",
       "path": "debt/count.json|debt/refresh-requested",
       "match": "exact",
@@ -471,7 +483,7 @@
     { "path": "red-ledger/*", "match": "glob", "why": "Its keyed per-tree subdir (red-ledger/<tree_key>/) and that subdir's own atomic-write scratch subdir (red-ledger/<tree_key>/.tmp), addressed by the tree key so a tree's observations stay private to it." },
     { "path": "specs", "match": "exact", "why": "The main-checkout SPEC-folder container." },
     { "path": "specs/archived", "match": "exact", "why": "Legacy archived-SPEC destination, preserved for repair and migration tooling." },
-    { "path": "telemetry", "match": "exact", "why": "The append-only cost-ledger container." },
+    { "path": "telemetry", "match": "exact", "why": "Append-only maintainer ledgers: cost telemetry and the audit re-spawn breadcrumb store." },
     { "path": "worthiness-ledger", "match": "exact", "why": "The per-tree worthiness-observation container." },
     { "path": "worthiness-ledger/*", "match": "glob", "why": "Its keyed per-tree subdir (worthiness-ledger/<tree_key>/), addressed by the tree key so a tree's worthiness observations stay private to it." }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ A release change that requires the adopter to act, run a command or hand-migrate
 
 ### Added
 
+- maintainer-only measurement of Code Audit Team re-spawns. The spawn oracle now records why each member is dispatched, and a reporting command turns the accumulated records into a count of clearances lost to a peer's merge rather than to a real content change, so the decision to re-key the marker can be made on evidence instead of anecdote.
 - a filed tech-debt issue now records the work that surfaced it, so a triager reading the backlog months later can tell which branch was under review, what that work was doing, and whether the cited file was one the reviewed change had already touched. The record is an HTML comment, so nothing changes in what a human reads on the issue, and it is diagnostic only: nothing matches on it, nothing gates on it, and a filing is never blocked because a field could not be determined. **Action required:** the backlog that predates this record carries no line to distinguish it from a write that failed, so run this once, per repository, at the point this change goes live there:
 
   ```bash

--- a/wiki/concepts/Local Working State.md
+++ b/wiki/concepts/Local Working State.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-07-01
-updated: 2026-07-20
+updated: 2026-08-02
 tags: [concept, claude, hooks]
 ---
 
@@ -38,6 +38,10 @@ Because the folder is invisible to git, residue a subsystem leaves behind never 
 | `harden/declines.json` | `/gaia-harden` | live | one copy shared by every tree, so an operator decline made in a linked worktree suppresses the candidate everywhere and survives the worktree's removal |
 
 A linked worktree's `.gaia/local` is a single symlink to the main checkout's `.gaia/local`, so every path in the table above resolves to one copy rather than forking per tree. `.gaia/state-registry.json` declares each entry's scope, and an entry that has to stay private to one tree gets that isolation from a tree key in its own path rather than from a directory of its own; see [[Worktrees]]. The same linking covers a second, disjoint set: the checkout-root gitignored `.env` / `.env.*` files (every basename matching `.env` or `.env.*`, excluding the committed `.env.example`). Each linked worktree gets `<worktree>/.env` (and any `.env.*`) symlinked to the main checkout's copy, so the worktree's `pnpm dev` and Playwright runs read the same local secrets without a manual copy. These files live at the checkout root, not under `.gaia/local/`, so they aren't rows in the table above.
+
+<!-- gaia:maintainer-only:start -->
+`telemetry/` also holds a second, maintainer-only ledger beside `cost.jsonl`: `telemetry/audit-respawn.jsonl`, the Code Audit Team spawn oracle's append-only re-spawn breadcrumb ledger, one record per member the digest-marker filter considers. It is shared like its `cost.jsonl` sibling, so every tree contributes to one copy, but it is bounded where that sibling is not: a session-start sweep, separate from the nine janitor sweeps below, age-drops records past a retention window and caps the line count, both knobs floor-clamped. It exists only on a clone that carries the spawn oracle.
+<!-- gaia:maintainer-only:end -->
 
 A **live** entry is load-bearing state that tooling reads. An **ephemeral** entry is consumed once and then orphaned; its owner is meant to prune it, and the janitor backstops what the owner misses.
 

--- a/wiki/decisions/Code Audit Team.md
+++ b/wiki/decisions/Code Audit Team.md
@@ -47,6 +47,20 @@ The spawn set equals the dispatched member set, filtered to drop a member whose 
 
 A member with nothing to audit is never spawned, and if a stale caller spawns it anyway, it self-skips (each member's agent file carries the skip clause).
 
+<!-- gaia:maintainer-only:start -->
+### Re-spawn breadcrumbs
+
+The digest-marker filter above is the one place that already holds both halves of a re-spawn decision: it has called `audit_digests_all` once for the whole roster and is about to read the clearance store. At that point it appends one JSON-Lines record per member it considers to `.gaia/local/telemetry/audit-respawn.jsonl`, so the write costs an append and derives no digest of its own. Each record carries `schema`, `ts`, `branch`, `head`, `merge_base`, `member`, `digest`, and `cleared`; `merge_base` is the merge-base of `refs/remotes/origin/main` and HEAD.
+
+The filter's own degrade path, no clearance reader or no digest batch available, writes nothing, because it derived no digest there either. `--no-carry-forward`, the ownerless probe, and every fail-closed answer above never reach the filter and write nothing for the same reason. The oracle records what it saw and decides nothing: it never classifies a re-spawn, and the breadcrumb never changes which members it names. A failed append leaves the spawn decision, its exit status, and its stdout byte-identical, with nothing on stderr, fail-open exactly like the mints-nothing guarantee above. The instrument reads in one direction only, the marker store, and writes only its own ledger, so a defect in it costs a missing or spurious record and never a false clear. A breadcrumb is not a clearance artifact, and the oracle still mints nothing.
+
+`.gaia/scripts/audit-respawn-report.sh` is the documented query over the accumulated ledger, `--since <days>` (default 30) and `--json`. It groups records by branch and member, orders each group by timestamp, and reads every consecutive pair for whether the digest rotated, whether the merge-base advanced, and whether a clearance was lost. It reports `records`, `transitions`, `peer_merge_respawns`, `own_change_respawns`, and `peer_merge_rotations_upper`; `peer_merge_respawns` is the headline, the single quantity a re-spawn caused by absorbing a peer's merge rather than the branch's own edits. Three caveats travel with it: a run that both absorbs main and lands its own edits counts as peer-merge, so within its class the count is an upper bound; the pairing needs an observation taken while the member was cleared, so the count is a lower bound on total incidence; and attribution is a query over recorded facts, never a judgement the resolver makes.
+
+The ledger is registered in `.gaia/state-registry.json` at `scope: shared` and reaped by `.gaia/scripts/audit-respawn-prune.sh`, delegated from the SessionStart hook. Two arms bound it: an age window (`GAIA_AUDIT_RESPAWN_RETENTION_DAYS`, default 90, floored at 45) and a line cap (`GAIA_AUDIT_RESPAWN_MAX_RECORDS`, default 20000, floored at 1000). The cap trims only records the age window has already dropped, so retention never falls below the window no matter how busy the repository gets; a record the sweep cannot classify is kept, never dropped.
+
+Keying the marker to the reviewed diff instead of the whole owned content is deferred, not rejected. The condition for revisiting it: the attribution query reports `peer_merge_respawns`, measured over at least one month of accumulated records, at a rate the maintainer judges to exceed the cost of the change.
+<!-- gaia:maintainer-only:end -->
+
 ## AND-aggregation at the merge gate
 
 The local merge deny-hook (`.claude/hooks/pr-merge-audit-check.sh`) resolves the dispatched member set, computes every roster member's own content digest in one walk, and requires **every** dispatched member cleared before allowing `gh pr merge`:

--- a/wiki/decisions/Code Audit Team.md
+++ b/wiki/decisions/Code Audit Team.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-07-09
 created: 2026-07-09
-updated: 2026-07-20
+updated: 2026-08-02
 tags: [decision, claude, audit, ci]
 ---
 
@@ -32,6 +32,8 @@ Roster parsing and per-path ownership live in one shared, sourced module, `.clau
 A sibling module, `.claude/hooks/lib/audit-machinery.sh`, holds the one list of **audit-machinery paths**: every file whose bytes can change what a member reviews, who reviews it, where a clearance lands, or whether a clearance is believed (the roster, the classifier and machinery modules themselves, the clearance writer and reader, the merge gate, the CI workflow and its bundled templates, the agent definitions, among others). A `.bats` suite is deliberately excluded, its bytes decide none of those four things; the suites are covered instead by the roster's own `.bats` globs (see below), which dispatch a real member to review them.
 
 Every member's clearance marker is keyed to a **content digest**, not the whole repository tree: a sha256 over exactly the files that member owns plus this machinery set (plus the in-scope-but-ownerless paths, for the default member; see [[PR Merge Workflow#Marker key]]). The machinery set is what makes a machinery edit rotate **every** member's digest, since it sits in every member's input set by construction, and because the classifier and machinery modules are themselves machinery, a classifier edit rotates every digest too. Machinery-list completeness is therefore load-bearing, not cosmetic: an unlisted gate-machinery file would rotate no member's key, a fail-open. `.gaia/scripts/audit-machinery-complete.sh` asserts every gate-machinery file (the trailer/status producers, the CI parsers, the dispatch resolvers, the noop detector, the disposition gate, among others) is matched by `audit_path_is_machinery`.
+
+The digest functions in `.claude/hooks/lib/audit-digest.sh` (`audit_digests_all`, `audit_member_digest`) take an optional ref argument, defaulting to `HEAD`; production callers pass a base sha through it to derive a prior digest at an incremental base rather than only at HEAD. The constraint that this machinery never resolves a main or tree root, and answers what key a tree writes under rather than where anything is, belongs to `.gaia/scripts/audit-key-lib.sh`, a property of that file, not of the digest lib. That the digest functions accept a ref proves the lib can hash a different tree; it does not mean the lib can scope to a diff between two trees, which would be a new capability, not a parameter already present.
 
 ## Dispatch resolver
 


### PR DESCRIPTION
## What

The Code Audit Team's spawn oracle re-dispatches a member whenever that member's content digest rotates, and one cause of a rotation is not a content change at all: a peer's merge landing under an already-audited branch. Nobody knows how often that actually happens.

This builds the instrument rather than the cure. The oracle appends one JSON-Lines breadcrumb per considered member at the one point that already holds both the digests and the marker store, a session-start sweep bounds the resulting ledger, and a documented query turns it into a count of peer-merge-attributable re-spawns.

## How

- `.gaia/scripts/audit-respawn-lib.sh`, sourced-only shared library: ledger path resolver, fail-open silent record writer, and two retention knobs with default-then-floor semantics.
- `.gaia/scripts/resolve-audit-spawn.sh` writes one breadcrumb per considered member, inside the digest-marker filter's active branch only. Its stdout and exit status stay byte-identical on every path.
- `.gaia/state-registry.json` registers the ledger with a real reaper. The retention window outranks the record cap: the cap may only trim records already outside the window.
- `.gaia/scripts/audit-respawn-prune.sh` reaps, delegated from the session-start hook. `.gaia/scripts/audit-respawn-report.sh` runs the documented attribution query.

## Notes

Exactly one changed path is audit machinery, `.gaia/scripts/resolve-audit-spawn.sh`; every other changed path returns flag `0`. No byte of the digest recipe or its consumers changes. Editing the oracle rotates all five member digests once, so this lands while no other pull request is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)