### PR TITLE
fix(cli): bound the release bump git spawn (#1157)

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -14658,6 +14658,11 @@ var readAutomationConfig = (repoRoot) => {
 
 // src/util/git-env.ts
 import { execFileSync } from "node:child_process";
+
+// src/util/git-buffer.ts
+var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
+
+// src/util/git-env.ts
 var execGaiaGitRaw = (args, cwd) => {
   const env = { ...process.env };
   delete env.GIT_DIR;
@@ -14669,11 +14674,10 @@ var execGaiaGitRaw = (args, cwd) => {
     env,
     // Node's 1 MiB default throws ENOBUFS on a large-output git command
     // (`git log` over a long history, `git status` on a very dirty tree).
-    // Matches `runGit` in wiki/util/git.ts, whose callers already hit that
-    // ceiling. The docblock above declares this the one chokepoint every
-    // git-shelling resolver routes through, so the ceiling belongs here
-    // rather than at the next caller to need it.
-    maxBuffer: 64 * 1024 * 1024,
+    // The docblock above declares this the one chokepoint every git-shelling
+    // resolver routes through, so the ceiling belongs here rather than at the
+    // next caller to need it.
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"]
   });
 };
@@ -28631,7 +28635,6 @@ var inspectWorkingTree = (cwd, runner = defaultRunner) => {
 
 // src/wiki/util/git.ts
 import { execFileSync as execFileSync5 } from "node:child_process";
-var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
 var runGit2 = (args, options = {}) => {
   const cwd = options.cwd ?? process.cwd();
   const result = execFileSync5("git", args, {

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -14657,6 +14657,11 @@ var readAutomationConfig = (repoRoot) => {
 
 // src/util/git-env.ts
 import { execFileSync } from "node:child_process";
+
+// src/util/git-buffer.ts
+var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
+
+// src/util/git-env.ts
 var execGaiaGitRaw = (args, cwd) => {
   const env = { ...process.env };
   delete env.GIT_DIR;
@@ -14668,11 +14673,10 @@ var execGaiaGitRaw = (args, cwd) => {
     env,
     // Node's 1 MiB default throws ENOBUFS on a large-output git command
     // (`git log` over a long history, `git status` on a very dirty tree).
-    // Matches `runGit` in wiki/util/git.ts, whose callers already hit that
-    // ceiling. The docblock above declares this the one chokepoint every
-    // git-shelling resolver routes through, so the ceiling belongs here
-    // rather than at the next caller to need it.
-    maxBuffer: 64 * 1024 * 1024,
+    // The docblock above declares this the one chokepoint every git-shelling
+    // resolver routes through, so the ceiling belongs here rather than at the
+    // next caller to need it.
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"]
   });
 };
@@ -17406,6 +17410,7 @@ var UNEXPECTED_EXIT9 = 2;
 var defaultRunner = (command, args, options) => spawnSync(command, args, {
   cwd: options.cwd,
   encoding: "utf8",
+  maxBuffer: MAX_GIT_BUFFER_BYTES,
   stdio: ["ignore", "pipe", "pipe"]
 });
 var parseFlags7 = (argv) => {
@@ -17674,7 +17679,6 @@ var HELP_TEXT20 = `Usage: gaia-maintainer release changelog [--draft] [--version
 `;
 var HELP_TOKENS20 = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var UNEXPECTED_EXIT10 = 2;
-var MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
 var defaultRunner2 = (command, args, options) => spawnSync2(command, args, {
   cwd: options.cwd,
   encoding: "utf8",
@@ -21723,13 +21727,12 @@ import path21 from "node:path";
 
 // src/wiki/util/git.ts
 import { execFileSync as execFileSync3 } from "node:child_process";
-var MAX_GIT_BUFFER_BYTES2 = 64 * 1024 * 1024;
 var runGit = (args, options = {}) => {
   const cwd = options.cwd ?? process.cwd();
   const result = execFileSync3("git", args, {
     cwd,
     encoding: "utf8",
-    maxBuffer: MAX_GIT_BUFFER_BYTES2,
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"]
   });
   return result.toString();

--- a/.gaia/cli/src/release/bump.test.ts
+++ b/.gaia/cli/src/release/bump.test.ts
@@ -14,7 +14,14 @@ import {
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {COMMIT_TYPES} from '../util/conventional-commit.js';
-import {aggregateBump, applyBump, classifyCommit, run} from './bump.js';
+import {
+  aggregateBump,
+  applyBump,
+  classifyCommit,
+  collectCommits,
+  defaultRunner,
+  run,
+} from './bump.js';
 import type {CommandRunner} from './bump.js';
 
 const expectedBump = (type: string): null | string => {
@@ -248,6 +255,16 @@ const failResult = (status: number): SpawnSyncReturns<string> => ({
   stdout: '',
 });
 
+const spawnErrorResult = (error: Error): SpawnSyncReturns<string> => ({
+  error,
+  output: ['', '', ''] as never,
+  pid: 0,
+  signal: null,
+  status: null,
+  stderr: '',
+  stdout: '',
+});
+
 const buildLogOutput = (
   commits: {body?: string; subject: string}[]
 ): string => {
@@ -275,6 +292,39 @@ const buildRunner =
 
     return okResult('');
   };
+
+describe('defaultRunner', () => {
+  // Asserted against a child that writes past Node's 1 MiB spawnSync default
+  // rather than against the constant, so the test fails if the bound is
+  // removed by any means.
+  test('reads child stdout past the 1 MiB spawnSync default', () => {
+    const size = 2 * 1024 * 1024;
+
+    const result = defaultRunner(
+      process.execPath,
+      ['-e', `process.stdout.write('x'.repeat(${size}))`],
+      {cwd: process.cwd()}
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.stdout).toHaveLength(size);
+  });
+});
+
+describe('collectCommits', () => {
+  // Pins the fail-closed contract: a spawn failure must block the release
+  // rather than degrade to "no commits", which aggregates to no bump and
+  // would propose the current version as if nothing had landed. The message
+  // shape is expectSuccess's, not changelog.ts's inline result.error check.
+  test('throws with the spawn error rather than returning no commits', () => {
+    const enobufsRunner: CommandRunner = () =>
+      spawnErrorResult(new Error('spawnSync git ENOBUFS'));
+
+    expect(() =>
+      collectCommits('/nonexistent', enobufsRunner, 'v1.0.0..HEAD')
+    ).toThrow('git log failed: spawnSync git ENOBUFS');
+  });
+});
 
 describe('release bump CLI', () => {
   let sandbox: Sandbox;

--- a/.gaia/cli/src/release/bump.test.ts
+++ b/.gaia/cli/src/release/bump.test.ts
@@ -311,15 +311,15 @@ describe('defaultRunner', () => {
   });
 });
 
+const enobufsRunner: CommandRunner = () =>
+  spawnErrorResult(new Error('spawnSync git ENOBUFS'));
+
 describe('collectCommits', () => {
   // Pins the fail-closed contract: a spawn failure must block the release
   // rather than degrade to "no commits", which aggregates to no bump and
   // would propose the current version as if nothing had landed. The message
   // shape is expectSuccess's, not changelog.ts's inline result.error check.
   test('throws with the spawn error rather than returning no commits', () => {
-    const enobufsRunner: CommandRunner = () =>
-      spawnErrorResult(new Error('spawnSync git ENOBUFS'));
-
     expect(() =>
       collectCommits('/nonexistent', enobufsRunner, 'v1.0.0..HEAD')
     ).toThrow('git log failed: spawnSync git ENOBUFS');

--- a/.gaia/cli/src/release/bump.ts
+++ b/.gaia/cli/src/release/bump.ts
@@ -38,6 +38,7 @@ import {
   parseConventionalCommitHeader,
 } from '../util/conventional-commit.js';
 import type {CommitType} from '../util/conventional-commit.js';
+import {MAX_GIT_BUFFER_BYTES} from '../util/git-buffer.js';
 
 const HELP_TEXT = `Usage: gaia-maintainer release bump [--auto]
 
@@ -62,10 +63,18 @@ export type CommandRunner = (
   options: {cwd: string}
 ) => SpawnSyncReturns<string>;
 
+/**
+ * `collectCommits` asks git for every subject *and body* since the last tag,
+ * so its output grows with the distance from that tag and passes Node's 1 MiB
+ * `spawnSync` default well before a release is due. Bumping is runbook step 5,
+ * one step ahead of the changelog, so an unbounded runner here blocks the
+ * release before `release changelog` is ever reached.
+ */
 export const defaultRunner: CommandRunner = (command, args, options) =>
   spawnSync(command, args as string[], {
     cwd: options.cwd,
     encoding: 'utf8',
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/.gaia/cli/src/release/bump.ts
+++ b/.gaia/cli/src/release/bump.ts
@@ -1,7 +1,7 @@
 /**
  * `gaia-maintainer release bump [--auto]` handler.
  *
- * Step 3 of the maintainer release runbook. Scans conventional-commit
+ * Step 2 of the maintainer release runbook. Scans conventional-commit
  * subjects (and bodies) since the last tag, classifies the highest
  * semver bump, and either reports the proposal or applies it to
  * `package.json` and `.gaia/VERSION`.
@@ -66,9 +66,9 @@ export type CommandRunner = (
 /**
  * `collectCommits` asks git for every subject *and body* since the last tag,
  * so its output grows with the distance from that tag and passes Node's 1 MiB
- * `spawnSync` default well before a release is due. Bumping is runbook step 5,
- * one step ahead of the changelog, so an unbounded runner here blocks the
- * release before `release changelog` is ever reached.
+ * `spawnSync` default well before a release is due. Bumping is runbook step 2
+ * and the changelog is step 5, so an unbounded runner here blocks the release
+ * three steps before `release changelog` is ever reached.
  */
 export const defaultRunner: CommandRunner = (command, args, options) =>
   spawnSync(command, args as string[], {

--- a/.gaia/cli/src/release/changelog.ts
+++ b/.gaia/cli/src/release/changelog.ts
@@ -30,6 +30,7 @@ import {
   parseConventionalCommitHeader,
 } from '../util/conventional-commit.js';
 import type {CommitType} from '../util/conventional-commit.js';
+import {MAX_GIT_BUFFER_BYTES} from '../util/git-buffer.js';
 
 const HELP_TEXT = `Usage: gaia-maintainer release changelog [--draft] [--version <X.Y.Z>]
 
@@ -59,11 +60,8 @@ export type CommandRunner = (
  * `collectCommits` asks git for every subject *and body* since the last tag,
  * so its output grows with the distance from that tag and passes Node's 1 MiB
  * `spawnSync` default well before a release is due, failing the command
- * closed with ENOBUFS. Matches the bound `wiki/util/git.ts` and
- * `util/git-env.ts` already use for git spawns.
+ * closed with ENOBUFS.
  */
-const MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
-
 export const defaultRunner: CommandRunner = (command, args, options) =>
   spawnSync(command, args as string[], {
     cwd: options.cwd,

--- a/.gaia/cli/src/util/git-buffer.ts
+++ b/.gaia/cli/src/util/git-buffer.ts
@@ -7,15 +7,13 @@
  * commit bodies over this repository's own `v1.6.1..HEAD` measures ~1.25 MB,
  * so a release-time reader is already over the default.
  *
- * 64 MiB is the value each reader had independently converged on before this
- * module existed. It is a ceiling, not an allocation: `spawnSync` grows its
- * buffer to what the child actually writes, so raising it costs nothing until
- * output that large arrives, and it exists only so a large-but-legitimate read
- * completes instead of throwing.
+ * 64 MiB is a ceiling, not an allocation: the buffer grows to what the child
+ * actually writes, so the headroom costs nothing until output that large
+ * arrives, and it exists only so a large-but-legitimate read completes
+ * instead of throwing.
  *
  * Not the bound for every spawn. `update/regen-regions.ts` keeps its own
  * `SPAWN_MAX_BUFFER_BYTES` at 32 MiB, because it bounds the region-digest
- * spawner rather than a history read, and the two limits answer to different
- * inputs.
+ * spawner rather than a history read.
  */
 export const MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;

--- a/.gaia/cli/src/util/git-buffer.ts
+++ b/.gaia/cli/src/util/git-buffer.ts
@@ -1,0 +1,21 @@
+/**
+ * The stdout ceiling every git-output reader in this CLI spawns under.
+ *
+ * Node defaults `spawnSync`/`execFileSync` to a 1 MiB `maxBuffer` and fails
+ * the call with `ENOBUFS` the moment a child writes past it. That is not a
+ * theoretical limit for a git command that reads history: `git log` with
+ * commit bodies over this repository's own `v1.6.1..HEAD` measures ~1.25 MB,
+ * so a release-time reader is already over the default.
+ *
+ * 64 MiB is the value each reader had independently converged on before this
+ * module existed. It is a ceiling, not an allocation: `spawnSync` grows its
+ * buffer to what the child actually writes, so raising it costs nothing until
+ * output that large arrives, and it exists only so a large-but-legitimate read
+ * completes instead of throwing.
+ *
+ * Not the bound for every spawn. `update/regen-regions.ts` keeps its own
+ * `SPAWN_MAX_BUFFER_BYTES` at 32 MiB, because it bounds the region-digest
+ * spawner rather than a history read, and the two limits answer to different
+ * inputs.
+ */
+export const MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;

--- a/.gaia/cli/src/util/git-env.ts
+++ b/.gaia/cli/src/util/git-env.ts
@@ -10,6 +10,7 @@
  * tree routes through here rather than `execFileSync('git', ...)` directly.
  */
 import {execFileSync} from 'node:child_process';
+import {MAX_GIT_BUFFER_BYTES} from './git-buffer.js';
 
 /**
  * The env-stripped call itself, returning git's output **verbatim**.
@@ -33,11 +34,10 @@ export const execGaiaGitRaw = (args: string[], cwd: string): string => {
     env,
     // Node's 1 MiB default throws ENOBUFS on a large-output git command
     // (`git log` over a long history, `git status` on a very dirty tree).
-    // Matches `runGit` in wiki/util/git.ts, whose callers already hit that
-    // ceiling. The docblock above declares this the one chokepoint every
-    // git-shelling resolver routes through, so the ceiling belongs here
-    // rather than at the next caller to need it.
-    maxBuffer: 64 * 1024 * 1024,
+    // The docblock above declares this the one chokepoint every git-shelling
+    // resolver routes through, so the ceiling belongs here rather than at the
+    // next caller to need it.
+    maxBuffer: MAX_GIT_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 };

--- a/.gaia/cli/src/wiki/util/git.ts
+++ b/.gaia/cli/src/wiki/util/git.ts
@@ -6,15 +6,14 @@
  * subcommand handler is responsible for translating to exit codes.
  */
 import {execFileSync} from 'node:child_process';
+import {MAX_GIT_BUFFER_BYTES} from '../../util/git-buffer.js';
 
 type RunOptions = {
   cwd?: string;
 };
 
 // `git log` over a large history easily exceeds the 1 MiB default and
-// throws ENOBUFS; 64 MiB covers any realistic sync window.
-const MAX_GIT_BUFFER_BYTES = 64 * 1024 * 1024;
-
+// throws ENOBUFS; the shared bound covers any realistic sync window.
 const runGit = (args: readonly string[], options: RunOptions = {}): string => {
   const cwd = options.cwd ?? process.cwd();
   const result = execFileSync('git', args, {


### PR DESCRIPTION
## What

`gaia-maintainer release bump` fails closed on this repository today:

```
$ .gaia/cli/gaia-maintainer release bump
bump: git log failed: spawnSync git ENOBUFS
```

`collectCommits` (`bump.ts:245`) reads every subject **and body** since the last tag.
Measured for `v1.6.1..HEAD`: **1,250,573 bytes** over 468 commits, past Node's 1 MiB
`spawnSync` default, which `bump.ts`'s own `defaultRunner` did not raise.

This is #1147's defect in the second file that carries it. Bumping is release runbook
**step 2** (`### 2. Apply the bump`); the changelog #1147 fixed is **step 5**
(`### 5. Graduate the CHANGELOG`). So #1158 alone did not unblock a release, and both had
to land.

> **Correction, made during the audit round.** This PR originally cited steps 5 and 7,
> inherited verbatim from #1157's issue body. Both numbers are wrong; the runbook
> (`.claude/commands/gaia-release.md`) numbers them 2 and 5. The substantive claim is
> unaffected and is in fact stronger: bump runs three steps ahead of the changelog rather
> than one. See the out-of-scope findings below for where the wrong numbers came from.

## Approach

Rather than adding a fourth copy of the 64 MiB literal, this hoists it to a shared
`.gaia/cli/src/util/git-buffer.ts` and adopts it at all four git-output readers, which is
what PR #1158's audit round asked for on this issue. The value is identical at every site,
so the three pre-existing readers are unchanged in behavior. `regen-regions.ts` keeps its
own 32 MiB bound: it spawns for region digests, not history reads.

## Verification

- **End-to-end**: `release bump` was exit 2 with `ENOBUFS`, now `v1.6.1 -> v1.7.0 (minor)`,
  exit 0. `release changelog --draft` still exit 0 with empty stderr, so both runbook steps
  are clear.
- **RED proof**: the real-child regression test failed before the fix with the production
  symptom verbatim (`code: 'ENOBUFS'`, `errno: -55`). It drives `defaultRunner` against a
  2 MiB child rather than asserting on the constant, so it fails if the bound is removed by
  any means, not only if the identifier changes.
- **Mutation proof**: the second test pins the fail-closed contract and is green in both
  directions, so it was proven by injecting a `return` ahead of `expectSuccess`'s throw.
  The mutation was confirmed applied with a diff before the run, and the source restored
  byte-identical after.
- **Adopter surface**: the hoist touches `wiki/util/git.ts` and `util/git-env.ts`, both in
  the adopter bundle, so `.gaia/cli/gaia` (manifest `owned`) changed. The bundle delta is
  only the constant's relocation at an identical value. `gaia wiki state --json` smoke-runs
  clean, and the distribution harness is 17/17.
- **Quality Gate**: all eight steps. Typecheck clean both workspaces; lint clean both; CLI
  130 files / 1872 tests, root 29 / 155, zero console warnings; Playwright 8; dev smoke
  HTTP 200; build clean. Plus `shell-lint` (193 scripts, 181 suites) and the distribution
  harness.

## Deliberately out of scope

`preflight.ts:43` and `commit-and-tag.ts:52` declare the same unbounded runner and are left
alone, with the issue's claim measured rather than trusted. Two independent measurements
agree it is not at risk: preflight's largest read is `git log --format=%s` (subjects only,
no bodies) at 36,700 bytes over `v1.6.1..HEAD`, and 71,722 bytes over the *entire*
repository history as the audit member measured it, ~14x under the 1 MiB default with no
body-carrying growth mechanism. `commit-and-tag` performs no history read at all. Raising a
spawn bound is not provably zero-behavior, so Invariant 9 does not license folding them in.

## Out-of-scope machinery findings (recorded, not filed)

- **`.gaia/cli/src/release/changelog.ts:4`** — the module docblock opens `Step 7 of the
  maintainer release runbook`, but `release changelog` is `### 5. Graduate the CHANGELOG`.
  A maintainer reading the file to place it in the release flow gets a wrong answer from
  the line that exists to give the right one. This is the likely origin of #1157's own
  wrong "step 5 / step 7" claim, which propagated into this PR before the audit caught it.
  Waived rather than filed: this PR already changes `changelog.ts`.
  <!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/cli/src/release/changelog.ts line=4 -->
  <!-- gaia-debt-origin: branch=debt/1157-release-bump-enobufs mode=drain unit=1157 changed=1 head=d2ddfbc162f322c23d426a3156397ac6fca9fdae -->

The same defect in three files this PR does **not** touch (`preflight.ts:4`,
`scrub-wiki.ts:4`, `commit-and-tag.ts:4`) is filed as **#1161**. `bump.ts:4` and `:69`
carried it too and are corrected here, since this PR owns that file.

## CHANGELOG

No entry. `release bump` is maintainer-only (`.gaia/cli/gaia-maintainer` is release-excluded
and absent from the manifest), and the adopter binary's only delta is a constant moving
between modules at the same value. Nothing adopter-observable changed and no adopter action
is required.

Closes #1157
