### PR TITLE
debt(tests): make three assertions check what their names claim (#1201, #1209, #1214)

### DIFF
--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -198,6 +198,67 @@ const readHardeningSettings = (
   };
 };
 
+// Exemption entries compared as ATOMS rather than as literal strings, because
+// pnpm does not store one exemption per entry. When a package needs more than
+// one exempted version it merges them into a single union entry,
+// `name@1.0.0 || 2.0.0`, and writes that back into `pnpm-workspace.yaml`
+// itself. Root's dependency closure is a superset of `.gaia/cli`'s, so the two
+// workspaces can legitimately need different version counts of one shared
+// package, at which point root carries the union and `.gaia/cli` carries the
+// single version. That is exactly the containment the two tests below permit,
+// and literal membership cannot see it: `arrayContaining` looks for
+// `semver@6.3.1`, finds only the union, and reds a required check over a valid
+// configuration.
+//
+// The shape is pnpm's own (`expandPackageVersionSpecs`, the inverse of the
+// `mergePackageVersionSpecs` that writes the union), mirrored here rather than
+// imported: pnpm is this repo's `packageManager`, not a dependency of either
+// workspace, so there is nothing to import from. Its parse is followed exactly,
+// including the scope-aware `@` split that keeps `@scope/name` from splitting on
+// its own leading `@`.
+//
+// One deliberate divergence, stated because a wrong normalization here is the
+// same false-positive class this exists to fix: pnpm runs each version through
+// `semver.valid`, which also folds spellings like `=1.2.3` and `v1.2.3` onto
+// `1.2.3`. Trimming is all that pnpm's OWN output needs (its union separator
+// leaves a leading space), and `semver` is a dependency of neither workspace. A
+// hand-written `v1.2.3` on one side and `1.2.3` on the other would therefore
+// still red. Add the dependency and use `semver.valid` if that ever happens; do
+// not grow a second normalizer by hand, which is how the sibling exactness
+// predicate accumulated four rounds of shape-by-shape repair.
+//
+// A name-only entry stays one atom, so exempting EVERY version of a package in
+// `.gaia/cli` is not contained by exempting one version of it at root. That is
+// asymmetric hardening and stays red, which is pnpm's reading too.
+//
+// A non-string entry is the exactness tests' finding, not this one's. It passes
+// through unexpanded so it still compares, rather than being dropped into a
+// silently smaller list on the containing side.
+const exemptionAtoms = (list: unknown[]): unknown[] => {
+  const atoms = new Set<unknown>();
+
+  for (const entry of list) {
+    if (typeof entry === 'string') {
+      const atIndex =
+        entry.startsWith('@') ? entry.indexOf('@', 1) : entry.indexOf('@');
+
+      if (atIndex === -1) {
+        atoms.add(entry);
+      } else {
+        const packageName = entry.slice(0, atIndex);
+
+        for (const version of entry.slice(atIndex + 1).split('||')) {
+          atoms.add(`${packageName}@${version.trim()}`);
+        }
+      }
+    } else {
+      atoms.add(entry);
+    }
+  }
+
+  return [...atoms];
+};
+
 describe('@gaia-react/lint pin parity', () => {
   const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
   const rootPin = readPin(path.join(repoRoot, 'package.json'));
@@ -303,72 +364,14 @@ describe('supply-chain hardening parity', () => {
   // Containment, not equality. Root's lists are supersets by design, so equality
   // would fail on `bippy` and `chokidar`; but an entry present ONLY in `.gaia/cli`
   // exempts a package from the setting above it in one workspace and not the other,
-  // which is the asymmetric hardening this describe block exists to catch.
-  // Compared as ATOMS rather than as literal strings, because pnpm does not
-  // store one exemption per entry. When a package needs more than one exempted
-  // version it merges them into a single union entry, `name@1.0.0 || 2.0.0`, and
-  // writes that back into `pnpm-workspace.yaml` itself. Root's dependency closure
-  // is a superset of `.gaia/cli`'s, so the two workspaces can legitimately need
-  // different version counts of one shared package, at which point root carries
-  // the union and `.gaia/cli` carries the single version. That is exactly the
-  // containment these tests exist to permit, and literal membership cannot see
-  // it: `arrayContaining` looks for `semver@6.3.1`, finds only the union, and
-  // reds a required check over a valid configuration.
-  //
-  // The shape is pnpm's own (`expandPackageVersionSpecs`, the inverse of the
-  // `mergePackageVersionSpecs` that writes the union), mirrored here rather than
-  // imported: pnpm is this repo's `packageManager`, not a dependency of either
-  // workspace, so there is nothing to import from. Its parse is followed exactly,
-  // including the scope-aware `@` split that keeps `@scope/name` from splitting
-  // on its own leading `@`.
-  //
-  // One deliberate divergence, stated because a wrong normalization here is the
-  // same false-positive class this fixes: pnpm runs each version through
-  // `semver.valid`, which also folds spellings like `=1.2.3` and `v1.2.3` onto
-  // `1.2.3`. Trimming is all that pnpm's OWN output needs (its union separator
-  // leaves a leading space), and `semver` is a dependency of neither workspace.
-  // A hand-written `v1.2.3` on one side and `1.2.3` on the other would therefore
-  // still red. Add the dependency and use `semver.valid` if that ever happens;
-  // do not grow a second normalizer by hand, which is how the sibling predicate
-  // below accumulated four rounds of shape-by-shape repair.
-  //
-  // A name-only entry stays one atom, so exempting EVERY version of a package in
-  // `.gaia/cli` is not contained by exempting one version of it at root. That is
-  // asymmetric hardening and stays red, which is pnpm's reading too.
-  const exemptionAtoms = (list: unknown[]): unknown[] => {
-    const atoms = new Set<unknown>();
-
-    for (const entry of list) {
-      // A non-string is the exactness tests' finding, not this one's. Passed
-      // through unexpanded so it still compares, rather than being dropped into
-      // a silently smaller list on the containing side.
-      if (typeof entry !== 'string') {
-        atoms.add(entry);
-        continue;
-      }
-
-      const atIndex = entry.startsWith('@')
-        ? entry.indexOf('@', 1)
-        : entry.indexOf('@');
-
-      if (atIndex === -1) {
-        atoms.add(entry);
-        continue;
-      }
-
-      const packageName = entry.slice(0, atIndex);
-
-      for (const version of entry.slice(atIndex + 1).split('||')) {
-        atoms.add(`${packageName}@${version.trim()}`);
-      }
-    }
-
-    return [...atoms];
-  };
-
+  // which is the asymmetric hardening this describe block exists to catch. The
+  // two sides are compared as atoms; see `exemptionAtoms` above for why literal
+  // membership cannot see a legitimate containment.
   test('.gaia/cli exempts nothing from the release-age window that root does not', () => {
     expect(exemptionAtoms(rootSettings.minimumReleaseAgeExclude)).toEqual(
-      expect.arrayContaining(exemptionAtoms(cliSettings.minimumReleaseAgeExclude))
+      expect.arrayContaining(
+        exemptionAtoms(cliSettings.minimumReleaseAgeExclude)
+      )
     );
   });
 

--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -375,19 +375,36 @@ describe('supply-chain hardening parity', () => {
     );
   });
 
-  test('a merged union contains the single version it was merged from', () => {
+  // The four below are unit tests of `exemptionAtoms` over constructed entries,
+  // not assertions about either live `pnpm-workspace.yaml`. Named for the helper
+  // so they cannot be read as live parity coverage: the two tests that do assert
+  // on the real files are the containment pair, above and below this block.
+  test('exemptionAtoms: a merged union contains the single version it merged', () => {
     expect(exemptionAtoms(['semver@6.3.1 || 6.3.2'])).toEqual(
       expect.arrayContaining(exemptionAtoms(['semver@6.3.1']))
     );
   });
 
-  test('a version only .gaia/cli exempts is still drift after expansion', () => {
+  // The scope-aware `@` split is the one part of pnpm's parse a plain
+  // `indexOf('@')` gets wrong, and a SCOPED UNION is the only input shape where
+  // the two spellings diverge: naive splitting yields the name-less atom
+  // `@2.0.0`, which reds containment on a valid pair, reintroducing exactly the
+  // false red this helper exists to remove. Without this test the branch is
+  // unpinned and collapsing it leaves every other test green, which is not
+  // hypothetical: a quality-review pass proposed that collapse on this very diff.
+  test('exemptionAtoms: a scoped union splits on the version @, not the scope @', () => {
+    expect(exemptionAtoms(['@scope/n@1.0.0 || 2.0.0'])).toEqual(
+      expect.arrayContaining(exemptionAtoms(['@scope/n@2.0.0']))
+    );
+  });
+
+  test('exemptionAtoms: a version only one side exempts is still drift', () => {
     expect(exemptionAtoms(['semver@6.3.1 || 6.3.2'])).not.toEqual(
       expect.arrayContaining(exemptionAtoms(['semver@6.3.3']))
     );
   });
 
-  test('exempting every version of a package is not contained by exempting one', () => {
+  test('exemptionAtoms: exempting every version is not contained by exempting one', () => {
     expect(exemptionAtoms(['semver@6.3.1'])).not.toEqual(
       expect.arrayContaining(exemptionAtoms(['semver']))
     );

--- a/.gaia/cli/src/lint-pin-parity.test.ts
+++ b/.gaia/cli/src/lint-pin-parity.test.ts
@@ -304,9 +304,89 @@ describe('supply-chain hardening parity', () => {
   // would fail on `bippy` and `chokidar`; but an entry present ONLY in `.gaia/cli`
   // exempts a package from the setting above it in one workspace and not the other,
   // which is the asymmetric hardening this describe block exists to catch.
+  // Compared as ATOMS rather than as literal strings, because pnpm does not
+  // store one exemption per entry. When a package needs more than one exempted
+  // version it merges them into a single union entry, `name@1.0.0 || 2.0.0`, and
+  // writes that back into `pnpm-workspace.yaml` itself. Root's dependency closure
+  // is a superset of `.gaia/cli`'s, so the two workspaces can legitimately need
+  // different version counts of one shared package, at which point root carries
+  // the union and `.gaia/cli` carries the single version. That is exactly the
+  // containment these tests exist to permit, and literal membership cannot see
+  // it: `arrayContaining` looks for `semver@6.3.1`, finds only the union, and
+  // reds a required check over a valid configuration.
+  //
+  // The shape is pnpm's own (`expandPackageVersionSpecs`, the inverse of the
+  // `mergePackageVersionSpecs` that writes the union), mirrored here rather than
+  // imported: pnpm is this repo's `packageManager`, not a dependency of either
+  // workspace, so there is nothing to import from. Its parse is followed exactly,
+  // including the scope-aware `@` split that keeps `@scope/name` from splitting
+  // on its own leading `@`.
+  //
+  // One deliberate divergence, stated because a wrong normalization here is the
+  // same false-positive class this fixes: pnpm runs each version through
+  // `semver.valid`, which also folds spellings like `=1.2.3` and `v1.2.3` onto
+  // `1.2.3`. Trimming is all that pnpm's OWN output needs (its union separator
+  // leaves a leading space), and `semver` is a dependency of neither workspace.
+  // A hand-written `v1.2.3` on one side and `1.2.3` on the other would therefore
+  // still red. Add the dependency and use `semver.valid` if that ever happens;
+  // do not grow a second normalizer by hand, which is how the sibling predicate
+  // below accumulated four rounds of shape-by-shape repair.
+  //
+  // A name-only entry stays one atom, so exempting EVERY version of a package in
+  // `.gaia/cli` is not contained by exempting one version of it at root. That is
+  // asymmetric hardening and stays red, which is pnpm's reading too.
+  const exemptionAtoms = (list: unknown[]): unknown[] => {
+    const atoms = new Set<unknown>();
+
+    for (const entry of list) {
+      // A non-string is the exactness tests' finding, not this one's. Passed
+      // through unexpanded so it still compares, rather than being dropped into
+      // a silently smaller list on the containing side.
+      if (typeof entry !== 'string') {
+        atoms.add(entry);
+        continue;
+      }
+
+      const atIndex = entry.startsWith('@')
+        ? entry.indexOf('@', 1)
+        : entry.indexOf('@');
+
+      if (atIndex === -1) {
+        atoms.add(entry);
+        continue;
+      }
+
+      const packageName = entry.slice(0, atIndex);
+
+      for (const version of entry.slice(atIndex + 1).split('||')) {
+        atoms.add(`${packageName}@${version.trim()}`);
+      }
+    }
+
+    return [...atoms];
+  };
+
   test('.gaia/cli exempts nothing from the release-age window that root does not', () => {
-    expect(rootSettings.minimumReleaseAgeExclude).toEqual(
-      expect.arrayContaining(cliSettings.minimumReleaseAgeExclude)
+    expect(exemptionAtoms(rootSettings.minimumReleaseAgeExclude)).toEqual(
+      expect.arrayContaining(exemptionAtoms(cliSettings.minimumReleaseAgeExclude))
+    );
+  });
+
+  test('a merged union contains the single version it was merged from', () => {
+    expect(exemptionAtoms(['semver@6.3.1 || 6.3.2'])).toEqual(
+      expect.arrayContaining(exemptionAtoms(['semver@6.3.1']))
+    );
+  });
+
+  test('a version only .gaia/cli exempts is still drift after expansion', () => {
+    expect(exemptionAtoms(['semver@6.3.1 || 6.3.2'])).not.toEqual(
+      expect.arrayContaining(exemptionAtoms(['semver@6.3.3']))
+    );
+  });
+
+  test('exempting every version of a package is not contained by exempting one', () => {
+    expect(exemptionAtoms(['semver@6.3.1'])).not.toEqual(
+      expect.arrayContaining(exemptionAtoms(['semver']))
     );
   });
 
@@ -374,8 +454,8 @@ describe('supply-chain hardening parity', () => {
   });
 
   test('.gaia/cli exempts nothing from the trust policy that root does not', () => {
-    expect(rootSettings.trustPolicyExclude).toEqual(
-      expect.arrayContaining(cliSettings.trustPolicyExclude)
+    expect(exemptionAtoms(rootSettings.trustPolicyExclude)).toEqual(
+      expect.arrayContaining(exemptionAtoms(cliSettings.trustPolicyExclude))
     );
   });
 });

--- a/.gaia/scripts/tests/audit-dirty-tree-posture.bats
+++ b/.gaia/scripts/tests/audit-dirty-tree-posture.bats
@@ -112,10 +112,22 @@ code-audit-maintainer-shell"
   WITHHOLD_SHAPED='withhold(s|ing)? (this|your) (pass|clearance|marker)'
 
   # The one legitimate form the alternation above still reaches: the exemption
-  # sentence's own negation, `does NOT withhold your pass`. Kept as narrow as
-  # that fact requires. A wide exclusion list would be a fail-open here, since
-  # every term in it is a way for a real withhold clause to go unseen.
-  WITHHOLD_NEGATED='(does not|never|cannot)'
+  # sentence's own negation, `does NOT withhold your pass`.
+  #
+  # The negator is ANCHORED TO THE VERB rather than merely required somewhere in
+  # the context window, and that anchor is the whole strength of this exclusion.
+  # Unanchored, any of these words appearing within 30 characters of a real
+  # withhold clause discards it, and they saturate this prose: `never` alone
+  # appears 33 times in the advisory member. Two house-style clauses got through
+  # the unanchored form, both carrying the contradiction the guard exists to
+  # catch, and both are pinned as fixtures below:
+  #
+  #   "…cannot be trusted, so withhold your marker until it is clean."
+  #   "This member never self-heals, and it will withhold this pass on dirt."
+  #
+  # Every term here is a way for a real withhold clause to go unseen, so the
+  # exclusion stays as narrow as the one legitimate sentence requires.
+  WITHHOLD_NEGATED='(does not|never|cannot) +withhold'
 
   # The run-order anchor, so the refusal is reachable from the member's own
   # order of operations rather than stated only beside the code block. The
@@ -134,8 +146,13 @@ member_path() {
 # preceding context so a reader can see which sentence tripped it. Case
 # insensitive on purpose: a reworded clause has no reason to keep the shouted
 # spelling of the sentence the gating members carry.
+#
+# Newlines are folded to spaces before matching, because `grep` is line-scoped
+# and a clause split across a line break would otherwise be invisible. The
+# guarded file carries unwrapped paragraphs today, so this closes the hole
+# before a reflow opens it rather than after.
 withhold_drift() {
-  grep -oiE ".{0,30}$WITHHOLD_SHAPED" "$1" | grep -viE "$WITHHOLD_NEGATED"
+  tr '\n' ' ' < "$1" | grep -oiE ".{0,30}$WITHHOLD_SHAPED" | grep -viE "$WITHHOLD_NEGATED"
   # Both greps exit 1 on no match, which is the passing case here, so the
   # function's own status must not carry it into a `set -e` test body.
   return 0
@@ -333,39 +350,70 @@ assert_pin_breaks() {
   assert_pin_breaks sentinel_line 's|dirty_in_scope="dirty-scope check failed"|dirty_in_scope=""|' "$SENTINEL_LINE"
 }
 
-@test "the advisory drift guard catches a reworded withhold clause (non-vacuity)" {
-  # The failure the byte-identical absence check could not see: the exemption
-  # paragraph stays exactly where it is, and a withhold clause sharing no
-  # sentence with the gating members' is added ahead of the handshake's
-  # "There is no withhold path here". The old exact-string pin reported green.
-  local src tmp anchor
+# assert_drift_caught TAG CLAUSE: the advisory member with CLAUSE inserted ahead
+# of the handshake's "There is no withhold path here", exemption paragraph left
+# exactly where it is, must trip the drift guard.
+#
+# That insertion shape is the failure the byte-identical absence check could not
+# see: nothing is reworded in place, a clause is ADDED, and the old exact-string
+# pin reported green on every one of these.
+assert_drift_caught() {
+  local tag="$1" clause="$2" src tmp anchor
   src="$(member_path "$ADVISORY")"
-  tmp="$BATS_TEST_TMPDIR/mutant-advisory-reworded.md"
+  tmp="$BATS_TEST_TMPDIR/mutant-advisory-$tag.md"
   anchor='There is no withhold path here;'
 
   grep -qF -- "$anchor" "$src" || {
-    echo "fixture broken: advisory member no longer carries the insertion anchor" >&2
+    echo "fixture broken: advisory member no longer carries the insertion anchor ($tag)" >&2
     return 1
   }
   [ -z "$(withhold_drift "$src")" ] || {
-    echo "fixture broken: advisory member already carries a withhold clause" >&2
+    echo "fixture broken: advisory member already carries a withhold clause ($tag)" >&2
     return 1
   }
 
-  awk -v anchor="$anchor" \
-    -v clause='When `dirty_in_scope` comes back non-empty, you withhold this pass and report that you must be re-dispatched once the operator commits or reverts.' \
+  awk -v anchor="$anchor" -v clause="$clause" \
     'index($0, anchor) && !done { print clause; print ""; done = 1 } { print }' \
     "$src" > "$tmp"
 
   grep -qF -- "$REFUSAL" "$tmp" && {
-    echo "fixture is not the reworded case: it carries the byte-identical contract" >&2
+    echo "fixture is not the reworded case: it carries the byte-identical contract ($tag)" >&2
     return 1
   }
   [ -n "$(withhold_drift "$tmp")" ] || {
-    echo "drift guard misses a reworded withhold clause; it only sees the copy-paste" >&2
+    echo "drift guard misses a withhold clause it must catch ($tag)" >&2
     return 1
   }
-  true
+  return 0
+}
+
+@test "the advisory drift guard catches a reworded withhold clause (non-vacuity)" {
+  assert_drift_caught reworded 'When `dirty_in_scope` comes back non-empty, you withhold this pass and report that you must be re-dispatched once the operator commits or reverts.'
+}
+
+@test "the advisory drift guard is not evaded by a nearby 'cannot' (non-vacuity)" {
+  # The negator is anchored to the verb, so a `cannot` that negates something
+  # else in the same sentence no longer discards the clause beside it. Under an
+  # unanchored exclusion this clause passed and the suite stayed green.
+  assert_drift_caught nearby_cannot 'A pass over a dirty tree cannot be trusted, so withhold your marker until it is clean.'
+}
+
+@test "the advisory drift guard is not evaded by a nearby 'never' (non-vacuity)" {
+  # `never` appears throughout this member legitimately, which is exactly why an
+  # unanchored exclusion was a fail-open rather than a narrow carve-out.
+  assert_drift_caught nearby_never 'This member never self-heals, and it will withhold this pass on dirt.'
+}
+
+@test "the advisory drift guard sees a clause split across a line break (non-vacuity)" {
+  # `grep` is line-scoped, so the scan folds newlines before matching. Written
+  # as a fixture rather than trusted: the guarded file's paragraphs are
+  # unwrapped today, and a reflow is what would otherwise open this hole.
+  #
+  # The break is written `\n` rather than as a literal newline in the argument.
+  # awk processes escape sequences in a `-v` assignment, so this reaches the
+  # mutant as a real line break, while a literal one is a hard error on the BSD
+  # awk this suite has to run under as well ("newline in string").
+  assert_drift_caught line_split 'When the check comes back non-empty you\nwithhold this pass until the operator commits or reverts.'
 }
 
 @test "the sentinel pin breaks when the carve-out is softened (non-vacuity)" {

--- a/.gaia/scripts/tests/audit-dirty-tree-posture.bats
+++ b/.gaia/scripts/tests/audit-dirty-tree-posture.bats
@@ -78,6 +78,16 @@ code-audit-maintainer-shell"
   SENTINEL_CARVEOUT='is a sentinel rather than a path and withholds unconditionally'
   NO_REFUSAL_ARTIFACT='**Withhold without writing a `.refused` artifact.**'
 
+  # The assignment that PRODUCES the sentinel the carve-out above protects.
+  # Pinned separately because the two say different things: SENTINEL_CARVEOUT
+  # pins the prose promising the sentinel is never remit-filtered, and CHECK_LINE
+  # pins only the `if` that detects the failure. Deleting this line from all five
+  # members left the suite reporting 18/18 ok while the fail-closed arm produced
+  # nothing to withhold on, which is the suite's own stated anti-goal. Matched
+  # without leading indentation: the content is what must not drift, and pinning
+  # the block's indentation too would red on a reflow that changes no meaning.
+  SENTINEL_LINE='dirty_in_scope="dirty-scope check failed"'
+
   # The byte-identical refusal contract.
   REFUSAL='**A non-empty `dirty_in_scope` WITHHOLDS this pass.**'
 
@@ -86,6 +96,26 @@ code-audit-maintainer-shell"
   # the sidecar write is the load-bearing half; pinning only the bolded opener
   # would let this clause be reworded or dropped with the suite still green.
   SIDECAR_CLAUSE='write the findings sidecar naming each dirty path'
+
+  # Withhold-shaped clauses, as an ERE alternation, for the advisory member's
+  # drift guard below. This matches an instruction that the member withholds
+  # ITS OWN pass, which is the meaning the advisory member must never acquire,
+  # rather than the one bolded sentence a byte-identical pin could see.
+  #
+  # Two spellings are deliberately NOT in it, both because the advisory member
+  # carries them legitimately. `write no marker` is its self-skip arm ("the only
+  # `no marker` case is the self-skip above"), and an unqualified `withhold`
+  # covers its own exemption prose ("why the four gating members withhold on
+  # it", "withholding would buy no guarantee"). Matching the verb plus the thing
+  # withheld is what separates an instruction to this member from a description
+  # of a sibling.
+  WITHHOLD_SHAPED='withhold(s|ing)? (this|your) (pass|clearance|marker)'
+
+  # The one legitimate form the alternation above still reaches: the exemption
+  # sentence's own negation, `does NOT withhold your pass`. Kept as narrow as
+  # that fact requires. A wide exclusion list would be a fail-open here, since
+  # every term in it is a way for a real withhold clause to go unseen.
+  WITHHOLD_NEGATED='(does not|never|cannot)'
 
   # The run-order anchor, so the refusal is reachable from the member's own
   # order of operations rather than stated only beside the code block. The
@@ -97,6 +127,18 @@ code-audit-maintainer-shell"
 
 member_path() {
   printf '%s/.claude/agents/%s.md' "$REPO_ROOT" "$1"
+}
+
+# withhold_drift FILE: print every withhold-shaped clause in FILE that is not
+# the exemption's own negation, one per line with up to 30 characters of
+# preceding context so a reader can see which sentence tripped it. Case
+# insensitive on purpose: a reworded clause has no reason to keep the shouted
+# spelling of the sentence the gating members carry.
+withhold_drift() {
+  grep -oiE ".{0,30}$WITHHOLD_SHAPED" "$1" | grep -viE "$WITHHOLD_NEGATED"
+  # Both greps exit 1 on no match, which is the passing case here, so the
+  # function's own status must not carry it into a `set -e` test body.
+  return 0
 }
 
 @test "every member file exists" {
@@ -141,6 +183,15 @@ member_path() {
   for m in $GATING; do
     assert_carries "$(member_path "$m")" "$METHOD_ANCHOR" || {
       echo "run order does not name the refusal: $m" >&2
+      return 1
+    }
+  done
+}
+
+@test "every member assigns the fail-closed sentinel it withholds on" {
+  for m in $MEMBERS; do
+    assert_carries "$(member_path "$m")" "$SENTINEL_LINE" || {
+      echo "fail-closed arm produces no sentinel to withhold on: $m" >&2
       return 1
     }
   done
@@ -194,9 +245,16 @@ member_path() {
   # This is the assertion that would have caught the round-4 Critical: applying
   # the withhold byte-identically to all five contradicted this member's own
   # always-clear charter, and a presence-only pin reported green either way.
+  #
+  # Scanned by meaning rather than by the one bolded sentence. An exact-string
+  # absence check only ever caught the byte-identical copy-paste: leaving the
+  # exemption paragraph intact and ADDING a reworded withhold clause restored
+  # the same contradiction with every test still green.
   f="$(member_path "$ADVISORY")"
-  assert_carries "$f" "$REFUSAL" && {
-    echo "advisory member has acquired the withhold contract it is exempt from" >&2
+  drift="$(withhold_drift "$f")"
+  [ -z "$drift" ] || {
+    echo "advisory member has acquired a withhold clause it is exempt from:" >&2
+    echo "$drift" >&2
     return 1
   }
   assert_carries "$f" "$NO_REFUSAL_ARTIFACT" && {
@@ -265,6 +323,49 @@ assert_pin_breaks() {
 
 @test "the print pin breaks when the result stops reaching stderr (non-vacuity)" {
   assert_pin_breaks print 's|>&2; fi|; fi|' "$PRINT_LINE"
+}
+
+@test "the sentinel-assignment pin breaks when the arm stops failing closed (non-vacuity)" {
+  # The mutant keeps the failure branch and its warning and only empties the
+  # value it assigns, so the check reports a clean tree on a status that could
+  # not run. A pin covering the variable name alone survives this and the test
+  # reds, which is the weakness that let the line go unpinned in the first place.
+  assert_pin_breaks sentinel_line 's|dirty_in_scope="dirty-scope check failed"|dirty_in_scope=""|' "$SENTINEL_LINE"
+}
+
+@test "the advisory drift guard catches a reworded withhold clause (non-vacuity)" {
+  # The failure the byte-identical absence check could not see: the exemption
+  # paragraph stays exactly where it is, and a withhold clause sharing no
+  # sentence with the gating members' is added ahead of the handshake's
+  # "There is no withhold path here". The old exact-string pin reported green.
+  local src tmp anchor
+  src="$(member_path "$ADVISORY")"
+  tmp="$BATS_TEST_TMPDIR/mutant-advisory-reworded.md"
+  anchor='There is no withhold path here;'
+
+  grep -qF -- "$anchor" "$src" || {
+    echo "fixture broken: advisory member no longer carries the insertion anchor" >&2
+    return 1
+  }
+  [ -z "$(withhold_drift "$src")" ] || {
+    echo "fixture broken: advisory member already carries a withhold clause" >&2
+    return 1
+  }
+
+  awk -v anchor="$anchor" \
+    -v clause='When `dirty_in_scope` comes back non-empty, you withhold this pass and report that you must be re-dispatched once the operator commits or reverts.' \
+    'index($0, anchor) && !done { print clause; print ""; done = 1 } { print }' \
+    "$src" > "$tmp"
+
+  grep -qF -- "$REFUSAL" "$tmp" && {
+    echo "fixture is not the reworded case: it carries the byte-identical contract" >&2
+    return 1
+  }
+  [ -n "$(withhold_drift "$tmp")" ] || {
+    echo "drift guard misses a reworded withhold clause; it only sees the copy-paste" >&2
+    return 1
+  }
+  true
 }
 
 @test "the sentinel pin breaks when the carve-out is softened (non-vacuity)" {

--- a/.gaia/scripts/tests/audit-dirty-tree-posture.bats
+++ b/.gaia/scripts/tests/audit-dirty-tree-posture.bats
@@ -109,7 +109,16 @@ code-audit-maintainer-shell"
   # it", "withholding would buy no guarantee"). Matching the verb plus the thing
   # withheld is what separates an instruction to this member from a description
   # of a sibling.
-  WITHHOLD_SHAPED='withhold(s|ing)? (this|your) (pass|clearance|marker)'
+  #
+  # `the` belongs in the determiner class as much as `this` and `your` do, and
+  # leaving it out missed the likeliest vector of all. `Withhold the marker on
+  # any unresolved Critical…` is the VERBATIM handshake sentence three gating
+  # members carry, so copy-pasting a sibling's real paragraph is the most
+  # probable way this member acquires the contract, and it was the one shape the
+  # scan could not see. The test below derives its fixtures from the gating
+  # members themselves rather than from invented rewordings, so a phrasing this
+  # class cannot reach reds when a sibling adopts it, not after it is pasted.
+  WITHHOLD_SHAPED='withhold(s|ing)? (this|your|the) (pass|clearance|marker)'
 
   # The one legitimate form the alternation above still reaches: the exemption
   # sentence's own negation, `does NOT withhold your pass`.
@@ -402,6 +411,48 @@ assert_drift_caught() {
   # `never` appears throughout this member legitimately, which is exactly why an
   # unanchored exclusion was a fail-open rather than a narrow carve-out.
   assert_drift_caught nearby_never 'This member never self-heals, and it will withhold this pass on dirt.'
+}
+
+# gating_withhold_phrases: every withhold-bearing phrase the GATING members
+# actually carry, deduped, one per line.
+#
+# Extraction is deliberately BROADER than WITHHOLD_SHAPED (any determiner, not
+# the three that pattern admits), because its job is to describe what the
+# siblings really say rather than to judge it. What it feeds is the test below,
+# which requires the drift scan to catch each one. That inverts the usual
+# failure: instead of the scan being taught one more phrasing every time a
+# reviewer finds one, a phrasing the scan cannot see reds here as soon as a
+# gating member adopts it, which is well before anyone can paste it into the
+# advisory member.
+gating_withhold_phrases() {
+  local m
+  for m in $GATING; do
+    tr '\n' ' ' < "$(member_path "$m")" \
+      | grep -oiE 'withhold[a-z]* [a-z]+ (pass|clearance|marker)'
+  done | sort -u
+  return 0
+}
+
+@test "the drift guard catches every withhold phrasing the gating members really use" {
+  # The four fixtures around this one are invented rewordings; this one is not.
+  # Each phrase here is lifted verbatim from a member whose paragraph a careless
+  # edit would copy wholesale, which is the vector that actually happens.
+  local phrase n=0
+  while IFS= read -r phrase; do
+    [ -n "$phrase" ] || continue
+    n=$((n + 1))
+    assert_drift_caught "real-$n" \
+      "When the check comes back non-empty you $phrase until the operator commits or reverts." || return 1
+  done <<PHRASES
+$(gating_withhold_phrases)
+PHRASES
+
+  # A floor, so a broken extraction cannot quietly turn this into a test that
+  # asserts nothing. The four gating members carry five distinct phrasings today.
+  [ "$n" -ge 4 ] || {
+    echo "extraction yielded only $n phrases; the derived fixture set has gone vacuous" >&2
+    return 1
+  }
 }
 
 @test "the advisory drift guard sees a clause split across a line break (non-vacuity)" {

--- a/.gaia/scripts/tests/bats-files-helper.bats
+++ b/.gaia/scripts/tests/bats-files-helper.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# The shared byte-identity primitives in .gaia/tests/helpers/files.sh.
+#
+# Every byte-identity claim across 11 bats suites in three directories now rests
+# on `assert_files_identical`, and a primitive that many assertions depend on is
+# the worst place for an unproven one: an edit hollowing it back toward the
+# `$(cat …)` comparison it replaced would green all 11 suites with nothing
+# reddening anywhere. The suites it serves prove their own pins by mutation;
+# this file holds the primitive to the same standard.
+#
+# The trailing-newline pair is the specific case that matters, because it is the
+# whole reason the helper exists: command substitution strips trailing newlines
+# from both sides, so `a\n` and `a\n\n\n` compare EQUAL through `$(cat …)` and
+# differ under `cmp`. Test 2 pins that difference directly.
+#
+# Assertion style note (`.claude/rules/bats-assertions.md`): assertions use
+# POSIX `[ ]` and explicit `return 1`, never a bare `[[ ]]`, so they fail
+# correctly under macOS's bash 3.2 as well as CI's bash 5.
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
+
+  A="$BATS_TEST_TMPDIR/a"
+  B="$BATS_TEST_TMPDIR/b"
+}
+
+@test "assert_files_identical accepts two files with identical bytes" {
+  printf 'one\ntwo\n' > "$A"
+  printf 'one\ntwo\n' > "$B"
+  assert_files_identical "$A" "$B"
+}
+
+@test "assert_files_identical rejects a pair differing only in a trailing newline" {
+  printf 'one\ntwo\n' > "$A"
+  printf 'one\ntwo\n\n\n' > "$B"
+
+  # Written as a positive match on the bad case per the bats-assertions rule.
+  assert_files_identical "$A" "$B" && {
+    echo "the helper accepts a trailing-newline difference; it has decayed into the \$(cat …) comparison it replaced" >&2
+    return 1
+  }
+
+  # And the control: that same pair IS equal through command substitution, which
+  # is the defect this primitive exists to remove rather than a hypothetical.
+  [ "$(cat "$A")" = "$(cat "$B")" ] || {
+    echo "control broken: the fixture pair no longer demonstrates the \$(cat …) strip" >&2
+    return 1
+  }
+}
+
+@test "assert_files_identical rejects a pair differing in the middle" {
+  printf 'one\ntwo\n' > "$A"
+  printf 'one\nTWO\n' > "$B"
+  assert_files_identical "$A" "$B" && return 1
+  true
+}
+
+@test "assert_files_identical fails rather than passes when a file is missing" {
+  printf 'one\n' > "$A"
+  # An absent path must never read as "identical". `cmp` exits non-zero and says
+  # which path it could not open.
+  assert_files_identical "$A" "$BATS_TEST_TMPDIR/does-not-exist" && return 1
+  true
+}
+
+@test "snapshot_file captures bytes that later writes to the source cannot change" {
+  printf 'before\n' > "$A"
+  local snap
+  snap="$(snapshot_file "$A")"
+
+  [ -n "$snap" ] || { echo "snapshot_file printed no path" >&2; return 1; }
+  [ "$snap" != "$A" ] || { echo "snapshot_file returned the source path itself" >&2; return 1; }
+
+  printf 'after\n' > "$A"
+  assert_files_identical "$snap" "$A" && {
+    echo "the snapshot tracked a later write; it is an alias, not a copy" >&2
+    return 1
+  }
+
+  printf 'before\n' > "$B"
+  assert_files_identical "$snap" "$B"
+}
+
+@test "snapshot_file preserves a trailing newline exactly" {
+  # The capture half of the same defect: a snapshot taken through command
+  # substitution would drop these, and the comparison could never see them again.
+  printf 'row\n\n\n' > "$A"
+  local snap
+  snap="$(snapshot_file "$A")"
+  assert_files_identical "$snap" "$A"
+}
+
+@test "two snapshots in one test do not collide" {
+  printf 'first\n' > "$A"
+  printf 'second\n' > "$B"
+  local s1 s2
+  s1="$(snapshot_file "$A")"
+  s2="$(snapshot_file "$B")"
+
+  [ "$s1" != "$s2" ] || { echo "both snapshots landed on one path" >&2; return 1; }
+  assert_files_identical "$s1" "$A"
+  assert_files_identical "$s2" "$B"
+}

--- a/.gaia/scripts/tests/cost-consolidate-absence.bats
+++ b/.gaia/scripts/tests/cost-consolidate-absence.bats
@@ -30,6 +30,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
 }
 
 @test "UAT-007: cost-consolidate.sh no longer exists" {
@@ -52,7 +54,7 @@ setup() {
   mkdir -p "$SANDBOX/.gaia/local/telemetry"
   ledger="$SANDBOX/.gaia/local/telemetry/cost.jsonl"
   printf '%s\n' '{"schema_version":1,"kind":"execute","spec_id":"SPEC-PRE","session_id":"pre","buckets":{"fresh_input":1,"cache_write":0,"cache_read":0,"output":0},"total":1}' > "$ledger"
-  before="$(cat "$ledger")"
+  before="$(snapshot_file "$ledger")"
 
   # Neither archived/ tree exists in this sandbox at all.
   [ ! -d "$SANDBOX/.gaia/local/specs/archived" ]
@@ -66,6 +68,6 @@ setup() {
   [ ! -d "$SANDBOX/.gaia/local/plans/archived" ]
 
   # The ledger is byte-identical: no row was appended.
-  after="$(cat "$ledger")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$ledger")"
+  assert_files_identical "$before" "$after"
 }

--- a/.gaia/scripts/tests/cost-reprice.bats
+++ b/.gaia/scripts/tests/cost-reprice.bats
@@ -46,6 +46,8 @@ setup() {
   SCRIPT="$SCRIPT_DIR/cost-reprice.sh"
   FIX_E2E="$(cd "$(dirname "$BATS_TEST_FILENAME")/fixtures/token-cost-e2e" && pwd)"
   FIX_PRICE="$(cd "$(dirname "$BATS_TEST_FILENAME")/fixtures/token-tally-price" && pwd)"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$BATS_TEST_DIRNAME/../../tests/helpers/files.sh"
 
   # Tracked, non-optional, and this suite is release-excluded so it only runs
   # where the script exists. A `skip` would green the suite on a rename.
@@ -118,21 +120,21 @@ run_deadline() {
 
 @test "a row that already prices correctly is left byte-identical" {
   seed_row 0.87925 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
 }
 
 @test "a second run changes nothing (idempotent)" {
   seed_row 0.76 2026-07-28T07:28:15Z
   run_reprice "$RATES_FULL"
-  after_first="$(cat "$LEDGER")"
+  after_first="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$after_first" ]
+  assert_files_identical "$LEDGER" "$after_first"
   grep -qF -- '0 row' <<<"$output"
 }
 
@@ -174,26 +176,26 @@ run_deadline() {
 @test "a row with no by_model attribution is left byte-identical" {
   jq -c -n '{schema_version:1, kind:"execute", session_id:"legacy",
              dollars:null, ts:"2026-07-28T07:28:15Z"}' >> "$LEDGER"
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
 }
 
 @test "--dry-run reports the change but writes nothing" {
   seed_row 0.76 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL" --dry-run
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   grep -qF -- '0.87925' <<<"$output"
 }
 
 @test "the pre-rewrite ledger is backed up before any row changes" {
   seed_row 0.76 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
@@ -204,7 +206,7 @@ run_deadline() {
   [ "$(find "$(dirname "$LEDGER")" -name 'cost.jsonl.bak.*' | wc -l | tr -d ' ')" -eq 1 ]
   bak="$(find "$(dirname "$LEDGER")" -name 'cost.jsonl.bak.*' | head -n 1)"
   [ -n "$bak" ]
-  [ "$(cat "$bak")" = "$before" ]
+  assert_files_identical "$bak" "$before"
 }
 
 @test "a second backup in the same second does not clobber the first" {
@@ -227,7 +229,7 @@ STUB
   chmod +x "$SANDBOX/bin/date"
 
   seed_row 0.76 2026-07-28T07:28:15Z
-  original="$(cat "$LEDGER")"
+  original="$(snapshot_file "$LEDGER")"
 
   run env PATH="$SANDBOX/bin:$PATH" bash "$SCRIPT" \
     --ledger "$LEDGER" --rate-table "$RATES_FULL"
@@ -248,7 +250,7 @@ STUB
   [ -f "$d/cost.jsonl.bak.20260101T000000Z" ]
   [ -f "$d/cost.jsonl.bak.20260101T000000Z.2" ]
   # Run 1's copy still holds run 1's pre-image, unclobbered.
-  [ "$(cat "$d/cost.jsonl.bak.20260101T000000Z")" = "$original" ]
+  assert_files_identical "$d/cost.jsonl.bak.20260101T000000Z" "$original"
 }
 
 @test "a row jq cannot process refuses the whole rewrite instead of dropping it" {
@@ -263,14 +265,14 @@ STUB
                cache_write_1h:360, cache_read:3000, output:"30"}},
              dollars:0.76, ts:"2026-07-28T07:28:15Z"}' >> "$LEDGER"
   seed_row 0.76 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -ne 0 ]
 
   # Nothing written, nothing dropped, and the refusal says so rather than
   # reporting a plausible-looking partial success.
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   [ "$(wc -l < "$LEDGER" | tr -d ' ')" -eq 3 ]
   [ "$(find "$(dirname "$LEDGER")" -name 'cost.jsonl.bak.*' | wc -l | tr -d ' ')" -eq 0 ]
   grep -qF -- 'would drop 1 row' <<<"$output"
@@ -286,11 +288,11 @@ STUB
                cache_write_1h:0, cache_read:0, output:30}},
              dollars:1.23, rate_table_id:"sha256:stale00000000000",
              ts:"2026-07-28T07:28:15Z"}' >> "$LEDGER"
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   grep -qF -- '0 row' <<<"$output"
 }
 
@@ -305,11 +307,11 @@ STUB
         cache_write_1h:0, cache_read:0, output:9999}}),
       dollars:5.00, rate_table_id:"sha256:stale00000000000",
       ts:"2026-07-28T07:28:15Z"}' >> "$LEDGER"
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   grep -qF -- '0 row' <<<"$output"
 }
 
@@ -342,11 +344,11 @@ STUB
     '{schema_version:1, kind:"execute", session_id:"anchorless", by_model:$bm,
       dollars:0.87925, rate_table_id:"sha256:stale00000000000", ts:null}' \
     >> "$LEDGER"
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run run_reprice "$RATES_FULL"
   [ "$status" -eq 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   grep -qF -- '0 row' <<<"$output"
 }
 
@@ -373,11 +375,11 @@ STUB
   # honored. Accepting one silently reprices THIS checkout while reporting
   # success for the one that was named.
   seed_row 0.76 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   run bash "$SCRIPT" "$SANDBOX" --ledger "$LEDGER" --rate-table "$RATES_FULL"
   [ "$status" -ne 0 ]
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   grep -qF -- 'unexpected argument' <<<"$output"
 }
 
@@ -409,13 +411,13 @@ STUB
   git -C "$repo" worktree add -b wt-branch "$wt" \
     || { echo "worktree add failed" >&2; return 1; }
 
-  before="$(cat "$repo/.gaia/local/telemetry/cost.jsonl")"
+  before="$(snapshot_file "$repo/.gaia/local/telemetry/cost.jsonl")"
   run env -u GAIA_MAIN_ROOT bash -c "cd '$wt' && bash .gaia/scripts/cost-reprice.sh"
   [ "$status" -ne 0 ]
 
   # Refused by name, pointing at the main checkout, and main's ledger untouched.
   grep -qF -- 'must run from the main checkout' <<<"$output"
-  [ "$(cat "$repo/.gaia/local/telemetry/cost.jsonl")" = "$before" ]
+  assert_files_identical "$repo/.gaia/local/telemetry/cost.jsonl" "$before"
 }
 
 @test "a missing main-only lib still refuses the worktree, it does not fail open" {
@@ -443,7 +445,7 @@ STUB
   git -C "$repo" worktree add -b wt-branch2 "$wt" \
     || { echo "worktree add failed" >&2; return 1; }
 
-  before="$(cat "$repo/.gaia/local/telemetry/cost.jsonl")"
+  before="$(snapshot_file "$repo/.gaia/local/telemetry/cost.jsonl")"
   run env -u GAIA_MAIN_ROOT bash -c "cd '$wt' && bash .gaia/scripts/cost-reprice.sh"
   [ "$status" -ne 0 ]
 
@@ -454,7 +456,7 @@ STUB
   # written as `grep … && return 1` returns non-zero when the needle is correctly
   # absent, so as a test's final line it would fail the good case. Per
   # .claude/rules/bats-assertions.md, the last line must be a positive assertion.
-  [ "$(cat "$repo/.gaia/local/telemetry/cost.jsonl")" = "$before" ]
+  assert_files_identical "$repo/.gaia/local/telemetry/cost.jsonl" "$before"
 }
 
 @test "an empty ledger is a success with nothing to do, not a failure" {
@@ -473,7 +475,7 @@ STUB
   # lost row either. With the lock held from outside, a correctly-scoped run
   # produces no report line and no backup at all.
   seed_row 0.76 2026-07-28T07:28:15Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   # Force the portable mkdir primitive and pre-create its lock dir, so the run
   # cannot acquire. A high stale threshold keeps it from being reclaimed.
@@ -485,7 +487,7 @@ STUB
       bash "$SCRIPT" --ledger "$LEDGER" --rate-table "$RATES_FULL"
   [ "$status" -ne 0 ]
 
-  [ "$(cat "$LEDGER")" = "$before" ]
+  assert_files_identical "$LEDGER" "$before"
   [ "$(find "$(dirname "$LEDGER")" -name 'cost.jsonl.bak.*' | wc -l | tr -d ' ')" -eq 0 ]
   # `->` appears only in a per-row report line ("$before -> $after"), so it is the
   # substring that proves classify ran. Matching on "reprice:" would not: the
@@ -579,7 +581,7 @@ SHIMEOF
 @test "#1091: a ledger that SHRANK mid-run refuses the replace instead of guessing" {
   seed_row 0.76 2026-07-28T07:28:15Z
   seed_row 0.76 2026-07-28T08:00:00Z
-  before="$(cat "$LEDGER")"
+  before="$(snapshot_file "$LEDGER")"
 
   SHIM="$BATS_TEST_TMPDIR/shim"
   mkdir -p "$SHIM"
@@ -603,7 +605,7 @@ SHIMEOF
   # the backup, taken before the truncation, still holds the original two rows.
   backup="$(find "$(dirname "$LEDGER")" -name 'cost.jsonl.bak.*' | head -n 1)"
   [ -n "$backup" ]
-  [ "$(cat "$backup")" = "$before" ]
+  assert_files_identical "$backup" "$before"
 }
 
 @test "#1091: an ordinary run reports no carry, so the message is not noise" {

--- a/.gaia/scripts/tests/plan-archive.bats
+++ b/.gaia/scripts/tests/plan-archive.bats
@@ -18,6 +18,8 @@ setup() {
   SCRIPT="$THIS_DIR/../plan-archive.sh"
   [ -x "$SCRIPT" ] || skip "plan-archive.sh not executable"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
 
   # Canonicalize via `pwd -P`: macOS resolves /tmp -> /private/tmp inside
   # `git rev-parse`, and the script derives its repo root the same way.
@@ -316,11 +318,11 @@ EOF
   write_cost_json "$SANDBOX/.gaia/local/specs/SPEC-006/plan" 2 0 0 0
   seed_cost_row execute spec_id SPEC-006 "" 2 0 0 0
   seed_plans_ledger '{"id":"PLAN-005","allocated_at":"2026-01-01T00:00:00Z","source":"allocated","subject":"x","status":"allocated"}'
-  ledger_before="$(cat "$SANDBOX/.gaia/local/plans/ledger.json")"
+  ledger_before="$(snapshot_file "$SANDBOX/.gaia/local/plans/ledger.json")"
   run run_in_sandbox ".gaia/local/specs/SPEC-006/plan"
   [ "$status" -eq 0 ]
   assert_deleted "$SANDBOX/.gaia/local/specs/SPEC-006/plan"
-  [ "$(cat "$SANDBOX/.gaia/local/plans/ledger.json")" = "$ledger_before" ]
+  assert_files_identical "$SANDBOX/.gaia/local/plans/ledger.json" "$ledger_before"
 }
 
 # --- 9. Best-effort: a missing ledger row for the stamp never blocks reduce -

--- a/.gaia/scripts/tests/write-audit-remits.bats
+++ b/.gaia/scripts/tests/write-audit-remits.bats
@@ -14,6 +14,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
   WRITER="$REPO_ROOT/.gaia/scripts/write-audit-remits.sh"
   CHECK="$REPO_ROOT/.gaia/scripts/verify-audit-roster.sh"
   # A hard failure, not a skip: a `skip` here would silently retire every
@@ -199,7 +201,7 @@ YAML
   [ "$status" -eq 0 ]
 
   local before
-  before="$(cat "$r/.claude/agents/code-audit-a.md")"
+  before="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
 
   sed '/^- `a\/b\/\*\.ts`$/d' "$r/.claude/agents/code-audit-a.md" > "$r/tmp-corrupt"
   mv "$r/tmp-corrupt" "$r/.claude/agents/code-audit-a.md"
@@ -208,8 +210,8 @@ YAML
   [ "$status" -eq 0 ]
 
   local after
-  after="$(cat "$r/.claude/agents/code-audit-a.md")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "UAT-006: repair announces a roster-ungranted glob with a - prefix, after the + list" {
@@ -442,15 +444,15 @@ YAML
   mv "$r/tmp-corrupt" "$f"
 
   local before
-  before="$(cat "$f")"
+  before="$(snapshot_file "$f")"
 
   run_writer "$r"
   [ "$status" -eq 1 ]
   assert_contains "code-audit-a"
 
   local after
-  after="$(cat "$f")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$f")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "malformed markers: a start marker with no end marker is refused, the file left byte-identical" {
@@ -473,15 +475,15 @@ YAML
   mv "$r/tmp-corrupt" "$f"
 
   local before
-  before="$(cat "$f")"
+  before="$(snapshot_file "$f")"
 
   run_writer "$r"
   [ "$status" -eq 1 ]
   assert_contains "code-audit-a"
 
   local after
-  after="$(cat "$f")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$f")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "malformed markers: a reversed pair (end before start) is refused, the file left byte-identical, tail intact" {
@@ -529,15 +531,15 @@ THIS TAIL MUST SURVIVE
 MD
 
   local before
-  before="$(cat "$f")"
+  before="$(snapshot_file "$f")"
 
   run_writer "$r"
   [ "$status" -eq 1 ]
   assert_contains "code-audit-a"
 
   local after
-  after="$(cat "$f")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$f")"
+  assert_files_identical "$before" "$after"
   grep -qxF -- "THIS TAIL MUST SURVIVE" "$f"
 }
 
@@ -558,15 +560,15 @@ auditors:
       - "a/**"
 YAML
   local before
-  before="$(cat "$r/.claude/agents/code-audit-a.md")"
+  before="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
 
   run_writer "$r"
   [ "$status" -eq 1 ]
   assert_contains "code-audit-a"
 
   local after
-  after="$(cat "$r/.claude/agents/code-audit-a.md")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
+  assert_files_identical "$before" "$after"
 }
 
 # ---------------------------------------------------------------------------
@@ -591,18 +593,18 @@ auditors:
       - "a/**"
 YAML
   local before_default before_a
-  before_default="$(cat "$r/.claude/agents/code-audit-default.md")"
-  before_a="$(cat "$r/.claude/agents/code-audit-a.md")"
+  before_default="$(snapshot_file "$r/.claude/agents/code-audit-default.md")"
+  before_a="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
 
   run env TMPDIR="$r/no-such-tmpdir" bash "$WRITER" --root "$r" --config "$r/.gaia/audit-ci.yml"
   [ "$status" -eq 1 ]
 
   # The definitions are untouched, and in particular no emptied region landed.
   local after_default after_a
-  after_default="$(cat "$r/.claude/agents/code-audit-default.md")"
-  after_a="$(cat "$r/.claude/agents/code-audit-a.md")"
-  [ "$before_default" = "$after_default" ]
-  [ "$before_a" = "$after_a" ]
+  after_default="$(snapshot_file "$r/.claude/agents/code-audit-default.md")"
+  after_a="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
+  assert_files_identical "$before_default" "$after_default"
+  assert_files_identical "$before_a" "$after_a"
 }
 
 @test "robustness: a body write that fails after mktemp succeeds is refused, definitions byte-identical" {
@@ -648,8 +650,8 @@ SH
   chmod +x "$shim/mktemp"
 
   local before_default before_a
-  before_default="$(cat "$r/.claude/agents/code-audit-default.md")"
-  before_a="$(cat "$r/.claude/agents/code-audit-a.md")"
+  before_default="$(snapshot_file "$r/.claude/agents/code-audit-default.md")"
+  before_a="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
 
   run env PATH="$shim:$PATH" bash "$WRITER" --root "$r" --config "$r/.gaia/audit-ci.yml"
   [ "$status" -eq 1 ]
@@ -663,10 +665,10 @@ SH
 
   # No emptied region landed: every definition is byte-identical.
   local after_default after_a
-  after_default="$(cat "$r/.claude/agents/code-audit-default.md")"
-  after_a="$(cat "$r/.claude/agents/code-audit-a.md")"
-  [ "$before_default" = "$after_default" ]
-  [ "$before_a" = "$after_a" ]
+  after_default="$(snapshot_file "$r/.claude/agents/code-audit-default.md")"
+  after_a="$(snapshot_file "$r/.claude/agents/code-audit-a.md")"
+  assert_files_identical "$before_default" "$after_default"
+  assert_files_identical "$before_a" "$after_a"
 }
 
 @test "robustness: a roster with no auditors block exits 0 and writes nothing" {

--- a/.gaia/tests/helpers/files.sh
+++ b/.gaia/tests/helpers/files.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Shared bats primitives for asserting that a file did not change.
+#
+# Sourced from a suite's `setup()`, in any of the three bats directories:
+#   . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
+#
+# This is the CROSS-DIRECTORY helper, distinct from the per-suite-directory
+# `.gaia/tests/lib/helpers/` and `.gaia/tests/hooks/helpers/`, which hold
+# executable fixture builders invoked as subprocesses rather than functions to
+# source. Suites under `.gaia/scripts/tests/`, `.gaia/tests/lib/` and
+# `.gaia/tests/hooks/` all use this one.
+#
+# API:
+#   snapshot_file FILE           - copy FILE's bytes aside; print the copy's path
+#   assert_files_identical A B   - `cmp` A against B; return 1 when they differ
+#
+# WHY THIS EXISTS, and why the obvious idiom is the bug it replaces.
+#
+# The convention these suites reached for was command substitution:
+#
+#   before="$(cat "$LEDGER")"
+#   ...
+#   [ "$(cat "$LEDGER")" = "$before" ]
+#
+# `$(…)` strips ALL trailing newlines from its output, on both sides. So a
+# regression that only appends or drops a trailing newline compares equal, and
+# it does so in the tests whose names promise byte identity (#1201, and #1047
+# before it). The comparison is not weaker at the margin; it is blind to exactly
+# the class of change a writer regression produces.
+#
+# Comparing FILES sidesteps the strip, because no file's bytes ever pass through
+# a command substitution. That is the fix the three sites #1047 repaired already
+# use by hand; this file is the reusable form of it, so the next byte-identity
+# test written reaches for a primitive rather than for `$(cat …)` out of habit.
+#
+# Sourced, so it enables no shell options of its own: bats runs each `@test`
+# body under `set -e` already, and a suite that wants more sets it itself.
+
+# snapshot_file FILE -> prints the path of a byte-exact copy of FILE.
+#
+# The copy lives under `$BATS_TEST_TMPDIR`, which bats removes after each test,
+# so a snapshot never outlives the test that took it and no suite has to clean
+# one up. `mktemp` names it, so two snapshots in one test cannot collide.
+#
+# `${BATS_TEST_TMPDIR:?}` rather than a fallback to `$TMPDIR`: outside a bats
+# test there is no correct place for these, and failing loudly beats scattering
+# copies somewhere nothing will collect them.
+snapshot_file() {
+  local src="$1" dir dest
+  dir="${BATS_TEST_TMPDIR:?snapshot_file must be called from inside a bats test}/.snapshots"
+
+  mkdir -p "$dir" || return 1
+  dest="$(mktemp "$dir/snapshot.XXXXXX")" || return 1
+  # `cp` rather than `cat >`: it is the byte-for-byte copy, and a read failure
+  # (an unreadable or absent source) fails here rather than producing an empty
+  # snapshot that would later compare equal to an emptied file.
+  cp "$src" "$dest" || return 1
+
+  printf '%s' "$dest"
+}
+
+# assert_files_identical A B: the two files hold identical bytes.
+#
+# `cmp` unsuppressed, so a failure names the differing byte offset instead of
+# only reporting that the two disagreed, and it also fails loudly when either
+# path is missing. The explicit `return 1` is what makes this safe anywhere in a
+# test body: per `.claude/rules/bats-assertions.md`, a bare non-final assertion
+# must fail through a real exit code rather than rely on `set -e`.
+assert_files_identical() {
+  cmp "$1" "$2" || return 1
+}

--- a/.gaia/tests/hooks/audit-disposition-check.bats
+++ b/.gaia/tests/hooks/audit-disposition-check.bats
@@ -20,6 +20,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
   LIB="$REPO_ROOT/.claude/hooks/lib/audit-dispositions.sh"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/audit-disposition-check.sh"
   DIGEST_CLI="$REPO_ROOT/.gaia/scripts/audit-member-digest.sh"
@@ -239,10 +241,10 @@ write_sidecar() { printf '%s\n' "$1" > "$SIDECAR"; }
 
 @test "seed-forward: fail-safe no-op on a missing prev sidecar" {
   printf '%s\n' '{"schema":1,"backend":"github","findings":[{"key":"K9","disposition":"filed"}]}' > "$SIDECAR"
-  before="$(cat "$SIDECAR")"
+  before="$(snapshot_file "$SIDECAR")"
   disposition_seed_forward "$BATS_TEST_TMPDIR/does-not-exist.json" "$SIDECAR"
-  after="$(cat "$SIDECAR")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$SIDECAR")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "seed-forward: fail-safe no-op on an unparseable prev sidecar" {

--- a/.gaia/tests/lib/ledger-title-repair.bats
+++ b/.gaia/tests/lib/ledger-title-repair.bats
@@ -16,6 +16,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
   SRC_LIB="$REPO_ROOT/.specify/extensions/gaia/lib"
   [ -x "$SRC_LIB/ledger-title-repair.sh" ] || skip "ledger-title-repair.sh not executable"
 
@@ -415,11 +417,11 @@ EOF
 }
 EOF
 
-  before="$(cat "$SANDBOX/.gaia/local/specs/ledger.json")"
+  before="$(snapshot_file "$SANDBOX/.gaia/local/specs/ledger.json")"
   run _run_repair
   [ "$status" -eq 0 ]
-  after="$(cat "$SANDBOX/.gaia/local/specs/ledger.json")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$SANDBOX/.gaia/local/specs/ledger.json")"
+  assert_files_identical "$before" "$after"
 }
 
 # --- 6. Idempotency -----------------------------------------------------------
@@ -487,16 +489,16 @@ EOF
 
   run _run_repair
   [ "$status" -eq 0 ]
-  specs_after_1="$(cat "$SANDBOX/.gaia/local/specs/ledger.json")"
-  plans_after_1="$(cat "$SANDBOX/.gaia/local/plans/ledger.json")"
+  specs_after_1="$(snapshot_file "$SANDBOX/.gaia/local/specs/ledger.json")"
+  plans_after_1="$(snapshot_file "$SANDBOX/.gaia/local/plans/ledger.json")"
 
   run _run_repair
   [ "$status" -eq 0 ]
-  specs_after_2="$(cat "$SANDBOX/.gaia/local/specs/ledger.json")"
-  plans_after_2="$(cat "$SANDBOX/.gaia/local/plans/ledger.json")"
+  specs_after_2="$(snapshot_file "$SANDBOX/.gaia/local/specs/ledger.json")"
+  plans_after_2="$(snapshot_file "$SANDBOX/.gaia/local/plans/ledger.json")"
 
-  [ "$specs_after_1" = "$specs_after_2" ]
-  [ "$plans_after_1" = "$plans_after_2" ]
+  assert_files_identical "$specs_after_1" "$specs_after_2"
+  assert_files_identical "$plans_after_1" "$plans_after_2"
 }
 
 # --- 7. Missing ledgers / usage -----------------------------------------------

--- a/.gaia/tests/lib/plan-ledger-update.bats
+++ b/.gaia/tests/lib/plan-ledger-update.bats
@@ -17,6 +17,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
   SRC_LIB="$REPO_ROOT/.specify/extensions/gaia/lib"
   SRC_SCRIPTS="$REPO_ROOT/.gaia/scripts"
   [ -x "$SRC_LIB/plan-ledger-update.sh" ] || skip "plan-ledger-update.sh not executable"
@@ -96,10 +98,10 @@ _row_field() {
 }
 
 @test "4: patch for a non-existent row exits 4 and mutates nothing" {
-  before="$(cat "$SANDBOX/$LEDGER_REL")"
+  before="$(snapshot_file "$SANDBOX/$LEDGER_REL")"
   run _update PLAN-999 '{"status":"merged"}'
   [ "$status" -eq 4 ]
-  [ "$(cat "$SANDBOX/$LEDGER_REL")" = "$before" ]
+  assert_files_identical "$SANDBOX/$LEDGER_REL" "$before"
 }
 
 @test "5: malformed patch JSON exits 5" {

--- a/.gaia/tests/lib/plan-reconcile.bats
+++ b/.gaia/tests/lib/plan-reconcile.bats
@@ -18,6 +18,8 @@
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$REPO_ROOT/.gaia/tests/helpers/files.sh"
   SRC_LIB="$REPO_ROOT/.specify/extensions/gaia/lib"
   SRC_SCRIPTS="$REPO_ROOT/.gaia/scripts"
   [ -x "$SRC_LIB/plan-reconcile.sh" ] || skip "plan-reconcile.sh not executable"
@@ -102,13 +104,13 @@ _row_field() {
 }
 
 @test "3: a non-PLAN-NNN id is a no-op, exits 0, leaves the ledger unchanged" {
-  before="$(cat "$SANDBOX/$LEDGER_REL")"
+  before="$(snapshot_file "$SANDBOX/$LEDGER_REL")"
   for id in cache-thing PLAN-x; do
     run _reconcile "$id"
     [ "$status" -eq 0 ]
   done
-  after="$(cat "$SANDBOX/$LEDGER_REL")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$SANDBOX/$LEDGER_REL")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "4a: a missing ledger exits 0 and creates nothing" {
@@ -119,11 +121,11 @@ _row_field() {
 }
 
 @test "4b: a missing row exits 0 and leaves the ledger unchanged" {
-  before="$(cat "$SANDBOX/$LEDGER_REL")"
+  before="$(snapshot_file "$SANDBOX/$LEDGER_REL")"
   run _reconcile PLAN-999
   [ "$status" -eq 0 ]
-  after="$(cat "$SANDBOX/$LEDGER_REL")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$SANDBOX/$LEDGER_REL")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "5: the plans status vocabulary guard holds; plan-reconcile never writes the retired 'completed' status" {

--- a/.gaia/tests/lib/spec-folder-layout.bats
+++ b/.gaia/tests/lib/spec-folder-layout.bats
@@ -11,6 +11,8 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$BATS_TEST_DIRNAME/../helpers/files.sh"
   ALLOC=".specify/extensions/gaia/lib/spec-allocator.sh"
   FOLDERIZE=".specify/extensions/gaia/lib/spec-folderize.sh"
   RENUMBER=".specify/extensions/gaia/lib/spec-renumber.sh"
@@ -39,9 +41,9 @@ _snapshot() {
     --seed-flat SPEC-001 --seed-flat SPEC-002 --seed-archived-flat SPEC-000)"
   cd "$REPO"
 
-  c1="$(cat "$REPO/.gaia/local/specs/SPEC-001.md")"
-  c2="$(cat "$REPO/.gaia/local/specs/SPEC-002.md")"
-  c0="$(cat "$REPO/.gaia/local/specs/archived/SPEC-000.md")"
+  c1="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-001.md")"
+  c2="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-002.md")"
+  c0="$(snapshot_file "$REPO/.gaia/local/specs/archived/SPEC-000.md")"
 
   run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
   [ "$status" -eq 0 ]
@@ -57,9 +59,9 @@ _snapshot() {
   [ ! -e "$REPO/.gaia/local/specs/archived/SPEC-000.md" ]
 
   # Contents moved byte-for-byte.
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/SPEC.md")" = "$c1" ]
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-002/SPEC.md")" = "$c2" ]
-  [ "$(cat "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md")" = "$c0" ]
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" "$c1"
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-002/SPEC.md" "$c2"
+  assert_files_identical "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md" "$c0"
 }
 
 # --- 2: idempotent re-run ----------------------------------------------------
@@ -114,8 +116,8 @@ _snapshot() {
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-flat SPEC-003 --seed-folder SPEC-003)"
   cd "$REPO"
 
-  flat_before="$(cat "$REPO/.gaia/local/specs/SPEC-003.md")"
-  fold_before="$(cat "$REPO/.gaia/local/specs/SPEC-003/SPEC.md")"
+  flat_before="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-003.md")"
+  fold_before="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-003/SPEC.md")"
 
   run bash -c "bash '$REPO/$FOLDERIZE' '$REPO' 2>&1 1>/dev/null"
   [ "$status" -eq 4 ]
@@ -123,8 +125,8 @@ _snapshot() {
   [[ "$output" == *"SPEC-003/SPEC.md"* ]]
 
   # Neither file modified.
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003.md")" = "$flat_before" ]
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003/SPEC.md")" = "$fold_before" ]
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-003.md" "$flat_before"
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-003/SPEC.md" "$fold_before"
 }
 
 # --- 6: tracked vs untracked -------------------------------------------------
@@ -267,9 +269,9 @@ _snapshot() {
     --seed-flat-sibling SPEC-001-FOLLOWUP-REPORT)"
   cd "$REPO"
 
-  c_spec="$(cat "$REPO/.gaia/local/specs/SPEC-001.md")"
-  c_report="$(cat "$REPO/.gaia/local/specs/SPEC-001-REPORT.md")"
-  c_followup="$(cat "$REPO/.gaia/local/specs/SPEC-001-FOLLOWUP-REPORT.md")"
+  c_spec="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-001.md")"
+  c_report="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-001-REPORT.md")"
+  c_followup="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-001-FOLLOWUP-REPORT.md")"
 
   run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
   [ "$status" -eq 0 ]
@@ -285,9 +287,9 @@ _snapshot() {
   [ ! -e "$REPO/.gaia/local/specs/SPEC-001-FOLLOWUP-REPORT.md" ]
 
   # Contents moved byte-for-byte.
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/SPEC.md")" = "$c_spec" ]
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/REPORT.md")" = "$c_report" ]
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-001/FOLLOWUP-REPORT.md")" = "$c_followup" ]
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-001/SPEC.md" "$c_spec"
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-001/REPORT.md" "$c_report"
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-001/FOLLOWUP-REPORT.md" "$c_followup"
 }
 
 # --- 12: sibling conflict ----------------------------------------------------
@@ -302,8 +304,8 @@ _snapshot() {
   git -C "$REPO" add .gaia/local/specs/SPEC-003/REPORT.md
   git -C "$REPO" commit --quiet -m "add foldered report"
 
-  flat_before="$(cat "$REPO/.gaia/local/specs/SPEC-003-REPORT.md")"
-  fold_before="$(cat "$REPO/.gaia/local/specs/SPEC-003/REPORT.md")"
+  flat_before="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-003-REPORT.md")"
+  fold_before="$(snapshot_file "$REPO/.gaia/local/specs/SPEC-003/REPORT.md")"
 
   run bash -c "bash '$REPO/$FOLDERIZE' '$REPO' 2>&1 1>/dev/null"
   [ "$status" -eq 4 ]
@@ -311,8 +313,8 @@ _snapshot() {
   [[ "$output" == *"SPEC-003/REPORT.md"* ]]
 
   # Neither file modified.
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003-REPORT.md")" = "$flat_before" ]
-  [ "$(cat "$REPO/.gaia/local/specs/SPEC-003/REPORT.md")" = "$fold_before" ]
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-003-REPORT.md" "$flat_before"
+  assert_files_identical "$REPO/.gaia/local/specs/SPEC-003/REPORT.md" "$fold_before"
 }
 
 # --- 13: idempotent re-run after sibling migration ---------------------------
@@ -341,7 +343,7 @@ _snapshot() {
     --seed-archived-flat-sibling SPEC-000-REPORT)"
   cd "$REPO"
 
-  c_report="$(cat "$REPO/.gaia/local/specs/archived/SPEC-000-REPORT.md")"
+  c_report="$(snapshot_file "$REPO/.gaia/local/specs/archived/SPEC-000-REPORT.md")"
 
   run bash -c "bash '$REPO/$FOLDERIZE' '$REPO'"
   [ "$status" -eq 0 ]
@@ -349,7 +351,7 @@ _snapshot() {
   [ -f "$REPO/.gaia/local/specs/archived/SPEC-000/SPEC.md" ]
   [ -f "$REPO/.gaia/local/specs/archived/SPEC-000/REPORT.md" ]
   [ ! -e "$REPO/.gaia/local/specs/archived/SPEC-000-REPORT.md" ]
-  [ "$(cat "$REPO/.gaia/local/specs/archived/SPEC-000/REPORT.md")" = "$c_report" ]
+  assert_files_identical "$REPO/.gaia/local/specs/archived/SPEC-000/REPORT.md" "$c_report"
 }
 
 # --- 10: read-only modes take no lock and create no folder -------------------

--- a/.gaia/tests/lib/spec-ledger-status.bats
+++ b/.gaia/tests/lib/spec-ledger-status.bats
@@ -26,6 +26,8 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$BATS_TEST_DIRNAME/../helpers/files.sh"
   # Statuses ledger-update.sh accepts: the four canonical unified values.
   WRITABLE="draft ready merged abandoned"
   # Retired values the guard now rejects (superseded by the unified vocabulary).
@@ -66,10 +68,10 @@ _plant_status() {
 
 @test "2: a rejected patch leaves the ledger byte-for-byte unchanged" {
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-draft SPEC-001)"
-  before="$(cat "$REPO/.gaia/local/specs/ledger.json")"
+  before="$(snapshot_file "$REPO/.gaia/local/specs/ledger.json")"
   run _ledger_update "$REPO" SPEC-001 '{"status":"shipped"}'
   [ "$status" -eq 6 ]
-  [ "$(cat "$REPO/.gaia/local/specs/ledger.json")" = "$before" ]
+  assert_files_identical "$REPO/.gaia/local/specs/ledger.json" "$before"
 }
 
 @test "3: every writable status (the unified vocabulary) is accepted" {

--- a/.gaia/tests/lib/spec-reconcile.bats
+++ b/.gaia/tests/lib/spec-reconcile.bats
@@ -12,6 +12,8 @@
 
 setup() {
   HELPERS="$BATS_TEST_DIRNAME/helpers"
+  # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
+  . "$BATS_TEST_DIRNAME/../helpers/files.sh"
   RECONCILE=".specify/extensions/gaia/lib/spec-reconcile.sh"
 }
 
@@ -110,25 +112,25 @@ _no_gh_path() {
 @test "8a: gh absent from PATH; exit 0, ledger unchanged" {
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-inprogress SPEC-006)"
   _promote_to_ready SPEC-006
-  before="$(cat "$REPO/.gaia/local/specs/ledger.json")"
+  before="$(snapshot_file "$REPO/.gaia/local/specs/ledger.json")"
   _no_gh_path
 
   run bash -c "PATH='$NO_GH_PATH' bash '$REPO/$RECONCILE' '$REPO'"
   [ "$status" -eq 0 ]
-  after="$(cat "$REPO/.gaia/local/specs/ledger.json")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$REPO/.gaia/local/specs/ledger.json")"
+  assert_files_identical "$before" "$after"
 }
 
 @test "8b: gh present but returns empty output; exit 0, ledger unchanged" {
   REPO="$("$HELPERS/tmp-spec-repo.sh" --seed-inprogress SPEC-006)"
   _promote_to_ready SPEC-006
-  before="$(cat "$REPO/.gaia/local/specs/ledger.json")"
+  before="$(snapshot_file "$REPO/.gaia/local/specs/ledger.json")"
   _stub_gh_empty
 
   run bash -c "PATH='$STUB_DIR:$PATH' bash '$REPO/$RECONCILE' '$REPO'"
   [ "$status" -eq 0 ]
-  after="$(cat "$REPO/.gaia/local/specs/ledger.json")"
-  [ "$before" = "$after" ]
+  after="$(snapshot_file "$REPO/.gaia/local/specs/ledger.json")"
+  assert_files_identical "$before" "$after"
 }
 
 # --- 9: a retired 'specified' row is off-vocab, never a merge candidate ---

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -215,6 +215,15 @@ jobs:
               - '.gaia/tests/forensics/**'
               - '.gaia/tests/hooks/**'
               - '.gaia/tests/lib/**'
+              # The cross-directory bats helper (.gaia/tests/helpers/) is sourced
+              # by suites in .gaia/scripts/tests/, .gaia/tests/lib/ and
+              # .gaia/tests/hooks/, and it holds the byte-identity assertion
+              # those suites depend on. It sits at the top of .gaia/tests/,
+              # matching none of the .gaia/tests/*/ globs above, so without this
+              # line an edit that weakened the helper alone would report
+              # `code=false`, skip every bats step, and green the job having run
+              # the assertions it broke zero times.
+              - '.gaia/tests/helpers/**'
               # The .gaia/tests/lib/ suites exercise the SPEC-ledger lib scripts
               # under .specify/extensions/gaia/lib/ (spec-archive-merged.sh and
               # its shared cost-consolidate.sh, the allocators, ledger-update,


### PR DESCRIPTION
Three assertions that did not check what their names claimed. Each is proved by mutating the mechanism it guards and watching the suite go red.

Closes #1201
Closes #1209
Closes #1214

## `#1214` — two load-bearing lines of the dirty-tree posture were unpinned

`SENTINEL_CARVEOUT` pinned the prose promising the fail-closed sentinel is never remit-filtered, and `CHECK_LINE` pinned only the `if`. The assignment that actually produces the sentinel was pinned by neither, so deleting `dirty_in_scope="dirty-scope check failed"` from all five members left the suite reporting 18/18 ok while the failure arm produced nothing to withhold on. It now carries its own pin across every member.

The advisory-drift guard compared one bolded sentence literally, so it only ever caught the byte-identical copy-paste. It now scans for withhold-shaped clauses by meaning (`withhold(s|ing)? (this|your|the) (pass|clearance|marker)`, case-insensitive), excluding only the exemption's own negation and anchoring that negator to the verb. Two spellings are deliberately out of the pattern because the advisory member carries them legitimately: `write no marker` is its self-skip arm, and an unqualified `withhold` covers its own exemption prose. Newlines are folded before matching, since `grep` is line-scoped. The fixtures are derived from the gating members' real phrasings rather than invented — see the audit-gate section below for why that inversion is the point.

**Proof.** Deleting the sentinel assignment from all five members reds test 6. Inserting a *reworded* withhold clause into the advisory member, exemption paragraph intact, reds test 12 — and the old exact-string guard was confirmed green on that same mutant.

## `#1209` — a valid asymmetric exemption pair red a required check

pnpm merges multiple exempted versions of one package into a single union entry, `name@1.0.0 || 2.0.0`, and writes that back itself. Root's dependency closure is a superset of `.gaia/cli`'s, so the two workspaces can legitimately need different version counts of a shared package: root carries the union, `.gaia/cli` carries the single version. Literal `arrayContaining` membership cannot see that as containment.

Both assertions now expand each side into the `name` / `name@version` atoms pnpm's own `expandPackageVersionSpecs` produces, following its scope-aware parse. Mirrored rather than imported: pnpm is this repo's `packageManager`, not a dependency of either workspace. One divergence is written into the comment — no `semver.valid` folding of `v1.2.3` — rather than left implicit.

**Proof.** Root carrying `semver@6.3.1 || 6.3.2` against `.gaia/cli`'s `semver@6.3.1` reds the pre-fix test file and passes after. It stays catchable both ways: `.gaia/cli` exempting a version root does not, and `.gaia/cli` exempting *all* versions where root exempts one, each still red.

## `#1201` — byte-identity assertions built on `$(cat …)`

Command substitution strips all trailing newlines from both sides, so a regression that only adds or drops one compared equal in the very tests whose names promise byte identity.

The issue's regex returns 87 candidates; they are candidates, not instances. Sweeping for comparisons where **both** sides are file contents yields 49, in two shapes the regex only half-covers (`[ "$(cat f)" = "$before" ]` and `[ "$before" = "$after" ]`). Two of those 49 are not the class and are untouched: `plan-allocator.bats:151` and `spec-allocator-remote.bats:98` compare allocator IDs a script *printed* into a file, where the strip is what you want. The remaining **47** now compare files, through a shared helper rather than hand-rolled `cmp` per call site, so the next byte-identity test written reaches for a primitive instead of `$(cat …)` out of habit.

`.gaia/tests/helpers/files.sh` is new and sourced from all three bats directories. It gets its own entry in `audit-ci-tests.yml`'s `code:` paths filter: it sits at the top of `.gaia/tests/`, matching none of the `.gaia/tests/*/` globs, so without it an edit weakening the helper alone would report `code=false`, skip every bats step, and green the job.

**Proof.** A real writer regression planted in `.gaia/scripts/cost-reprice.sh` (append a trailing newline on the no-op arm, the exact path those tests call "left byte-identical") reds **six** tests on the new assertions and **zero** on the old ones.

## Verification

Quality Gate run in full, all green: typecheck, lint, `vitest`, and `build` at the root; typecheck, lint and 1980 tests in `.gaia/cli`; Playwright (8 passed, 1 skipped) and the dev smoke test. `shell-lint.sh` passes over 195 scripts and 189 suites. Every mutation above was run after committing, so `git checkout --` could take nothing else with it, and every one was reverted to a clean tree.

**No CHANGELOG entry.** All 15 changed files were checked against `.gaia/manifest.json` and none is in it, so nothing here ships; all three issues are `surface:maintainer`.

## Accepted residuals (audit round 2, `code-audit-maintainer-node`)

Both are Suggestions on an already-marked member whose digest nothing else rotates, so folding
either in buys a full re-dispatch for a comment. Recorded here instead, per the digest economics in
`wiki/concepts/PR Merge Workflow.md`.

- **A name-only entry is not contained by a versioned one, in either direction.** Root exempting
  every version of a package (`semver`) while `.gaia/cli` exempts one (`semver@6.3.1`) reds the
  containment assertion even though root is strictly broader. Real, but **inert today** (the only
  name-only entry, `@gaia-react/lint`, is name-only on both sides), **unchanged from the pre-diff
  literal comparison**, and faithful to pnpm's own `expandPackageVersionSpecs`, which likewise
  yields a single atom for a name-only spec. Changing it would diverge from the vendor parse this
  helper deliberately mirrors.
- **Two of the four `exemptionAtoms` tests stay green under an identity mutation.** True: only the
  merged-union and scoped-union cases red when the helper is replaced by `list => list`. The other
  two are kept deliberately, because they pin a different property, that expansion does not make
  containment *vacuous* in the direction that would hide real drift.

## Audit gate

Three rounds. Round 1 dispatched all three resolved members; `code-audit-github-workflows` cleared
with zero findings and has held a valid marker since. Rounds 2 and 3 re-dispatched only the members
whose content digests had rotated.

Every finding raised against this PR was **fixed**, not accepted, except the two residuals above.
The two Important findings were both real defects in this PR's own new guards, and both are worth
naming because they are the failure this batch exists to fix, reappearing one level up:

1. The drift guard's negation exclusion matched `does not` / `never` / `cannot` anywhere in the
   context window rather than against the verb. Since `never` alone appears 33 times in the guarded
   file, two house-style withhold clauses passed it. Fixed by anchoring the negator to the verb.
2. The drift pattern required the determiner `this` or `your`, so it missed `withhold **the**
   marker`, which is the verbatim handshake sentence three gating members carry, i.e. the likeliest
   copy-paste vector of all. Fixed by admitting `the`, and, more importantly, by **deriving the
   fixture set from the gating members themselves** so a phrasing the scan cannot reach reds when a
   sibling adopts it rather than after it is pasted.

The second repair is deliberately not a third alternation patch: two consecutive rounds finding the
regex one shape short is the enrichment loop, and the derived-fixture inversion is what ends it.

## Accepted residuals (audit round 3, `code-audit-maintainer-shell`)

Round 3 came back clean: no Critical, no Important, three Suggestions. Shell is marked and nothing
else rotates its digest, so folding any of these in buys a full re-dispatch of the roster's most
expensive member for comment-level improvements. Recorded here instead.

- **`gating_withhold_phrases` dedupes case-sensitively while extracting case-insensitively.** So
  `withhold the marker` and `Withhold the marker` both survive `sort -u`: the five extracted phrases
  are **four** distinct ones case-insensitively, and the `>= 4` anti-vacuity floor therefore carries
  one entry of slack. **The comment beside that floor saying "five distinct phrasings today" is
  inaccurate on this point** and is corrected here rather than in the file. The primary assertion is
  unaffected: every extracted phrase must still be caught, and all five are. The fix, when someone
  is next in that file, is `| tr '[:upper:]' '[:lower:]' | sort -u`.
- **The shared helper is sourced by four different path spellings.** Three lib suites use
  `$BATS_TEST_DIRNAME/../helpers/files.sh` on the line after they set `HELPERS` to a *different*
  directory one component away, and `cost-reprice.bats` uses a third spelling where its siblings use
  `$REPO_ROOT`. Consistency, not a defect; standardizing on `$REPO_ROOT/.gaia/tests/helpers/files.sh`
  needs `REPO_ROOT` derived in three suites that lack it.
- **A test name reads "every member assigns the fail-closed sentinel it withholds on"** while
  looping all five members, including the advisory one that never withholds. The loop bound is
  correct (that member does carry the assignment, and records rather than withholds on it); only the
  wording invites a later "fix" to `GATING` that would be wrong.

None is filed as tech debt. Each sits on a path this PR already changes, which is the waive term in
the merge workflow's cross-remit rule, and none has been observed to spread.
