### PR TITLE
fix(cli): bound the release changelog git spawn (#1147)

### DIFF
--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -17674,9 +17674,11 @@ var HELP_TEXT20 = `Usage: gaia-maintainer release changelog [--draft] [--version
 `;
 var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT10 = 2;
+var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
 var defaultRunner2 = (command, args, options) => spawnSync2(command, args, {
   cwd: options.cwd,
   encoding: "utf8",
+  maxBuffer: MAX_GIT_BUFFER_BYTES,
   stdio: ["ignore", "pipe", "pipe"]
 });
 var takeValue7 = (argv, index, flag) => {
@@ -21721,13 +21723,13 @@ import path21 from "node:path";
 
 // src/wiki/util/git.ts
 import { execFileSync as execFileSync3 } from "node:child_process";
-var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
+var MAX_GIT_BUFFER_BYTES2 = 64 * 1024 * 1024;
 var runGit = (args, options = {}) => {
   const cwd = options.cwd ?? process.cwd();
   const result = execFileSync3("git", args, {
     cwd,
     encoding: "utf8",
-    maxBuffer: MAX_GIT_BUFFER_BYTES,
+    maxBuffer: MAX_GIT_BUFFER_BYTES2,
     stdio: ["ignore", "pipe", "pipe"]
   });
   return result.toString();

--- a/.gaia/cli/src/release/changelog.test.ts
+++ b/.gaia/cli/src/release/changelog.test.ts
@@ -8,6 +8,8 @@ import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {
+  collectCommits,
+  defaultRunner,
   graduateChangelog,
   groupCommits,
   renderBlock,
@@ -48,6 +50,16 @@ const failResult = (status: number): SpawnSyncReturns<string> => ({
   stdout: '',
 });
 
+const spawnErrorResult = (error: Error): SpawnSyncReturns<string> => ({
+  error,
+  output: ['', '', ''] as never,
+  pid: 0,
+  signal: null,
+  status: null,
+  stderr: '',
+  stdout: '',
+});
+
 const buildLogOutput = (
   commits: {body?: string; subject: string}[]
 ): string => {
@@ -74,6 +86,35 @@ const buildRunner =
 
     return okResult('');
   };
+
+describe('defaultRunner', () => {
+  // Asserted against a child that writes past Node's 1 MiB spawnSync default
+  // rather than against the constant, so the test fails if the bound is
+  // removed by any means.
+  test('reads child stdout past the 1 MiB spawnSync default', () => {
+    const size = 2 * 1024 * 1024;
+
+    const result = defaultRunner(
+      process.execPath,
+      ['-e', `process.stdout.write('x'.repeat(${size}))`],
+      {cwd: process.cwd()}
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.stdout).toHaveLength(size);
+  });
+});
+
+const enobufsRunner: CommandRunner = () =>
+  spawnErrorResult(new Error('spawnSync git ENOBUFS'));
+
+describe('collectCommits', () => {
+  test('throws with the spawn error rather than returning no commits', () => {
+    expect(() =>
+      collectCommits('/nonexistent', enobufsRunner, 'v1.0.0..HEAD')
+    ).toThrow('git log failed: spawnSync git ENOBUFS');
+  });
+});
 
 describe('groupCommits', () => {
   test('routes feat → Added, fix → Fixed, refactor/perf/docs → Changed', () => {

--- a/.gaia/cli/src/release/changelog.ts
+++ b/.gaia/cli/src/release/changelog.ts
@@ -55,10 +55,20 @@ export type CommandRunner = (
   options: {cwd: string}
 ) => SpawnSyncReturns<string>;
 
+/**
+ * `collectCommits` asks git for every subject *and body* since the last tag,
+ * so its output grows with the distance from that tag and passes Node's 1 MiB
+ * `spawnSync` default well before a release is due, failing the command
+ * closed with ENOBUFS. Matches the bound `wiki/util/git.ts` and
+ * `util/git-env.ts` already use for git spawns.
+ */
+const MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
+
 export const defaultRunner: CommandRunner = (command, args, options) =>
   spawnSync(command, args as string[], {
     cwd: options.cwd,
     encoding: 'utf8',
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 


### PR DESCRIPTION
Closes #1147

## What

`release changelog` reads every commit subject **and body** since the last tag, so its `git log` output grows with the distance from that tag. `defaultRunner` declared no `maxBuffer`, so Node's 1 MiB `spawnSync` default applied and the command failed closed with `ENOBUFS` once the range passed it, which is worst exactly when a release is due.

Reproduced on `main` before the fix, and it is not marginal: 461 commits and **1,248,452 bytes** at `v1.6.1..HEAD`.

```
$ .gaia/cli/gaia-maintainer release changelog --draft
changelog: git log failed: spawnSync git ENOBUFS
```

After: exit 0, 376 lines of rendered block, empty stderr, against that same 1.2 MB log.

## How

- `MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024` on the runner rather than on `collectCommits`'s call site, so `lastTag` and every other caller of this file's runner are covered by one bound.
- 64 MiB and that name match `wiki/util/git.ts:16` and `util/git-env.ts:40`, the CLI's two other git-output readers. `regen-regions.ts:933`'s 32 MiB is the region-digest spawner, a different job.
- File-local, like all three precedents. A shared export would mean touching three other files that sit at two different values, which is outside this fix.

## Guard proofs

Both new tests were proven able to fail before being relied on.

- `defaultRunner reads child stdout past the 1 MiB spawnSync default` — RED before the fix with the exact production symptom (`Error: spawnSync … ENOBUFS`, `code: 'ENOBUFS'`), GREEN after. It drives a real child that writes 2 MiB, so it fails if the bound is removed by any means, not just if the constant is renamed.
- `collectCommits throws with the spawn error rather than returning no commits` — the failure arm the issue notes is unexercised. Proven by mutation: replacing the `throw` with `return []` turns it RED; the file was restored byte-identical afterwards.

`bash .gaia/tests/shell-lint.sh` is not implicated (no shell changed) and no bats suite touches these paths.

## Quality Gate

All eight steps from `wiki/decisions/Quality Gate.md`. Root and CLI typecheck clean; root lint clean and `lint:cli` clean; CLI 130 files / 1870 tests, root 29 / 155, zero console warnings; Playwright 8 passed; dev smoke HTTP 200; production build clean.

`.gaia/cli/gaia-maintainer` is rebundled. The adopter `gaia` binary is byte-identical, checked rather than assumed.

## CHANGELOG

No entry. `.gaia/cli/src` and `.gaia/cli/gaia-maintainer` are both release-excluded (`.gaia/release-exclude:121,133`) and absent from `.gaia/manifest.json`; the one shipped path in the area, `.gaia/cli/gaia`, is unchanged. Nothing here is adopter-observable.

## Out-of-scope finding, filed

**#1157**: `bump.ts:65` carries the identical unbounded `defaultRunner`, and `bump.ts:235` runs the same `git log --format=%s%n%b`, so `gaia-maintainer release bump` dies with the same `ENOBUFS` on this tree today. That is release runbook **step 5**, one step ahead of the step 7 this PR fixes, so the runbook needs both.

Filed rather than folded in: `bump.ts` is untouched by this PR, so the touched-file waive in `wiki/concepts/PR Merge Workflow.md` `#### Cross-remit findings` does not apply; and raising a spawn bound is a behavior change, which the drain plan's batching rule does not license across files.

`preflight.ts:43` and `commit-and-tag.ts:52` declare the same unbounded runner but read `git log --format=%s`, `rev-parse`, and `status --porcelain`, which are orders of magnitude smaller. Not at risk, noted in #1157 so the next reader does not re-derive it.
