### PR TITLE
debt(tests): seven test-accuracy fixes, one reviewer context (#1035, #1036, #1045, #1046, #1047, #1136, #1190)

### DIFF
--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -461,15 +461,13 @@ describe('computeMissing: paths named after Object.prototype keys', () => {
     const built = manifestWithFiles({['__proto__']: 'owned'});
     const committed = roundTrip(built);
 
-    // Which stage drops it, named rather than left as "the way back in",
-    // because these two assertions are a canary on that stage's behaviour and a
-    // reader who has to go find it cannot tell a real regression from a
-    // dependency moving underneath. `serialize` emits the key, and `JSON.parse`
-    // KEEPS it as an own property; `ManifestSchema`'s `z.record` is what drops
-    // it, by re-assigning each entry into a fresh object, where a plain
-    // assignment to `__proto__` with a string value is a no-op. So a zod bump
-    // that changes record's `__proto__` handling flips the two lines below and
-    // reds this suite.
+    // Which stage drops it, named because these two assertions are a canary on
+    // that stage and a reader who has to go find it cannot tell a real
+    // regression from a dependency moving underneath. `serialize` emits the
+    // key, `JSON.parse` KEEPS it as an own property, and `ManifestSchema`'s
+    // `z.record` is what drops it, by an explicit guard rather than by any
+    // language-level invariant. So a zod bump that reworks that guard flips the
+    // two lines below and reds this suite.
     expect(serialize(built)).toContain('"__proto__"');
     expect(Object.hasOwn(committed.files, '__proto__')).toBe(false);
     expect(Object.keys(committed.files)).toEqual([]);

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -461,8 +461,15 @@ describe('computeMissing: paths named after Object.prototype keys', () => {
     const built = manifestWithFiles({['__proto__']: 'owned'});
     const committed = roundTrip(built);
 
-    // `serialize` emits the key perfectly well; it is the way back in that
-    // drops it, so the loss is invisible to anyone reading the written file.
+    // Which stage drops it, named rather than left as "the way back in",
+    // because these two assertions are a canary on that stage's behaviour and a
+    // reader who has to go find it cannot tell a real regression from a
+    // dependency moving underneath. `serialize` emits the key, and `JSON.parse`
+    // KEEPS it as an own property; `ManifestSchema`'s `z.record` is what drops
+    // it, by re-assigning each entry into a fresh object, where a plain
+    // assignment to `__proto__` with a string value is a no-op. So a zod bump
+    // that changes record's `__proto__` handling flips the two lines below and
+    // reds this suite.
     expect(serialize(built)).toContain('"__proto__"');
     expect(Object.hasOwn(committed.files, '__proto__')).toBe(false);
     expect(Object.keys(committed.files)).toEqual([]);

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -391,6 +391,15 @@ const manifestWithFiles = (files: ManifestShape['files']): ManifestShape => ({
   version: '1.0.0',
 });
 
+/**
+ * The path a committed manifest actually takes: written by `serialize`, read
+ * back by `JSON.parse`, then validated by the schema. Hand-built
+ * `ManifestShape` objects skip all three, so a case that never calls this
+ * proves nothing about what survives the trip.
+ */
+const roundTrip = (manifest: ManifestShape): ManifestShape =>
+  ManifestSchema.parse(JSON.parse(serialize(manifest)));
+
 describe('computeMissing: paths named after Object.prototype keys', () => {
   test.each([
     'constructor',
@@ -427,23 +436,23 @@ describe('computeMissing: paths named after Object.prototype keys', () => {
   // shape: `ManifestSchema: regions` and `byte-identity vs
   // generate-manifest.mjs` both assert through a real parse.
   //
-  // Every key here is written computed. A bare `{__proto__: 'owned'}` object
+  // Every key below is written computed. A bare `{__proto__: 'owned'}` object
   // literal sets the PROTOTYPE instead of defining an own property, which
   // would make these cases test nothing at all.
-  const roundTrip = (manifest: ManifestShape): ManifestShape =>
-    ManifestSchema.parse(JSON.parse(serialize(manifest)));
-
   test.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
     'a manifest path named %s survives the real serialize/parse round trip and is still reported missing',
     (file) => {
       const committed = roundTrip(manifestWithFiles({[file]: 'owned'}));
 
       expect(Object.hasOwn(committed.files, file)).toBe(true);
-      expect(computeMissing(manifestWithFiles({[file]: 'owned'}), committed)).toEqual(
-        []
-      );
       expect(
-        computeMissing(manifestWithFiles({[file]: 'owned'}), manifestWithFiles({}))
+        computeMissing(manifestWithFiles({[file]: 'owned'}), committed)
+      ).toEqual([]);
+      expect(
+        computeMissing(
+          manifestWithFiles({[file]: 'owned'}),
+          manifestWithFiles({})
+        )
       ).toEqual([file]);
     }
   );

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -418,6 +418,54 @@ describe('computeMissing: paths named after Object.prototype keys', () => {
 
     expect(computeMissing(expected, actual)).toEqual([]);
   });
+
+  // The rows above hand-build `ManifestShape` objects, so not one of them
+  // crosses `ManifestSchema`. Read alone they imply all five names are proven
+  // to reach `lookupClass` through the path a committed manifest actually
+  // takes. Only four are, and the two cases below are what make the list say
+  // so rather than merely be true. The surrounding convention settles the
+  // shape: `ManifestSchema: regions` and `byte-identity vs
+  // generate-manifest.mjs` both assert through a real parse.
+  //
+  // Every key here is written computed. A bare `{__proto__: 'owned'}` object
+  // literal sets the PROTOTYPE instead of defining an own property, which
+  // would make these cases test nothing at all.
+  const roundTrip = (manifest: ManifestShape): ManifestShape =>
+    ManifestSchema.parse(JSON.parse(serialize(manifest)));
+
+  test.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'a manifest path named %s survives the real serialize/parse round trip and is still reported missing',
+    (file) => {
+      const committed = roundTrip(manifestWithFiles({[file]: 'owned'}));
+
+      expect(Object.hasOwn(committed.files, file)).toBe(true);
+      expect(computeMissing(manifestWithFiles({[file]: 'owned'}), committed)).toEqual(
+        []
+      );
+      expect(
+        computeMissing(manifestWithFiles({[file]: 'owned'}), manifestWithFiles({}))
+      ).toEqual([file]);
+    }
+  );
+
+  test('a manifest path named __proto__ does not survive the round trip, so it never reaches the guard', () => {
+    const built = manifestWithFiles({['__proto__']: 'owned'});
+    const committed = roundTrip(built);
+
+    // `serialize` emits the key perfectly well; it is the way back in that
+    // drops it, so the loss is invisible to anyone reading the written file.
+    expect(serialize(built)).toContain('"__proto__"');
+    expect(Object.hasOwn(committed.files, '__proto__')).toBe(false);
+    expect(Object.keys(committed.files)).toEqual([]);
+
+    // The consequence, and why this is a suggestion rather than a bug: the
+    // entry is absent from `actual.files` on EVERY run, so `computeMissing`
+    // reports it missing forever and the drift/answer gate blocks
+    // permanently. That fails closed, never a silent pass. It is also why no
+    // end-to-end row is possible for this name, and why the unit row above is
+    // the whole of the coverage it can have.
+    expect(computeMissing(built, committed)).toEqual(['__proto__']);
+  });
 });
 
 describe('computeDrift: regionDrift', () => {

--- a/.gaia/scripts/tests/region-marker-conformance.bats
+++ b/.gaia/scripts/tests/region-marker-conformance.bats
@@ -297,7 +297,7 @@ classify_check() {
 # ---------------------------------------------------------------------------
 
 @test "inverted fixture: all three reject the reversed pair (convergence, not divergence)" {
-  local body ts_dir writer_dir check_dir before after
+  local body ts_dir writer_dir check_dir fixture before
   body="$(fixture_inverted)"
   ts_dir="$(make_sandbox inverted-ts "$body")"
   writer_dir="$(make_sandbox inverted-writer "$body")"
@@ -307,14 +307,21 @@ classify_check() {
   [ "$status" -eq 0 ]
   [ "$output" = "malformed/inverted" ]
 
-  before="$(cat "$writer_dir/.claude/agents/code-audit-fixture.md")"
+  fixture="$writer_dir/.claude/agents/code-audit-fixture.md"
+  before="$BATS_TEST_TMPDIR/inverted-before.md"
+  # The pre-run bytes, copied aside rather than captured into a variable:
+  # `$(cat …)` strips all trailing newlines from both sides, so a writer that
+  # deleted or added exactly a trailing newline would satisfy a
+  # byte-identity claim it had in fact broken.
+  cp "$fixture" "$before"
+
   run classify_writer "$writer_dir"
   [ "$status" -eq 0 ]
   [ "$output" = "fail" ]
   # The writer never deletes bytes outside a pair it can identify: a reversed
-  # pair leaves the file byte-identical to before the run.
-  after="$(cat "$writer_dir/.claude/agents/code-audit-fixture.md")"
-  [ "$before" = "$after" ]
+  # pair leaves the file byte-identical to before the run. `cmp` unsuppressed,
+  # so a regression names the differing byte offset.
+  cmp "$before" "$fixture" || return 1
 
   run classify_check "$check_dir"
   [ "$status" -eq 0 ]

--- a/.gaia/scripts/tests/region-regen-convergence.bats
+++ b/.gaia/scripts/tests/region-regen-convergence.bats
@@ -152,20 +152,34 @@ YAML
   # including an early abort that never reached a single invariant. The
   # stronger the regression, the more reliably it would green.
   #
-  # `verify-audit-roster.sh`'s exit-code vocabulary is what settles which
-  # floor: 0 is ran-and-clean, 1 is ran-and-reported-violations, 2 is every
-  # way of not running (unknown argument, a flag missing its value, an
-  # unresolvable root, a roster that is not there). Pinning 1 therefore
-  # excludes 2, excludes any crash code, and excludes a checker stubbed out to
-  # succeed -- the three shapes an early abort takes -- without saying
-  # anything about WHICH invariants fired.
+  # `verify-audit-roster.sh`'s exit-code vocabulary settles most of it: 0 is
+  # ran-and-clean, 1 is ran-and-reported-violations, and 2 is MOST ways of not
+  # running (unknown argument, a flag missing its value, an unresolvable root,
+  # a roster that is not there). Pinning 1 excludes 2, excludes any crash code,
+  # and excludes a checker stubbed out to succeed, without saying anything
+  # about WHICH invariants fired.
   #
-  # 1 is structural here, not incidental: this scratch tree carries no
-  # machinery lists at all, so the registration invariant always fires and the
-  # run always reports. Verified by running it, not assumed. If a later
-  # fixture registers them and the run goes clean, this line fails loudly and
-  # is meant to -- that is a prompt to re-read the floor, not to delete it.
+  # The status alone is NOT sufficient, and the exception is precise:
+  # `verify-audit-roster.sh:184` exits **1** on `roster-parsing library
+  # unavailable`, having evaluated zero invariants. `setup()` does not cover
+  # it, because it checks that `audit-scope.sh` EXISTS, while that guard fires
+  # when the file is present but no longer defines
+  # `_audit_scope_parse_auditors` -- a rename refactor. Its output matches no
+  # parity pattern, so the check below would return 0 and green on the exact
+  # early abort this floor exists to reject.
+  #
+  # So the status is paired with a positive liveness needle: at least one
+  # finding block, which only a run that reached the reporting stage can emit.
+  # A needle rather than a wider status range, because widening admits 0 and
+  # loses the stubbed-to-succeed case. Neither line says which invariant fired.
   [ "$status" -eq 1 ]
+  grep -qE '^verify-audit-roster: FAIL ' <<<"$output" || return 1
+
+  # A finding is structural here, not incidental: this scratch tree carries no
+  # machinery lists at all, so the registration invariant always fires and the
+  # run always reports. Verified by running it, not assumed. If a later fixture
+  # registers them and the run goes clean, these two lines fail loudly and are
+  # meant to -- that is a prompt to re-read the floor, not to delete it.
 
   # An `&& return 1` as the test body's OWN final line would make the good
   # case (no match, exit 1) become the test's own failing exit status; the

--- a/.gaia/scripts/tests/region-regen-convergence.bats
+++ b/.gaia/scripts/tests/region-regen-convergence.bats
@@ -142,13 +142,31 @@ YAML
   [ "$status" -eq 0 ]
 
   run_check "$sb"
-  # The check's process-wide exit status answers several invariants at once
-  # (default-member-count, machinery registration, glob disjointness, remit
-  # parity for every OTHER member too) and is insensitive to any one
-  # region's content, so a green exit here proves nothing about the
-  # perturbed-then-repaired member specifically. Only the absence of ITS
-  # finding means anything, so the exit status is never asserted.
+  # A floor, before the finding check below. The check's process-wide exit
+  # status cannot be read as a verdict on THIS member: it answers several
+  # invariants at once (default-member-count, machinery registration, glob
+  # disjointness, remit parity for every OTHER member too) and is insensitive
+  # to any one region's content. But having declined it as a verdict, this
+  # test still needs it as a LIVENESS signal, and without one the assertion
+  # below passes on any output that fails to match the parity pattern --
+  # including an early abort that never reached a single invariant. The
+  # stronger the regression, the more reliably it would green.
   #
+  # `verify-audit-roster.sh`'s exit-code vocabulary is what settles which
+  # floor: 0 is ran-and-clean, 1 is ran-and-reported-violations, 2 is every
+  # way of not running (unknown argument, a flag missing its value, an
+  # unresolvable root, a roster that is not there). Pinning 1 therefore
+  # excludes 2, excludes any crash code, and excludes a checker stubbed out to
+  # succeed -- the three shapes an early abort takes -- without saying
+  # anything about WHICH invariants fired.
+  #
+  # 1 is structural here, not incidental: this scratch tree carries no
+  # machinery lists at all, so the registration invariant always fires and the
+  # run always reports. Verified by running it, not assumed. If a later
+  # fixture registers them and the run goes clean, this line fails loudly and
+  # is meant to -- that is a prompt to re-read the floor, not to delete it.
+  [ "$status" -eq 1 ]
+
   # An `&& return 1` as the test body's OWN final line would make the good
   # case (no match, exit 1) become the test's own failing exit status; the
   # `if` form keeps that exit status internal to the condition.
@@ -222,10 +240,20 @@ YAML
 
   # Not a self-comparison: this fails if a bug hardcoded a fixed region body
   # regardless of the roster it was handed.
-  local content_a content_b
-  content_a="$(cat "$sb_a/.claude/agents/code-audit-region-only.md")"
-  content_b="$(cat "$sb_b/.claude/agents/code-audit-region-only.md")"
-  [ "$content_a" != "$content_b" ]
+  #
+  # Compared as FILES, never through `$(cat …)`: command substitution strips
+  # all trailing newlines from both sides, so two bodies differing only there
+  # would compare equal. `-s` because on this side the expected outcome is a
+  # difference, and an unsuppressed `cmp` would print one on every good run.
+  local file_a="$sb_a/.claude/agents/code-audit-region-only.md"
+  local file_b="$sb_b/.claude/agents/code-audit-region-only.md"
+  # The bad case written as a positive match: identical files make `cmp -s`
+  # exit 0 and the test return 1. The trailing `true` is required because this
+  # is the body's FINAL statement -- without it, differing files leave `cmp`'s
+  # own non-zero status as the AND-list's, which would fail the test in exactly
+  # the case it exists to pass.
+  cmp -s "$file_a" "$file_b" && return 1
+  true
 }
 
 # ---------------------------------------------------------------------------
@@ -245,20 +273,30 @@ auditors:
 YAML
   write_agent_stub "$sb" code-audit-region-idem
 
-  run_writer "$sb"
-  [ "$status" -eq 0 ]
-  local first
-  first="$(cat "$sb/.claude/agents/code-audit-region-idem.md")"
+  local agent="$sb/.claude/agents/code-audit-region-idem.md"
+  local first="$BATS_TEST_TMPDIR/first-run.md"
 
   run_writer "$sb"
   [ "$status" -eq 0 ]
-  local second
-  second="$(cat "$sb/.claude/agents/code-audit-region-idem.md")"
+  # The first run's bytes, copied aside rather than captured into a variable.
+  cp "$agent" "$first"
+
+  run_writer "$sb"
+  [ "$status" -eq 0 ]
 
   # Content only, never inode or mtime: the writer's final `mv "$tmp" "$agent"`
   # is unconditional, so both runs always replace the file and an mtime
   # assertion would fail even on a correct implementation.
-  [ "$first" = "$second" ]
+  #
+  # Byte-exact, which is what this test's name promises and what `$(cat …)`
+  # could not deliver: command substitution strips ALL trailing newlines from
+  # both sides, so a writer regression that only gained or dropped one was
+  # invisible to the single test whose name says it would catch exactly that.
+  # A trailing-newline difference inside a marker-delimited generated region is
+  # precisely the drift this suite exists to pin. `cmp` unsuppressed, so a
+  # regression reports the differing byte offset instead of only that the two
+  # runs disagreed.
+  cmp "$first" "$agent"
 }
 
 # ---------------------------------------------------------------------------

--- a/.gaia/tests/distribution/17-gaia-update-merge-region.sh
+++ b/.gaia/tests/distribution/17-gaia-update-merge-region.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# SC2016 is intentional: the two release-resolution greps' single-quoted
-# patterns carry a literal `$LATEST_DIR`, matched as text, not expanded.
-# shellcheck disable=SC2016
 # 17-gaia-update-merge-region.sh
 #
 # Adopter-flow regression: runs `gaia update merge-region` against the
@@ -336,9 +333,19 @@ log "scenario 8 (help lists merge-region and regen-regions): OK"
 # whose installed binary predates them can still reach them.
 # This is the grep-assertable half of that rule: the skill carries the
 # release-resolved form and carries no working-tree-resolved one.
+#
+# The two SC2016 disables below are per-line rather than file-wide on purpose.
+# Each of these patterns carries a literal `$LATEST_DIR` that is matched as
+# text and must not expand, which is exactly what SC2016 reports. Scoping the
+# directive to the two lines that earn it keeps the rule live everywhere else,
+# and the single-quoted `node -e` body in scenario 3 is why that matters: a
+# later edit writing `'$FIXTURES/x'` inside it expecting shell expansion is an
+# SC2016 hit worth seeing, and a file-wide disable would swallow it silently.
+# shellcheck disable=SC2016
 grep -q '"\$LATEST_DIR/\.gaia/cli/gaia" update merge-region' \
   "$PROJECT_ROOT/.claude/skills/update-gaia/SKILL.md" \
   || { fail "scenario 9: SKILL.md is missing the release-resolved merge-region invocation"; exit 1; }
+# shellcheck disable=SC2016
 grep -q '"\$LATEST_DIR/\.gaia/cli/gaia" update regen-regions' \
   "$PROJECT_ROOT/.claude/skills/update-gaia/SKILL.md" \
   || { fail "scenario 9: SKILL.md is missing the release-resolved regen-regions invocation"; exit 1; }

--- a/.gaia/tests/distribution/17-gaia-update-merge-region.sh
+++ b/.gaia/tests/distribution/17-gaia-update-merge-region.sh
@@ -45,6 +45,30 @@ START_MARKER='<!-- test-region:start -->'
 END_MARKER='<!-- test-region:end -->'
 PLACEHOLDER='<<<gaia:region>>>'
 
+# Every invocation below that asserts SUCCESS captures the CLI's stderr here
+# instead of discarding it, and its failure branch prints what it captured.
+# `2>/dev/null` on a success-asserting call leaves the `||` branch with nothing
+# to report but the exit code, which is the one fact the branch being taken
+# already implies; on a runner nobody is sitting in front of, that costs a local
+# reproduction to learn anything at all. Redirecting to a file rather than
+# dropping the redirect keeps stdout clean for the JSON the caller parses.
+#
+# The discriminator is what the scenario asserts, not its number: scenario 7
+# asserts FAILURE, so its diagnostic is expected noise and it keeps its own
+# suppression.
+CLI_STDERR="$FIXTURES/cli-stderr.txt"
+: > "$CLI_STDERR"
+
+report_cli_stderr() {
+  if [ -s "$CLI_STDERR" ]; then
+    printf -- '--- gaia stderr ---\n' >&2
+    cat "$CLI_STDERR" >&2
+    printf -- '--- end gaia stderr ---\n' >&2
+  else
+    printf -- '(gaia wrote nothing to stderr)\n' >&2
+  fi
+}
+
 # --- Scenario 1: region-only divergence -----------------------------------
 # `current` differs from `baseline` only inside the region; `latest` differs
 # from `baseline` only outside it. Masking the region should make the two
@@ -62,8 +86,8 @@ S1_JSON="$("$GAIA" update merge-region \
   --latest "$FIXTURES/s1-latest.txt" \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>/dev/null)" \
-  || { fail "scenario 1: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  --json 2>"$CLI_STDERR")" \
+  || { fail "scenario 1: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
 
 printf '%s' "$S1_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -93,8 +117,8 @@ S2_JSON="$("$GAIA" update merge-region \
   --latest "$FIXTURES/s2-latest.txt" \
   --current "$FIXTURES/s2-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>/dev/null)" \
-  || { fail "scenario 2: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  --json 2>"$CLI_STDERR")" \
+  || { fail "scenario 2: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
 
 printf '%s' "$S2_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -129,26 +153,38 @@ S3_JSON="$("$GAIA" update merge-region \
   --latest "$FIXTURES/s3-latest.txt" \
   --current "$FIXTURES/s3-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>/dev/null)" \
-  || { fail "scenario 3: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  --json 2>"$CLI_STDERR")" \
+  || { fail "scenario 3: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
 
-printf '%s' "$S3_JSON" | node -e "
-  const fs = require('node:fs');
-  const r = JSON.parse(fs.readFileSync(0, 'utf8'));
+# The fixture paths reach node through the ENVIRONMENT, never interpolated by
+# the shell into the JS source. `$FIXTURES` derives from `mktemp -d`, so a
+# single quote or a backslash in `TMPDIR` would otherwise land inside a JS
+# string literal and break the eval with a syntax error that names nothing a
+# maintainer can act on. The body is single-quoted for the same reason: with no
+# shell expansion into it at all, the property holds by construction rather than
+# by every future edit remembering it. Same shape as the sibling probe at
+# `.gaia/scripts/tests/region-marker-conformance.bats`.
+printf '%s' "$S3_JSON" \
+  | GAIA_S3_BASELINE="$FIXTURES/s3-baseline.txt" \
+    GAIA_S3_LATEST="$FIXTURES/s3-latest.txt" \
+    GAIA_S3_CURRENT="$FIXTURES/s3-current.txt" \
+    node -e '
+  const fs = require("node:fs");
+  const r = JSON.parse(fs.readFileSync(0, "utf8"));
   if (r.markers.bailed !== true)
-    throw new Error('expected markers.bailed=true, got ' + r.markers.bailed);
-  if (r.markers.current.scan !== 'malformed')
-    throw new Error('expected markers.current.scan=malformed, got ' + r.markers.current.scan);
+    throw new Error("expected markers.bailed=true, got " + r.markers.bailed);
+  if (r.markers.current.scan !== "malformed")
+    throw new Error("expected markers.current.scan=malformed, got " + r.markers.current.scan);
   const raw = {
-    baseline: fs.readFileSync('$FIXTURES/s3-baseline.txt', 'utf8'),
-    latest: fs.readFileSync('$FIXTURES/s3-latest.txt', 'utf8'),
-    current: fs.readFileSync('$FIXTURES/s3-current.txt', 'utf8'),
+    baseline: fs.readFileSync(process.env.GAIA_S3_BASELINE, "utf8"),
+    latest: fs.readFileSync(process.env.GAIA_S3_LATEST, "utf8"),
+    current: fs.readFileSync(process.env.GAIA_S3_CURRENT, "utf8"),
   };
-  for (const side of ['baseline', 'latest', 'current']) {
+  for (const side of ["baseline", "latest", "current"]) {
     if (r.normalized[side] !== raw[side])
-      throw new Error('normalized.' + side + ' is not byte-identical to its input file');
+      throw new Error("normalized." + side + " is not byte-identical to its input file");
   }
-" || { fail "scenario 3 (malformed markers) did not match the expected global-bail shape"; exit 1; }
+' || { fail "scenario 3 (malformed markers) did not match the expected global-bail shape"; exit 1; }
 log "scenario 3 (malformed markers, global bail): OK"
 
 # --- Scenario 4: absent markers on baseline and current -------------------
@@ -165,8 +201,8 @@ S4_JSON="$("$GAIA" update merge-region \
   --latest "$FIXTURES/s4-latest.txt" \
   --current "$FIXTURES/s4-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>/dev/null)" \
-  || { fail "scenario 4: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  --json 2>"$CLI_STDERR")" \
+  || { fail "scenario 4: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
 
 printf '%s' "$S4_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -188,37 +224,60 @@ S5_ARGS=(update merge-region \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
-S5_FIRST="$("$GAIA" "${S5_ARGS[@]}" 2>/dev/null)" \
-  || { fail "scenario 5: first invocation exited non-zero"; exit 1; }
-S5_SECOND="$("$GAIA" "${S5_ARGS[@]}" 2>/dev/null)" \
-  || { fail "scenario 5: second invocation exited non-zero"; exit 1; }
+S5_FIRST="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
+  || { fail "scenario 5: first invocation exited non-zero"; report_cli_stderr; exit 1; }
+S5_SECOND="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
+  || { fail "scenario 5: second invocation exited non-zero"; report_cli_stderr; exit 1; }
 [ "$S5_FIRST" = "$S5_SECOND" ] \
   || { fail "scenario 5 (idempotence): two invocations on the same inputs produced different output"; exit 1; }
 log "scenario 5 (idempotence): OK"
 
 # --- Scenario 6: post-update idempotence -----------------------------------
-# Copying `latest` over `current` simulates the post-update working tree. A
-# second `/update-gaia` run cannot reach the merge walk at all once
+# `current` byte-identical to `latest` simulates the post-update working tree.
+# A second `/update-gaia` run cannot reach the merge walk at all once
 # `.gaia/VERSION` is bumped, so this is the only layer that can observe a
-# re-invocation against the post-update state. The verdict this run returns
-# need not equal the pre-update verdict, because once the working copy equals
-# the release copy the same inputs resolve to `already-latest`; the assertable
-# property is that repeated re-invocations against the SAME post-update
-# state produce the SAME output.
-cp "$FIXTURES/s1-latest.txt" "$FIXTURES/s1-current.txt"
+# re-invocation against the post-update state.
+#
+# Two independent properties, and the first is why this scenario is not a
+# restatement of scenario 5. Scenario 5 establishes that the function is stable
+# across two calls on the PRE-update inputs; repeating that on a different set
+# of inputs adds no failure mode. What is only observable here is the VERDICT:
+# once the working copy equals the release copy, the same three sides resolve to
+# `already-latest` rather than to scenario 1's `no-adopter-drift`, which is the
+# state every adopter's tree is left in and the one a re-run must recognize.
+#
+# Dedicated `s6-*` fixtures rather than a `cp` over `s1-current.txt`. Mutating a
+# scenario-1 fixture in place is safe only for as long as nothing below this
+# line reads it for its pre-update content: any scenario later inserted above,
+# or any reordering of this file, silently gets post-update content and passes
+# for the wrong reason.
+printf 'outside-A\n%s\nregion-baseline-1\nregion-baseline-2\n%s\noutside-B\n' \
+  "$START_MARKER" "$END_MARKER" > "$FIXTURES/s6-baseline.txt"
+printf 'outside-A-changed\n%s\nregion-baseline-1\nregion-baseline-2\n%s\noutside-B\n' \
+  "$START_MARKER" "$END_MARKER" > "$FIXTURES/s6-latest.txt"
+# The post-update working tree: the adopter's copy IS the release copy.
+cp "$FIXTURES/s6-latest.txt" "$FIXTURES/s6-current.txt"
+
 S6_ARGS=(update merge-region \
-  --baseline "$FIXTURES/s1-baseline.txt" \
-  --latest "$FIXTURES/s1-latest.txt" \
-  --current "$FIXTURES/s1-current.txt" \
+  --baseline "$FIXTURES/s6-baseline.txt" \
+  --latest "$FIXTURES/s6-latest.txt" \
+  --current "$FIXTURES/s6-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
-S6_FIRST="$("$GAIA" "${S6_ARGS[@]}" 2>/dev/null)" \
-  || { fail "scenario 6: first post-update invocation exited non-zero"; exit 1; }
-S6_SECOND="$("$GAIA" "${S6_ARGS[@]}" 2>/dev/null)" \
-  || { fail "scenario 6: second post-update invocation exited non-zero"; exit 1; }
+S6_FIRST="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
+  || { fail "scenario 6: first post-update invocation exited non-zero"; report_cli_stderr; exit 1; }
+S6_SECOND="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
+  || { fail "scenario 6: second post-update invocation exited non-zero"; report_cli_stderr; exit 1; }
+
+printf '%s' "$S6_FIRST" | node -e '
+  const r = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+  if (r.verdict !== "already-latest")
+    throw new Error("expected verdict already-latest, got " + r.verdict);
+' || { fail "scenario 6: the post-update state did not resolve to already-latest"; exit 1; }
+
 [ "$S6_FIRST" = "$S6_SECOND" ] \
   || { fail "scenario 6 (post-update idempotence): re-invocation was not stable"; exit 1; }
-log "scenario 6 (post-update idempotence): OK"
+log "scenario 6 (post-update verdict and idempotence): OK"
 
 # --- Scenario 7: error path -------------------------------------------------
 if "$GAIA" update merge-region \

--- a/.gaia/tests/distribution/17-gaia-update-merge-region.sh
+++ b/.gaia/tests/distribution/17-gaia-update-merge-region.sh
@@ -57,15 +57,28 @@ PLACEHOLDER='<<<gaia:region>>>'
 # asserts FAILURE, so its diagnostic is expected noise and it keeps its own
 # suppression.
 #
-# CALL ORDER IS LOAD-BEARING: `report_cli_stderr` runs BEFORE `fail`, never
-# after. `fail` returns 1 rather than exiting, and the `{ ...; }` group is the
-# LAST command of its AND-OR list, so `set -e` is NOT suppressed inside it and
-# aborts the script the moment `fail` returns. Anything written after `fail` in
-# one of these branches is dead code that never runs, which is how a diagnostic
-# that looks present prints nothing. (The trailing `exit 1` in each branch is
-# unreachable for the same reason; it predates this comment and is kept as the
-# statement of intent.) Verified by driving a real non-zero exit through
-# scenario 1, not by reading.
+# WHY NOT THE SIBLING IDIOM. Several other scenarios in this directory
+# (07, 08, 10, 11, 12, 13, 14) solve the same problem the other way: keep
+# `2>/dev/null`, and on failure re-run the identical command unsuppressed for a
+# human to read. Capturing to a file is preferred here because it reports the
+# bytes the FAILING run actually emitted, where a re-run reports a second,
+# different execution: it can succeed, or fail differently, and it doubles the
+# work on the one path that is already going wrong. This is also the fix the
+# issue itself names. The cost is honest and worth stating: this directory now
+# holds two mechanisms for one job and neither lives in `lib/lib.sh`, which is
+# filed rather than fixed here, because converging the other seven scenarios is
+# not this change's scope.
+#
+# CALL ORDER IS LOAD-BEARING, which is why `fail_with_stderr` exists rather
+# than an inline group at each site. `report_cli_stderr` runs BEFORE `fail`,
+# never after: `fail` returns 1 rather than exiting, and the `||` right-hand
+# side is the LAST command of its AND-OR list, so `set -e` is NOT suppressed
+# there and aborts the script the moment `fail` returns. Anything sequenced
+# after `fail` is dead code that never runs, which is how a diagnostic that
+# looks present prints nothing. (`fail_with_stderr`'s own trailing `exit 1` is
+# unreachable for that reason and is kept as the statement of intent, matching
+# every other failure branch in this file.) Verified by driving a real non-zero
+# exit through scenario 1, not by reading.
 CLI_STDERR="$FIXTURES/cli-stderr.txt"
 : > "$CLI_STDERR"
 
@@ -77,6 +90,14 @@ report_cli_stderr() {
   else
     printf -- '(gaia wrote nothing to stderr)\n' >&2
   fi
+}
+
+# The one failure branch every success-asserting invocation below uses, so the
+# order above is stated once rather than repeated at eight call sites.
+fail_with_stderr() {
+  report_cli_stderr
+  fail "$1"
+  exit 1
 }
 
 # --- Scenario 1: region-only divergence -----------------------------------
@@ -97,7 +118,7 @@ S1_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 1: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  || fail_with_stderr "scenario 1: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S1_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -128,7 +149,7 @@ S2_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s2-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 2: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  || fail_with_stderr "scenario 2: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S2_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -164,7 +185,7 @@ S3_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s3-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 3: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  || fail_with_stderr "scenario 3: gaia update merge-region exited non-zero on staged tree"
 
 # The fixture paths reach node through the ENVIRONMENT, never interpolated by
 # the shell into the JS source. `$FIXTURES` derives from `mktemp -d`, so a
@@ -212,7 +233,7 @@ S4_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s4-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 4: gaia update merge-region exited non-zero on staged tree"; exit 1; }
+  || fail_with_stderr "scenario 4: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S4_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -235,9 +256,9 @@ S5_ARGS=(update merge-region \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
 S5_FIRST="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 5: first invocation exited non-zero"; exit 1; }
+  || fail_with_stderr "scenario 5: first invocation exited non-zero"
 S5_SECOND="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 5: second invocation exited non-zero"; exit 1; }
+  || fail_with_stderr "scenario 5: second invocation exited non-zero"
 [ "$S5_FIRST" = "$S5_SECOND" ] \
   || { fail "scenario 5 (idempotence): two invocations on the same inputs produced different output"; exit 1; }
 log "scenario 5 (idempotence): OK"
@@ -256,28 +277,28 @@ log "scenario 5 (idempotence): OK"
 # `already-latest` rather than to scenario 1's `no-adopter-drift`, which is the
 # state every adopter's tree is left in and the one a re-run must recognize.
 #
-# Dedicated `s6-*` fixtures rather than a `cp` over `s1-current.txt`. Mutating a
-# scenario-1 fixture in place is safe only for as long as nothing below this
-# line reads it for its pre-update content: any scenario later inserted above,
-# or any reordering of this file, silently gets post-update content and passes
-# for the wrong reason.
-printf 'outside-A\n%s\nregion-baseline-1\nregion-baseline-2\n%s\noutside-B\n' \
-  "$START_MARKER" "$END_MARKER" > "$FIXTURES/s6-baseline.txt"
-printf 'outside-A-changed\n%s\nregion-baseline-1\nregion-baseline-2\n%s\noutside-B\n' \
-  "$START_MARKER" "$END_MARKER" > "$FIXTURES/s6-latest.txt"
-# The post-update working tree: the adopter's copy IS the release copy.
-cp "$FIXTURES/s6-latest.txt" "$FIXTURES/s6-current.txt"
+# Scenario 1's baseline and latest are READ here, deliberately: the contrast
+# with scenario 1 is the point, same two sides, a different `current`, a
+# different verdict. Reading them is also what scenarios 5 and 7 already do.
+#
+# What this scenario must not do is WRITE one. A `cp` over `s1-current.txt`
+# is safe only for as long as nothing below that line reads it for its
+# pre-update content, so any scenario later inserted above, or any reordering
+# of this file, silently gets post-update content and passes for the wrong
+# reason. The post-update state therefore lands in its own `s6-current.txt`
+# and every `s1-*` file is left exactly as scenario 1 wrote it.
+cp "$FIXTURES/s1-latest.txt" "$FIXTURES/s6-current.txt"
 
 S6_ARGS=(update merge-region \
-  --baseline "$FIXTURES/s6-baseline.txt" \
-  --latest "$FIXTURES/s6-latest.txt" \
+  --baseline "$FIXTURES/s1-baseline.txt" \
+  --latest "$FIXTURES/s1-latest.txt" \
   --current "$FIXTURES/s6-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
 S6_FIRST="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 6: first post-update invocation exited non-zero"; exit 1; }
+  || fail_with_stderr "scenario 6: first post-update invocation exited non-zero"
 S6_SECOND="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { report_cli_stderr; fail "scenario 6: second post-update invocation exited non-zero"; exit 1; }
+  || fail_with_stderr "scenario 6: second post-update invocation exited non-zero"
 
 printf '%s' "$S6_FIRST" | node -e '
   const r = JSON.parse(require("node:fs").readFileSync(0, "utf8"));

--- a/.gaia/tests/distribution/17-gaia-update-merge-region.sh
+++ b/.gaia/tests/distribution/17-gaia-update-merge-region.sh
@@ -56,6 +56,16 @@ PLACEHOLDER='<<<gaia:region>>>'
 # The discriminator is what the scenario asserts, not its number: scenario 7
 # asserts FAILURE, so its diagnostic is expected noise and it keeps its own
 # suppression.
+#
+# CALL ORDER IS LOAD-BEARING: `report_cli_stderr` runs BEFORE `fail`, never
+# after. `fail` returns 1 rather than exiting, and the `{ ...; }` group is the
+# LAST command of its AND-OR list, so `set -e` is NOT suppressed inside it and
+# aborts the script the moment `fail` returns. Anything written after `fail` in
+# one of these branches is dead code that never runs, which is how a diagnostic
+# that looks present prints nothing. (The trailing `exit 1` in each branch is
+# unreachable for the same reason; it predates this comment and is kept as the
+# statement of intent.) Verified by driving a real non-zero exit through
+# scenario 1, not by reading.
 CLI_STDERR="$FIXTURES/cli-stderr.txt"
 : > "$CLI_STDERR"
 
@@ -87,7 +97,7 @@ S1_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { fail "scenario 1: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 1: gaia update merge-region exited non-zero on staged tree"; exit 1; }
 
 printf '%s' "$S1_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -118,7 +128,7 @@ S2_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s2-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { fail "scenario 2: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 2: gaia update merge-region exited non-zero on staged tree"; exit 1; }
 
 printf '%s' "$S2_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -154,7 +164,7 @@ S3_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s3-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { fail "scenario 3: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 3: gaia update merge-region exited non-zero on staged tree"; exit 1; }
 
 # The fixture paths reach node through the ENVIRONMENT, never interpolated by
 # the shell into the JS source. `$FIXTURES` derives from `mktemp -d`, so a
@@ -202,7 +212,7 @@ S4_JSON="$("$GAIA" update merge-region \
   --current "$FIXTURES/s4-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json 2>"$CLI_STDERR")" \
-  || { fail "scenario 4: gaia update merge-region exited non-zero on staged tree"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 4: gaia update merge-region exited non-zero on staged tree"; exit 1; }
 
 printf '%s' "$S4_JSON" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
@@ -225,9 +235,9 @@ S5_ARGS=(update merge-region \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
 S5_FIRST="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { fail "scenario 5: first invocation exited non-zero"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 5: first invocation exited non-zero"; exit 1; }
 S5_SECOND="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { fail "scenario 5: second invocation exited non-zero"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 5: second invocation exited non-zero"; exit 1; }
 [ "$S5_FIRST" = "$S5_SECOND" ] \
   || { fail "scenario 5 (idempotence): two invocations on the same inputs produced different output"; exit 1; }
 log "scenario 5 (idempotence): OK"
@@ -265,9 +275,9 @@ S6_ARGS=(update merge-region \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
 S6_FIRST="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { fail "scenario 6: first post-update invocation exited non-zero"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 6: first post-update invocation exited non-zero"; exit 1; }
 S6_SECOND="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
-  || { fail "scenario 6: second post-update invocation exited non-zero"; report_cli_stderr; exit 1; }
+  || { report_cli_stderr; fail "scenario 6: second post-update invocation exited non-zero"; exit 1; }
 
 printf '%s' "$S6_FIRST" | node -e '
   const r = JSON.parse(require("node:fs").readFileSync(0, "utf8"));

--- a/.gaia/tests/lib/doc-audit-promote-source.bats
+++ b/.gaia/tests/lib/doc-audit-promote-source.bats
@@ -260,6 +260,19 @@ setup() {
   # edit above the wiki write, which loses the content on a failed write.
   local loop
   loop="$(scoped '^### Per-action loop' '^### ')"
+  # BOTH the operative clause and its rationale, because pinning only the
+  # rationale lets the two come apart. Reordering the arm so the source edit
+  # precedes the wiki writes, while leaving the sentence below in place, keeps
+  # every other assertion in this suite green; what survives is a document that
+  # still explains why something happens where it no longer happens, which is
+  # exactly the incoherent partial edit a reviewer is least likely to catch by
+  # reading. The two coherent variants -- reorder AND rewrite the rationale, or
+  # drop the rationale -- both die on one needle or the other.
+  #
+  # This extends the general rule in `scoped`'s header from pinning WHERE
+  # something sits to pinning WHAT sits there. Both literals occur exactly once
+  # in the target file and in no other suite, so neither is a tautology.
+  grep -qF -- 'then act on the source **last**' <<<"$loop"
   grep -qF -- 'The source goes last so a wiki write that fails leaves it intact' <<<"$loop"
 }
 
@@ -384,6 +397,12 @@ setup() {
   # unverified.
   local verify
   verify="$(scoped '^### Post-apply verification' '^### ')"
+  # Same shape as the apply-arm test above, with a narrower consequence: the
+  # rationale needle alone leaves nothing rejecting the absence check being
+  # ADDED BACK while the sentence explaining why it would be wrong stays put.
+  # The operative clause is what states the arm's actual behaviour, so it is
+  # pinned alongside the reason for it.
+  grep -qF -- 'The `replace` arm asserts no absence' <<<"$verify"
   grep -qF -- 'asserting its absence would downgrade a correct apply' <<<"$verify"
 }
 


### PR DESCRIPTION
Seven tech-debt issues, one reviewer context, one sentence: **the test asserts less than its name claims.** Each member is proved by running a suite rather than by a reading, which is what qualifies them as a batch.

Closes #1035
Closes #1036
Closes #1045
Closes #1046
Closes #1047
Closes #1136
Closes #1190

## What each member changes

**#1045** — distribution scenarios that assert success captured the CLI's stderr into `/dev/null`, so the `||` branch could report only the exit code, the one fact the branch being taken already implies. They now capture it to a file and print it from the failure branch. Scenario 7 keeps its suppression: it asserts failure, so its diagnostic is expected noise.

**#1036** — scenario 3 interpolated `$FIXTURES` straight into single-quoted JS string literals inside `node -e`. The paths now reach node through the environment and the JS body is single-quoted, so no shell expansion enters it at all.

**#1035** — scenario 6 asserted only stability across two invocations, which scenario 5 already establishes for the same function; it now asserts the `already-latest` verdict that is only observable in the post-update state. It also gets dedicated `s6-*` fixtures instead of overwriting a scenario-1 fixture in place.

**#1046** — the convergence parity test declined the checker's process-wide exit status as a verdict, correctly, and put nothing in its place, so an early abort that never reached an invariant would emit unmatched text and green the test. It now pins status `1`, the ran-and-reported code.

**#1047** — three comparisons went through `$(cat …)`, which strips all trailing newlines from both sides, so a trailing-newline regression was invisible to the test whose name promises byte identity. All three now compare files with `cmp`.

**#1136** — the prototype-key `test.each` list hand-built `ManifestShape` objects, so no row crossed `ManifestSchema` and the list implied end-to-end coverage the suite did not have. Four names now round-trip through `serialize` → `JSON.parse` → schema parse; `__proto__` gets its own case recording that `z.record` drops it, and that the resulting permanent drift-gate block fails closed.

**#1190** — two doc-conformance tests pinned the *rationale* for a placement without the operative clause it justifies, so the clause could move while the rationale stayed put and the suite ran green. Both now pin the clause alongside the reason.

## The step's own defect, found by a mutant rather than by reading

`report_cli_stderr` was first written *after* `fail` in each `|| { … }` branch. `fail` returns 1 rather than exiting, and the group is the last command of its AND-OR list, so `set -e` is **not** suppressed inside it and aborts the script the moment `fail` returns. The report was dead code: a diagnostic that looked present and printed nothing, while all nine scenarios still passed. Only a mutant driving a real non-zero exit exposed it. Fixed in `8d1186ee`, with the mechanism pinned in a comment so the order cannot be undone as a tidy-up.

The trailing `exit 1` in each of those branches is unreachable for the same reason. It is **pre-existing**, and is left in place and documented rather than deleted, per the coding guidelines' pre-existing-dead-code rule.

## Guard proofs

Every new assertion was proved able to fail, and where a pre-fix counterpart existed it was shown blind to the same mutant.

| Mutant | Result |
|---|---|
| post-update state perturbed so the verdict is not `already-latest` | killed |
| scenario 1 `--current` → missing file | killed; branch prints the CLI's own `region_file_missing` payload |
| fixture dir forced to `/tmp/gaia-s17-it's a \dir` | pre-fix dies with `SyntaxError: missing ) after argument list`; fixed passes |
| `run_check` stubbed to an early abort (`exit 2`) | killed; **pre-fix returns `ok`** |
| agent file gains one trailing newline between the two reads | killed; **pre-fix returns `ok`** |
| same, on the reversed-pair byte-identity claim | killed; **pre-fix returns `ok`** |
| both sandboxes given the same roster | killed |
| `roundTrip` bypasses `ManifestSchema.parse` | killed |
| `__proto__` added back to the surviving-four list | killed |
| source edit hoisted above the wiki writes, rationale left in place | killed; **pre-fix returns `ok`** |
| absence check reinstated in the verify arm, rationale left in place | killed; **pre-fix returns `ok`** |

One proof was discarded as hollow rather than counted: an end-to-end run under a hostile `TMPDIR` passed, but **macOS `mktemp -t` ignores `TMPDIR`**, so no fixture ever landed in that directory. The real proof forces the `FIXTURES=` assignment instead. On Linux CI `mktemp -t` does honour `TMPDIR`, so the hazard is real on the runner and simply not reproducible that way on a Mac.

## What the Quality Gate's simplify step changed

Two findings applied:

- The eight identical report-then-fail groups collapse into one `fail_with_stderr` helper, so the load-bearing call order is stated once instead of at every site.
- Scenario 6 now **reads** scenario 1's baseline and latest instead of writing byte-identical copies of them. The contrast with scenario 1 is the point of the scenario, reading those fixtures is what scenarios 5 and 7 already do, and the defect `#1035` names is the **write** over `s1-current.txt`, which is gone either way. Verified structurally: no scenario writes an `s1-*` fixture after scenario 1's own block.

Both mutants covering the reworked code were re-run afterwards and still kill.

One finding was **not** applied: moving `report_cli_stderr` into `lib/lib.sh`. That file's header marks its API frozen, and converging the seven sibling scenarios is not this change's scope. Filed instead, and the file's header comment now records why this scenario departs from the sibling idiom rather than leaving the divergence unexamined.

## New tech-debt filed

- **#1201** — the `$(cat …)` byte-identity defect `#1047` names exists at ~87 further candidate sites across 14 other files. Filed rather than fixed: out of scope, and the deeper fix is a shared `assert_files_identical` helper rather than more hand-rolled `cmp` calls.
- **#1202** — the distribution suite now holds two competing CLI-stderr diagnostic mechanisms and neither lives in `lib/lib.sh`.

Both are cross-remit: non-security, on paths this PR does not change.

## Verification

Quality Gate run rather than recalled, and it **applies** here (`manifest.test.ts` matches the `*.ts` trigger). Typecheck 0 root and CLI; `pnpm lint` 0; `pnpm lint:cli` found 3 and they were fixed; root tests 155 passed, CLI tests 1957 passed, no console warnings; Playwright 8 passed; dev smoke HTTP 200; build 0.

Beyond the gate: `shell-lint` passed; `.gaia/scripts/tests` 1401 ok / 0 not ok and `.gaia/tests/lib` 448 ok / 0 not ok, both under bash 5 so local matches CI; distribution harness 34 PASS / 0 FAIL. `pnpm -C .gaia/cli bundle` was run and the tree stayed clean, so no rebundle is owed — checked rather than assumed, per S9i.

## Scope note

`#1045`'s title names scenarios 1-4, and the fix also covers scenarios 5 and 6. That is the issue's **own** stated discriminator rather than an extension of it: it keeps scenario 7's suppression explicitly *because it asserts failure*, so every success-asserting invocation is in scope. Scenarios 5 and 6 assert success and carried the identical `2>/dev/null`. Fixing four of the six sites while rewriting scenario 6's invocations for `#1035` would have left the rule stated correctly on one surface and wrongly on another, which is this repo's most-repeated defect class.

## CHANGELOG

No entry. Decided from the merge workflow's own worthiness list, whose **Not worthy** clause names this case in as many words: *"test-only changes that alter no shipped behavior"*. All five changed files are test files and no command behaves differently.
