### PR TITLE
wiki: sync through b027e62

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "7e80178585f6cab7d7783203c990bdc3f7a62164",
-  "last_evaluated_at": "2026-08-05T01:26:45Z",
+  "last_evaluated_sha": "b027e62df7b9e814d7f0ad3928c2b7f9b9d0559a",
+  "last_evaluated_at": "2026-08-05T05:19:27Z",
   "last_consolidated_sha": "baad8972ee9d300aee847b84f17d72e45c1fbddf",
   "last_consolidated_at": "2026-07-29T05:58:30Z"
 }

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,7 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-08-05 b027e62d SKIP - eslint.config guard rewrite (#1153) already documented in-commit across wiki/concepts/Claude Hooks.md, ESLint Fixes.md, wiki/decisions/Code Audit Team.md, pnpm.md, wiki/dependencies/Storybook.md, gaia-lint.md, wiki/modules/Claude Integration.md; verified accurate
 - 2026-08-05 7e801785 SKIP - internal correctness fix, trailing-newline preservation; existing wiki description accurate at its abstraction level
 - 2026-08-05 ae974ea0 SKIP - internal correctness fix, whole-file reconstruction for Edit/MultiEdit; existing wiki description accurate at its abstraction level
 - 2026-08-05 31d5aa2c SKIP - internal correctness fix to the eslint-config guard's block-comment tracking; existing wiki description accurate at its abstraction level


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to b027e62.