### PR TITLE
chore(wiki): wrap the CLI pin-parity note in maintainer-only markers

### DIFF
--- a/wiki/dependencies/gaia-lint.md
+++ b/wiki/dependencies/gaia-lint.md
@@ -83,7 +83,9 @@ The `resources+/` and `actions+/` carve-out means UI-layer files may import type
 
 `.gaia/cli` (`@gaia-react/cli`) is a second consumer, with its own `.gaia/cli/eslint.config.mjs` in its separate pnpm workspace. It consumes `base`/`react`/`testing`/`styleHygiene`/`guardrails`/`prettier` with `sourceDir: 'src'`, omitting the React-app-only presets (`storybook`, `playwright`, `betterTailwind`). It spreads `react` only because `base` transitively references `react/*` rules; the ruleset is inert on the CLI's non-JSX TypeScript. It disables a small Node/CLI set (`sonarjs/no-os-command-from-path`, `no-relative-import-paths`, `check-file/folder-match-with-fex`, `testing-library/render-result-naming-convention`) and extends the `unicorn/prevent-abbreviations` ignore list for CLI idioms. `.gaia/cli/eslint.config.mjs` is the source of truth for the full rule table.
 
+<!-- gaia:maintainer-only:start -->
 Because `.gaia/cli` pins `@gaia-react/lint` independently in its own lockfile, nothing else keeps its version in step with the root workspace's pin. `.gaia/cli/src/lint-pin-parity.test.ts` asserts both workspaces declare the same version, and `cli-tests.yml` includes root `package.json` in its path filter so the guard runs on the pull request that causes any drift, not just on a later unrelated `.gaia/cli/**` change.
+<!-- gaia:maintainer-only:end -->
 
 ## See also
 


### PR DESCRIPTION
## What

`main` fails the distribution harness today, and has since `1dae29c8` (the wiki sync in #1156) landed:

```
leaks (1):
  [maintainer-paths] wiki/dependencies/gaia-lint.md:86  .gaia/cli/src/
FAIL  01-files-present.sh
… 15 of 17 scenarios abort on `build-staging failed` behind the same leak
```

The paragraph documenting the lint-pin-parity guard cites `.gaia/cli/src/lint-pin-parity.test.ts`. That path is release-excluded (`.gaia/release-exclude:121`), so on an adopter's copy of this page it names a file the reader does not have. The leak check is right; the paragraph needed a wrap.

Fixed by wrapping it in `<!-- gaia:maintainer-only:start -->` / `<!-- gaia:maintainer-only:end -->`, which is what `.claude/rules/wiki-style.md` prescribes for statements specific to the maintainer repo: maintainers keep the note, bundle-time scrub strips it for adopters. Markers are balanced, so the release build's marker check is satisfied.

## Verification

`bash .gaia/tests/distribution/run-all.sh` — **17/17 PASS, 0 leaks** (exit 0). Before the wrap: 2 PASS, 15 FAIL.

The Quality Gate skips by its own rule: the diff is one markdown file under `wiki/`, so no staged file is something typecheck / lint / tests / build can inspect.

## Why main went red without anyone noticing

`cli-tests.yml`'s `code` paths filter has no `wiki/**` entry, so a wiki-only PR skips the scenario step entirely (the harness reported `pass` in 5s on #1156; it takes ~27s when it actually runs). The leak check reads shipped **wiki** content, so the one class of PR that can introduce this leak is exactly the class the filter excuses. That gap is the same file and the same class as #1129, so it belongs to that issue's fix rather than to a new one; noted there.

## CHANGELOG

No entry. Nothing adopter-observable changes: the wrapped paragraph is a maintainer-repo statement that was never true on an adopter clone, and no behavior, flag, or command changes.
