### PR TITLE
wiki: sync through a7c0878

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "43e4bb705d4ce3aca9447f85c40ac03ab7a880db",
-  "last_evaluated_at": "2026-07-31T01:03:52Z",
+  "last_evaluated_sha": "a7c0878a8e782630539b03348ba15eecc48e4e71",
+  "last_evaluated_at": "2026-08-02T03:45:29Z",
   "last_consolidated_sha": "baad8972ee9d300aee847b84f17d72e45c1fbddf",
   "last_consolidated_at": "2026-07-29T05:58:30Z"
 }

--- a/wiki/concepts/Generated Regions.md
+++ b/wiki/concepts/Generated Regions.md
@@ -2,7 +2,7 @@
 type: concept
 status: active
 created: 2026-07-22
-updated: 2026-07-22
+updated: 2026-08-02
 tags: [release, update, claude, drift]
 ---
 
@@ -37,7 +37,9 @@ The verdict itself, `no-upstream-change` / `no-adopter-drift` / `already-latest`
 
 ## Regeneration
 
-`gaia update regen-regions` is the authoritative half: once the oracle confirms a declared region's divergence is confined to its markers, this command re-runs the declaration's own shipped regeneration command against the adopter's post-merge tree, one region at a time. It is confined to the region's own declared paths: every file under those paths is backed up first, and any write the regeneration command makes outside its declared paths is reverted when a pre-image exists to restore, or reported when it does not. A region named by the merge walk's skip or conflict lists, or whose declaration itself is malformed, is refused or skipped rather than regenerated, and neither a refusal nor a regeneration failure ever fails the update. The regeneration command always runs as a fixed argv, interpreter plus operand plus arguments, never through a shell-interpreted string.
+`gaia update regen-regions` is the authoritative half: once the oracle confirms a declared region's divergence is confined to its markers, this command re-runs the declaration's own shipped regeneration command against the adopter's post-merge tree, one region at a time. Every file under the region's declared paths is backed up first. Inside those directories, where the pre-run snapshot exists, any path the regeneration command leaves different from the declared set counts as an undeclared write: a deletion is reverted from its pre-image, and a creation, having none, is removed. Outside the region's declared directories entirely there is no snapshot to compare against, so a write there is reported rather than undone. A symlink follows the same rule by its target string rather than its content: one the command deletes, retargets, or replaces with a regular file is restored to its original target, and one it creates is removed; restoring a link writes no content and follows nothing, so whatever it points at is never touched.
+
+A region named by the merge walk's skip or conflict lists, or whose declaration itself is malformed, is refused or skipped rather than regenerated. A manifest whose `regions` key is present but not an array is refused by name at this same step; a manifest that is not an object at all never reaches this step, since the loader that reads it finds no `regions` key to be wrong-typed and falls back to zero declarations. A regeneration command that exits non-zero, one that never launches, and one that runs but is killed by this runner's own time or output ceiling are reported as three distinct outcomes, since each has a different remedy. Neither a refusal nor a regeneration failure ever fails the update. The regeneration command always runs as a fixed argv, interpreter plus operand plus arguments, never through a shell-interpreted string.
 
 ## The one-release lag
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,22 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-08-02 a7c0878 SKIP - docs: bats-assertions.md absence-check trap and fix documented, comment-only script clarification; instruction-prose and comment fix, no wiki-tracked fact changed
+- 2026-08-02 556a1a8 WORTHY - re-spawn ledger measures peer-merge vs own-change re-dispatch before any re-keying decision; wiki/decisions/Code Audit Team.md, wiki/concepts/Local Working State.md updated in-commit
+- 2026-08-02 eafc3bc WORTHY - every disposition route now stamps a provenance line beside its dedup key; wiki/concepts/Audit Disposition and Debt Fix.md updated in-commit
+- 2026-08-02 5f96c53 SKIP - machinery-waive eligibility widened to the union of gate-machinery paths and the PR's own changed files; wiki/concepts/Audit Disposition and Debt Fix.md already documents this union rule (verified by .gaia/tests/lib/doc-machinery-waive-prose.bats), no page delta needed
+- 2026-08-02 5fee8d4 WORTHY - marker block owns its own separator, roster pin reports the count it saw; wiki/decisions/Bundle-time Scrub.md updated in-commit
+- 2026-08-02 261178f WORTHY - regen-regions confinement now correctly reverts deletions/creations and symlinks, and distinguishes killed from spawn-failed regeneration → wiki/concepts/Generated Regions.md refined (Regeneration section)
+- 2026-08-02 98e2f64 SKIP - prototype-key lookups fail closed in two more CLI parsers, merge-workspace's sort separator switched to a unicode escape so the file reads as text; internal correctness fixes, no documented behavior change
+- 2026-08-02 08eb04f WORTHY - per-call window closes at ';', suite path ships wrapped; wiki/concepts/Code Review Audit Agent.md updated in-commit
+- 2026-08-02 a8a2d59 SKIP - merge-audit-ci's flag parser now guards Object.prototype key names; internal argv-parsing correctness fix, no prototype pollution and no documented behavior change
+- 2026-08-02 fc1b1a7 WORTHY - update-class table now states what the merge walk does; wiki/concepts/Update Workflow.md, wiki/decisions/Folding Shell Scripts into the CLI Binary.md updated in-commit
+- 2026-08-02 01b0be9 WORTHY - all five audit members review the content their marker covers; wiki/concepts/Code Review Audit Agent.md updated in-commit
+- 2026-08-02 9aa5f0d SKIP - check-audit-key-callers fails closed on a root it cannot scan; closes a latent contract hole in an undocumented internal script
+- 2026-08-02 8101481 SKIP - BASE_REF exemption tightened to a whole-identifier match in the static drift checker; internal correctness fix to undocumented tooling, no wiki-tracked fact changed
+- 2026-08-02 8a63812 WORTHY - all five Code Audit Team members key findings to one review base, FULL_BASE kept for the self-skip arm; wiki/concepts/Code Review Audit Agent.md, PR Merge Workflow.md, Incremental CI Skipping.md updated in-commit
+- 2026-08-02 d21b424 SKIP - two more bats setup() gates fail closed on CI; extends the already-established fail-closed pattern to two more suites, no new doc surface
+- 2026-08-02 daa0ebf SKIP - wiki: self-referential prior sync commit, no further wiki action
 - 2026-07-31 1a9a812 WORTHY - all five Code Audit Team members resolve the review base through resolve-audit-base.sh, with the whole-PR fork point kept as FULL_BASE for the self-skip arm alone; wiki/concepts/Code Review Audit Agent.md, wiki/concepts/PR Merge Workflow.md, wiki/concepts/Incremental CI Skipping.md updated in-commit
 - 2026-07-31 43e4bb7 SKIP - PyYAML precondition gate now fails instead of skips on CI; maintainer-only test-infra hardening below the level PR Merge Workflow.md's guard description tracks
 - 2026-07-31 119d14e WORTHY - self-heal retrigger jobs capped inside the poller window, Playwright installs one browser engine; wiki/concepts/PR Merge Workflow.md updated in-commit (verify-before-dispatch section)


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to a7c0878.