### PR TITLE
debt(tests): one shared primitive per suite for CLI-stderr diagnostics and hook invocation (#1202, #1219)

### DIFF
--- a/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
+++ b/.gaia/tests/distribution/07-gaia-init-strip-branding.sh
@@ -28,7 +28,10 @@ require_cmd rsync "rsync required for adopter-flow scaffold copy"
 
 STAGING="$(mktemp -d -t gaia-dist-init-stage-XXXXXX)"
 SCAFFOLD="$(mktemp -d -t gaia-dist-init-scaffold-XXXXXX)"
-trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+# Outside the scaffold, which this scenario asserts on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-init-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -52,15 +55,8 @@ fi
 # own pwd; never `cd "$SCAFFOLD"` at scenario scope, since other
 # scenarios sourced or invoked from `run-all.sh` may rely on $PWD.
 TITLE="Test Project"
-STDOUT="$(cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" 2>/dev/null)" || {
-  # Re-run with stderr unsuppressed for diagnosis. The `fail; exit 1`
-  # below runs unconditionally; the diagnostic re-run's exit code is
-  # intentionally ignored (`|| :`).
-  log "gaia init strip-branding exited non-zero; rerunning with stderr:"
-  ( cd "$SCAFFOLD" && "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE" ) || :
-  fail "gaia init strip-branding exited non-zero on staged tree"
-  exit 1
-}
+STDOUT="$(cd "$SCAFFOLD" && run_cli "$SCAFFOLD/.gaia/cli/gaia" init strip-branding --title "$TITLE")" \
+  || fail_with_stderr "gaia init strip-branding exited non-zero on staged tree"
 
 if [ -n "$STDOUT" ]; then
   log "unexpected stdout from strip-branding (contract: no stdout on success):"

--- a/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
+++ b/.gaia/tests/distribution/08-gaia-init-cli-sequence.sh
@@ -54,7 +54,10 @@ require_cmd rsync "rsync required for adopter-flow scaffold copy"
 
 STAGING="$(mktemp -d -t gaia-dist-init-stage-XXXXXX)"
 SCAFFOLD="$(mktemp -d -t gaia-dist-init-scaffold-XXXXXX)"
-trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+# Outside the staged tree, which these scenarios assert on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-init-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -109,15 +112,8 @@ export GAIA_TELEMETRY_PING_DISABLE=1
 run_step() {
   local label="$1"; shift
   local stdout
-  stdout="$(cd "$SCAFFOLD" && "$GAIA" "$@" 2>/dev/null)" || {
-    # Re-run with stderr unsuppressed for diagnosis. The `fail; exit 1`
-    # below runs unconditionally; the diagnostic re-run's exit code is
-    # intentionally ignored (`|| :`).
-    log "gaia $* exited non-zero; rerunning with stderr:"
-    ( cd "$SCAFFOLD" && "$GAIA" "$@" ) || :
-    fail "gaia $* exited non-zero on staged tree (step: $label)"
-    exit 1
-  }
+  stdout="$(cd "$SCAFFOLD" && run_cli "$GAIA" "$@")" \
+    || fail_with_stderr "gaia $* exited non-zero on staged tree (step: $label)"
   if [ -n "$stdout" ]; then
     log "unexpected stdout from gaia $* (contract: no stdout on success):"
     printf '%s\n' "$stdout" >&2

--- a/.gaia/tests/distribution/10-gaia-scaffold-templates.sh
+++ b/.gaia/tests/distribution/10-gaia-scaffold-templates.sh
@@ -33,7 +33,10 @@ require_cmd rsync "rsync required for adopter-flow scaffold copy"
 
 STAGING="$(mktemp -d -t gaia-dist-scaffold-stage-XXXXXX)"
 SCAFFOLD="$(mktemp -d -t gaia-dist-scaffold-scaffold-XXXXXX)"
-trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+# Outside the staged tree, which these scenarios assert on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-scaffold-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -67,12 +70,8 @@ done
 run_scaffold() {
   local label="$1"; shift
   local stdout
-  stdout="$(cd "$SCAFFOLD" && "$GAIA" scaffold "$@" 2>/dev/null)" || {
-    log "gaia scaffold $* exited non-zero; rerunning with stderr:"
-    ( cd "$SCAFFOLD" && "$GAIA" scaffold "$@" ) || :
-    fail "gaia scaffold $* exited non-zero on staged tree (kind: $label)"
-    exit 1
-  }
+  stdout="$(cd "$SCAFFOLD" && run_cli "$GAIA" scaffold "$@")" \
+    || fail_with_stderr "gaia scaffold $* exited non-zero on staged tree (kind: $label)"
   printf '%s' "$stdout"
 }
 

--- a/.gaia/tests/distribution/11-gaia-setup-cli-flow.sh
+++ b/.gaia/tests/distribution/11-gaia-setup-cli-flow.sh
@@ -36,7 +36,10 @@ require_cmd rsync "rsync required for adopter-flow scaffold copy"
 
 STAGING="$(mktemp -d -t gaia-dist-setup-stage-XXXXXX)"
 SCAFFOLD="$(mktemp -d -t gaia-dist-setup-scaffold-XXXXXX)"
-trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+# Outside the staged tree, which these scenarios assert on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-setup-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -58,12 +61,8 @@ git -C "$SCAFFOLD" init -q
 run_setup() {
   local label="$1"; shift
   local stdout
-  stdout="$(cd "$SCAFFOLD" && "$GAIA" setup "$@" 2>/dev/null)" || {
-    log "gaia setup $* exited non-zero; rerunning with stderr:"
-    ( cd "$SCAFFOLD" && "$GAIA" setup "$@" ) || :
-    fail "gaia setup $* exited non-zero on staged tree (step: $label)"
-    exit 1
-  }
+  stdout="$(cd "$SCAFFOLD" && run_cli "$GAIA" setup "$@")" \
+    || fail_with_stderr "gaia setup $* exited non-zero on staged tree (step: $label)"
   printf '%s' "$stdout"
 }
 

--- a/.gaia/tests/distribution/12-gaia-ping-events.sh
+++ b/.gaia/tests/distribution/12-gaia-ping-events.sh
@@ -32,7 +32,10 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 source "$HERE/lib/lib.sh"
 
 STAGING="$(mktemp -d -t gaia-dist-ping-stage-XXXXXX)"
-trap 'rm -rf "$STAGING"' EXIT
+# Outside the staged tree, which these scenarios assert on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-ping-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -48,12 +51,8 @@ GAIA="$STAGING/.gaia/cli/gaia"
 run_ping_ok() {
   local label="$1"; shift
   local stdout
-  stdout="$(cd "$STAGING" && GAIA_TELEMETRY_PING_DISABLE=1 "$GAIA" ping "$@" 2>/dev/null)" || {
-    log "gaia ping $* exited non-zero; rerunning with stderr:"
-    ( cd "$STAGING" && GAIA_TELEMETRY_PING_DISABLE=1 "$GAIA" ping "$@" ) || :
-    fail "gaia ping $* exited non-zero on staged tree (event: $label)"
-    exit 1
-  }
+  stdout="$(cd "$STAGING" && GAIA_TELEMETRY_PING_DISABLE=1 run_cli "$GAIA" ping "$@")" \
+    || fail_with_stderr "gaia ping $* exited non-zero on staged tree (event: $label)"
   if [ -n "$stdout" ]; then
     log "unexpected stdout from ping $label (fire-and-forget: no stdout on success):"
     printf '%s\n' "$stdout" >&2

--- a/.gaia/tests/distribution/13-gaia-update-merge-workspace.sh
+++ b/.gaia/tests/distribution/13-gaia-update-merge-workspace.sh
@@ -35,6 +35,7 @@ source "$HERE/lib/lib.sh"
 STAGING="$(mktemp -d -t gaia-dist-update-stage-XXXXXX)"
 FIXTURES="$(mktemp -d -t gaia-dist-update-fix-XXXXXX)"
 trap 'rm -rf "$STAGING" "$FIXTURES"' EXIT
+capture_cli_stderr "$FIXTURES/cli-stderr.txt"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -48,19 +49,12 @@ printf 'minimumReleaseAge: 2880\n' > "$FIXTURES/latest.yaml"
 printf 'minimumReleaseAge: 1440\n' > "$FIXTURES/current.yaml"
 
 # --- JSON verdict --------------------------------------------------------
-VERDICT="$("$GAIA" update merge-workspace \
+VERDICT="$(run_cli "$GAIA" update merge-workspace \
   --baseline "$FIXTURES/baseline.yaml" \
   --latest "$FIXTURES/latest.yaml" \
   --current "$FIXTURES/current.yaml" \
-  --json 2>/dev/null)" || {
-  log "gaia update merge-workspace exited non-zero; rerunning with stderr:"
-  "$GAIA" update merge-workspace \
-    --baseline "$FIXTURES/baseline.yaml" \
-    --latest "$FIXTURES/latest.yaml" \
-    --current "$FIXTURES/current.yaml" --json || :
-  fail "gaia update merge-workspace exited non-zero on staged tree"
-  exit 1
-}
+  --json)" \
+  || fail_with_stderr "gaia update merge-workspace exited non-zero on staged tree"
 
 printf '%s' "$VERDICT" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0,'utf8'));

--- a/.gaia/tests/distribution/14-gaia-update-deps.sh
+++ b/.gaia/tests/distribution/14-gaia-update-deps.sh
@@ -38,7 +38,10 @@ require_cmd rsync "rsync required for adopter-flow scaffold copy"
 
 STAGING="$(mktemp -d -t gaia-dist-udeps-stage-XXXXXX)"
 SCAFFOLD="$(mktemp -d -t gaia-dist-udeps-scaffold-XXXXXX)"
-trap 'rm -rf "$STAGING" "$SCAFFOLD"' EXIT
+# Outside the staged tree, which these scenarios assert on file by file.
+CLI_STDERR_FILE="$(mktemp -t gaia-dist-udeps-stderr-XXXXXX)"
+trap 'rm -rf "$STAGING" "$SCAFFOLD" "$CLI_STDERR_FILE"' EXIT
+capture_cli_stderr "$CLI_STDERR_FILE"
 
 "$HERE/lib/build-staging.sh" "$STAGING" \
   || { fail "build-staging failed"; exit 1; }
@@ -64,12 +67,8 @@ JSON
 LEDGER="$SCAFFOLD/.gaia/local/declined-updates.json"
 
 # --- decline --source --skip --------------------------------------------
-DECLINE_OUT="$(cd "$SCAFFOLD" && "$GAIA" update-deps decline --source updates.json --skip react-router 2>/dev/null)" || {
-  log "gaia update-deps decline exited non-zero; rerunning with stderr:"
-  ( cd "$SCAFFOLD" && "$GAIA" update-deps decline --source updates.json --skip react-router ) || :
-  fail "gaia update-deps decline exited non-zero on staged tree"
-  exit 1
-}
+DECLINE_OUT="$(cd "$SCAFFOLD" && run_cli "$GAIA" update-deps decline --source updates.json --skip react-router)" \
+  || fail_with_stderr "gaia update-deps decline exited non-zero on staged tree"
 printf '%s' "$DECLINE_OUT" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0,'utf8'));
   if (!Array.isArray(r.snoozed) || !r.snoozed.includes('react-router')) {
@@ -80,8 +79,8 @@ printf '%s' "$DECLINE_OUT" | node -e "
   || { fail "gaia update-deps decline did not write .gaia/local/declined-updates.json"; exit 1; }
 
 # --- decline --clear -----------------------------------------------------
-CLEAR_OUT="$(cd "$SCAFFOLD" && "$GAIA" update-deps decline --clear 2>/dev/null)" \
-  || { fail "gaia update-deps decline --clear exited non-zero"; exit 1; }
+CLEAR_OUT="$(cd "$SCAFFOLD" && run_cli "$GAIA" update-deps decline --clear)" \
+  || fail_with_stderr "gaia update-deps decline --clear exited non-zero"
 printf '%s' "$CLEAR_OUT" | node -e "
   const r = JSON.parse(require('node:fs').readFileSync(0,'utf8'));
   if (r.cleared !== true) throw new Error('expected {cleared:true}, got ' + JSON.stringify(r));

--- a/.gaia/tests/distribution/17-gaia-update-merge-region.sh
+++ b/.gaia/tests/distribution/17-gaia-update-merge-region.sh
@@ -42,60 +42,15 @@ START_MARKER='<!-- test-region:start -->'
 END_MARKER='<!-- test-region:end -->'
 PLACEHOLDER='<<<gaia:region>>>'
 
-# Every invocation below that asserts SUCCESS captures the CLI's stderr here
-# instead of discarding it, and its failure branch prints what it captured.
-# `2>/dev/null` on a success-asserting call leaves the `||` branch with nothing
-# to report but the exit code, which is the one fact the branch being taken
-# already implies; on a runner nobody is sitting in front of, that costs a local
-# reproduction to learn anything at all. Redirecting to a file rather than
-# dropping the redirect keeps stdout clean for the JSON the caller parses.
+# Every invocation below that asserts SUCCESS runs through `run_cli`, which
+# captures the CLI's stderr here instead of discarding it, and reports it from
+# `fail_with_stderr`. Both live in `lib/lib.sh`, whose header explains the
+# mechanism and the load-bearing call order.
 #
 # The discriminator is what the scenario asserts, not its number: scenario 7
 # asserts FAILURE, so its diagnostic is expected noise and it keeps its own
 # suppression.
-#
-# WHY NOT THE SIBLING IDIOM. Several other scenarios in this directory
-# (07, 08, 10, 11, 12, 13, 14) solve the same problem the other way: keep
-# `2>/dev/null`, and on failure re-run the identical command unsuppressed for a
-# human to read. Capturing to a file is preferred here because it reports the
-# bytes the FAILING run actually emitted, where a re-run reports a second,
-# different execution: it can succeed, or fail differently, and it doubles the
-# work on the one path that is already going wrong. This is also the fix the
-# issue itself names. The cost is honest and worth stating: this directory now
-# holds two mechanisms for one job and neither lives in `lib/lib.sh`, which is
-# filed rather than fixed here, because converging the other seven scenarios is
-# not this change's scope.
-#
-# CALL ORDER IS LOAD-BEARING, which is why `fail_with_stderr` exists rather
-# than an inline group at each site. `report_cli_stderr` runs BEFORE `fail`,
-# never after: `fail` returns 1 rather than exiting, and the `||` right-hand
-# side is the LAST command of its AND-OR list, so `set -e` is NOT suppressed
-# there and aborts the script the moment `fail` returns. Anything sequenced
-# after `fail` is dead code that never runs, which is how a diagnostic that
-# looks present prints nothing. (`fail_with_stderr`'s own trailing `exit 1` is
-# unreachable for that reason and is kept as the statement of intent, matching
-# every other failure branch in this file.) Verified by driving a real non-zero
-# exit through scenario 1, not by reading.
-CLI_STDERR="$FIXTURES/cli-stderr.txt"
-: > "$CLI_STDERR"
-
-report_cli_stderr() {
-  if [ -s "$CLI_STDERR" ]; then
-    printf -- '--- gaia stderr ---\n' >&2
-    cat "$CLI_STDERR" >&2
-    printf -- '--- end gaia stderr ---\n' >&2
-  else
-    printf -- '(gaia wrote nothing to stderr)\n' >&2
-  fi
-}
-
-# The one failure branch every success-asserting invocation below uses, so the
-# order above is stated once rather than repeated at eight call sites.
-fail_with_stderr() {
-  report_cli_stderr
-  fail "$1"
-  exit 1
-}
+capture_cli_stderr "$FIXTURES/cli-stderr.txt"
 
 # --- Scenario 1: region-only divergence -----------------------------------
 # `current` differs from `baseline` only inside the region; `latest` differs
@@ -109,12 +64,12 @@ printf 'outside-A-changed\n%s\nregion-baseline-1\nregion-baseline-2\n%s\noutside
 printf 'outside-A\n%s\nregion-current-1\nregion-current-2\n%s\noutside-B\n' \
   "$START_MARKER" "$END_MARKER" > "$FIXTURES/s1-current.txt"
 
-S1_JSON="$("$GAIA" update merge-region \
+S1_JSON="$(run_cli "$GAIA" update merge-region \
   --baseline "$FIXTURES/s1-baseline.txt" \
   --latest "$FIXTURES/s1-latest.txt" \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>"$CLI_STDERR")" \
+  --json)" \
   || fail_with_stderr "scenario 1: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S1_JSON" | node -e "
@@ -140,12 +95,12 @@ printf 'outside-A-current\n%s\nregion-current\n%s\noutside-B\n' \
 printf 'outside-A-latest\n%s\nregion-latest\n%s\noutside-B\n' \
   "$START_MARKER" "$END_MARKER" > "$FIXTURES/s2-latest.txt"
 
-S2_JSON="$("$GAIA" update merge-region \
+S2_JSON="$(run_cli "$GAIA" update merge-region \
   --baseline "$FIXTURES/s2-baseline.txt" \
   --latest "$FIXTURES/s2-latest.txt" \
   --current "$FIXTURES/s2-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>"$CLI_STDERR")" \
+  --json)" \
   || fail_with_stderr "scenario 2: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S2_JSON" | node -e "
@@ -176,12 +131,12 @@ printf 'outside-A\n%s\nregion-baseline\n%s\noutside-B\n' \
 printf 'outside-A\n%s\nregion-current\noutside-B\n' \
   "$START_MARKER" > "$FIXTURES/s3-current.txt"
 
-S3_JSON="$("$GAIA" update merge-region \
+S3_JSON="$(run_cli "$GAIA" update merge-region \
   --baseline "$FIXTURES/s3-baseline.txt" \
   --latest "$FIXTURES/s3-latest.txt" \
   --current "$FIXTURES/s3-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>"$CLI_STDERR")" \
+  --json)" \
   || fail_with_stderr "scenario 3: gaia update merge-region exited non-zero on staged tree"
 
 # The fixture paths reach node through the ENVIRONMENT, never interpolated by
@@ -224,12 +179,12 @@ printf 'no markers here at all\njust plain text\n' > "$FIXTURES/s4-current.txt"
 printf 'outside-A\n%s\nregion-latest\n%s\noutside-B\n' \
   "$START_MARKER" "$END_MARKER" > "$FIXTURES/s4-latest.txt"
 
-S4_JSON="$("$GAIA" update merge-region \
+S4_JSON="$(run_cli "$GAIA" update merge-region \
   --baseline "$FIXTURES/s4-baseline.txt" \
   --latest "$FIXTURES/s4-latest.txt" \
   --current "$FIXTURES/s4-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
-  --json 2>"$CLI_STDERR")" \
+  --json)" \
   || fail_with_stderr "scenario 4: gaia update merge-region exited non-zero on staged tree"
 
 printf '%s' "$S4_JSON" | node -e "
@@ -252,9 +207,9 @@ S5_ARGS=(update merge-region \
   --current "$FIXTURES/s1-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
-S5_FIRST="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
+S5_FIRST="$(run_cli "$GAIA" "${S5_ARGS[@]}")" \
   || fail_with_stderr "scenario 5: first invocation exited non-zero"
-S5_SECOND="$("$GAIA" "${S5_ARGS[@]}" 2>"$CLI_STDERR")" \
+S5_SECOND="$(run_cli "$GAIA" "${S5_ARGS[@]}")" \
   || fail_with_stderr "scenario 5: second invocation exited non-zero"
 [ "$S5_FIRST" = "$S5_SECOND" ] \
   || { fail "scenario 5 (idempotence): two invocations on the same inputs produced different output"; exit 1; }
@@ -292,9 +247,9 @@ S6_ARGS=(update merge-region \
   --current "$FIXTURES/s6-current.txt" \
   --start-marker "$START_MARKER" --end-marker "$END_MARKER" \
   --json)
-S6_FIRST="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
+S6_FIRST="$(run_cli "$GAIA" "${S6_ARGS[@]}")" \
   || fail_with_stderr "scenario 6: first post-update invocation exited non-zero"
-S6_SECOND="$("$GAIA" "${S6_ARGS[@]}" 2>"$CLI_STDERR")" \
+S6_SECOND="$(run_cli "$GAIA" "${S6_ARGS[@]}")" \
   || fail_with_stderr "scenario 6: second post-update invocation exited non-zero"
 
 printf '%s' "$S6_FIRST" | node -e '

--- a/.gaia/tests/distribution/README.md
+++ b/.gaia/tests/distribution/README.md
@@ -17,7 +17,7 @@ Maintainer-only validation of the post-scrub GAIA tarball. Excluded from the rel
 .gaia/tests/distribution/
 ├── run-all.sh                   # top-level driver
 ├── lib/
-│   ├── lib.sh                   # pass/fail/log/require_cmd, PROJECT_ROOT
+│   ├── lib.sh                   # pass/fail/log/require_cmd, PROJECT_ROOT, CLI stderr capture
 │   ├── build-staging.sh         # builds staging tarball into $1 (mktemp dir)
 │   └── docker.sh                # Layer 2 image build + container run helpers
 ├── 01-files-present.sh          # manifest/exclude/sentinel presence

--- a/.gaia/tests/distribution/lib/lib.sh
+++ b/.gaia/tests/distribution/lib/lib.sh
@@ -8,12 +8,15 @@
 # intentionally does NOT enable `set -e`; sourcing would inherit it into
 # the caller, which is fine, but explicit-in-scenario is the convention.
 #
-# API (frozen; see plan README):
+# API:
 #   PROJECT_ROOT  - absolute path to GAIA repo root (git rev-parse --show-toplevel)
 #   pass MSG      - prints "PASS  <basename of $0>: MSG" to stdout; returns 0
 #   fail MSG      - prints "FAIL  <basename of $0>: MSG" to stderr; returns 1
 #   log MSG       - prints "  - MSG" to stderr (non-failing diagnostic)
 #   require_cmd CMD [MESSAGE]  - exits 1 if CMD is not on PATH
+#   capture_cli_stderr PATH    - declares PATH as this scenario's stderr capture file
+#   run_cli CMD [ARG...]       - runs CMD with stderr captured; stdout passes through
+#   fail_with_stderr MSG       - reports the captured stderr, then fails and exits 1
 
 # Resolve once; export so all functions can reference.
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
@@ -46,4 +49,67 @@ require_cmd() {
     printf '%s\n' "$message" >&2
     exit 1
   }
+}
+
+# --- CLI stderr diagnostics ------------------------------------------------
+#
+# A scenario that asserts a CLI call SUCCEEDS has to keep the call's stderr off
+# stdout, because stdout is the JSON (or the emptiness) it is about to assert
+# on. Dropping stderr with `2>/dev/null` leaves the failure branch with nothing
+# to report but the exit code, which is the one fact the branch being taken
+# already implies; on a runner nobody is sitting in front of, that costs a local
+# reproduction to learn anything at all.
+#
+# So capture it. These three functions are the whole mechanism:
+#
+#   capture_cli_stderr "$FIXTURES/cli-stderr.txt"   # once, after the scratch dir exists
+#   out="$(cd "$SCAFFOLD" && run_cli "$GAIA" scaffold component Foo)" \
+#     || fail_with_stderr "gaia scaffold component exited non-zero on staged tree"
+#
+# The capture path is the caller's, not this library's: every scenario already
+# owns a scratch dir removed by its own `trap … EXIT`, and a trap installed here
+# would be silently replaced by the scenario's own.
+#
+# WHY NOT RE-RUN THE COMMAND UNSUPPRESSED. Reporting the bytes the FAILING run
+# emitted is the point. A re-run is a second, different execution: it can
+# succeed (leaving the failure unexplained), fail differently, or double the
+# side effects on the one path already going wrong.
+#
+# CALL ORDER IS LOAD-BEARING, which is why `fail_with_stderr` exists rather than
+# an inline group at each call site. The stderr report runs BEFORE `fail`, never
+# after: `fail` returns 1 rather than exiting, and the `||` right-hand side is
+# the LAST command of its AND-OR list, so `set -e` is NOT suppressed there and
+# aborts the scenario the moment `fail` returns. Anything sequenced after `fail`
+# is dead code, which is how a diagnostic that looks present prints nothing.
+# (`fail_with_stderr`'s own trailing `exit 1` is unreachable for that reason and
+# is kept as the statement of intent, matching every other failure branch.)
+
+# capture_cli_stderr PATH
+# Declares PATH as this scenario's capture file and truncates it. Call once,
+# after the scratch directory holding PATH exists.
+capture_cli_stderr() {
+  CLI_STDERR="$1"
+  : > "$CLI_STDERR"
+}
+
+# run_cli CMD [ARG...]
+# Runs CMD with stderr redirected to the capture file; stdout passes through for
+# the caller to capture. Returns CMD's exit status.
+run_cli() {
+  "$@" 2> "${CLI_STDERR:?run_cli requires capture_cli_stderr to have been called}"
+}
+
+# fail_with_stderr MSG
+# The failure branch every success-asserting `run_cli` call uses: report what
+# the failing run wrote to stderr, then fail, then exit.
+fail_with_stderr() {
+  if [ -s "${CLI_STDERR:?fail_with_stderr requires capture_cli_stderr to have been called}" ]; then
+    printf -- '--- gaia stderr ---\n' >&2
+    cat "$CLI_STDERR" >&2
+    printf -- '--- end gaia stderr ---\n' >&2
+  else
+    printf -- '(gaia wrote nothing to stderr)\n' >&2
+  fi
+  fail "$1"
+  exit 1
 }

--- a/.gaia/tests/hooks/audit-disposition-check.bats
+++ b/.gaia/tests/hooks/audit-disposition-check.bats
@@ -18,6 +18,7 @@
 # (.claude/rules/bats-assertions.md): `grep -q` / `[ ]` / explicit `return 1`.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
   # snapshot_file + assert_files_identical: byte identity without `$(cat …)`.
@@ -317,20 +318,10 @@ write_frontend_marker() {
 run_disposition_hook() {
   local root="$1" cmd="${2:-gh pr merge 30 --squash --delete-branch}" json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "cd '$root' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$root" "$json" "$HOOK_ABS"
 }
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" || return 1
-  return 0
-}
 
 # ---------------------------------------------------------------------------
 # SPEC-064 fixtures: a pull-request-shaped repository (a base commit on
@@ -769,7 +760,7 @@ orphan_commit_on_current_branch() {
   mkdir -p "$ROOT"
   seed_repo "$ROOT"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: no marker at all, but sidecar has a confirmed offender -> DENY (offender check is independent of marker state)" {
@@ -783,7 +774,7 @@ orphan_commit_on_current_branch() {
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   install_gh_mock ok '[]'
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "filed-but-missing: v1 class=y path=b line=2" <<<"$output" || return 1
 }
 
@@ -797,7 +788,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"github","findings":[{"key":"v1 class=holistic/x path=.claude/hooks/lib/audit-machinery.sh line=1","disposition":"machinery_waived"}]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: a machinery_waived entry whose path is NOT machinery -> DENY (abuse-check offender)" {
@@ -810,7 +801,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"github","findings":[{"key":"v1 class=holistic/x path=app/x.ts line=1","disposition":"machinery_waived"}]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "machinery-waived-not-eligible: v1 class=holistic/x path=app/x.ts line=1" <<<"$output" || return 1
 }
 
@@ -823,7 +814,7 @@ orphan_commit_on_current_branch() {
   mkdir -p "$ROOT/.gaia/local/audit"
   printf 'not json {' > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: sidecar backend absent -> fail open (allow) even with a filed entry" {
@@ -836,7 +827,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"absent","findings":[{"key":"K","disposition":"filed"}]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: gh unreachable -> fail open (allow), no filed offender" {
@@ -850,7 +841,7 @@ orphan_commit_on_current_branch() {
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   install_gh_mock fail
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: a marker valid for a rotated-away (stale) digest does not trigger the absent-sidecar arm -> allow" {
@@ -865,7 +856,7 @@ orphan_commit_on_current_branch() {
   printf 'export const y = 2;\n' >> "$ROOT/app/x.ts"
   git -C "$ROOT" commit -aqm "rotate"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ---------------------------------------------------------------------------
@@ -884,7 +875,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"github","findings":[{"key":"v1 class=x path=app/y.ts line=1","disposition":"machinery_waived"}]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "machinery-waived-not-eligible: v1 class=x path=app/y.ts line=1" <<<"$output" || return 1
 }
 
@@ -896,7 +887,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"github","findings":[{"key":"v1 class=x path=.claude/hooks/lib/audit-machinery.sh line=1","disposition":"machinery_waived"}]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
   grep -qF -- "changed-files-unverified: v1 class=x path=.claude/hooks/lib/audit-machinery.sh line=1" <<<"$output" || return 1
 }
 
@@ -909,7 +900,7 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"sha":"%s","backend":"github","findings":[{"key":"v1 class=x path=.gaia/cli/src/fixture.ts line=1","severity":"suggestion","security_class":false,"disposition":"machinery_waived"}]}\n' \
     "$head_sha" > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
   [ "$(jq -r '.findings[0].issue_number // "null"' "$ROOT/.gaia/local/audit/${digest}.dispositions.json")" = "null" ]
   [ ! -f "$ROOT/.gaia/local/debt/refresh-requested" ]
 }
@@ -926,7 +917,7 @@ orphan_commit_on_current_branch() {
   [ -n "$digest" ] || skip "could not derive digest"
   write_frontend_marker "$ROOT" "$digest"
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "sidecar" <<<"$output" || return 1
 }
 
@@ -941,14 +932,14 @@ orphan_commit_on_current_branch() {
   printf '{"schema":1,"backend":"github","findings":[]}\n' \
     > "$ROOT/.gaia/local/audit/${digest}.dispositions.json"
   run_disposition_hook "$ROOT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook: digest cannot be derived (non-git root) -> DENY (fail closed)" {
   ROOT="$BATS_TEST_TMPDIR/nogit"
   mkdir -p "$ROOT"
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "could not be derived" <<<"$output" || return 1
 }
 
@@ -1009,6 +1000,6 @@ orphan_commit_on_current_branch() {
   # 4. Run the standalone gate at the new HEAD with gh stubbed per TST-007.
   install_gh_mock ok '[]'
   run_disposition_hook "$ROOT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "filed-but-missing: v1 class=y path=app/x.ts line=1" <<<"$output" || return 1
 }

--- a/.gaia/tests/hooks/audit-root-resolution.bats
+++ b/.gaia/tests/hooks/audit-root-resolution.bats
@@ -60,6 +60,7 @@
 # bare non-repository cwd.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
 
   MAIN=$(mktemp -d -t audit-root-main-XXXXXX)
@@ -786,7 +787,7 @@ run_audit_root_block() {
   main_frontend_digest="$(digest_of "$MAIN" code-audit-frontend)"
   payload="$(write_merge_payload)"
 
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   [ "$status" -eq 0 ]
   grep -qF -- "$wt_frontend_digest" <<<"$output" || { echo "deny output does not name WT's frontend digest ($wt_frontend_digest): $output" >&2; return 1; }
   grep -qF -- "$main_frontend_digest" <<<"$output" && { echo "deny output names MAIN's digest instead of WT's" >&2; return 1; }
@@ -801,7 +802,7 @@ run_audit_root_block() {
   done
   payload="$(write_merge_payload)"
 
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<<"$output" && { echo "expected allow, got deny: $output" >&2; return 1; }
   return 0
@@ -815,7 +816,7 @@ run_audit_root_block() {
   done
   payload="$(write_merge_payload)"
 
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<<"$output" || { echo "expected deny (wrong-digest marker must not clear), got allow: $output" >&2; return 1; }
 }
@@ -830,7 +831,7 @@ run_audit_root_block() {
     [ "$m" = "code-audit-frontend" ] && write_sidecar_at "$MAIN" "$digest"
   done
   payload="$(write_merge_payload)"
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   if grep -qF -- '"permissionDecision": "deny"' <<<"$output"; then
     echo "baseline (unmutated) stage 7 store assertion failed: $output" >&2
     restore_file "$HOOK_MERGE" "$orig_sum"
@@ -842,7 +843,7 @@ run_audit_root_block() {
   rm -rf "$MAIN/.gaia/local"
   wt_frontend_digest="$(digest_of "$WT" code-audit-frontend)"
   payload="$(write_merge_payload)"
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   if ! grep -qF -- "$wt_frontend_digest" <<<"$output"; then
     echo "baseline (unmutated) stage 7 digest assertion failed: $output" >&2
     restore_file "$HOOK_MERGE" "$orig_sum"
@@ -873,14 +874,14 @@ run_audit_root_block() {
     [ "$m" = "code-audit-frontend" ] && write_sidecar_at "$MAIN" "$digest"
   done
   payload="$(write_merge_payload)"
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   grep -qF -- '"permissionDecision": "deny"' <<<"$output" && store_went_red=1
 
   # Digest assertion, mutated: must stay green -- tree_root's own derivation
   # is untouched by this mutation and still walks WT.
   rm -rf "$MAIN/.gaia/local"
   payload="$(write_merge_payload)"
-  run bash -c 'cd "$1" && cat "$2" | bash "$3"' _ "$WT" "$payload" "$HOOK_MERGE"
+  invoke_hook_in "$WT" "$(cat "$payload")" "$HOOK_MERGE"
   grep -qF -- "$wt_frontend_digest" <<<"$output" && digest_stayed_green=1
 
   restore_file "$HOOK_MERGE" "$orig_sum"

--- a/.gaia/tests/hooks/audit-scope-lib.bats
+++ b/.gaia/tests/hooks/audit-scope-lib.bats
@@ -267,7 +267,7 @@ golden_commit() {
 golden_run_hook() {
   local json
   json=$(jq -n '{tool_name: "Bash", tool_input: {command: "gh pr merge 1 --squash"}}')
-  run bash -c "cd '$GREPO' && printf '%s' '$json' | bash '$HOOK'"
+  invoke_hook_in "$GREPO" "$json" "$HOOK"
 }
 
 @test "golden table: pure wiki-only diff allows" {

--- a/.gaia/tests/hooks/audit-scope-lib.bats
+++ b/.gaia/tests/hooks/audit-scope-lib.bats
@@ -15,6 +15,7 @@
 # unless it is the test's last command.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
   SCOPE_LIB="$REPO_ROOT/.claude/hooks/lib/audit-scope.sh"
@@ -374,7 +375,7 @@ golden_run_hook() {
   chmod +x "$SANDBOX/.claude/hooks/pr-merge-audit-check.sh"
 
   json=$(jq -n '{tool_name: "Bash", tool_input: {command: "gh pr merge 1 --squash"}}')
-  run bash -c "cd '$SANDBOX' && printf '%s' '$json' | bash '$SANDBOX/.claude/hooks/pr-merge-audit-check.sh'"
+  invoke_hook_in "$SANDBOX" "$json" "$SANDBOX/.claude/hooks/pr-merge-audit-check.sh"
   rm -rf "$SANDBOX"
 
   [ "$status" -eq 0 ]

--- a/.gaia/tests/hooks/block-bare-test.bats
+++ b/.gaia/tests/hooks/block-bare-test.bats
@@ -20,6 +20,7 @@
 # `git commit -m "...pnpm test..."` were being denied.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/block-bare-test.sh
 }
 
@@ -27,105 +28,97 @@ setup() {
 run_hook() {
   local cmd="$1" payload
   payload=$(jq -nc --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "printf '%s' '$payload' | bash '$HOOK'"
+  invoke_hook "$payload" "$HOOK"
 }
 
-assert_blocked() {
-  [ "$status" -eq 2 ]
-  [[ "$output" == *"BLOCKED"* ]]
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
 
 # --- blocked: a real bare invocation starts watch mode ------------------------
 
 @test "(a) bare pnpm test is blocked" {
   run_hook 'pnpm test'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "bare npm test is blocked" {
   run_hook 'npm test'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "bare pnpm run test is blocked" {
   run_hook 'pnpm run test'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "(e) env-prefixed FOO=bar pnpm test is blocked" {
   run_hook 'FOO=bar pnpm test'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "pnpm test after a separator is blocked (command position, not prose)" {
   run_hook 'echo hi && pnpm test'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "pnpm test inside a command substitution is blocked (it would run)" {
   run_hook 'echo $(pnpm test)'
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 # --- allowed: --run opts out of watch mode ------------------------------------
 
 @test "(b) pnpm test --run <scope> is allowed" {
   run_hook 'pnpm test --run app/x'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "pnpm run test --run is allowed" {
   run_hook 'pnpm run test --run'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # --- allowed: prose mentions are not invocations (the fixed false positives) --
 
 @test "(c) gh pr create --body mentioning pnpm test --run is allowed" {
   run_hook 'gh pr create --body "see `pnpm test --run` output"'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "(d) git commit -m mentioning pnpm test is allowed" {
   run_hook 'git commit -m "run pnpm test later"'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "git commit -m mentioning bare pnpm test (no --run) is allowed" {
   run_hook 'git commit -m "remember to run pnpm test"'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "echo of the phrase into a file is allowed" {
   run_hook 'echo "pnpm test" > notes.txt'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # --- allowed: the test: carve-out (a package script that exits on its own) ----
 
 @test "(f) pnpm test:ci is allowed (test: token, not bare test)" {
   run_hook 'pnpm test:ci'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "(g) pnpm run test:lint-staged is allowed" {
   run_hook 'pnpm run test:lint-staged'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # --- allowed: unrelated commands ----------------------------------------------
 
 @test "pnpm typecheck is allowed" {
   run_hook 'pnpm typecheck'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "an empty command is allowed" {
   run_hook ''
-  assert_allowed
+  assert_allowed_by_exit
 }

--- a/.gaia/tests/hooks/block-env-read.bats
+++ b/.gaia/tests/hooks/block-env-read.bats
@@ -21,6 +21,7 @@
 # an indirectly-invoked bats suite at all.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-env-read.sh"
   WRITE_HOOK_ABS="$HOOKS_SRC/block-env-write.sh"
@@ -37,84 +38,76 @@ run_hook_read() {
   local path="$1"
   local json
   json=$(jq -n --arg p "$path" '{tool_name: "Read", tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_bash() {
   local cmd="$1"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_write_hook_edit() {
   local tool="$1" path="$2"
   local json
   json=$(jq -n --arg t "$tool" --arg p "$path" '{tool_name: $t, tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$WRITE_HOOK_ABS"
+  invoke_hook "$json" "$WRITE_HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  ! grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
 # --- Read-tool denies (UAT-001, UAT-002) ---
 
 @test "Read .env.local is denied" {
   run_hook_read ".env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Read .env.production is denied" {
   run_hook_read ".env.production"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Read a nested packages/api/.env.production is denied" {
   run_hook_read "packages/api/.env.production"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- Read-tool allow (UAT-003) ---
 
 @test "Read .env.example is allowed" {
   run_hook_read ".env.example"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Bash denies: recognized readers against variants (UAT-001, UAT-002) ---
 
 @test "cat .env.local is denied" {
   run_hook_bash "cat .env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "cat .env.production is denied" {
   run_hook_bash "cat .env.production"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "cat a nested packages/api/.env.production is denied" {
   run_hook_bash "cat packages/api/.env.production"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- Bash denies: residual read paths (UAT-004) ---
 
 @test "source .env is denied" {
   run_hook_bash "source .env"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test ". ./.env is denied" {
   run_hook_bash ". ./.env"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "x=\$(<.env) is denied" {
@@ -123,100 +116,100 @@ assert_allowed() {
   # would expand $(<.env) here and defeat the test.
   # shellcheck disable=SC2016
   run_hook_bash 'x=$(<.env)'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "xxd .env is denied" {
   run_hook_bash "xxd .env"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "true && cat .env.local is denied (compound-command segment walk)" {
   run_hook_bash "true && cat .env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "cd /tmp; cat .env.local is denied (semicolon segment walk)" {
   run_hook_bash "cd /tmp; cat .env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "false || cat .env.local is denied (or segment walk)" {
   run_hook_bash "false || cat .env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- Bash denies: bare environment dumps (UAT-005) ---
 
 @test "bare env is denied" {
   run_hook_bash "env"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "bare printenv is denied" {
   run_hook_bash "printenv"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "printenv NODE_ENV is denied (printenv has no runner form)" {
   run_hook_bash "printenv NODE_ENV"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- Bash allows: env as a runner (UAT-005) ---
 
 @test "env NODE_ENV=production node app.js is allowed" {
   run_hook_bash "env NODE_ENV=production node app.js"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Bash allows: false-positive guards (UAT-006) ---
 
 @test "pnpm dev is allowed" {
   run_hook_bash "pnpm dev"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "pnpm i && pnpm dev is allowed (benign compound command)" {
   run_hook_bash "pnpm i && pnpm dev"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cat app/services/env.ts is allowed" {
   run_hook_bash "cat app/services/env.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cat README.md is allowed" {
   run_hook_bash "cat README.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cp .env.example .env is allowed" {
   run_hook_bash "cp .env.example .env"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "grep '.env' .gitignore is allowed (pattern, not a file read)" {
   run_hook_bash "grep '.env' .gitignore"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "ls -la .env is allowed (non-reading)" {
   run_hook_bash "ls -la .env"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cat .env.example is allowed (UAT-003)" {
   run_hook_bash "cat .env.example"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Self-leak (UAT-009) ---
 
 @test "env SECRET=hunter2 cat .env.local is denied without leaking the inline value" {
   run_hook_bash "env SECRET=hunter2 cat .env.local"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "hunter2" <<<"$output" && return 1
   grep -qF -- "env SECRET=hunter2 cat .env.local" <<<"$output" && return 1
   return 0
@@ -226,12 +219,12 @@ assert_allowed() {
 
 @test "Edit on .env.local is denied by block-env-write.sh (UAT-007)" {
   run_write_hook_edit "Edit" ".env.local"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Write on .env.example is allowed by block-env-write.sh (UAT-007)" {
   run_write_hook_edit "Write" ".env.example"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Structural ---
@@ -272,7 +265,7 @@ assert_allowed() {
 
 @test "a benign Bash command allows without short-circuiting the chain (UAT-008)" {
   run_hook_bash "pnpm dev"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "hook header documents the corrected posture (UAT-010)" {

--- a/.gaia/tests/hooks/block-env-read.bats
+++ b/.gaia/tests/hooks/block-env-read.bats
@@ -28,12 +28,9 @@ setup() {
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
 }
 
-# Quote-safe delivery (mandatory): several payloads below carry Bash commands
-# that contain single quotes of their own (grep '.env' .gitignore, env
-# SECRET=hunter2 cat .env.local). Re-wrapping $json in an outer
-# single-quoted `bash -c '...'` string would let those embedded quotes
-# terminate the wrapper early. Passing $json and the hook path as positional
-# args instead means no re-quoting happens.
+# Several payloads below carry Bash commands with single quotes of their own
+# (grep '.env' .gitignore, env SECRET=hunter2 cat .env.local), so delivery goes
+# through `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook_read() {
   local path="$1"
   local json

--- a/.gaia/tests/hooks/block-eslint-config-edit.bats
+++ b/.gaia/tests/hooks/block-eslint-config-edit.bats
@@ -84,8 +84,8 @@ cfg() {
   printf '%s' "$TMP/$name"
 }
 
-# Quote-safe delivery: fixtures carry quotes of their own, so the JSON payload
-# and the hook path go in as positional args rather than being re-wrapped.
+# The fixtures here carry quotes of their own, so delivery goes through
+# `invoke_hook` (helpers/run-hook.sh), which passes the payload positionally.
 run_hook() {
   invoke_hook "$1" "$HOOK_ABS"
 }

--- a/.gaia/tests/hooks/block-eslint-config-edit.bats
+++ b/.gaia/tests/hooks/block-eslint-config-edit.bats
@@ -42,6 +42,7 @@
 # real edit would carry.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-eslint-config-edit.sh"
   TMP=$(mktemp -d "${BATS_TMPDIR:-/tmp}/eslint-hook.XXXXXX")
@@ -86,7 +87,7 @@ cfg() {
 # Quote-safe delivery: fixtures carry quotes of their own, so the JSON payload
 # and the hook path go in as positional args rather than being re-wrapped.
 run_hook() {
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$1" "$HOOK_ABS"
+  invoke_hook "$1" "$HOOK_ABS"
 }
 
 run_edit() {
@@ -107,36 +108,28 @@ run_tool() {
   run_hook "$(jq -n --arg t "$1" --argjson i "$2" '{tool_name: $t, tool_input: $i}')"
 }
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
 
-assert_denied() {
-  [ "$status" -eq 2 ]
-  grep -qF -- 'BLOCKED' <<<"$output"
-}
 
 # --- path gate, the only thing that decides anything ------------------------
 
 @test "allows an edit to a file that is not an eslint config" {
   run_edit "$(cfg 'const a = 1;' 'home.tsx')" 'const a = 1;' 'const a = 2;'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "allows an edit to a lookalike filename" {
   run_edit "$(cfg 'rules: {}' 'eslint.config.md')" 'rules: {}' "rules: {a: 'off'}"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "allows a source file whose name merely ends in the guarded one" {
   run_edit "$(cfg 'const a = 1;' 'my-eslint.config.mjs')" 'const a = 1;' 'const a = 2;'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "allows a file whose name merely starts with the guarded one" {
   run_edit "$(cfg 'const a = 1;' 'eslint.config.mjs.bak')" 'const a = 1;' 'const a = 2;'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # This fixture is pinned between two limits that pull in opposite directions,
@@ -168,7 +161,7 @@ assert_denied() {
     '{tool_name: "Edit", tool_input: {file_path: $p, old_string: "a", new_string: "b"}}' \
     >"$TMP/payload.json"
   run bash -c 'bash "$2" <"$1"' _ "$TMP/payload.json" "$HOOK_ABS"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 # Every other fixture builds its path under $TMP, so all of them carry a slash
@@ -176,7 +169,7 @@ assert_denied() {
 # case, narrowing the group to `(/)` is undetected.
 @test "guards a config named with no directory component at all" {
   run_tool Edit '{"file_path": "eslint.config.mjs", "old_string": "a", "new_string": "b"}'
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "guards every extension ESLint resolves, at any depth" {
@@ -194,12 +187,12 @@ assert_denied() {
 @test "denies the reactRouter migration, which is legitimate and denied anyway" {
   run_edit "$(cfg)" '  ...lint.react,' '  ...lint.react,
   ...lint.reactRouter,'
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a comment-only change" {
   run_edit "$(cfg)" ' * Config for the app.' ' * ESLint config for the app.'
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a blank-line-only change" {
@@ -209,12 +202,12 @@ export default" "const lint = gaiaLint();
 
 
 export default"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a Write whose content only changes a comment" {
   run_write "$(cfg)" "${DEFAULT_BODY/Config for the app./ESLint config for the app.}"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a MultiEdit whose every pair is a comment or an added spread" {
@@ -222,7 +215,7 @@ export default"
     '{file_path: $p,
       edits: [{old_string: " * Config for the app.", new_string: " * ESLint config."},
               {old_string: "  ...lint.react,", new_string: "  ...lint.react,\n  ...lint.reactRouter,"}]}')"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 # --- and every shape it would deny too, so the floor is pinned --------------
@@ -230,18 +223,18 @@ export default"
 @test "denies adding a rule override" {
   run_edit "$(cfg)" "    rules: {'no-console': 'off'}," \
     "    rules: {'no-console': 'off', 'no-empty-pattern': 'off'},"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies removing a preset spread" {
   run_edit "$(cfg)" '  ...lint.guardrails,
 ' ''
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a Write that replaces the whole config" {
   run_write "$(cfg)" 'export default [];'
-  assert_denied
+  assert_blocked_by_exit
 }
 
 # --- the message is what makes the bluntness honest -------------------------
@@ -283,27 +276,27 @@ export default"
 
 @test "denies a tool shape it cannot otherwise read on a guarded path" {
   run_tool NotebookEdit "$(jq -n --arg p "$(cfg)" '{file_path: $p}')"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies an Edit on a guarded path carrying no strings at all" {
   run_tool Edit "$(jq -n --arg p "$(cfg)" '{file_path: $p}')"
-  assert_denied
+  assert_blocked_by_exit
 }
 
 @test "denies a Write on a guarded path that does not exist yet" {
   run_write "$TMP/eslint.config.ts" 'export default [];'
-  assert_denied
+  assert_blocked_by_exit
 }
 
 # --- a payload naming no file cannot be judged, and is not an exemption -----
 
 @test "exits zero on a payload carrying no file_path" {
   run_tool Edit '{"old_string": "a", "new_string": "b"}'
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "exits zero on a payload that is not readable JSON" {
   run_hook 'not json at all'
-  assert_allowed
+  assert_allowed_by_exit
 }

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -60,10 +60,8 @@ make_workdir() {
   WORKDIR=$(mktemp -d -t gaia-yaml-write-XXXXXX)
 }
 
-# Quote-safe delivery (mandatory, mirrors block-worktree-path-mismatch.bats):
-# pass $json and $HOOK_ABS as positional args to an inner bash -c rather than
-# re-wrapping in an outer single-quoted string, so embedded quotes/newlines in
-# a payload never terminate the wrapper early.
+# Payloads here carry both quotes and newlines, so delivery goes through
+# `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook_write() {
   local path="$1" content="$2"
   local json

--- a/.gaia/tests/hooks/block-invalid-yaml-write.bats
+++ b/.gaia/tests/hooks/block-invalid-yaml-write.bats
@@ -44,6 +44,7 @@ require_yaml_parser() {
 # CI branch's `return 1` fails each test individually and attaches its message,
 # rather than aborting the run.
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-invalid-yaml-write.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -67,33 +68,24 @@ run_hook_write() {
   local path="$1" content="$2"
   local json
   json=$(jq -n --arg p "$path" --arg c "$content" '{tool_name: "Write", tool_input: {file_path: $p, content: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_edit() {
   local path="$1" old="$2" new="$3"
   local json
   json=$(jq -n --arg p "$path" --arg o "$old" --arg n "$new" '{tool_name: "Edit", tool_input: {file_path: $p, old_string: $o, new_string: $n}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_multiedit() {
   local path="$1" edits_json="$2"
   local json
   json=$(jq -n --arg p "$path" --argjson e "$edits_json" '{tool_name: "MultiEdit", tool_input: {file_path: $p, edits: $e}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # --- the parser gate itself ---
 #
@@ -140,13 +132,13 @@ assert_allowed() {
 @test "Write of a .yaml file with a mid-sentence colon-space plain scalar is denied" {
   make_workdir
   run_hook_write "$WORKDIR/foo.yaml" $'title: fix this: it breaks\n'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Write of a .md file whose frontmatter has an unquoted colon-space value is denied" {
   make_workdir
   run_hook_write "$WORKDIR/foo.md" $'---\ndescription: works in isolation: its guarantees hold\n---\nbody\n'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- allowed: Write with valid YAML ---
@@ -154,25 +146,25 @@ assert_allowed() {
 @test "Write of a .yaml file with a properly quoted colon-space value is allowed" {
   make_workdir
   run_hook_write "$WORKDIR/foo.yaml" $'title: "fix this: it breaks"\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write of a .md file with valid frontmatter is allowed" {
   make_workdir
   run_hook_write "$WORKDIR/foo.md" $'---\nname: foo\ndescription: a normal description\n---\nbody\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write of a .md file with no frontmatter at all is allowed" {
   make_workdir
   run_hook_write "$WORKDIR/foo.md" $'# Just a heading\n\nSome prose: with a colon.\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write of a non-YAML, non-Markdown file is allowed (out of scope)" {
   make_workdir
   run_hook_write "$WORKDIR/foo.ts" $'const x: number = 1;\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- fail-open: an internal error never turns into a surprise deny ---
@@ -181,7 +173,7 @@ assert_allowed() {
   make_workdir
   printf 'title: caf\xe9 time\n' >"$WORKDIR/foo.yaml"
   run_hook_write "$WORKDIR/foo.yaml" $'title: valid\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- regression-only: pre-existing brokenness never locks out a file ---
@@ -190,14 +182,14 @@ assert_allowed() {
   make_workdir
   printf '%s' $'---\ndescription: works in isolation: its guarantees hold\n---\nold body\n' >"$WORKDIR/foo.md"
   run_hook_write "$WORKDIR/foo.md" $'---\ndescription: works in isolation: its guarantees hold\n---\nnew body\n'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Edit to the body of a file whose frontmatter is already broken is allowed" {
   make_workdir
   printf '%s' $'---\ndescription: works in isolation: its guarantees hold\n---\nold body\n' >"$WORKDIR/foo.md"
   run_hook_edit "$WORKDIR/foo.md" "old body" "new body, unrelated to the frontmatter"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Edit: reconstructs resulting content from the on-disk file ---
@@ -206,34 +198,34 @@ assert_allowed() {
   make_workdir
   printf '%s' $'---\ndescription: fine\n---\nbody\n' >"$WORKDIR/foo.md"
   run_hook_edit "$WORKDIR/foo.md" "description: fine" "description: works in isolation: its guarantees hold"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Edit that keeps frontmatter valid is allowed" {
   make_workdir
   printf '%s' $'---\ndescription: fine\n---\nbody\n' >"$WORKDIR/foo.md"
   run_hook_edit "$WORKDIR/foo.md" "description: fine" "description: still fine"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Edit introducing a space-hash comment truncation into a .yaml value is denied" {
   make_workdir
   printf '%s' $'title: sweep\n' >"$WORKDIR/foo.yaml"
   run_hook_edit "$WORKDIR/foo.yaml" "title: sweep" "title: sweep #9"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Edit on a file that does not exist yet fails open (allowed)" {
   make_workdir
   run_hook_edit "$WORKDIR/nope.yaml" "a" "b"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Edit whose old_string is not found in the current file fails open (allowed)" {
   make_workdir
   printf '%s' $'title: fine\n' >"$WORKDIR/foo.yaml"
   run_hook_edit "$WORKDIR/foo.yaml" "not-present-anywhere" "title: broken: value"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- MultiEdit ---
@@ -243,7 +235,7 @@ assert_allowed() {
   printf '%s' $'---\ndescription: fine\nother: ok\n---\nbody\n' >"$WORKDIR/foo.md"
   edits='[{"old_string":"description: fine","new_string":"description: fine"},{"old_string":"other: ok","new_string":"other: works in isolation: its guarantees hold"}]'
   run_hook_multiedit "$WORKDIR/foo.md" "$edits"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "MultiEdit that keeps content valid is allowed" {
@@ -251,7 +243,7 @@ assert_allowed() {
   printf '%s' $'---\ndescription: fine\nother: ok\n---\nbody\n' >"$WORKDIR/foo.md"
   edits='[{"old_string":"description: fine","new_string":"description: still fine"},{"old_string":"other: ok","new_string":"other: still ok"}]'
   run_hook_multiedit "$WORKDIR/foo.md" "$edits"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- ignored: not our matcher ---
@@ -260,8 +252,8 @@ assert_allowed() {
   make_workdir
   local json
   json=$(jq -n --arg p "$WORKDIR/foo.yaml" '{tool_name: "Read", tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
-  assert_allowed
+  invoke_hook "$json" "$HOOK_ABS"
+  assert_allowed_by_json
 }
 
 # --- structural ---

--- a/.gaia/tests/hooks/block-main-destructive-git.bats
+++ b/.gaia/tests/hooks/block-main-destructive-git.bats
@@ -15,6 +15,7 @@
 # cwd). The hook always exits 0; allow vs deny is carried in stdout.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-main-destructive-git.sh"
 
@@ -53,49 +54,41 @@ run_hook() {
   local cmd="$1"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$REPO" "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"permissionDecision": "deny"'* ]]
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [[ "$output" != *'"permissionDecision": "deny"'* ]]
-}
 
 # --- denied ---
 
 @test "git commit on main is denied" {
   on_main
   run_hook 'git commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "plain git push from main is denied" {
   on_main
   run_hook 'git push'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git push origin main (refspec) is denied from a feature branch" {
   on_feature
   run_hook 'git push origin main'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "force-push to main is denied from a feature branch" {
   on_feature
   run_hook 'git push --force origin main'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "home-repo git -C commit on main is denied" {
   on_main
   run_hook "git -C $REPO commit -m \"x\""
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- allowed ---
@@ -103,31 +96,31 @@ assert_allowed() {
 @test "git commit on a feature branch is allowed" {
   on_feature
   run_hook 'git commit -m "x"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "git push origin feature from a feature branch is allowed" {
   on_feature
   run_hook 'git push origin feature'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "plain git push from a feature branch is allowed" {
   on_feature
   run_hook 'git push'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "foreign-repo commit is allowed even though it targets main" {
   on_main
   run_hook "git -C $FOREIGN commit -m \"x\""
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a non-git command is ignored" {
   on_main
   run_hook 'pnpm run build'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- setup standdown: the .gaia/local/setup-in-progress sentinel suspends ---
@@ -138,7 +131,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local"
   touch "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git commit -m "x"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "setup sentinel allows git push origin main from main" {
@@ -146,7 +139,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local"
   touch "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git push origin main'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "enforcement resumes once the setup sentinel is removed" {
@@ -154,10 +147,10 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local"
   touch "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git commit -m "x"'
-  assert_allowed
+  assert_allowed_by_json
   rm -f "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "setup sentinel is a total standdown: force-push to main is allowed" {
@@ -165,7 +158,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local"
   touch "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git push --force origin main'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a stale setup sentinel self-heals: enforcement resumes without removal" {
@@ -176,7 +169,7 @@ assert_allowed() {
   # crashed before cleanup must NOT keep main-branch protection suspended.
   touch -t 200001010000 "$REPO/.gaia/local/setup-in-progress"
   run_hook 'git commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- command-position anchoring: the words appear, but git is not the program ---
@@ -184,19 +177,19 @@ assert_allowed() {
 @test "grep for the text 'git commit' is allowed on main" {
   on_main
   run_hook 'grep -n -e git commit app/foo.ts'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "echo of 'git push origin main' is allowed on main" {
   on_main
   run_hook 'echo "git push origin main"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "echo 'git commit' piped to grep is allowed on main" {
   on_main
   run_hook 'echo git commit && grep -n foo bar'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- command-position anchoring still catches real invocations ---
@@ -204,11 +197,11 @@ assert_allowed() {
 @test "git commit after an unrelated piped command is denied on main" {
   on_main
   run_hook 'echo hi | git commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git push origin main after && is denied" {
   on_feature
   run_hook 'true && git push origin main'
-  assert_denied
+  assert_denied_by_json
 }

--- a/.gaia/tests/hooks/block-manifest-write.bats
+++ b/.gaia/tests/hooks/block-manifest-write.bats
@@ -17,12 +17,9 @@ setup() {
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
 }
 
-# Quote-safe delivery (mandatory): several payloads below carry Bash commands
-# that contain single quotes of their own (echo '{}' > ..., sed -i '' ..., a
-# jq '...' filter). Re-wrapping $json in an outer single-quoted `bash -c '...'`
-# string would let those embedded quotes terminate the wrapper early and strip
-# the inner quoting before it reaches the hook. Passing $json and $HOOK_ABS as
-# positional args instead means no re-quoting happens.
+# Several payloads below carry Bash commands with single quotes of their own
+# (echo '{}' > ..., sed -i '' ..., a jq '...' filter), so delivery goes through
+# `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook_edit() {
   local tool="$1" path="$2"
   local json

--- a/.gaia/tests/hooks/block-manifest-write.bats
+++ b/.gaia/tests/hooks/block-manifest-write.bats
@@ -11,6 +11,7 @@
 # carrying the allow/deny decision in stdout JSON.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-manifest-write.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -26,75 +27,67 @@ run_hook_edit() {
   local tool="$1" path="$2"
   local json
   json=$(jq -n --arg t "$tool" --arg p "$path" '{tool_name: $t, tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_bash() {
   local cmd="$1"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"permissionDecision": "deny"'* ]]
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [[ "$output" != *'"permissionDecision": "deny"'* ]]
-}
 
 # --- denied: edit tools, no exemption ---
 
 @test "Edit on .gaia/manifest.json is denied" {
   run_hook_edit "Edit" ".gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Write on .gaia/manifest.json is denied" {
   run_hook_edit "Write" ".gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "MultiEdit on .gaia/manifest.json is denied" {
   run_hook_edit "MultiEdit" ".gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Edit on an absolute path ending /.gaia/manifest.json is denied" {
   run_hook_edit "Edit" "/Users/you/projects/my-app/.gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- allowed: edit tools ---
 
 @test "Edit on .gaia/manifest.json.tmp is allowed" {
   run_hook_edit "Edit" ".gaia/manifest.json.tmp"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Edit on .gaia/manifest.json.bak is allowed" {
   run_hook_edit "Edit" ".gaia/manifest.json.bak"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write on public/site.webmanifest is allowed" {
   run_hook_edit "Write" "public/site.webmanifest"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Edit on an unrelated plan README is allowed" {
   run_hook_edit "Edit" ".gaia/local/plans/x/README.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- denied: Bash write vectors, no marker ---
 
 @test "jq rewrite redirected back into the manifest is denied" {
   run_hook_bash "jq '.files += {\"app/x.tsx\":\"owned\"}' .gaia/manifest.json > .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "echo redirect overwriting the manifest is denied (quote-safety canary)" {
@@ -102,172 +95,172 @@ assert_allowed() {
   # here proves the harness's quote-safe delivery is wired correctly, not
   # just that the guard logic works.
   run_hook_bash "echo '{}' > .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "append redirect onto the manifest is denied" {
   run_hook_bash "cat frag >> .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "sed -i with a macOS empty backup suffix targeting the manifest is denied" {
   run_hook_bash "sed -i '' 's/a/b/' .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "sed -i (GNU, no backup suffix) targeting the manifest is denied" {
   run_hook_bash "sed -i 's/a/b/' .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "cp with the manifest as destination is denied" {
   run_hook_bash "cp /tmp/x.json .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "mv with the manifest as destination is denied" {
   run_hook_bash "mv /tmp/x.json .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "tee targeting the manifest is denied" {
   run_hook_bash "tee .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "sponge targeting the manifest is denied" {
   run_hook_bash "jq '.files' .gaia/manifest.json | sponge .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a quoted redirect target is still denied" {
   run_hook_bash 'echo x > ".gaia/manifest.json"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "marker as an echo argument does not exempt the redirect it precedes" {
   run_hook_bash 'echo GAIA_MANIFEST_WRITE=hi > .gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "marker inside a quoted string does not exempt the redirect it precedes" {
   # Quote-safe delivery (mandatory): the command text carries its own double
   # quotes around the marker.
   run_hook_bash 'echo "GAIA_MANIFEST_WRITE=x" > .gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a marked segment does not exempt a later unmarked segment after &&" {
   run_hook_bash "GAIA_MANIFEST_WRITE=1 echo ok && sed -i '' 's/a/b/' .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "marker inside a sed script does not exempt the in-place edit" {
   run_hook_bash "sed -i '' 's/GAIA_MANIFEST_WRITE=//' .gaia/manifest.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: multi-line commands ---
 
 @test "a redirect write on line 2 of a multi-line command is denied" {
   run_hook_bash $'echo ok\nprintf x > .gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a marker on line 1 does not exempt an unmarked write on line 2" {
   run_hook_bash $'GAIA_MANIFEST_WRITE=1 echo ok\nsed -i \'\' \'s/a/b/\' .gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a blank line between statements does not break detection of a later write" {
   run_hook_bash $'echo prep\n\nprintf x > .gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: no-space redirect shapes ---
 
 @test "a no-space redirect (>path, no space after >) onto the manifest is denied" {
   run_hook_bash 'echo x >.gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a no-space append redirect (>>path, no space after >>) onto the manifest is denied" {
   run_hook_bash 'echo x >>.gaia/manifest.json'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a no-space redirect with a \$(...) prefix in the target is denied" {
   run_hook_bash 'echo x >"$(pwd)/.gaia/manifest.json"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a no-space redirect to a manifest-adjacent path is still allowed" {
   run_hook_bash 'echo x >.gaia/manifest.json.bak'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: Bash with the GAIA_MANIFEST_WRITE= exemption marker ---
 
 @test "marked release cp is allowed" {
   run_hook_bash 'GAIA_MANIFEST_WRITE=release cp "$LATEST_DIR/.gaia/manifest.json" .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a marked write on line 2 of a multi-line command is allowed" {
   run_hook_bash $'echo prep\nGAIA_MANIFEST_WRITE=release cp x .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "marked remove-i18n jq step is allowed" {
   run_hook_bash "GAIA_MANIFEST_WRITE=remove-i18n jq 'del(.files[\"app/i18n.ts\"])' .gaia/manifest.json > .gaia/manifest.json.tmp"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "marked remove-i18n mv step is allowed" {
   run_hook_bash 'GAIA_MANIFEST_WRITE=remove-i18n mv .gaia/manifest.json.tmp .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "marker among multiple leading env assignments is still exempt" {
   run_hook_bash 'FOO=1 GAIA_MANIFEST_WRITE=release cp x .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: Bash with no write vector (legitimate reads / release CLI) ---
 
 @test "the release CLI mentioning manifest with no write vector is allowed" {
   run_hook_bash '.gaia/cli/gaia-maintainer release manifest'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cat of the manifest is allowed" {
   run_hook_bash 'cat .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "jq read of the manifest is allowed" {
   run_hook_bash "jq '.files' .gaia/manifest.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "grep over the manifest is allowed" {
   run_hook_bash 'grep owned .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "git add of the manifest is allowed" {
   run_hook_bash 'git add .gaia/manifest.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "cp with the manifest as source (not destination) is allowed" {
   run_hook_bash 'cp .gaia/manifest.json /tmp/backup.json'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "redirect to a different manifest-adjacent path is allowed" {
   run_hook_bash 'echo x > .gaia/manifest.json.bak'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- structural ---

--- a/.gaia/tests/hooks/block-no-verify.bats
+++ b/.gaia/tests/hooks/block-no-verify.bats
@@ -18,6 +18,7 @@
 # output and those assertions would fail rather than false-pass.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-no-verify.sh"
 
@@ -54,81 +55,73 @@ run_hook() {
   local cmd="$1"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$REPO" "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  [[ "$output" == *'"permissionDecision": "deny"'* ]]
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [[ "$output" != *'"permissionDecision": "deny"'* ]]
-}
 
 # --- denied ---
 
 @test "git commit --no-verify is denied" {
   run_hook 'git commit --no-verify -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git commit -n is denied" {
   run_hook 'git commit -n -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git commit with bundled short flags -anm is denied" {
   run_hook 'git commit -anm "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "HUSKY=0 git commit is denied" {
   run_hook 'HUSKY=0 git commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git -c core.hooksPath=/dev/null commit is denied" {
   run_hook 'git -c core.hooksPath=/dev/null commit -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "git push --no-verify is denied" {
   run_hook 'git push --no-verify'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "HUSKY=0 git push is denied" {
   run_hook 'HUSKY=0 git push origin feature'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- allowed ---
 
 @test "plain git commit on a feature branch is allowed" {
   run_hook 'git commit -m "x"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "git push -n (dry-run) is allowed" {
   run_hook 'git push -n origin feature'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "git push --dry-run is allowed" {
   run_hook 'git push --dry-run origin feature'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "plain git push on a feature branch is allowed" {
   run_hook 'git push origin feature'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "HUSKY=1 git commit is allowed (enabling is not a bypass)" {
   run_hook 'HUSKY=1 git commit -m "x"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "home-repo git -C commit (no bypass) is allowed" {
@@ -136,22 +129,22 @@ assert_allowed() {
   # `git -C <home> commit` must pass; only lowercase `-c core.hooksPath=`
   # (the next test) carries a bypass.
   run_hook "git -C $REPO commit -m \"x\""
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "foreign-repo commit with a bypass is allowed (out of scope)" {
   run_hook "git -C $FOREIGN commit --no-verify -m \"x\""
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a non-commit/push git command with a hooksPath override is ignored" {
   run_hook 'git -c core.hooksPath=/dev/null status'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a non-git command is ignored" {
   run_hook 'pnpm run build'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- command-position anchoring: the words appear, but git is not the program ---
@@ -160,37 +153,37 @@ assert_allowed() {
   # The reported false positive: -n belongs to grep, 'git commit' is the search
   # pattern. git is not in command position, so nothing fires.
   run_hook 'grep -n -e git commit app/foo.ts'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "echo of 'git commit' piped to grep -n is allowed" {
   run_hook 'echo git commit && grep -n foo bar'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "real git commit followed by grep -n is allowed (-n is grep's)" {
   # -n is scoped to the git segment; the grep on the other side of && is inert.
   run_hook 'git commit -m "x" && grep -n foo bar'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "tail -n over a file path containing 'commit' is allowed" {
   run_hook 'tail -n 5 git-commit-notes.txt'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- command-position anchoring still catches real bypasses ---
 
 @test "git commit -n after an unrelated piped command is denied" {
   run_hook 'echo hi | git commit -n -m "x"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "bypass orphaned by a pipe inside the commit message is still denied" {
   # Segment-splitting on the quoted '|' would orphan --no-verify from its git
   # segment; the whole-command safety net re-asserts it.
   run_hook 'git commit -m "a|b" --no-verify'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- deny message names the documented over-block case ---
@@ -202,7 +195,7 @@ assert_allowed() {
   # flag position) so this test pins the message that case actually gets,
   # not the message a real bypass gets from an identical-looking command.
   run_hook 'git commit -m "use --no-verify next time"'
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "documented over-block" <<<"$output" || return 1
 }
 
@@ -211,7 +204,7 @@ assert_allowed() {
   # to commit, since push carries no message text a token could be mentioned
   # inside.
   run_hook 'git push --no-verify'
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "documented over-block" <<<"$output" && return 1
   return 0
 }

--- a/.gaia/tests/hooks/block-rm-rf.bats
+++ b/.gaia/tests/hooks/block-rm-rf.bats
@@ -24,11 +24,11 @@ setup() {
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
 }
 
-# Quote-safe delivery (mandatory): every payload here is about quoting, so the
-# command text must reach the hook byte-for-byte. Passing $json and $HOME_ABS
-# as positional args means no outer re-quoting can strip the inner quotes
-# under test. Payloads are written in single quotes so `$HOME` stays the
-# literal 5-character string the guard must match, never this machine's home.
+# Every payload here is about quoting, so the command text must reach the hook
+# byte-for-byte: delivery goes through `invoke_hook` (helpers/run-hook.sh)
+# rather than any local variant. Payloads are written in single quotes so
+# `$HOME` stays the literal 5-character string the guard must match, never this
+# machine's home.
 run_hook_bash() {
   local cmd="$1"
   local json

--- a/.gaia/tests/hooks/block-rm-rf.bats
+++ b/.gaia/tests/hooks/block-rm-rf.bats
@@ -18,6 +18,7 @@
 # the quotes sit inside the token rather than around it.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-rm-rf.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -32,26 +33,16 @@ run_hook_bash() {
   local cmd="$1"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # Asserts the deny fired for the *stated* reason, not merely that some deny
 # fired. Without this, a target denied by the wrong case arm (say, `$HOME`
 # caught by the absolute-path arm) still reads as a pass.
 assert_denied_because() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
+  assert_denied_by_json
   grep -qF -- "$1" <<<"$output"
 }
 
@@ -59,57 +50,57 @@ assert_denied_because() {
 
 @test "rm -rf / is denied" {
   run_hook_bash 'rm -rf /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \$HOME is denied" {
   run_hook_bash 'rm -rf $HOME'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf ~ is denied" {
   run_hook_bash 'rm -rf ~'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf ~/ is denied" {
   run_hook_bash 'rm -rf ~/'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \$HOME/projects is denied" {
   run_hook_bash 'rm -rf $HOME/projects'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf . is denied" {
   run_hook_bash 'rm -rf .'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf * is denied" {
   run_hook_bash 'rm -rf *'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf .git is denied" {
   run_hook_bash 'rm -rf .git'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf node_modules is denied" {
   run_hook_bash 'rm -rf node_modules'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -fr / (reversed flags) is denied" {
   run_hook_bash 'rm -fr /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm --no-preserve-root -rf / is denied" {
   run_hook_bash 'rm --no-preserve-root -rf /'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: double-quoted targets ---
@@ -120,66 +111,66 @@ assert_denied_because() {
 
 @test "rm -rf \"\$HOME\" (quoted) is denied" {
   run_hook_bash 'rm -rf "$HOME"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"/\" (quoted) is denied" {
   run_hook_bash 'rm -rf "/"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \".\" (quoted) is denied" {
   run_hook_bash 'rm -rf "."'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"*\" (quoted) is denied" {
   run_hook_bash 'rm -rf "*"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"~\" (quoted) is denied" {
   run_hook_bash 'rm -rf "~"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \".git\" (quoted) is denied" {
   run_hook_bash 'rm -rf ".git"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"node_modules\" (quoted) is denied" {
   run_hook_bash 'rm -rf "node_modules"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"\$HOME/projects\" (fully quoted path) is denied" {
   run_hook_bash 'rm -rf "$HOME/projects"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"\$HOME\"/projects (quotes inside the token) is denied" {
   # Quoting only the expansion and leaving the rest bare is just as idiomatic,
   # and leaves the quote characters mid-token rather than surrounding it.
   run_hook_bash 'rm -rf "$HOME"/projects'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: single-quoted targets ---
 
 @test "rm -rf '\$HOME' (single-quoted) is denied" {
   run_hook_bash "rm -rf '\$HOME'"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf '/' (single-quoted) is denied" {
   run_hook_bash "rm -rf '/'"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf '.git' (single-quoted) is denied" {
   run_hook_bash "rm -rf '.git'"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: the ${HOME} brace form ---
@@ -190,22 +181,22 @@ assert_denied_because() {
 
 @test "rm -rf \${HOME} (brace form) is denied" {
   run_hook_bash 'rm -rf ${HOME}'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"\${HOME}\" (quoted brace form) is denied" {
   run_hook_bash 'rm -rf "${HOME}"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \"\${HOME}/projects\" (quoted brace path) is denied" {
   run_hook_bash 'rm -rf "${HOME}/projects"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm -rf \${HOME}/.config (brace path) is denied" {
   run_hook_bash 'rm -rf ${HOME}/.config'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: a dangerous target in a non-first rm segment ---
@@ -216,22 +207,22 @@ assert_denied_because() {
 
 @test "a dangerous target in the second rm segment (&&) is denied" {
   run_hook_bash 'rm -rf dist && rm -rf /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a dangerous target in the second rm segment (;) is denied" {
   run_hook_bash 'rm -rf dist ; rm -rf ~'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a dangerous target in the second rm segment (||) is denied" {
   run_hook_bash 'rm -rf dist || rm -rf .git'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a dangerous target in the third rm segment is denied" {
   run_hook_bash 'cd /tmp && rm -rf build && rm -rf $HOME'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: operand-first flag order ---
@@ -242,17 +233,17 @@ assert_denied_because() {
 
 @test "rm \$HOME -rf (operand before flags) is denied" {
   run_hook_bash 'rm $HOME -rf'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm .git -rf (operand before flags) is denied" {
   run_hook_bash 'rm .git -rf'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm ~ -rf (operand before flags) is denied" {
   run_hook_bash 'rm ~ -rf'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: backslash-newline continuations ---
@@ -265,25 +256,25 @@ assert_denied_because() {
 @test "a continuation-line \$HOME target is denied" {
   run_hook_bash 'rm -rf \
   $HOME/.cache/foo'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation-line root target is denied" {
   run_hook_bash 'rm -rf \
   /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation-line quoted brace target is denied" {
   run_hook_bash 'rm -rf \
   "${HOME}"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation split between rm and its flags is denied" {
   run_hook_bash 'rm \
   -rf /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a benign continuation-line cleanup is allowed" {
@@ -291,7 +282,7 @@ assert_denied_because() {
   run_hook_bash 'rm -rf \
   dist \
   build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A continuation may split a token mid-word. Bash removes the backslash-newline
@@ -302,25 +293,25 @@ assert_denied_because() {
 @test "a continuation splitting \$HOME mid-token is denied" {
   run_hook_bash 'rm -rf $HOM\
 E'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation splitting a quoted \$HOME mid-token is denied" {
   run_hook_bash 'rm -rf "$HO\
 ME"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation splitting node_modules mid-token is denied" {
   run_hook_bash 'rm -rf node_modul\
 es'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a continuation splitting .git mid-token is denied" {
   run_hook_bash 'rm -rf .gi\
 t'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: backslash-escaped targets ---
@@ -366,17 +357,17 @@ t'
   # The bare form carries no -r/-f at all, so only the widened short-circuit
   # reaches it. The -rf variant above does not cover this path.
   run_hook_bash 'rm --no-preserve-root /'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "rm \${HOME} -rf (brace form, operand first) is denied" {
   run_hook_bash 'rm ${HOME} -rf'
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- denied: for the right reason ---
 #
-# assert_denied alone cannot tell a correct deny from a deny by the wrong arm.
+# assert_denied_by_json alone cannot tell a correct deny from a deny by the wrong arm.
 
 @test "\$HOME denies via the \$HOME arm, not the absolute-path arm" {
   run_hook_bash 'rm -rf "$HOME"'
@@ -718,27 +709,27 @@ t'
 
 @test "/bin/rm -rf dist (path-qualified word, whitelisted target) is allowed" {
   run_hook_bash '/bin/rm -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "/usr/bin/rm -rf dist (path-qualified word, whitelisted target) is allowed" {
   run_hook_bash '/usr/bin/rm -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "/bin/RM -rf dist (path-qualified, uppercase word) is allowed" {
   run_hook_bash '/bin/RM -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "/bin/rm -rf build/output (path-qualified word) is allowed" {
   run_hook_bash '/bin/rm -rf build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "echo hi && /bin/rm -rf dist (path-qualified word in a later segment) is allowed" {
   run_hook_bash 'echo hi && /bin/rm -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The dangerous shapes must still deny, and must deny via the TARGET's own arm.
@@ -784,33 +775,33 @@ t'
 
 @test "rm -rf .gaia/local/plans/x is allowed" {
   run_hook_bash 'rm -rf .gaia/local/plans/x'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf .gaia/local/cache/x is allowed" {
   run_hook_bash 'rm -rf .gaia/local/cache/x'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf dist is allowed" {
   run_hook_bash 'rm -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf build/output is allowed" {
   run_hook_bash 'rm -rf build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf \"dist\" (quoted whitelist entry) is allowed" {
   # Quote-stripping must not turn a benign quoted target into a denial.
   run_hook_bash 'rm -rf "dist"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf ./\"dist\" (quotes inside a benign token) is allowed" {
   run_hook_bash 'rm -rf ./"dist"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: the ABSOLUTE spelling of a whitelisted scratch path ---
@@ -830,22 +821,22 @@ t'
 
 @test "rm -f of an absolute .gaia/local/audit path is allowed" {
   run_hook_bash 'rm -f /Users/you/projects/my-app/.gaia/local/audit/issue-body-x.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf of an absolute .gaia/local/plans path is allowed" {
   run_hook_bash 'rm -rf /Users/you/projects/my-app/.gaia/local/plans/x'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf of an absolute dist path is allowed" {
   run_hook_bash 'rm -rf /Users/you/projects/my-app/dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf of an absolute build path is allowed" {
   run_hook_bash 'rm -rf /Users/you/projects/my-app/build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The suffix match must not reach up to a filesystem-root directory. `/dist` is a
@@ -910,7 +901,7 @@ t'
   # Collapsing the dot segment must land the token ON the whitelist, not merely
   # off the deny arm: this is the same directory as the plain spelling.
   run_hook_bash 'rm -rf /Users/you/projects/my-app/./dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A `..` segment makes an absolute path resolve somewhere the spelling does not
@@ -943,24 +934,24 @@ t'
 
 @test "rm -rf of worktree scratch under .gaia/local is allowed" {
   run_hook_bash 'rm -rf /Users/you/projects/my-app/.claude/worktrees/c-text-matcher-guards/.gaia/local/audit/issue-body.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -f of worktree scratch under .gaia/local is allowed" {
   run_hook_bash 'rm -f /Users/you/projects/my-app/.claude/worktrees/c-text-matcher-guards/.gaia/local/audit/issue-body.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "flagless rm of worktree scratch under .gaia/local is allowed" {
   run_hook_bash 'rm /Users/you/projects/my-app/.claude/worktrees/c-text-matcher-guards/.gaia/local/audit/issue-body.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "the same scratch path resolved to the main checkout is allowed" {
   # `.gaia/local/audit` is a symlink out of the worktree, so an agent may spell
   # either end of it. Both are the same directory and both must be allowed.
   run_hook_bash 'rm -f /Users/you/projects/my-app/.gaia/local/audit/issue-body.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- a hyphenated PATH COMPONENT is not a destructive flag ---
@@ -977,12 +968,12 @@ t'
 
 @test "a hyphenated path component ending in r is not read as a flag" {
   run_hook_bash 'rm /Users/you/projects/my-matcher/notes.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a hyphenated path component ending in f is not read as a flag" {
   run_hook_bash 'rm /Users/you/projects/my-perf/notes.md'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm \"-rf\" / (quoted flag) is still denied" {
@@ -1021,7 +1012,7 @@ t'
 
 @test "an unflagged rm segment is not judged on a sibling's flag" {
   run_hook_bash 'rm -rf dist && rm /abs/path/file'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a heredoc quoting shell-cwd.md's own example beside a real rm -rf is allowed" {
@@ -1029,7 +1020,7 @@ t'
 cat > /tmp/body.md <<EOF
 - `rm /abs/path/file`, not `cd /abs/path && rm file`
 EOF'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a FLAGGED sibling segment is still judged" {
@@ -1051,31 +1042,31 @@ EOF'
 
 @test "rm -rf on an unknown relative path is allowed" {
   run_hook_bash 'rm -rf some/scratch/dir'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf on an unrelated quoted variable is allowed" {
   run_hook_bash 'rm -rf "$SCRATCH_DIR"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf \${HOMEBREW_PREFIX} (a \$HOME-prefixed neighbour) is allowed" {
   # The brace arms must be anchored, not prefix matches: a variable whose name
   # merely starts with HOME is not $HOME.
   run_hook_bash 'rm -rf ${HOMEBREW_PREFIX}'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf \${PWD}/dist (a \$PWD-prefixed whitelist entry) is allowed" {
   # `$PWD/x` IS `x`, so rewriting the prefix must land this on the dist
   # whitelist. Denying every $PWD path would be the easy over-fix.
   run_hook_bash 'rm -rf ${PWD}/dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf \$PWD/.gaia/local/cache/x is allowed" {
   run_hook_bash 'rm -rf $PWD/.gaia/local/cache/x'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: globs and dots the dotfile-glob arm must not swallow ---
@@ -1086,56 +1077,56 @@ EOF'
 
 @test "rm -rf .gaia/local/plans/* (a glob inside a whitelisted path) is allowed" {
   run_hook_bash 'rm -rf .gaia/local/plans/*'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf .gaia/local/audit/*/findings is allowed" {
   run_hook_bash 'rm -rf .gaia/local/audit/*/findings'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf .gitignore (a dotfile with no glob) is allowed" {
   # Starting with a dot is not the hazard; expanding in the cwd is.
   run_hook_bash 'rm -rf .gitignore'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf dist/{a,b} (a scoped brace list with no glob) is allowed" {
   run_hook_bash 'rm -rf dist/{a,b}'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: quoted separators must not manufacture a denial ---
 
 @test "a benign chain whose first command carries a quoted ; is allowed" {
   run_hook_bash 'echo "a;b" && rm -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a benign quoted chain is still split on its real separators" {
   run_hook_bash 'rm -rf dist && rm -rf "build/output"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a benign multi-segment rm chain is allowed" {
   # Inspecting every segment must not turn an ordinary cleanup chain into a deny.
   run_hook_bash 'rm -rf dist && rm -rf build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm -rf node_modules_backup (a node_modules-prefixed neighbour) is allowed" {
   run_hook_bash 'rm -rf node_modules_backup'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "rm without -rf is allowed" {
   run_hook_bash 'rm file.txt'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a command with no rm at all is allowed" {
   run_hook_bash 'ls -la node_modules'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: the .claude arm must not swallow its neighbours ---
@@ -1144,7 +1135,7 @@ EOF'
   # The arm is anchored, not a prefix match: a directory whose name merely starts
   # with `.claude` is not `.claude`.
   run_hook_bash 'rm -rf .claudia'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: the command-word rule must not manufacture a denial ---
@@ -1155,34 +1146,34 @@ EOF'
 
 @test "RM file.txt (uppercase word, no -rf) is allowed" {
   run_hook_bash 'RM file.txt'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "r\"\"m file.txt (quote-split word, no -rf) is allowed" {
   run_hook_bash 'r""m file.txt'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "RM -rf dist (uppercase word, whitelisted target) is allowed" {
   run_hook_bash 'RM -rf dist'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "r\"\"m -rf build/output (quote-split word, whitelisted target) is allowed" {
   run_hook_bash 'r""m -rf build/output'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "charm -rf x (a word merely ENDING in rm) is allowed" {
   # The leading boundary is what keeps the widened command-word match from firing
   # on every word that happens to contain `rm`.
   run_hook_bash 'charm -rf x'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "git commit -m \"warm restart\" (rm inside a word) is allowed" {
   run_hook_bash 'git commit -m "warm restart"'
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- the walk's position-preserving invariant, asserted directly ---

--- a/.gaia/tests/hooks/block-secrets-write.bats
+++ b/.gaia/tests/hooks/block-secrets-write.bats
@@ -37,6 +37,7 @@
 # buries the oracle's real output under a warning that is correct for every hit.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-secrets-write.sh"
 }
@@ -48,14 +49,14 @@ run_hook_write() {
   local body="$1"
   local json
   json=$(jq -n --arg c "$body" '{tool_name: "Write", tool_input: {content: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_edit() {
   local body="$1"
   local json
   json=$(jq -n --arg s "$body" '{tool_name: "Edit", tool_input: {new_string: $s}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 # The two above carry no file_path, which is what every test written before the
@@ -66,7 +67,7 @@ run_hook_write_path() {
   local json
   json=$(jq -n --arg p "$path" --arg c "$body" \
     '{tool_name: "Write", tool_input: {file_path: $p, content: $c}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_edit_path() {
@@ -75,7 +76,7 @@ run_hook_edit_path() {
   local json
   json=$(jq -n --arg p "$path" --arg s "$body" \
     '{tool_name: "Edit", tool_input: {file_path: $p, new_string: $s}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 # MultiEdit sits on the same `Edit|Write|MultiEdit` matcher as the two above and
@@ -89,7 +90,7 @@ run_hook_multiedit_path() {
   local json
   json=$(jq -n --arg p "$path" --arg s "$body" \
     '{tool_name: "MultiEdit", tool_input: {file_path: $p, edits: [{new_string: $s}]}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 # A deny fixture that grows past one of rule 4's scan caps keeps passing while no
@@ -104,24 +105,18 @@ run_hook_multiedit_path() {
 # condition is FALSE. As a function's last command that inverts the whole
 # assertion, so it can only ever sit before one.
 assert_denied() {
-  [ "$status" -eq 0 ]
   grep -qF -- 'this guard judges in one write' <<<"$output" && return 1
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
+  assert_denied_by_json
 }
 
 # The opt-in variant, for the fixtures that cross a cap on purpose. Callers
 # follow it with a grep for the specific cap, since this one only pins that some
 # cap fired.
 assert_denied_cap() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
+  assert_denied_by_json
   grep -qF -- 'this guard judges in one write' <<<"$output"
 }
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  ! grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
 # --- The three secret-shaped patterns still deny ---
 
@@ -234,27 +229,27 @@ assert_allowed() {
 
 @test "an empty value is allowed" {
   run_hook_write "$(printf 'API_KEY=\n')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a bare \$VAR value is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '$MY_API_KEY')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a braced \${VAR} value is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '${MY_API_KEY}')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a named placeholder value is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' 'placeholder')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "content with no secret shape at all is allowed" {
   run_hook_write "export function add(a, b) { return a + b }"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The tightened arms have to stay usable: these are the placeholder values the
@@ -263,27 +258,27 @@ assert_allowed() {
 
 @test "an angle-bracket placeholder is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '<your-key-here>')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a your- placeholder is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' 'your-api-key-here')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a bare example placeholder is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' 'example')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an example domain placeholder is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' 'example.com')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an exported \$VAR value is allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$MY_API_KEY')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Recognizing the declaration keywords pulls shell lines into a rule written for
@@ -293,22 +288,22 @@ assert_allowed() {
 
 @test "an expansion carrying a default operator is allowed" {
   run_hook_write "$(printf 'export GITHUB_TOKEN=%s\n' '"${GITHUB_TOKEN:-}"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a positional expansion is allowed" {
   run_hook_write "$(printf 'local CACHE_KEY=%s\n' '"${1}"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an expansion followed by a literal path is allowed" {
   run_hook_write "$(printf 'readonly SIGNING_KEY=%s\n' '"${REPO_ROOT}/dev.pem"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a named fake placeholder is allowed" {
   run_hook_write "$(printf 'export GH_TOKEN=%s\n' '"fake-token"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The expansion allowance is bounded by the same segment rule as the placeholder
@@ -381,12 +376,12 @@ assert_allowed() {
 
 @test "a long but segmented your- placeholder is allowed" {
   run_hook_write "$(printf 'GITHUB_TOKEN=%s\n' 'your-github-personal-access-token')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an underscore-segmented your_ placeholder is allowed" {
   run_hook_write "$(printf 'SUPABASE_ANON_KEY=%s\n' 'your_supabase_anon_key_here')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a short unbroken run behind a placeholder prefix is denied" {
@@ -409,17 +404,17 @@ assert_allowed() {
 
 @test "a value that is wholly a command substitution is allowed" {
   run_hook_write "$(printf 'AUDIT_KEY="%s"\n' '$(gaia_audit_key "$BASE_SHA")')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an unquoted command substitution value is allowed" {
   run_hook_write "$(printf 'SESSION_TOKEN=%s\n' '$(mint_token)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a command substitution is allowed through Edit too" {
   run_hook_edit "$(printf 'AUDIT_KEY="%s"\n' '$(gaia_audit_key "$BASE_SHA")')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- The declaration keyword carries its options ---
@@ -464,22 +459,22 @@ assert_allowed() {
 
 @test "a trailing comment does not defeat the value extraction" {
   run_hook_write "$(printf 'export GITHUB_TOKEN=%s\n' '"$GH_PAT" # for gh cli')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a trailing or-clause does not defeat the value extraction" {
   run_hook_write "$(printf 'local API_KEY=%s\n' '"$1" || true')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an unbraced positional is allowed" {
   run_hook_write "$(printf 'local API_KEY=%s\n' '"$1"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "two concatenated references are allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '"${A}${B}"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A trailing comment strips the comment, not the scan: a literal secret ahead of
@@ -520,7 +515,7 @@ assert_allowed() {
 
 @test "ordinary prose in a trailing comment is allowed" {
   run_hook_write "$(printf 'export GITHUB_TOKEN=%s\n' '"$GH_PAT" # authentication for the gh cli')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # `typeset` is bash's synonym for `declare`, so it belongs with the other three.
@@ -539,17 +534,17 @@ assert_allowed() {
 
 @test "an or-separator inside a command substitution is allowed" {
   run_hook_write "$(printf 'AUDIT_KEY=%s\n' '"$(gaia_audit_key "$BASE" "$ROOT" 2>/dev/null || true)"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an and-separator inside a command substitution is allowed" {
   run_hook_write "$(printf 'GH_TOKEN=%s\n' '$(gh auth token 2>/dev/null && :)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a separator inside an angle-bracket placeholder is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '<paste || generate>')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A separator inside the value AND a tail on the same line is the case the
@@ -561,17 +556,17 @@ assert_allowed() {
 
 @test "a guarded substitution ahead of a trailing comment is allowed" {
   run_hook_write "$(printf 'export GH_TOKEN=%s\n' '$(gh auth token 2>/dev/null || true) # for gh cli')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a guarded substitution ahead of an executable tail is allowed" {
   run_hook_write "$(printf 'local API_KEY=%s\n' '$(cat f || true) && echo done')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a quoted guarded substitution ahead of a comment is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '"$(gaia_audit_key "$B" "$R" 2>/dev/null || true)" # base key')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Masking the cut point widens nothing else, because the allowlist still reads
@@ -633,7 +628,7 @@ assert_allowed() {
 @test "a guarded substitution in a long value under the cap is allowed" {
   long=$(printf '%*s' 4000 '' | tr ' ' 'a')
   run_hook_write "$(printf 'export API_KEY=$(echo %s || true) # note\n' "$long")"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a value over the mask cap falls back to the raw cut" {
@@ -676,7 +671,7 @@ assert_allowed() {
 
 @test "an allowed assignment in an executable tail is allowed" {
   run_hook_write "$(printf 'API_KEY=%s\n' '$X ; OTHER_TOKEN=${Y}')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The fragment split is a `tr`, not a parser, so a `||` or `&&` INSIDE a parked
@@ -688,12 +683,12 @@ assert_allowed() {
 
 @test "a guarded substitution in a parked assignment is allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; export API_TOKEN=$(gh auth token 2>/dev/null || true)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an and-guarded substitution in a parked assignment is allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; export GH_TOKEN=$(gh auth token 2>/dev/null && :)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ...and the bound runs one way only. A sibling fragment carrying a literal is
@@ -722,7 +717,7 @@ assert_allowed() {
 
 @test "two guarded substitutions in one tail are allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; A_TOKEN=$(gh auth token 2>/dev/null || true) ; B_TOKEN=$(id -u 2>/dev/null || true)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The mask is not verdict-preserving: erasing a substitution body erases what
@@ -732,7 +727,7 @@ assert_allowed() {
 
 @test "an assignment inside a substitution body in a tail is allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; A_TOKEN=$(foo ; B_KEY=hunter2xyz123 )')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Second, the erased body takes an inner `>` with it, so a `<…>` wrapper that
@@ -743,7 +738,7 @@ assert_allowed() {
 
 @test "a bracket-wrapped substitution carrying a redirect in a tail is allowed" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; A_TOKEN=<$(gh auth token 2>/dev/null)>')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Erasing a body erases any assignment inside it, so the flag has to come off
@@ -755,7 +750,7 @@ assert_allowed() {
 
 @test "an assignment inside a substitution does not expose the tail to the shape rule" {
   run_hook_write "$(printf 'export API_KEY=%s\n' '$X ; OUT=$(cd repo ; export GH_TOKEN=$T ; git checkout 3ea35f1756b5375b0691436907e14ee8d2dbc43b)')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The same line, long enough that the flag pass's reader is still writing when
@@ -775,7 +770,7 @@ assert_allowed() {
   local filler
   filler=$(head -c 40000 < /dev/zero | tr '\0' 'a')
   run_hook_write "$(printf 'export API_KEY=%s\n' "\$X ; OUT=\$(cd repo ; export GH_TOKEN=\$T ; echo ${filler} ; git checkout 3ea35f1756b5375b0691436907e14ee8d2dbc43b)")"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ...and the shape backstop survives that split. A tail carrying no watched
@@ -803,7 +798,7 @@ assert_allowed() {
 @test "an allowed assignment in a secret-shaped executable tail is allowed" {
   local ref="LONGVARNAME""1234567"
   run_hook_write "$(printf 'API_KEY=%s\n' "\$X ; OTHER_TOKEN=\${$ref}")"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # `secret_shaped` is fed by process substitution for the same reason the flag
@@ -843,13 +838,13 @@ assert_allowed() {
 
 @test "a short placeholder assignment in .env.example is allowed" {
   run_hook_write_path '.env.example' "$(printf 'SESSION_SECRET=%s\n' 'local')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "the tracked .env.example content is allowed whole" {
   run_hook_write_path '.env.example' "$(printf '%s\n%s\n%s\n' \
     'SITE_URL=http://localhost:5173' 'SESSION_SECRET=local' 'MSW_ENABLED=true')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The values the ALLOWLIST would refuse and shape accepts. These are the whole
@@ -857,27 +852,27 @@ assert_allowed() {
 
 @test "an all-letter word in .env.example is allowed" {
   run_hook_write_path '.env.example' "$(printf 'SESSION_SECRET=%s\n' 'development')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a localhost URL in .env.example is allowed" {
   run_hook_write_path '.env.example' "$(printf 'API_KEY=%s\n' 'http://localhost:3001/api/')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a short value in .env.example is allowed through Edit too" {
   run_hook_edit_path '.env.example' "$(printf 'SESSION_SECRET=%s\n' '"local"')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a short value in .env.example is allowed through MultiEdit too" {
   run_hook_multiedit_path '.env.example' "$(printf 'SESSION_SECRET=%s\n' 'local')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a nested .env.example is matched by basename" {
   run_hook_write_path 'packages/api/.env.example' "$(printf 'SESSION_SECRET=%s\n' 'local')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ...and the values shape still refuses there. A committed file is the worst
@@ -913,7 +908,7 @@ assert_allowed() {
 @test "a segmented UUID-format value in .env.example is allowed" {
   run_hook_write_path '.env.example' \
     "$(printf 'API_KEY=%s\n' '550e8400-e29b-41d4-a716-446655440000')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "the same UUID-format value outside .env.example is denied" {
@@ -925,7 +920,7 @@ assert_allowed() {
 @test "a slash-broken value in .env.example is allowed" {
   run_hook_write_path '.env.example' \
     "$(printf 'API_KEY=%s\n' 'aB3xK9pQ7zR2/wL5tN8mV4cX/pQ7zR2wL5tN')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Dropping the allowlist drops the executable-tail rescan with it: the whole
@@ -944,7 +939,7 @@ assert_allowed() {
 @test "an executable tail in .env.example is judged by shape, not the rescan" {
   run_hook_write_path '.env.example' \
     "$(printf 'SESSION_SECRET=%s ; API_KEY=%s\n' 'local' 'abcd')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "the same executable tail outside .env.example is denied by the rescan" {
@@ -1047,7 +1042,7 @@ assert_allowed() {
 @test "a write at the matching-line cap is still judged" {
   many=$(for i in $(seq 1 200); do printf 'A%d_KEY=${FOO}\n' "$i"; done)
   run_hook_write "$many"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The test above passes both when all 200 lines were judged and when a
@@ -1101,7 +1096,7 @@ assert_allowed() {
 @test "a large write carrying few matching lines is allowed" {
   bulk=$(for i in $(seq 1 2500); do printf 'const value%d = "ordinary line";\n' "$i"; done)
   run_hook_write "$bulk$(printf '\nA_KEY=${FOO}\n')"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The size cap is what bounds the work, since one line can carry unboundedly
@@ -1118,7 +1113,7 @@ assert_allowed() {
 @test "a single matching line at the judged-size cap is still judged" {
   name=$(printf '%*s' 65527 '' | tr ' ' 'A')
   run_hook_write "$(printf 'A_KEY=${%s}\n' "$name")"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a single matching line one character over the judged-size cap is denied" {

--- a/.gaia/tests/hooks/block-secrets-write.bats
+++ b/.gaia/tests/hooks/block-secrets-write.bats
@@ -42,9 +42,9 @@ setup() {
   HOOK_ABS="$HOOKS_SRC/block-secrets-write.sh"
 }
 
-# Quote-safe delivery: the payloads below carry shell snippets with quotes of
-# their own, so $json and the hook path go in as positional args rather than
-# being re-wrapped in an outer quoted string.
+# The payloads below carry shell snippets with quotes of their own, so
+# delivery goes through `invoke_hook` (helpers/run-hook.sh) rather than any
+# local variant.
 run_hook_write() {
   local body="$1"
   local json

--- a/.gaia/tests/hooks/block-selfheal-paths.bats
+++ b/.gaia/tests/hooks/block-selfheal-paths.bats
@@ -23,10 +23,9 @@ setup() {
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
 }
 
-# Quote-safe delivery (mandatory, per block-manifest-write.bats precedent):
-# several payloads below carry Bash commands with their own single quotes
-# (sed -i '' ...). Passing $json and $HOOK_ABS as positional args to an
-# inner `bash -c` avoids re-quoting that would strip the embedded quoting.
+# Several payloads below carry Bash commands with their own single quotes
+# (sed -i '' ...), so delivery goes through `invoke_hook`
+# (helpers/run-hook.sh) rather than any local variant.
 run_hook_edit() {
   local agent="$1" tool="$2" path="$3"
   local json

--- a/.gaia/tests/hooks/block-selfheal-paths.bats
+++ b/.gaia/tests/hooks/block-selfheal-paths.bats
@@ -17,6 +17,7 @@
 # the allow/deny decision in stdout JSON.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-selfheal-paths.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -34,7 +35,7 @@ run_hook_edit() {
   else
     json=$(jq -n --arg t "$tool" --arg p "$path" '{tool_name: $t, tool_input: {file_path: $p}}')
   fi
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_bash() {
@@ -45,95 +46,86 @@ run_hook_bash() {
   else
     json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
   fi
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # --- the gate binds members, not the tree (criteria 5, 6) ---
 
 @test "no agent_type (main session / orchestrator): editing test/foo.ts is allowed" {
   run_hook_edit "" "Edit" "test/foo.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "no agent_type: editing .gaia/audit-ci.yml is allowed" {
   run_hook_edit "" "Edit" ".gaia/audit-ci.yml"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "no agent_type: editing .github/workflows/tests.yml is allowed" {
   run_hook_edit "" "Edit" ".github/workflows/tests.yml"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "agent_type general-purpose (non-member subagent): editing test/foo.ts is allowed" {
   run_hook_edit "general-purpose" "Edit" "test/foo.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- a member denied on the refused set, criteria 1, 2, 7 (UAT-026/UAT-027) ---
 
 @test "code-audit-frontend editing test/foo.ts is denied and names the path" {
   run_hook_edit "code-audit-frontend" "Edit" "test/foo.ts"
-  assert_denied
+  assert_denied_by_json
   grep -qF 'test/foo.ts' <<<"$output"
 }
 
 @test "code-audit-frontend editing .github/workflows/tests.yml is denied and names the path" {
   run_hook_edit "code-audit-frontend" "Edit" ".github/workflows/tests.yml"
-  assert_denied
+  assert_denied_by_json
   grep -qF '.github/workflows/tests.yml' <<<"$output"
 }
 
 @test "code-audit-frontend editing .gaia/audit-ci.yml is denied and names the path" {
   run_hook_edit "code-audit-frontend" "Edit" ".gaia/audit-ci.yml"
-  assert_denied
+  assert_denied_by_json
   grep -qF '.gaia/audit-ci.yml' <<<"$output"
 }
 
 @test "code-audit-frontend editing .claude/rules/foo.md is denied" {
   run_hook_edit "code-audit-frontend" "Edit" ".claude/rules/foo.md"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing wiki/concepts/Foo.md is denied" {
   run_hook_edit "code-audit-frontend" "Edit" "wiki/concepts/Foo.md"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing root package.json is denied" {
   run_hook_edit "code-audit-frontend" "Edit" "package.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing root tsconfig.base.json is denied" {
   run_hook_edit "code-audit-frontend" "Edit" "tsconfig.base.json"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing root vite.config.ts is denied" {
   run_hook_edit "code-audit-frontend" "Edit" "vite.config.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "an advisory member (code-audit-github-workflows) is denied on .github/workflows/tests.yml too" {
   run_hook_edit "code-audit-github-workflows" "Edit" ".github/workflows/tests.yml"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-maintainer-shell editing test/foo.ts is denied (every member, not just the self-healer)" {
   run_hook_edit "code-audit-maintainer-shell" "Edit" "test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- every test surface is refused, not just test/ ---
@@ -147,46 +139,46 @@ assert_allowed() {
 
 @test "code-audit-frontend editing .playwright/e2e/hydration.spec.ts is denied and names the path" {
   run_hook_edit "code-audit-frontend" "Edit" ".playwright/e2e/hydration.spec.ts"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- '.playwright/e2e/hydration.spec.ts' <<<"$output"
 }
 
 @test "code-audit-frontend editing .playwright/utils.ts is denied (the whole tree, not just e2e/)" {
   run_hook_edit "code-audit-frontend" "Edit" ".playwright/utils.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing .storybook/preview.ts is denied and names the path" {
   run_hook_edit "code-audit-frontend" "Edit" ".storybook/preview.ts"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- '.storybook/preview.ts' <<<"$output"
 }
 
 @test "code-audit-frontend editing .storybook/chromatic/decorator.tsx is denied" {
   run_hook_edit "code-audit-frontend" "Edit" ".storybook/chromatic/decorator.tsx"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend redirecting into a .playwright/ spec is denied" {
   run_hook_bash "code-audit-frontend" "echo x > .playwright/e2e/hydration.spec.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- an app-only edit still allowed, criterion 3 ---
 
 @test "code-audit-frontend editing app/foo.ts is allowed" {
   run_hook_edit "code-audit-frontend" "Edit" "app/foo.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write tool: code-audit-frontend writing app/Foo/index.tsx is allowed" {
   run_hook_edit "code-audit-frontend" "Write" "app/Foo/index.tsx"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "MultiEdit tool: code-audit-frontend editing test/foo.ts is denied" {
   run_hook_edit "code-audit-frontend" "MultiEdit" "test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- .gaia/local/ is the members' own gitignored artifact dir, never refused ---
@@ -197,39 +189,39 @@ assert_allowed() {
 
 @test "code-audit-frontend writing its findings sidecar under .gaia/local/audit/ is allowed" {
   run_hook_edit "code-audit-frontend" "Write" ".gaia/local/audit/2cea369b.code-audit-frontend.findings.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "code-audit-frontend writing its disposition sidecar under .gaia/local/audit/ is allowed" {
   run_hook_edit "code-audit-frontend" "Write" ".gaia/local/audit/abc123.dispositions.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Bash: code-audit-frontend redirecting into a .gaia/local/audit/ sidecar is allowed" {
   run_hook_bash "code-audit-frontend" "printf '%s' '{}' > .gaia/local/audit/abc123.dispositions.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "code-audit-frontend editing .gaia/localfoo/x.sh (a sibling, not the carve-out) is denied" {
   run_hook_edit "code-audit-frontend" "Edit" ".gaia/localfoo/x.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "code-audit-frontend editing .gaia/scripts/x.sh (machinery, not .gaia/local) is denied" {
   run_hook_edit "code-audit-frontend" "Edit" ".gaia/scripts/x.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- root vs nested build config, criterion 4 ---
 
 @test "code-audit-frontend editing nested app/foo.config.ts is allowed (root-only arm)" {
   run_hook_edit "code-audit-frontend" "Edit" "app/foo.config.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "code-audit-frontend editing nested app/package.json is allowed (root-only arm)" {
   run_hook_edit "code-audit-frontend" "Edit" "app/package.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- absolute paths relativize against the repo root ---
@@ -238,107 +230,107 @@ assert_allowed() {
   local repo_root
   repo_root=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   run_hook_edit "code-audit-frontend" "Edit" "$repo_root/test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "an absolute path OUTSIDE the repo root is left alone (allowed)" {
   run_hook_edit "code-audit-frontend" "Edit" "/tmp/some-other-place/test/foo.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- Bash write vectors ---
 
 @test "Bash: code-audit-frontend redirecting into test/foo.ts is denied" {
   run_hook_bash "code-audit-frontend" "echo x > test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend appending into .gaia/audit-ci.yml is denied" {
   run_hook_bash "code-audit-frontend" "cat frag >> .gaia/audit-ci.yml"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend tee into .github/workflows/tests.yml is denied" {
   run_hook_bash "code-audit-frontend" "tee .github/workflows/tests.yml"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend sponge into test/foo.ts is denied" {
   run_hook_bash "code-audit-frontend" "cat test/foo.ts | sponge test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend sed -i (macOS empty-suffix) on .gaia/audit-ci.yml is denied" {
   run_hook_bash "code-audit-frontend" "sed -i '' 's/a/b/' .gaia/audit-ci.yml"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend sed -i (GNU) on test/foo.ts is denied" {
   run_hook_bash "code-audit-frontend" "sed -i 's/a/b/' test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend cp with test/foo.ts as destination is denied" {
   run_hook_bash "code-audit-frontend" "cp /tmp/x.ts test/foo.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend mv with .github/workflows/x.yml as destination is denied" {
   run_hook_bash "code-audit-frontend" "mv /tmp/x.yml .github/workflows/x.yml"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Bash: code-audit-frontend cp with test/foo.ts as SOURCE (not destination) is allowed" {
   run_hook_bash "code-audit-frontend" "cp test/foo.ts /tmp/backup.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Bash: code-audit-frontend redirecting into app/foo.ts is allowed" {
   run_hook_bash "code-audit-frontend" "echo x > app/foo.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Bash: no agent_type, redirecting into .gaia/audit-ci.yml is allowed (orchestrator)" {
   run_hook_bash "" "echo x > .gaia/audit-ci.yml"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Bash: a plain git command with no write vector is allowed" {
   run_hook_bash "code-audit-frontend" "git status"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- the remit writer is an execution-shape refusal, not a write-shape one ---
 
 @test "SPEC-056 UAT-015: code-audit-frontend running the remit writer is denied" {
   run_hook_bash "code-audit-frontend" "bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "finding" <<<"$output"
 }
 
 @test "SPEC-056 UAT-015: an advisory member running the remit writer is denied too" {
   run_hook_bash "code-audit-maintainer-shell" "bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer invoked by an absolute path is denied" {
   run_hook_bash "code-audit-frontend" "bash /Users/you/projects/my-app/.gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer invoked with a leading ./ is denied" {
   run_hook_bash "code-audit-frontend" "bash ./.gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: no agent_type running the remit writer is allowed" {
   run_hook_bash "" "bash .gaia/scripts/write-audit-remits.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "SPEC-056 UAT-015: a non-member subagent running the remit writer is allowed" {
   run_hook_bash "general-purpose" "bash .gaia/scripts/write-audit-remits.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "SPEC-056 UAT-015: neither payload writes a file" {
@@ -353,7 +345,7 @@ assert_allowed() {
 
 @test "SPEC-056 UAT-015: running the roster CHECK is still allowed for a member" {
   run_hook_bash "code-audit-frontend" "bash .gaia/scripts/verify-audit-roster.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "SPEC-056 UAT-015: shellcheck naming the writer as an argument is allowed, not an invocation" {
@@ -363,44 +355,44 @@ assert_allowed() {
   # naming the writer as an argument must stay allowed, including the
   # shell auditor's own mandated methodology against this very file.
   run_hook_bash "code-audit-maintainer-shell" "shellcheck .gaia/scripts/write-audit-remits.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer invoked bare (no interpreter) is denied" {
   run_hook_bash "code-audit-frontend" ".gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer invoked after a && separator is denied" {
   run_hook_bash "code-audit-frontend" "true && bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- execution-position anchor: skip interpreter options and env assignments ---
 
 @test "SPEC-056 UAT-015: bash -x <writer> is denied" {
   run_hook_bash "code-audit-frontend" "bash -x .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: sh -x <writer> is denied" {
   run_hook_bash "code-audit-frontend" "sh -x .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: bash --norc <writer> is denied" {
   run_hook_bash "code-audit-frontend" "bash --norc .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: env FOO=1 <writer> is denied" {
   run_hook_bash "code-audit-frontend" "env FOO=1 .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: nohup <writer> is denied" {
   run_hook_bash "code-audit-frontend" "nohup .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- execution-position anchor: separators glued to a neighbouring token ---
@@ -413,27 +405,27 @@ assert_allowed() {
 @test "SPEC-056 UAT-015: the writer chained onto the check with '; ' is denied" {
   run_hook_bash "code-audit-frontend" \
     "bash .gaia/scripts/verify-audit-roster.sh; bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer after a glued '; ' with no interpreter is denied" {
   run_hook_bash "code-audit-frontend" "true; .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer after a pipe glued to the previous token is denied" {
   run_hook_bash "code-audit-frontend" "echo x| bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer after a fully glued && is denied" {
   run_hook_bash "code-audit-frontend" "true&&bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: the writer after a glued || is denied" {
   run_hook_bash "code-audit-frontend" "false|| bash .gaia/scripts/write-audit-remits.sh"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "SPEC-056 UAT-015: separator padding does not deny a read-only command naming the writer" {
@@ -441,7 +433,7 @@ assert_allowed() {
   # the writer as an argument, with a separator elsewhere, must stay allowed.
   run_hook_bash "code-audit-maintainer-shell" \
     "bash .gaia/scripts/verify-audit-roster.sh; shellcheck .gaia/scripts/write-audit-remits.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "SPEC-056 UAT-015: separator padding leaves the write-shape loop intact" {
@@ -449,7 +441,7 @@ assert_allowed() {
   # are load-bearing. A redirect into a refused path must still deny with a
   # stderr redirect present in the same command.
   run_hook_bash "code-audit-frontend" "echo x > .claude/agents/code-audit-frontend.md 2>&1"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- execution-position anchor: multi-line, subshell, and brace-group shapes ---
@@ -464,45 +456,45 @@ assert_allowed() {
 @test "the writer on line 2 of a multi-line payload is denied" {
   run_hook_bash "code-audit-frontend" \
     $'R=$(git rev-parse --show-toplevel)\nbash "$R/.gaia/scripts/write-audit-remits.sh"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a write vector on line 2 of a multi-line payload is denied" {
   run_hook_bash "code-audit-frontend" $'echo start\necho x > test/foo.ts'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a write vector continued across a backslash-newline is denied" {
   # The continuation folds to a space, not a `;`. Folding it to a separator
   # would break the cp destination scan at the line boundary and allow this.
   run_hook_bash "code-audit-frontend" $'cp /tmp/x.ts \\\n  test/foo.ts'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "the writer inside a subshell is denied" {
   run_hook_bash "code-audit-frontend" "(bash .gaia/scripts/write-audit-remits.sh)"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "the writer invoked bare inside a subshell is denied" {
   run_hook_bash "code-audit-frontend" "(.gaia/scripts/write-audit-remits.sh)"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "the writer inside a brace group is denied" {
   run_hook_bash "code-audit-frontend" "{ bash .gaia/scripts/write-audit-remits.sh; }"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "the writer inside a command substitution is denied" {
   run_hook_bash "code-audit-frontend" "OUT=\$(bash .gaia/scripts/write-audit-remits.sh)"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "the writer after a cd inside a subshell is denied" {
   run_hook_bash "code-audit-frontend" \
     "(cd .gaia/scripts && bash write-audit-remits.sh)"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a read-only command naming the writer inside a subshell is allowed" {
@@ -510,7 +502,7 @@ assert_allowed() {
   # command merely NAMES the writer as an argument must stay allowed.
   run_hook_bash "code-audit-maintainer-shell" \
     "(shellcheck .gaia/scripts/write-audit-remits.sh)"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "an awk brace program does not make its trailing argument an execution position" {
@@ -518,7 +510,7 @@ assert_allowed() {
   # position, so the file argument after a quoted brace program stays allowed.
   run_hook_bash "code-audit-maintainer-shell" \
     "awk '{print}' .gaia/scripts/write-audit-remits.sh"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Padding characters shred any shell construct that embeds them mid-token, and
@@ -541,44 +533,44 @@ assert_allowed() {
 # under test; double-quoting would expand it away and hollow out the assertion.
 @test "the writer reached through a braced variable is denied" {
   run_hook_bash "code-audit-frontend" 'bash "${R}/.gaia/scripts/write-audit-remits.sh"'
-  assert_denied
+  assert_denied_by_json
 }
 
 # shellcheck disable=SC2016 # the literal `${VAR}` IS the payload under test
 @test "the writer reached through a braced variable with no interpreter is denied" {
   run_hook_bash "code-audit-frontend" '${R}/.gaia/scripts/write-audit-remits.sh'
-  assert_denied
+  assert_denied_by_json
 }
 
 # shellcheck disable=SC2016 # the literal `${VAR}` IS the payload under test
 @test "the writer reached through a braced variable after an interpreter option is denied" {
   run_hook_bash "code-audit-frontend" 'sh -x ${D}/write-audit-remits.sh'
-  assert_denied
+  assert_denied_by_json
 }
 
 # shellcheck disable=SC2016 # the literal `$(cmd)` IS the payload under test
 @test "the writer reached through a command substitution in the path is denied" {
   run_hook_bash "code-audit-frontend" 'bash "$(pwd)/.gaia/scripts/write-audit-remits.sh"'
-  assert_denied
+  assert_denied_by_json
 }
 
 # shellcheck disable=SC2016 # the literal `$(cmd)` IS the payload under test
 @test "the writer reached through a command substitution with no interpreter is denied" {
   run_hook_bash "code-audit-frontend" '"$(pwd)/.gaia/scripts/write-audit-remits.sh"'
-  assert_denied
+  assert_denied_by_json
 }
 
 # shellcheck disable=SC2016 # the literal `$(cmd)` IS the payload under test
 @test "the writer reached through a command substitution after an interpreter option is denied" {
   run_hook_bash "code-audit-frontend" 'sh -x "$(pwd)/write-audit-remits.sh"'
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "bracket padding leaves the write-shape loop intact" {
   # The write-shape loop reads the UNPADDED token array. A subshell-wrapped
   # redirect into an allowed path must still be allowed.
   run_hook_bash "code-audit-frontend" "(echo x > app/foo.ts)"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- structural ---

--- a/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
+++ b/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
@@ -68,10 +68,8 @@ make_other_repo() {
   git -C "$OTHER_REPO" init -q --initial-branch=main
 }
 
-# Quote-safe delivery (mandatory, mirrors block-worktree-path-mismatch.bats):
-# pass $json and $HOOK_ABS as positional args to an inner bash -c rather than
-# re-wrapping in an outer single-quoted string, so embedded quotes in a
-# payload path never terminate the wrapper early.
+# A payload path can carry quotes of its own, so delivery goes through
+# `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook() {
   local project="$1" cwd="$2"
   local json

--- a/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
+++ b/.gaia/tests/hooks/block-serena-cross-tree-activation.bats
@@ -16,6 +16,7 @@
 # `return 1`, never `!`-negation.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-serena-cross-tree-activation.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -76,7 +77,7 @@ run_hook() {
   local json
   json=$(jq -n --arg p "$project" --arg c "$cwd" \
     '{tool_name: "mcp__serena__activate_project", cwd: $c, tool_input: {project: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_hook_other_tool() {
@@ -84,19 +85,10 @@ run_hook_other_tool() {
   local json
   json=$(jq -n --arg t "$tool" --arg c "$cwd" \
     '{tool_name: $t, cwd: $c, tool_input: {project: "gaia"}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # --- NAME arm ---
 
@@ -104,7 +96,7 @@ assert_allowed() {
   make_repo
   make_worktree "debt/1-foo" "debt/1-foo"
   run_hook "gaia" "$WT"
-  assert_denied
+  assert_denied_by_json
   # The reason names the worktree's own root, the value to pass instead.
   grep -qF -- "$WT" <<<"$output" || return 1
 }
@@ -113,14 +105,14 @@ assert_allowed() {
   make_repo
   make_worktree "debt/2-foo" "debt/2-foo"
   run_hook "some-other-project" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "from the main checkout, the bare name is allowed (the correct activation)" {
   make_repo
   make_worktree "debt/3-foo" "debt/3-foo"
   run_hook "gaia" "$REPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- PATH arm ---
@@ -129,7 +121,7 @@ assert_allowed() {
   make_repo
   make_worktree "debt/4-foo" "debt/4-foo"
   run_hook "$REPO" "$WT"
-  assert_denied
+  assert_denied_by_json
   grep -qF -- "$WT" <<<"$output" || return 1
 }
 
@@ -139,14 +131,14 @@ assert_allowed() {
   WT_A="$WT"
   make_worktree "debt/5-b" "debt/5-b"
   run_hook "$WT_A" "$WT"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "from a linked worktree, its own absolute path is allowed" {
   make_repo
   make_worktree "debt/6-foo" "debt/6-foo"
   run_hook "$WT" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "from a linked worktree, an absolute path in a different repository is allowed" {
@@ -154,14 +146,14 @@ assert_allowed() {
   make_worktree "debt/7-foo" "debt/7-foo"
   make_other_repo
   run_hook "$OTHER_REPO" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "from the main checkout, a linked worktree's path is denied (the symmetric arm)" {
   make_repo
   make_worktree "debt/8-foo" "debt/8-foo"
   run_hook "$WT" "$REPO"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- ignored / fail-open ---
@@ -170,7 +162,7 @@ assert_allowed() {
   make_repo
   make_worktree "debt/9-foo" "debt/9-foo"
   run_hook_other_tool "mcp__serena__find_symbol" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a payload whose cwd is not a repository fails open (allowed)" {
@@ -181,7 +173,7 @@ assert_allowed() {
   # running this suite, which is not the state under test.
   cd "$NONREPO"
   run_hook "gaia" "$NONREPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- structural ---

--- a/.gaia/tests/hooks/block-spec-plan-chain.bats
+++ b/.gaia/tests/hooks/block-spec-plan-chain.bats
@@ -33,9 +33,8 @@ teardown() {
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
 }
 
-# Quote-safe delivery: payloads carry paths and command strings of their own, so
-# $json and $HOOK_ABS go in as positional args rather than being re-wrapped in an
-# outer single-quoted `bash -c '...'` string.
+# Payloads carry paths and command strings of their own, so delivery goes
+# through `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook() {
   local json="$1"
   invoke_hook "$json" "$HOOK_ABS"

--- a/.gaia/tests/hooks/block-spec-plan-chain.bats
+++ b/.gaia/tests/hooks/block-spec-plan-chain.bats
@@ -15,6 +15,7 @@
 # allow/deny decision in stdout JSON.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-spec-plan-chain.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
@@ -37,7 +38,7 @@ teardown() {
 # outer single-quoted `bash -c '...'` string.
 run_hook() {
   local json="$1"
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 run_skill() {
@@ -73,6 +74,12 @@ stamp_session() {
   [ -f "$REPO/.gaia/local/cache/spec-chain-${1:-$SESSION}.json" ]
 }
 
+# Both assertions are deliberately narrower than the shared
+# `assert_denied_by_json` / `assert_allowed_by_json` pair in
+# helpers/run-hook.sh, so this suite keeps its own rather than trading down:
+# the deny reads the decision as a JSON FIELD rather than as a substring, and
+# this hook says nothing at all when it allows, which the shared allow does not
+# require.
 assert_denied() {
   [ "$status" -eq 0 ]
   [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<<"$output")" = "deny" ]

--- a/.gaia/tests/hooks/block-worktree-path-mismatch.bats
+++ b/.gaia/tests/hooks/block-worktree-path-mismatch.bats
@@ -106,10 +106,8 @@ make_worktree() {
   WT="$REPO/.claude/worktrees/$rel"
 }
 
-# Quote-safe delivery (mandatory, mirrors block-manifest-write.bats): pass
-# $json and $HOOK_ABS as positional args to an inner bash -c rather than
-# re-wrapping in an outer single-quoted string, so embedded quotes in a
-# payload path never terminate the wrapper early.
+# A payload path can carry quotes of its own, so delivery goes through
+# `invoke_hook` (helpers/run-hook.sh) rather than any local variant.
 run_hook_edit() {
   local tool="$1" path="$2"
   local json

--- a/.gaia/tests/hooks/block-worktree-path-mismatch.bats
+++ b/.gaia/tests/hooks/block-worktree-path-mismatch.bats
@@ -16,6 +16,7 @@
 # `return 1`, never `!`-negation.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOKS_SRC=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)
   HOOK_ABS="$HOOKS_SRC/block-worktree-path-mismatch.sh"
   SETTINGS_ABS="${HOOKS_SRC%/hooks}/settings.json"
@@ -113,7 +114,7 @@ run_hook_edit() {
   local tool="$1" path="$2"
   local json
   json=$(jq -n --arg t "$tool" --arg p "$path" '{tool_name: $t, tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 # Same delivery contract as run_hook_edit, plus the payload's `cwd` field: the
@@ -125,7 +126,7 @@ run_hook_edit_cwd() {
   local json
   json=$(jq -n --arg t "$tool" --arg p "$path" --arg c "$cwd" \
     '{tool_name: $t, cwd: $c, tool_input: {file_path: $p}}')
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$HOOK_ABS"
+  invoke_hook "$json" "$HOOK_ABS"
 }
 
 # An unrelated git repository, used to check that a payload cwd naming some
@@ -138,16 +139,7 @@ make_other_repo() {
   git -C "$OTHER_REPO" init -q --initial-branch=main
 }
 
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # --- allowed: editing inside the current worktree ---
 
@@ -156,7 +148,7 @@ assert_allowed() {
   make_worktree "debt/1-foo" "debt/1-foo"
   cd "$WT"
   run_hook_edit "Edit" "$WT/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "Write on a new file under an existing subdirectory of the current worktree is allowed" {
@@ -165,7 +157,7 @@ assert_allowed() {
   mkdir -p "$WT/sub"
   cd "$WT"
   run_hook_edit "Write" "$WT/sub/new.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "MultiEdit on a tracked file inside the current worktree is allowed" {
@@ -173,7 +165,7 @@ assert_allowed() {
   make_worktree "debt/3-foo" "debt/3-foo"
   cd "$WT"
   run_hook_edit "MultiEdit" "$WT/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- denied: the #841 regression, a stale path into a different checkout ---
@@ -183,7 +175,7 @@ assert_allowed() {
   make_worktree "debt/4-foo" "debt/4-foo"
   cd "$WT"
   run_hook_edit "Edit" "$REPO/f"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "Write targeting the main checkout while the session is inside the worktree is denied" {
@@ -191,7 +183,7 @@ assert_allowed() {
   make_worktree "debt/5-foo" "debt/5-foo"
   cd "$WT"
   run_hook_edit "Write" "$REPO/new.ts"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "MultiEdit targeting the main checkout while the session is inside the worktree is denied" {
@@ -199,7 +191,7 @@ assert_allowed() {
   make_worktree "debt/6-foo" "debt/6-foo"
   cd "$WT"
   run_hook_edit "MultiEdit" "$REPO/f"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- allowed: no linked-worktree session, nothing to guard ---
@@ -209,7 +201,7 @@ assert_allowed() {
   make_worktree "debt/7-foo" "debt/7-foo"
   cd "$REPO"
   run_hook_edit "Edit" "$WT/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Regression: both roots the guard compares are symlink-canonicalized (main_root
@@ -226,7 +218,7 @@ assert_allowed() {
   ln -s "$REPO" "$SYMLINK_REPO"
   cd "$SYMLINK_REPO"
   run_hook_edit "Edit" "$WT/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- allowed: the shared .gaia/local tree ---
@@ -246,7 +238,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/audit" "$WT/.gaia/local/audit"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/audit/issue-body-abc123.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The exemption is a path-prefix test, so it must not leak to a sibling whose
@@ -257,7 +249,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/localish"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/localish/notes.md"
-  assert_denied
+  assert_denied_by_json
 }
 
 # link-worktree.sh now symlinks the worktree's whole .gaia/local wholesale to
@@ -278,7 +270,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/handoff/$own_key"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/handoff/$own_key/HANDOFF-2026-01-01.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a worktree-mode write to a PEER tree's keyed handoff subtree in the main checkout is denied" {
@@ -290,7 +282,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/handoff/$peer_key"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/handoff/$peer_key/HANDOFF-2026-01-01.md"
-  assert_denied
+  assert_denied_by_json
   # The refusal has to name the key, not repeat the generic stale-path advice.
   # Re-resolving the repository root does not move a path that reaches main
   # through the one .gaia/local symlink, so the generic message would send the
@@ -307,7 +299,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/handoff"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/handoff/HANDOFF-2026-01-01.md"
-  assert_denied
+  assert_denied_by_json
 }
 
 # tech-debt #934. plan.md puts the plan folder in the main checkout by contract
@@ -323,7 +315,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/plans/PLAN-001"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/plans/PLAN-001/PROGRESS.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The spec-colocated arm of the same contract: a plan under
@@ -335,7 +327,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/specs/SPEC-009/plan"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/specs/SPEC-009/plan/PROGRESS.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The plans/specs carve-out is a path-segment match like the shared-state arm
@@ -346,7 +338,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/plansible"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/plansible/notes.md"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The remaining symlinked dirs get the same coverage as audit/, so a future
@@ -359,7 +351,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/debt" "$WT/.gaia/local/debt"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/debt/refresh-requested"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a write under the worktree's symlinked .gaia/local/telemetry is allowed" {
@@ -370,7 +362,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/telemetry" "$WT/.gaia/local/telemetry"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/telemetry/tally.jsonl"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a write under the worktree's symlinked .gaia/local/cache/shared is allowed" {
@@ -381,7 +373,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/cache/shared" "$WT/.gaia/local/cache/shared"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/cache/shared/blob.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # Once .gaia/local is one shared symlink, cache/ has no worktree-side copy at
@@ -396,7 +388,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/cache"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/cache/draft-SPEC-001.md"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # setup-state.json is a symlinked FILE, so its target_dir is the worktree's own
@@ -411,7 +403,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/setup-state.json" "$WT/.gaia/local/setup-state.json"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/setup-state.json"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # fixture-main-dir/ is a synthetic third main-only directory in the fixture
@@ -426,7 +418,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/fixture-main-dir/some-lock"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/fixture-main-dir/some-lock/lock"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The exemption is registry-driven (gaia_registry_recognizes +
@@ -448,7 +440,7 @@ assert_allowed() {
   ln -s "$REPO/.gaia/local/newshared" "$WT/.gaia/local/newshared"
   cd "$WT"
   run_hook_edit "Write" "$WT/.gaia/local/newshared/marker"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The converse of the auto-exempt case: the guard exempts ONLY what the
@@ -463,7 +455,7 @@ assert_allowed() {
   mkdir -p "$REPO/.gaia/local/unregistered"
   cd "$WT"
   run_hook_edit "Write" "$REPO/.gaia/local/unregistered/notes.md"
-  assert_denied
+  assert_denied_by_json
   # An unregistered path under .gaia/local is denied because the guard cannot
   # tell shared state from per-tree state without a registry row, and it must
   # say that rather than blame a stale path -- the same reason as the peer-key
@@ -490,7 +482,7 @@ assert_allowed() {
   make_worktree "debt/14-b" "debt/14-b"
   cd "$WT"
   run_hook_edit "Edit" "$WT_A/f"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The payload cwd is authoritative for the acting tree, so the target-side
@@ -508,7 +500,7 @@ assert_allowed() {
   WT_B="$WT"
   cd "$REPO"
   run_hook_edit_cwd "Edit" "$WT_A/f" "$WT_B"
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- ignored: not our matcher ---
@@ -518,7 +510,7 @@ assert_allowed() {
   make_worktree "debt/8-foo" "debt/8-foo"
   cd "$WT"
   run_hook_edit "Read" "$REPO/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- fail-open: anything the guard cannot resolve ---
@@ -528,7 +520,7 @@ assert_allowed() {
   make_worktree "debt/9-foo" "debt/9-foo"
   cd "$WT"
   run_hook_edit "Write" "/no-such-parent-dir-xyz/new.ts"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "a target outside any git repository fails open (allowed)" {
@@ -537,7 +529,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$WT"
   run_hook_edit "Edit" "$NONREPO/scratch.txt"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A process cwd outside every git repository leaves the hook with no checkout to
@@ -549,7 +541,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$NONREPO"
   run_hook_edit "Edit" "$REPO/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- the calling agent's cwd comes from the payload ---
@@ -566,7 +558,7 @@ assert_allowed() {
   make_worktree "debt/22-foo" "debt/22-foo"
   cd "$REPO"
   run_hook_edit_cwd "Edit" "$REPO/f" "$WT"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The mirror of the case above: the same payload cwd, targeting that agent's own
@@ -576,7 +568,7 @@ assert_allowed() {
   make_worktree "debt/23-foo" "debt/23-foo"
   cd "$REPO"
   run_hook_edit_cwd "Edit" "$WT/f" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A payload without `cwd` still adjudicates off the process cwd. The rest of
@@ -587,7 +579,7 @@ assert_allowed() {
   make_worktree "debt/24-foo" "debt/24-foo"
   cd "$WT"
   run_hook_edit "Edit" "$REPO/f"
-  assert_denied
+  assert_denied_by_json
 }
 
 # A payload cwd the hook cannot resolve is not a reason to stop guarding. Both
@@ -598,7 +590,7 @@ assert_allowed() {
   make_worktree "debt/25-foo" "debt/25-foo"
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "/no-such-agent-cwd-xyz"
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "a payload cwd naming a directory outside any git repository falls back to the process cwd" {
@@ -607,7 +599,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "$NONREPO"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The payload cwd is authoritative for tree identity whenever it is absolute and
@@ -623,7 +615,7 @@ assert_allowed() {
   make_other_repo
   cd "$REPO"
   run_hook_edit_cwd "Edit" "$REPO/f" "$OTHER_REPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The accepted residual of making the payload authoritative (the dropped
@@ -643,7 +635,7 @@ assert_allowed() {
   make_other_repo
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "$OTHER_REPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The payload cwd is honored only when it is absolute. The absolute check gates
@@ -661,7 +653,7 @@ assert_allowed() {
   ln -s "$REPO" "$WT/linkdir"
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "linkdir"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The mirror of the load-bearing deny case above, and the one case reading the
@@ -674,7 +666,7 @@ assert_allowed() {
   make_worktree "debt/29-foo" "debt/29-foo"
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "$REPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # A payload cwd below the main checkout's root, not at it. The shared resolver
@@ -690,7 +682,7 @@ assert_allowed() {
   mkdir -p "$REPO/sub"
   cd "$WT"
   run_hook_edit_cwd "Edit" "$REPO/f" "$REPO/sub"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # tech-debt #940. main_root used to derive from the hook's own process cwd even
@@ -706,7 +698,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$NONREPO"
   run_hook_edit_cwd "Edit" "$REPO/f" "$WT"
-  assert_denied
+  assert_denied_by_json
 }
 
 # The mirror of the case above: the same payload cwd, targeting that agent's own
@@ -717,7 +709,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$NONREPO"
   run_hook_edit_cwd "Edit" "$WT/f" "$WT"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # The payload is authoritative and both roots come from it, so a target in a
@@ -732,7 +724,7 @@ assert_allowed() {
   NONREPO=$(mktemp -d -t gaia-wt-mismatch-nonrepo-XXXXXX)
   cd "$NONREPO"
   run_hook_edit_cwd "Edit" "$REPO/f" "$OTHER_REPO"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- defense in depth: the file_path chain's own two guards ---
@@ -765,7 +757,7 @@ assert_allowed() {
   cd "$WT"
   export CDPATH="$REPO/.gaia/local/audit"
   run_hook_edit "Write" "inner/f"
-  assert_denied
+  assert_denied_by_json
 }
 
 # `dirname --` killer. A file_path whose leading component reads as an option
@@ -779,7 +771,7 @@ assert_allowed() {
   make_worktree "debt/35-foo" "debt/35-foo"
   cd "$WT"
   run_hook_edit "Write" "-x/f"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- structural ---

--- a/.gaia/tests/hooks/capture-gh-artifact.bats
+++ b/.gaia/tests/hooks/capture-gh-artifact.bats
@@ -7,6 +7,7 @@
 # real .gaia/local/cache/.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/capture-gh-artifact.sh"
@@ -47,14 +48,14 @@ build_repo() {
 run_hook() {
   local cmd="$1" out="${2:-}" sid="${3:-S1}" input
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use "$sid" Bash "$cmd" "$out")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
 }
 
 # run_hook_raw <json> - for payloads the helper's required-param mock cannot
 # express (an empty session_id).
 run_hook_raw() {
   local input="$1"
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
 }
 
 # breadcrumb_path <branch>: the exact keyed filename the hook (and the real
@@ -134,7 +135,7 @@ any_breadcrumb_exists() {
   build_repo
   cd "$REPO"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Edit "gh pr create")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 
   any_breadcrumb_exists && return 1
@@ -213,7 +214,7 @@ any_breadcrumb_exists() {
 
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "gh pr create --title x" \
     "https://github.com/gaia-react/gaia/pull/712")
-  PATH="$nojq_bin" run bash -c "echo '$input' | '$HOOK_ABS'"
+  PATH="$nojq_bin" invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 

--- a/.gaia/tests/hooks/capture-red-observations.bats
+++ b/.gaia/tests/hooks/capture-red-observations.bats
@@ -24,6 +24,7 @@
 # developer's scratch ledger is never clobbered.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   REPO_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   # The hook recomputes RED signals via the Node helper, which resolves
   # `typescript` from node_modules; skip where deps aren't installed (e.g. the
@@ -63,13 +64,14 @@ run_capture() {
   payload=$(jq -n --arg t "$tool" --arg c "$cmd" \
     '{tool_name: $t, tool_input: {command: $c}, tool_response: {stdout: "", stderr: "", interrupted: false}}')
 
-  # Export the override so it reaches the hook on the RIGHT side of the pipe
-  # (a `VAR=x cmd | hook` prefix would set it on the left command, not the hook).
-  local env_prefix=""
+  # The override is set on the invocation as a whole, so it is in the
+  # environment the hook inherits rather than on one side of the pipe.
   if [ -n "$override_rel" ]; then
-    env_prefix="export RED_CAPTURE_JSON_OVERRIDE='$REPO_ROOT/$override_rel'; "
+    RED_CAPTURE_JSON_OVERRIDE="$REPO_ROOT/$override_rel" \
+      invoke_hook_in "$REPO_ROOT" "$payload" "$HOOK"
+  else
+    invoke_hook_in "$REPO_ROOT" "$payload" "$HOOK"
   fi
-  run bash -c "cd '$REPO_ROOT' && ${env_prefix}printf '%s' '$payload' | bash '$HOOK'"
 }
 
 # Count ledger lines (0 when the file is absent).
@@ -217,7 +219,7 @@ ledger_lines() {
 # --- robustness: malformed input, empty command -------------------------------
 
 @test "malformed stdin (not json) exits 0 and writes nothing" {
-  run bash -c "cd '$REPO_ROOT' && printf 'not json at all' | bash '$HOOK'"
+  invoke_hook_in "$REPO_ROOT" 'not json at all' "$HOOK"
   [ "$status" -eq 0 ]
   [ "$(ledger_lines)" -eq 0 ]
 }

--- a/.gaia/tests/hooks/commit-nudge.bats
+++ b/.gaia/tests/hooks/commit-nudge.bats
@@ -1,19 +1,23 @@
 #!/usr/bin/env bats
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/wiki-commit-nudge.sh
 }
 
 teardown() {
+  # `return 0` because the guard is an AND-list: with no $REPO to remove it
+  # would otherwise leave teardown non-zero and fail an innocent test.
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
+  return 0
 }
 
 @test "non-Bash tool: silent no-op" {
   REPO=$("$HELPERS/tmp-git-repo.sh")
   cd "$REPO"
   input=$(jq -n '{session_id:"S1",tool_name:"Edit",tool_input:{file_path:"x"}}')
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -22,7 +26,7 @@ teardown() {
   REPO=$("$HELPERS/tmp-git-repo.sh")
   cd "$REPO"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "ls -la")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -31,7 +35,7 @@ teardown() {
   REPO=$("$HELPERS/tmp-git-repo.sh")
   cd "$REPO"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "git commit-tree foo")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -40,7 +44,7 @@ teardown() {
   REPO=$("$HELPERS/tmp-git-repo.sh")
   cd "$REPO"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "git commit --amend --no-edit")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -49,7 +53,7 @@ teardown() {
   REPO=$("$HELPERS/tmp-git-repo.sh" --commits 1)
   cd "$REPO"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash 'git commit -m "feat: add foo"')
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[wiki nudge]"* ]]
   [[ "$output" == *"Committed"* ]]
@@ -62,7 +66,7 @@ teardown() {
   git add wiki/foo.md
   git commit --quiet -m "wiki: auto-commit 2026-05-03"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "git commit -m wiki")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -77,7 +81,7 @@ EOF
   git add wiki/.state.json
   git commit --quiet -m "feat: another"
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash 'git commit -m "feat: another"')
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [[ "$output" == *"commits behind"* ]]
 }
 
@@ -86,8 +90,12 @@ EOF
   cd "$REPO"
   rm -f wiki/.state.json
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash 'git commit -m "feat: x"')
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[wiki nudge]"* ]]
   [[ "$output" != *"commits behind"* ]]
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/debt-sentinel-touch.bats
+++ b/.gaia/tests/hooks/debt-sentinel-touch.bats
@@ -12,6 +12,7 @@
 # matching command proceeds).
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/debt-sentinel-touch.sh
   command -v jq >/dev/null 2>&1 || skip "jq required"
@@ -19,7 +20,10 @@ setup() {
 }
 
 teardown() {
+  # `return 0` because the guard is an AND-list: with no $REPO to remove it
+  # would otherwise leave teardown non-zero and fail an innocent test.
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
+  return 0
 }
 
 # run_hook <command>: feed a PostToolUse Bash payload carrying <command> to the
@@ -29,7 +33,7 @@ run_hook() {
   cd "$REPO" || return 1
   local input
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "$1")
-  run bash -c "printf '%s' '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 }
 
@@ -75,7 +79,7 @@ assert_not_armed() { [ ! -f "$REPO/$SENTINEL_REL" ]; }
   REPO=$("$HELPERS/tmp-git-repo.sh")
   cd "$REPO" || return 1
   input=$(jq -n '{tool_name:"Edit",tool_input:{file_path:"x"}}')
-  run bash -c "printf '%s' '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   assert_not_armed
 }
@@ -98,4 +102,8 @@ assert_not_armed() { [ ! -f "$REPO/$SENTINEL_REL" ]; }
 @test "close mentioned inside a --body string is not a real invocation" {
   run_hook 'gh pr create --body "remember to gh issue close 590 later"'
   assert_not_armed
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/debt-session-reconcile.bats
+++ b/.gaia/tests/hooks/debt-session-reconcile.bats
@@ -14,6 +14,7 @@
 # answer from.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/debt-session-reconcile.sh
   command -v jq >/dev/null 2>&1 || skip "jq required"
 
@@ -37,7 +38,7 @@ write_cache() {
 # run_hook: run the hook from the sandbox, draining a synthetic SessionStart
 # payload on stdin.
 run_hook() {
-  run bash -c "cd '$SANDBOX' && printf '%s' '{\"hook_event_name\":\"SessionStart\"}' | '$HOOK_ABS'"
+  invoke_hook_in "$SANDBOX" '{"hook_event_name":"SessionStart"}' "$HOOK_ABS"
   [ "$status" -eq 0 ]
 }
 
@@ -73,7 +74,11 @@ run_hook() {
 
 @test "empty stdin is drained without error" {
   write_cache 2
-  run bash -c "cd '$SANDBOX' && '$HOOK_ABS' < /dev/null"
+  invoke_hook_in "$SANDBOX" "" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -f "$SENTINEL" ]
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/distribution-preflight-check.bats
+++ b/.gaia/tests/hooks/distribution-preflight-check.bats
@@ -37,6 +37,7 @@
 # `<positive-bad-case> && return 1`, never `! grep -q`.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
   REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/distribution-preflight-check.sh"
@@ -109,25 +110,23 @@ EOF
 }
 
 # run_hook COMMAND [TOOL_NAME]: drive the hook with a PreToolUse payload.
-# The payload goes through a file rather than a here-string so command bodies
-# carrying quotes and newlines survive verbatim. cwd is the fixture repo
-# because the hook resolves .gaia/cli/gaia-maintainer repo-relative.
+# cwd is the fixture repo because the hook resolves .gaia/cli/gaia-maintainer
+# repo-relative.
 run_hook() {
-  local cmd="$1" tool="${2:-Bash}" payload_file="$BATS_TEST_TMPDIR/payload.json"
-  jq -n --arg t "$tool" --arg c "$cmd" \
-    '{tool_name: $t, tool_input: {command: $c}}' > "$payload_file"
-  run bash -c "cd \"\$1\" && bash \"\$2\" < \"\$3\"" _ \
-    "$FIXTURE" "$HOOK_ABS" "$payload_file"
+  local cmd="$1" tool="${2:-Bash}" payload
+  payload=$(jq -n --arg t "$tool" --arg c "$cmd" \
+    '{tool_name: $t, tool_input: {command: $c}}')
+  invoke_hook_in "$FIXTURE" "$payload" "$HOOK_ABS"
 }
 
 assert_deny() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" || return 1
+  assert_denied_by_json
 }
 
 assert_allow() {
-  [ "$status" -eq 0 ]
-  grep -qF -- 'deny' <<<"$output" && return 1
+  assert_allowed_by_json
+  # This hook is additionally silent when it allows, which the shared pair does
+  # not require; asserted on top of it rather than in place of it.
   [ -z "$output" ]
 }
 

--- a/.gaia/tests/hooks/drift-check.bats
+++ b/.gaia/tests/hooks/drift-check.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK="$BATS_TEST_DIRNAME/../../../.claude/hooks/wiki-drift-check.sh"
   # Hook is invoked relative to its own repo. Resolve to absolute.
@@ -8,7 +9,10 @@ setup() {
 }
 
 teardown() {
+  # `return 0` because the guard is an AND-list: with no $REPO to remove it
+  # would otherwise leave teardown non-zero and fail an innocent test.
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
+  return 0
 }
 
 @test "no state file: silent no-op" {
@@ -16,7 +20,7 @@ teardown() {
   cd "$REPO"
   rm -f wiki/.state.json
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -29,7 +33,7 @@ teardown() {
 {"version":1,"last_evaluated_sha":"$head","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
   [ -f .claude/wiki-drift-checked ]
@@ -44,7 +48,7 @@ EOF
 {"version":1,"last_evaluated_sha":"$base","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[wiki state]"* ]]
   [[ "$output" == *"5 commits ahead"* ]]
@@ -62,11 +66,11 @@ EOF
 
   # First call: emits reminder
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ -n "$output" ]
 
   # Second call same session: no output
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -83,7 +87,7 @@ EOF
   bash -c "echo '$input1' | '$HOOK_ABS'" >/dev/null
 
   input2=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S2)
-  run bash -c "echo '$input2' | '$HOOK_ABS'"
+  invoke_hook "$input2" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[wiki state]"* ]]
   grep -q "session_id=S2" .claude/wiki-drift-checked
@@ -97,7 +101,7 @@ EOF
 {"version":1,"last_evaluated_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -110,7 +114,7 @@ EOF
   cat > wiki/.state.json <<EOF
 {"version":1,"last_evaluated_sha":"$head","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
-  run bash -c "echo 'not json' | '$HOOK_ABS'"
+  invoke_hook 'not json' "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -127,7 +131,7 @@ EOF
 {"version":1,"last_evaluated_sha":"$base","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
   grep -q "drift_count=0" .claude/wiki-drift-checked
@@ -145,8 +149,12 @@ EOF
 {"version":1,"last_evaluated_sha":"$base","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" user-prompt-submit S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"2 commits ahead"* ]]
   grep -q "drift_count=2" .claude/wiki-drift-checked
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/helpers/run-hook.sh
+++ b/.gaia/tests/hooks/helpers/run-hook.sh
@@ -2,6 +2,13 @@
 # Shared harness for the .gaia/tests/hooks bats suites: one quote-safe hook
 # invocation, and one assertion pair per deny mechanism.
 #
+# The directive below is the one thing this file needs that a suite does not:
+# `status` and `output` are set by bats' own `run`, which is invisible to the
+# linter here because this is a `.sh` held to the strictest severity floor
+# rather than a `.bats` file (see .gaia/tests/shell-lint.sh). Scoped to the one
+# code, so every other finding in this file still fires.
+# shellcheck disable=SC2154
+#
 # Source it from `setup()`, never `setup_file()`. bats runs `setup_file` in a
 # separate process, so functions defined there are invisible to test bodies:
 #

--- a/.gaia/tests/hooks/helpers/run-hook.sh
+++ b/.gaia/tests/hooks/helpers/run-hook.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Shared harness for the .gaia/tests/hooks bats suites: one quote-safe hook
+# invocation, and one assertion pair per deny mechanism.
+#
+# Source it from `setup()`, never `setup_file()`. bats runs `setup_file` in a
+# separate process, so functions defined there are invisible to test bodies:
+#
+#   setup() {
+#     . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
+#     HOOK_ABS="$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/x.sh"
+#   }
+#
+# A suite keeps its own payload-building wrapper and calls the invocation here
+# to deliver it, so `run_hook`-style suite-local names never collide with these.
+#
+# WHY THE PAYLOAD IS POSITIONAL. `invoke_hook` passes the payload and the hook
+# path as arguments to the inner `bash -c`, rather than interpolating them into
+# an outer quoted string. Interpolation is not a style choice: a fixture
+# carrying a quote of its own terminates the wrapper early and the hook then
+# reads a DIFFERENT payload than the one the fixture spells. The hook denies for
+# the wrong reason, or never parses the payload at all, and the test greens
+# having proved nothing about the case it is named for.
+#
+# ASSERTION PAIRS ARE NAMED FOR THE MECHANISM, not for the verdict, because the
+# suites here test hooks with two incompatible deny contracts. A generic
+# `assert_denied` hides which contract is under test, and a suite that picks the
+# wrong one asserts against a mechanism its hook never uses.
+#
+# Every form below is bash-3.2 safe per .claude/rules/bats-assertions.md: `[ ]`
+# for status and emptiness, `grep -qF` for a substring, `<positive> && return 1`
+# for an absence. A bare `[[ ]]` and a `!`-negation both fail to fail on a
+# non-final assertion line.
+
+# invoke_hook PAYLOAD HOOK
+# Pipes PAYLOAD to HOOK, capturing status/output through bats' `run`.
+invoke_hook() {
+  run bash -c 'printf %s "$1" | bash "$2"' _ "$1" "$2"
+}
+
+# invoke_hook_in DIR PAYLOAD HOOK
+# Same, with DIR as the working directory. Hooks that resolve their own
+# libraries or repo state relative to cwd need this rather than `invoke_hook`.
+invoke_hook_in() {
+  run bash -c 'cd "$1" && printf %s "$2" | bash "$3"' _ "$1" "$2" "$3"
+}
+
+# --- mechanism 1: the exit code carries the verdict ------------------------
+# The hook blocks by exiting 2 with a BLOCKED message, and allows by exiting 0
+# silently. PreToolUse reads exit 2 as a block and shows the message to Claude.
+# Under this contract a hook says nothing at all when it allows, so the allow
+# assertion is an assertion of silence.
+
+assert_blocked_by_exit() {
+  [ "$status" -eq 2 ]
+  grep -qF -- 'BLOCKED' <<<"$output"
+}
+
+assert_allowed_by_exit() {
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- mechanism 2: JSON on stdout carries the verdict -----------------------
+# The hook always exits 0; a deny is a `"permissionDecision": "deny"` field in
+# the JSON it writes to stdout, and an allow writes no deny. A suite whose hook
+# is additionally silent on an allow asserts that on top of the pair here,
+# rather than trading this assertion for that one.
+
+assert_denied_by_json() {
+  [ "$status" -eq 0 ]
+  grep -qF -- '"permissionDecision": "deny"' <<<"$output"
+}
+
+assert_allowed_by_json() {
+  [ "$status" -eq 0 ]
+  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
+  return 0
+}

--- a/.gaia/tests/hooks/post-findings-block-on-merge.bats
+++ b/.gaia/tests/hooks/post-findings-block-on-merge.bats
@@ -25,6 +25,7 @@
 # branch under test, i.e. the sandbox's own init commit.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/post-findings-block-on-merge.sh
   SETTINGS_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude" && pwd)/settings.json
   CI_CONFIG_RESOLVER_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.gaia/scripts" && pwd)/read-audit-ci-config.sh
@@ -169,7 +170,7 @@ run_merge_hook() {
   local tool="${2:-Bash}"
   local json
   json=$(jq -n --arg c "$cmd" --arg t "$tool" '{tool_name: $t, tool_input: {command: $c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$REPO" "$json" "$HOOK_ABS"
 }
 
 write_sidecar() {

--- a/.gaia/tests/hooks/pr-merge-audit-check.bats
+++ b/.gaia/tests/hooks/pr-merge-audit-check.bats
@@ -46,6 +46,7 @@
 # removes this copy explicitly.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/pr-merge-audit-check.sh
   RESOLVER_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.gaia/scripts" && pwd)/resolve-audit-members.sh
   SPAWN_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.gaia/scripts" && pwd)/resolve-audit-spawn.sh
@@ -126,7 +127,7 @@ run_merge_hook_at() {
   local json
   json=$(jq -n --arg c "$cmd" \
     '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "cd '$root' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$root" "$json" "$HOOK_ABS"
 }
 
 # Run the hook with a `gh pr merge` command, from inside the repo.
@@ -293,18 +294,8 @@ EOF
 }
 
 # Assert the most recent run_merge_hook call allowed the merge.
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" && return 1
-  return 0
-}
 
 # Assert the most recent run_merge_hook call denied the merge.
-assert_denied() {
-  [ "$status" -eq 0 ]
-  grep -qF -- '"permissionDecision": "deny"' <<<"$output" || return 1
-  return 0
-}
 
 # Assert NAME is present as a whole line in NEWLINE-separated SET.
 assert_in_set() {
@@ -592,7 +583,7 @@ assert_not_in_set() {
 
   before_pool="$(pool_snapshot)"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
   after_pool="$(pool_snapshot)"
   [ "$before_pool" = "$after_pool" ]
 }
@@ -624,7 +615,7 @@ assert_not_in_set() {
 
   write_marker "code-audit-maintainer-node"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ---------------------------------------------------------------------------
@@ -665,7 +656,7 @@ assert_not_in_set() {
   write_refused "code-audit-frontend"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "UAT-004: refusal precedence also applies to a specialized member" {
@@ -675,7 +666,7 @@ assert_not_in_set() {
   write_refused "code-audit-maintainer-shell"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
   grep -qF "code-audit-maintainer-shell: REFUSED" <<< "$output" || return 1
 }
 
@@ -691,7 +682,7 @@ assert_not_in_set() {
   commit_files "Dockerfile" "FROM scratch"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "UAT-011: a stale frontend marker does not clear a merge that adds a nested ownerless public asset" {
@@ -700,7 +691,7 @@ assert_not_in_set() {
   commit_files "public/logo.svg" "<svg></svg>"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 }
 
 # ---------------------------------------------------------------------------
@@ -719,7 +710,7 @@ assert_not_in_set() {
   rm -f "$REPO/.gaia/local/audit/${digest}.dispositions.json"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
   grep -qF "disposition sidecar" <<< "$output" || return 1
 }
 
@@ -730,7 +721,7 @@ assert_not_in_set() {
   write_sidecar '[{"key":"v1 class=x path=app/x.ts line=1","disposition":"filed"}]' "github"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
   grep -qF "filed-but-missing" <<< "$output" || return 1
   grep -qF "v1 class=x path=app/x.ts line=1" <<< "$output" || return 1
 }
@@ -742,7 +733,7 @@ assert_not_in_set() {
   write_sidecar '[]' "absent"
 
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ---------------------------------------------------------------------------
@@ -784,7 +775,7 @@ assert_not_in_set() {
   ]' "github"
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
   grep -qF "machinery-waived-not-eligible: v1 class=x path=app/y.ts line=1" <<<"$output" || return 1
   grep -qF "machinery-waived-not-eligible: v1 class=x path=app/x.tsx line=1" <<<"$output" || return 1
   grep -qF "machinery-waived-not-eligible: v1 class=x path=x.ts line=1" <<<"$output" || return 1
@@ -805,7 +796,7 @@ assert_not_in_set() {
     {"key":"v1 class=x path=app/x.ts line=1","severity":"suggestion","security_class":false,"disposition":"machinery_waived"}
   ]' "github"
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
   grep -qF "machinery-waived-not-eligible: v1 class=x path=app/y.ts line=1" <<<"$output" || return 1
 
   # Drop the sibling offender; the surviving entry is keyed to app/x.ts, a
@@ -813,7 +804,7 @@ assert_not_in_set() {
   write_sidecar '[{"key":"v1 class=x path=app/x.ts line=1","severity":"suggestion","security_class":false,"disposition":"machinery_waived"}]' "github"
   run_merge_hook
   grep -qF '"permissionDecision": "deny"' <<<"$output" && return 1
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "machinery_waived abuse-check: an unresolvable base still denies a non-machinery key (gate-machinery term, not the git failure)" {
@@ -823,7 +814,7 @@ assert_not_in_set() {
   write_sidecar_at "$repo" '[{"key":"v1 class=x path=app/other.ts line=1","severity":"suggestion","security_class":false,"disposition":"machinery_waived"}]' "github"
 
   run_merge_hook_at "$repo"
-  assert_denied
+  assert_denied_by_json
   grep -qF "machinery-waived-not-eligible: v1 class=x path=app/other.ts line=1" <<<"$output" || return 1
 }
 
@@ -844,7 +835,7 @@ assert_not_in_set() {
   # this case cannot pass on a gate that returned before reading anything.
   grep -qF "changed-files-unverified: v1 class=x path=.claude/hooks/lib/audit-machinery.sh line=1" <<<"$output" || return 1
   grep -qF '"permissionDecision": "deny"' <<<"$output" && return 1
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "machinery_waived abuse-check: a resolved base with a genuinely empty diff still denies a non-machinery key, with no note" {
@@ -861,7 +852,7 @@ assert_not_in_set() {
   run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS' 2>&1"
 
   grep -qF "machinery-waived-not-eligible: v1 class=x path=app/other.ts line=1" <<<"$output" || return 1
-  assert_denied
+  assert_denied_by_json
   grep -qF "changed-files-unverified" <<<"$output" && return 1
   grep -qF "changed-files-not-attributable" <<<"$output" && return 1
   return 0
@@ -876,14 +867,14 @@ assert_not_in_set() {
   # (an arm unconditional on the diff base) must deny.
   write_sidecar_at "$repo" '[{"key":"v1 class=x path=sibling line=1","severity":"suggestion","security_class":false,"disposition":"pending","pending_reason":"definitive"}]' "github"
   run_merge_hook_at "$repo"
-  assert_denied
+  assert_denied_by_json
   grep -qF "pending(definitive): v1 class=x path=sibling line=1" <<<"$output" || return 1
 
   # With zero findings at all, the unresolvable base by itself must never
   # deny: nothing depends on it.
   write_sidecar_at "$repo" '[]' "github"
   run_merge_hook_at "$repo"
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # ---------------------------------------------------------------------------
@@ -911,7 +902,7 @@ assert_not_in_set() {
   [ "$set" = "code-audit-frontend" ]
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: root tsconfig.json spawns the default member alone, and its marker allows" {
@@ -920,7 +911,7 @@ assert_not_in_set() {
   [ "$set" = "code-audit-frontend" ]
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: a CI workflow spawns the workflows member only (not the default), and its marker allows" {
@@ -930,7 +921,7 @@ assert_not_in_set() {
   assert_not_in_set "code-audit-frontend" "$set"
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: framework shell spawns the shell member only (not the default), and its marker allows" {
@@ -940,7 +931,7 @@ assert_not_in_set() {
   assert_not_in_set "code-audit-frontend" "$set"
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: framework CLI TypeScript spawns the node member only (not the default), and its marker allows" {
@@ -950,7 +941,7 @@ assert_not_in_set() {
   assert_not_in_set "code-audit-frontend" "$set"
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: skills prose spawns the prose member only (not the default), and its marker allows" {
@@ -960,7 +951,7 @@ assert_not_in_set() {
   assert_not_in_set "code-audit-frontend" "$set"
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: mixed app/ + framework shell spawns both, sorted, and their markers allow" {
@@ -970,7 +961,7 @@ assert_not_in_set() {
   [ "$set" = "$expected" ]
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: wiki + .claude + root markdown spawns nobody, and no markers still allows" {
@@ -984,7 +975,7 @@ assert_not_in_set() {
   set=$(spawn_set)
   [ -z "$set" ]
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: root Dockerfile (in-scope, ownerless) denies unmarked and allows once spawned" {
@@ -996,13 +987,13 @@ assert_not_in_set() {
   # Dockerfile), but the legacy out-of-scope gate still denies because
   # Dockerfile is in-scope. Writing no markers must still deny.
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 
   # The oracle's ownerless probe names the default member for exactly this
   # case, so spawning it and writing its marker clears the gate.
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: nested public/** (in-scope, ownerless) denies unmarked and allows once spawned" {
@@ -1011,11 +1002,11 @@ assert_not_in_set() {
   [ "$set" = "code-audit-frontend" ]
 
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-deadlock: ownerless Dockerfile riding with a specialized member spawns the specialized member only" {
@@ -1031,7 +1022,7 @@ assert_not_in_set() {
   [ "$set" = "code-audit-maintainer-shell" ]
   write_markers_for_spawn_set "$set"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 # --- No useless spawn: withholding a spawned member's marker must deny -----
@@ -1040,25 +1031,25 @@ assert_not_in_set() {
   commit_files "app/x.tsx" "export const X = 1" ".gaia/scripts/y.sh" "#!/bin/bash"
   write_marker "code-audit-frontend"
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 }
 
 @test "FC-4 no-useless-spawn: mixed diff denies with only the shell marker, then allows once both are present" {
   commit_files "app/x.tsx" "export const X = 1" ".gaia/scripts/y.sh" "#!/bin/bash"
   write_marker "code-audit-maintainer-shell"
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 
   write_marker "code-audit-frontend"
   run_merge_hook
-  assert_allowed
+  assert_allowed_by_json
 }
 
 @test "FC-4 no-useless-spawn: framework-shell-only diff denies with a frontend marker instead of the shell one" {
   commit_files ".gaia/scripts/y.sh" "#!/bin/bash"
   write_marker "code-audit-frontend"
   run_merge_hook
-  assert_denied
+  assert_denied_by_json
 }
 
 # --- Linked-worktree anchoring (regression) ---------------------------------
@@ -1116,7 +1107,7 @@ run_merge_hook_in_worktree() {
   local cmd="gh pr merge 30 --squash --delete-branch"
   local json
   json=$(jq -n --arg c "$cmd" '{tool_name: "Bash", tool_input: {command: $c}}')
-  run bash -c "cd '$WT' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$WT" "$json" "$HOOK_ABS"
 }
 
 teardown_linked_worktree() {

--- a/.gaia/tests/hooks/provision-worktree.bats
+++ b/.gaia/tests/hooks/provision-worktree.bats
@@ -24,6 +24,7 @@
 # `return 1`.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK_ABS="$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/provision-worktree.sh"
   REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
 }
@@ -142,7 +143,7 @@ SH
   make_main
   WT="$(add_worktree feat-enter)"
 
-  run bash -c "printf '%s' '$(enter_payload "$WT")' | bash '$HOOK_ABS'"
+  invoke_hook "$(enter_payload "$WT")" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -L "$WT/.gaia/local" ] || return 1
 }
@@ -155,7 +156,7 @@ SH
   WT="$(add_worktree feat-sessionstart)"
 
   payload="$(jq -nc --arg p "$WT" '{hook_event_name: "SessionStart", source: "startup", cwd: $p}')"
-  run bash -c "printf '%s' '$payload' | bash '$HOOK_ABS'"
+  invoke_hook "$payload" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -L "$WT/.gaia/local" ] || return 1
 }
@@ -167,7 +168,7 @@ SH
   make_main
 
   payload="$(jq -nc --arg p "$MAIN" '{hook_event_name: "SessionStart", source: "startup", cwd: $p}')"
-  run bash -c "printf '%s' '$payload' | bash '$HOOK_ABS'"
+  invoke_hook "$payload" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 
   # No symlink was created over main's own real directory, and nothing was
@@ -213,7 +214,7 @@ SH
   mkdir -p "$WT/.gaia/local/audit"
   echo orphaned > "$WT/.gaia/local/audit/orphan.txt"
 
-  run bash -c "printf '%s' '$(enter_payload "$WT")' | bash '$HOOK_ABS'"
+  invoke_hook "$(enter_payload "$WT")" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 
   [ -L "$WT/.gaia/local" ] || return 1
@@ -230,7 +231,7 @@ SH
   WT="$(add_worktree feat-byhand)"
   [ -L "$WT/.gaia/local" ] && return 1
 
-  run bash -c "printf '%s' '$(enter_payload "$WT")' | bash '$HOOK_ABS'"
+  invoke_hook "$(enter_payload "$WT")" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -L "$WT/.gaia/local" ] || return 1
 }
@@ -268,7 +269,7 @@ SH
   mkdir -p "$WT/.react-router/types"
   echo LEFTOVER > "$WT/.react-router/types/.stamp"
 
-  run bash -c "printf '%s' '$(enter_payload "$WT")' | bash '$HOOK_ABS'"
+  invoke_hook "$(enter_payload "$WT")" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   grep -qF LEFTOVER "$WT/.react-router/types/.stamp" && return 1
   [ "$(cat "$WT/.react-router/types/.stamp")" = "$WT" ]
@@ -449,7 +450,7 @@ SH
   echo main-red > "$MAIN/.gaia/local/red-ledger/observations.jsonl"
 
   payload="$(jq -nc --arg p "$MAIN" '{hook_event_name: "SessionStart", source: "startup", cwd: $p}')"
-  run bash -c "printf '%s' '$payload' | bash '$HOOK_ABS'"
+  invoke_hook "$payload" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 
   key="$(tree_key_for "$MAIN")"
@@ -638,7 +639,7 @@ SH
   echo main-own-data > "$MAIN/.gaia/local/red-ledger/$key/observations.jsonl"
 
   payload="$(jq -nc --arg p "$MAIN" '{hook_event_name: "SessionStart", source: "startup", cwd: $p}')"
-  run bash -c "printf '%s' '$payload' | bash '$HOOK_ABS'"
+  invoke_hook "$payload" "$HOOK_ABS"
   [ "$status" -eq 0 ]
 
   grep -qF -- "CUTOVER MIGRATION" <<<"$output" && return 1

--- a/.gaia/tests/hooks/red-verify-commit-check.bats
+++ b/.gaia/tests/hooks/red-verify-commit-check.bats
@@ -26,6 +26,7 @@
 # createRequire(import.meta.url), so the signal recompute works.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   # The hook recomputes RED signals via the Node helper, which resolves
   # `typescript` from node_modules; skip where deps aren't installed (e.g. the
@@ -122,7 +123,7 @@ run_commit_hook() {
   local cmd="${1:-git commit -m change}"
   local json
   json=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$REPO" "$json" "$HOOK_ABS"
 }
 
 denied() { [[ "$output" == *'"permissionDecision": "deny"'* ]]; }

--- a/.gaia/tests/hooks/red-verify-e2e.bats
+++ b/.gaia/tests/hooks/red-verify-e2e.bats
@@ -27,6 +27,7 @@
 # edited-after-RED proves the handshake breaks when the body changes.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   # Both hooks recompute RED signals via the Node helper, which resolves
   # `typescript` from node_modules; skip where deps aren't installed (e.g. the
@@ -92,7 +93,7 @@ run_capture() {
   local payload
   payload=$(jq -nc --arg c "pnpm test --run $file_rel" \
     '{tool_name:"Bash", tool_input:{command:$c}, tool_response:{stdout:"", stderr:"", interrupted:false}}')
-  run bash -c "cd '$REPO' && export RED_CAPTURE_JSON_OVERRIDE='$json_abs'; printf '%s' '$payload' | bash '$CAPTURE_HOOK'"
+  RED_CAPTURE_JSON_OVERRIDE="$json_abs" invoke_hook_in "$REPO" "$payload" "$CAPTURE_HOOK"
 }
 
 # Drive the CHECK hook for a `git commit` PreToolUse, from inside the tmp repo.
@@ -100,7 +101,7 @@ run_check() {
   local cmd="${1:-git commit -m change}"
   local payload
   payload=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$payload' | bash '$CHECK_HOOK'"
+  invoke_hook_in "$REPO" "$payload" "$CHECK_HOOK"
 }
 
 # Write a canned vitest json reporting ONE failing per-test result. Args:
@@ -202,13 +203,13 @@ test("adds two numbers", () => {
 # ---------------------------------------------------------------------------
 @test "bare pnpm test is still blocked by block-bare-test.sh (exit 2)" {
   payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"pnpm test"}}')
-  run bash -c "printf '%s' '$payload' | bash '$BARE_TEST_HOOK'"
+  invoke_hook "$payload" "$BARE_TEST_HOOK"
   [ "$status" -eq 2 ]
   [[ "$output" == *"BLOCKED"* ]]
 }
 
 @test "pnpm test --run is NOT blocked by block-bare-test.sh" {
   payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"pnpm test --run app/utils/x/index.test.ts"}}')
-  run bash -c "printf '%s' '$payload' | bash '$BARE_TEST_HOOK'"
+  invoke_hook "$payload" "$BARE_TEST_HOOK"
   [ "$status" -eq 0 ]
 }

--- a/.gaia/tests/hooks/serena-code-search-guard.bats
+++ b/.gaia/tests/hooks/serena-code-search-guard.bats
@@ -24,6 +24,7 @@
 # repo per test also means the block-once cache starts empty every time.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOOK=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/serena-code-search-guard.sh
 
   REPO=$(mktemp -d -t serena-guard-repo-XXXXXX)
@@ -60,18 +61,10 @@ mk_bash() {
 # Pipe $1 (a payload) to the hook from inside the repo. $2 overrides HOME.
 run_hook() {
   local payload="$1" home="${2:-$FAKEHOME}"
-  run bash -c "cd '$REPO' && printf '%s' '$payload' | HOME='$home' bash '$HOOK'"
+  HOME="$home" invoke_hook_in "$REPO" "$payload" "$HOOK"
 }
 
-assert_blocked() {
-  [ "$status" -eq 2 ]
-  [[ "$output" == *"BLOCKED"* ]]
-}
 
-assert_allowed() {
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-}
 
 # ===========================================================================
 # Grep matcher: regression-lock the existing structured-field behavior.
@@ -79,58 +72,58 @@ assert_allowed() {
 
 @test "grep: bare identifier with no scope narrowing is blocked" {
   run_hook "$(mk_grep 'useBreakpoint' '' '' '')"
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "grep: a prose pattern with a space is allowed" {
   run_hook "$(mk_grep 'some phrase' '' '' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: a pattern with regex metacharacters is allowed" {
   run_hook "$(mk_grep 'foo.*bar' '' '' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: a non-TS type filter is allowed" {
   run_hook "$(mk_grep 'useBreakpoint' '' '' 'css')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: a *.md glob is allowed" {
   run_hook "$(mk_grep 'useBreakpoint' '' '*.md' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: a path outside app/ and test/ is allowed" {
   run_hook "$(mk_grep 'useBreakpoint' 'wiki' '' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: a pattern shorter than 3 chars is allowed" {
   run_hook "$(mk_grep 'ab' '' '' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: block-once - the identical blocked grep re-run within the window passes" {
   local p; p=$(mk_grep 'useBreakpoint' '' '' '' 'sGrepOnce')
   run_hook "$p"
-  assert_blocked
+  assert_blocked_by_exit
   run_hook "$p"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: no tsconfig.json is a no-op (allow)" {
   rm -f "$REPO/tsconfig.json"
   run_hook "$(mk_grep 'useBreakpoint' '' '' '')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "grep: serena unregistered is a no-op (allow)" {
   local emptyhome; emptyhome=$(mktemp -d -t serena-guard-nohome-XXXXXX)
   run_hook "$(mk_grep 'useBreakpoint' '' '' '')" "$emptyhome"
   rm -rf "$emptyhome"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # ===========================================================================
@@ -139,22 +132,22 @@ assert_allowed() {
 
 @test "bash: grep -rn over app/ is blocked" {
   run_hook "$(mk_bash 'grep -rn "useBreakpoint" app/')"
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "bash: rg over app/components is blocked" {
   run_hook "$(mk_bash 'rg "handleSubmit" app/components')"
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "bash: ag over test/ is blocked" {
   run_hook "$(mk_bash 'ag SomeSymbol test/')"
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 @test "bash: grep --include=*.ts over app is blocked" {
   run_hook "$(mk_bash 'grep --include=*.ts -rn "MyType" app')"
-  assert_blocked
+  assert_blocked_by_exit
 }
 
 # ===========================================================================
@@ -163,67 +156,67 @@ assert_allowed() {
 
 @test "bash: a git-diff pipeline is allowed" {
   run_hook "$(mk_bash 'git diff | grep "foo"')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a lint pipeline with context flags is allowed" {
   run_hook "$(mk_bash 'pnpm lint | grep -A2 "warning"')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a wiki-lint scan scoped to .claude/ is allowed" {
   run_hook "$(mk_bash 'grep -rn "wiki-lint" .claude/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a playwright-output pipeline is allowed" {
   run_hook "$(mk_bash 'playwright-cli screenshot out.png | grep passed')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a path-literal pattern searched in a JSON file is allowed" {
   run_hook "$(mk_bash 'grep -n "app/languages/" manifest.json')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a multi-word pattern is allowed" {
   run_hook "$(mk_bash 'grep -rn "some phrase here" app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a regex-alternation pattern is allowed" {
   run_hook "$(mk_bash 'grep -rEn "foo|bar" app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a pattern shorter than 3 chars is allowed" {
   run_hook "$(mk_bash 'grep -rn "ab" app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a scope that is not TS/TSX is allowed" {
   run_hook "$(mk_bash 'grep -rn "useThing" app/foo.md')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a compound command is allowed" {
   run_hook "$(mk_bash 'echo useBreakpoint && grep -rn useBreakpoint app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: rg with no resolvable app/test scope is allowed" {
   run_hook "$(mk_bash 'rg useBreakpoint')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: a non-grep command is allowed" {
   run_hook "$(mk_bash 'ls app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: grep as prose inside a quoted commit message is allowed" {
   run_hook "$(mk_bash 'git commit -m "grep useBreakpoint in app"')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 # ===========================================================================
@@ -233,20 +226,20 @@ assert_allowed() {
 @test "bash: block-once - the identical blocked grep re-run within the window passes" {
   local p; p=$(mk_bash 'grep -rn "useBreakpoint" app/' 'sBashOnce')
   run_hook "$p"
-  assert_blocked
+  assert_blocked_by_exit
   run_hook "$p"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: no tsconfig.json is a no-op (allow)" {
   rm -f "$REPO/tsconfig.json"
   run_hook "$(mk_bash 'grep -rn "useBreakpoint" app/')"
-  assert_allowed
+  assert_allowed_by_exit
 }
 
 @test "bash: serena unregistered is a no-op (allow)" {
   local emptyhome; emptyhome=$(mktemp -d -t serena-guard-nohome-XXXXXX)
   run_hook "$(mk_bash 'grep -rn "useBreakpoint" app/')" "$emptyhome"
   rm -rf "$emptyhome"
-  assert_allowed
+  assert_allowed_by_exit
 }

--- a/.gaia/tests/hooks/session-stop.bats
+++ b/.gaia/tests/hooks/session-stop.bats
@@ -1,12 +1,16 @@
 #!/usr/bin/env bats
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   HOOK_ABS=$(cd "$BATS_TEST_DIRNAME/../../../.claude/hooks" && pwd)/wiki-session-stop.sh
 }
 
 teardown() {
+  # `return 0` because the guard is an AND-list: with no $REPO to remove it
+  # would otherwise leave teardown non-zero and fail an innocent test.
   [ -n "${REPO:-}" ] && rm -rf "$REPO"
+  return 0
 }
 
 @test "no session-start marker: silent no-op" {
@@ -17,7 +21,7 @@ teardown() {
 {"version":1,"last_evaluated_sha":"$head","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" stop S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -32,7 +36,7 @@ EOF
 {"version":1,"last_evaluated_sha":"$head","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" stop S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -51,7 +55,7 @@ EOF
 {"version":1,"last_evaluated_sha":"$head","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" stop S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -71,7 +75,7 @@ EOF
 {"version":1,"last_evaluated_sha":"$start","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
   input=$("$HELPERS/mock-hook-input.sh" stop S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"[wiki end-of-session]"* ]]
   [[ "$output" == *"3 times"* ]]
@@ -92,10 +96,10 @@ EOF
 EOF
 
   input=$("$HELPERS/mock-hook-input.sh" stop S1)
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ -n "$output" ]
 
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -112,7 +116,11 @@ EOF
   cat > wiki/.state.json <<EOF
 {"version":1,"last_evaluated_sha":"$start","last_evaluated_at":"2026-01-01T00:00:00Z"}
 EOF
-  run bash -c "echo 'not-json{{' | '$HOOK_ABS'"
+  invoke_hook 'not-json{{' "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/token-rollup-merge.bats
+++ b/.gaia/tests/hooks/token-rollup-merge.bats
@@ -11,6 +11,7 @@
 # (build_repo below), matching what a real checkout has.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/token-rollup-merge.sh"
@@ -88,7 +89,7 @@ run_hook() {
   # run_hook <command>
   local cmd="$1" input
   input=$("$HELPERS/mock-hook-input.sh" post-tool-use S1 Bash "$cmd")
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
 }
 
 # ---------- 1. Renders spec+plan+execute+Total at merge (UAT-006) ----------
@@ -297,7 +298,11 @@ run_hook() {
     '{session_id:$sid, transcript_path:"/tmp/t.jsonl", cwd:".", hook_event_name:"PostToolUse",
       tool_name:"Bash", tool_input:{command:$cmd},
       tool_response:{stdout:"", stderr:"merge failed", exit_code:1, interrupted:false}}')
-  run bash -c "echo '$input' | '$HOOK_ABS'"
+  invoke_hook "$input" "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Cycle cost (SPEC-042)"* ]]
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/token-tally-review.bats
+++ b/.gaia/tests/hooks/token-tally-review.bats
@@ -16,6 +16,7 @@
 # token-tally.sh (a recording stub stands in at the same repo-relative path).
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HELPERS="$BATS_TEST_DIRNAME/helpers"
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
   HOOK_ABS="$REPO_ROOT/.claude/hooks/token-tally-review.sh"
@@ -129,7 +130,7 @@ run_hook_stop() {
 @test "empty/garbage payload: exit 0" {
   build_repo
   cd "$REPO"
-  run bash -c "echo 'not-json{{' | '$HOOK_ABS'"
+  invoke_hook 'not-json{{' "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ ! -f "$CALLS_FILE" ]
 }
@@ -137,7 +138,7 @@ run_hook_stop() {
 @test "truly empty stdin: exit 0" {
   build_repo
   cd "$REPO"
-  run bash -c "echo '' | '$HOOK_ABS'"
+  invoke_hook '' "$HOOK_ABS"
   [ "$status" -eq 0 ]
   [ ! -f "$CALLS_FILE" ]
 }
@@ -323,4 +324,8 @@ EOF
   [ "$status" -eq 0 ]
   [ -f "$CALLS_FILE" ]
   rm -rf "$PATHSTUB"
+}
+
+@test "the hook file is executable" {
+  [ -x "$HOOK_ABS" ]
 }

--- a/.gaia/tests/hooks/worthiness-presence-check.bats
+++ b/.gaia/tests/hooks/worthiness-presence-check.bats
@@ -28,6 +28,7 @@
 # `"permissionDecision": "deny"`, an allow emits nothing.
 
 setup() {
+  . "$BATS_TEST_DIRNAME/helpers/run-hook.sh"
   HOME_ROOT=$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)
   # The hook (and this suite's seed helpers) recompute signals via the Node
   # helper, which resolves `typescript` from node_modules; skip where deps
@@ -123,7 +124,7 @@ run_merge_hook() {
   local cmd="${1:-gh pr merge 30 --squash --delete-branch}"
   local json
   json=$(jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
-  run bash -c "cd '$REPO' && printf '%s' '$json' | bash '$HOOK_ABS'"
+  invoke_hook_in "$REPO" "$json" "$HOOK_ABS"
 }
 
 denied() { [[ "$output" == *'"permissionDecision": "deny"'* ]]; }


### PR DESCRIPTION
Closes #1202
Closes #1219

Two test suites had grown their own copies of one primitive each, and in both cases the copies had drifted. This gives each directory a shared home for its primitive and converges every call site on it.

## `#1202`, the distribution suite's CLI-stderr diagnostic

Every scenario asserting a CLI call *succeeds* has to keep that call's stderr off stdout, because stdout is the JSON it is about to parse. Nine scenarios solved that two different ways and neither lived in `lib/lib.sh`: seven hand-copied a block that re-runs the identical command unsuppressed on failure, one captured stderr to a file.

`lib/lib.sh` now carries the mechanism as `capture_cli_stderr` / `run_cli` / `fail_with_stderr`, and all nine scenarios use it.

- **Mechanism B won, and the reason is substantive rather than aesthetic.** A re-run is a second, different execution: it can succeed and leave the failure unexplained, fail differently, or double the side effects on the one path already going wrong. Capturing reports the bytes the *failing* run emitted. This is also the fix `#1045` named.
- **The capture path is the caller's**, declared once per scenario. A library-allocated temp file would need a library-installed `EXIT` trap, and every scenario sets its own `trap` afterwards, which would silently replace it. Scenarios with a scratch dir that is not the tree under assertion use it; the rest `mktemp` a file and add it to the trap they already have.
- **Extending the frozen API was a deliberate call, which is why `#1202` exists as an issue.** The header's `API (frozen; see plan README)` points at the plan document for the suite's original pull request, which no longer exists in `.gaia/local/plans`, so the freeze is undocumented and unenforceable. The `frozen` marker is dropped rather than left pointing nowhere, and the header's API list gains the three functions.
- `14-gaia-update-deps.sh` had a second success-asserting call (`decline --clear`) with no diagnostic at all. It gets one for free.

## `#1219`, the hook suites' invocation and assertions

`.gaia/tests/hooks/helpers/run-hook.sh` is new, beside the two helpers already there. It holds `invoke_hook` / `invoke_hook_in` and **two assertion pairs named for the mechanism they check**, because these suites test hooks with two incompatible deny contracts:

| contract | deny | allow |
|---|---|---|
| exit code carries the verdict | `assert_blocked_by_exit` (exit 2 + `BLOCKED`) | `assert_allowed_by_exit` (exit 0, silent) |
| JSON on stdout carries the verdict | `assert_denied_by_json` | `assert_allowed_by_json` |

A generic `assert_denied` hides which contract is under test, which is how `block-eslint-config-edit.bats` came to call its exit-2 assertion `assert_denied`.

33 suites converted. Every form in the helper is bash-3.2 safe per `.claude/rules/bats-assertions.md`; four suites' copies were not (`[[ ]]` matchers in `block-manifest-write` / `block-main-destructive-git` / `block-no-verify`, a `!`-negation in `block-secrets-write` and `block-env-read`), and those fix themselves by converging.

**Nothing was weakened to fit the shared form.** Three suites assert more than the pair does and keep the extra:

- `block-spec-plan-chain.bats` keeps its own pair entirely: its deny reads the decision as a JSON *field* rather than as a substring, and its hook is silent on an allow. Both are narrower than the shared pair, so trading would lose coverage. The reason is now a comment in the file.
- `distribution-preflight-check.bats` composes: `assert_allowed_by_json` **plus** its own empty-output assertion.
- `block-secrets-write.bats` composes: its `assert_denied` / `assert_denied_cap` keep the cap-message guard that never propagated to its siblings.

**Two things the conversion changed that are worth naming:**

1. **Seven suites gained an `is executable` test.** They reached the hook by direct execution (`| '$HOOK_ABS'`), so the exec bit was under test only incidentally; the shared invocation runs `bash "$hook"`. Rather than smuggle the property back through the delivery form, each suite that had no such test now names it. Eight suites already did.
2. **Four teardowns are fixed.** `[ -n "${REPO:-}" ] && rm -rf "$REPO"` is an AND-list that returns 1 when there is no scratch repo to remove, failing an innocent test. Every existing test happened to create one; the new exec tests do not, which surfaced it. Fixed with the `return 0` the sibling suites already use.

Ten suites opened with a paragraph restating the positional-argument mechanism line by line. Each keeps the part still about that suite (what its own payloads carry) and names the helper for the rest.

## What is deliberately left alone

- **`pr-merge-audit-check.bats:832` and `:852`** merge stderr into `$output` with `2>&1`, which the tests' own comments say is deliberate. The helper does not express that and should not.
- **`block-rm-rf.bats:1346` and `:1357`** `source` the hook to probe a helper and to prove it leaks no shell options. Not deliveries.
- **`block-eslint-config-edit.bats:170`** feeds a 1MB payload from a file on purpose.

## Verification

- **19-case adversarial proof for `run-hook.sh`**, run against throwaway hooks in a scratch tree. Each assertion is proved to **fail** when the property it names is false: a `BLOCKED` message on the wrong exit code, a silent exit-2 block, a noisy allow, a deny on a non-zero exit, a missing deny. Each is also proved to fail **from a non-final line**, which is the hollow-assertion trap `.claude/rules/bats-assertions.md` exists for. Delivery is proved byte-identical for a payload carrying single quotes, double quotes and a newline, through both `invoke_hook` and `invoke_hook_in`, plus the cwd and the env-prefix behaviour that several suites depend on.
- **12-case adversarial proof for the `lib.sh` capture**: the failing run's stderr is reported, stdout stays clean, a silent failure says so, an earlier call's stderr is never reported as this one's, and a scenario that forgot `capture_cli_stderr` fails closed instead of running the command. Plus an end-to-end mutation of scenario 13 (a missing `--baseline`) that printed the real CLI error inside the fenced block ahead of the FAIL line.
- Every touched distribution scenario run individually; `shell-lint.sh`; the bats suites under bash 5.

**The Quality Gate skips by its own criterion.** Its grep over the 44 changed files returns nothing: no `.ts|tsx|js|jsx|mjs|cjs|css`, no gate-affecting config. `simplify` is step 1 of that gate and skips with it. The verification this diff owes is the shell gate and the suites, above.

**No CHANGELOG entry is owed**, verified rather than assumed: all 44 changed files were checked against `.gaia/manifest.json` and none is in it, so nothing ships. Both issues are `surface:maintainer`.

## Out-of-scope findings

- **Filed as #1232**: `.gaia/tests/concurrency/concurrency.bats` hand-rolls the same delivery idiom 14 times and cannot reach the new helper, because 13 of the copies wrap it in `run_in` or an env prefix while the helper calls bats' `run` itself. Filed rather than waived because that file is outside this pull request. Stated honestly in the issue: all 14 copies are already the quote-safe form, so the mangling failure mode is not present there; what is present is the condition that produced the drift here, no shared primitive to reach for.

## Audit gate

Round 1, `code-audit-maintainer-shell` (the only member the roster dispatches for an all-`.bats`/`.sh` diff). **Clean: no Critical, no Important, two Suggestions.** The member verified rather than read: `@test` count 1088 → 1095 with no test deleted and no assertion loosened, every removed local assertion replaced by an equal-or-stronger shared one, all five helper forms mutation-proved in non-final position on bash 3.2.57 *and* bash 5.3.15, and the full hooks directory green at 1297/1297.

Both Suggestions are **in-scope and accepted rather than folded in**, per the digest economics in `wiki/concepts/PR Merge Workflow.md`: the member is already marked and nothing else is rotating its digest, so folding either in buys a full re-dispatch to re-earn the marker, and neither is consequential enough to be worth it.

**1. `helpers/run-hook.sh:44`, interpreter selection moved from shebang to PATH.** `invoke_hook` runs `bash "$hook"`, so a hook's own shebang no longer picks the interpreter. Two of the eight affected hooks (`debt-sentinel-touch.sh`, `debt-session-reconcile.sh`) pin `#!/bin/bash` where the other six pin `#!/usr/bin/env bash`; verified. Accepted, and the reason is not only cost: **the fidelity this trades away is fidelity the repo tells maintainers not to rely on.** CI runs these suites on `ubuntu-latest`, where `/bin/bash` is bash 5 either way, so the difference only ever existed on a maintainer's local macOS run, and `.claude/rules/bats-assertions.md` directs local bats runs through the bash-5 guard for exactly that reason. The member confirmed no live failure: both suites pass 20/20 under either interpreter. Normalizing the two shebangs would change which bash runs an adopter's hook, which is a production change that deserves its own review rather than a ride-along on a test refactor.

**2. `pr-merge-audit-check.bats:832` and `:852` stay on the pre-refactor idiom**, because they merge stderr with `2>&1` and the helper has no variant for that. Accepted; the exemption is named in "What is deliberately left alone" above so the next reader does not read it as a miss. Both payloads are jq-built from a fixed command with no quote of their own, which the member confirmed.

The member wrote its marker and findings sidecar, stamped the trailer, pushed, and posted the `GAIA-Audit` success status. The dispatch classified `real` against both artifacts.
