### PR TITLE
debt(tests): gate git auto-maintenance in the commit-classify sandbox (#1216)

### DIFF
--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -892,7 +892,19 @@ describe('commit-classify sandbox fixture', () => {
         controlRoot
       );
 
-      expect(autoMaintenanceSpawns(controlTrace).length).toBeGreaterThan(0);
+      const controlSpawns = autoMaintenanceSpawns(controlTrace);
+      expect(controlSpawns.length).toBeGreaterThan(0);
+      // The control's own run must stay in the foreground, or the `finally`
+      // below deletes `controlRoot` out from under a live background git. A
+      // count alone cannot see that: the parent records the child either way,
+      // so this test would pass green while leaking the orphan the whole
+      // fixture exists to prevent. Asserted as an absence to stay portable,
+      // git predating the task set spawns `git gc --auto`, which carries no
+      // detach flag at all and passes, while modern git catches a
+      // `maintenance.autoDetach` that a later edit dropped as redundant.
+      expect(controlSpawns.some((line) => line.includes('"--detach"'))).toBe(
+        false
+      );
 
       const sandboxTrace = path.join(traceRoot, 'sandbox.json');
       vi.stubEnv('GIT_TRACE2_EVENT', sandboxTrace);

--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -95,12 +95,14 @@ const sandboxGit = (root: string, args: string[]): string => {
  * when `git maintenance` replaced `git gc --auto`, and the git the fixture
  * runs under is whatever the machine or the CI runner supplies:
  *
- * - `maintenance.auto=false` is the gate on modern git, and it covers the whole
- *   task set. `gc.auto` governs only the gc heuristic, so it says nothing about
- *   the `loose-objects` and `incremental-repack` tasks, and those are the ones
- *   that pack.
- * - `gc.auto=0` is the same gate for git predating that task set, which reaches
- *   the repository through `git gc --auto` instead.
+ * - `maintenance.auto=false` is the documented gate on the spawn, and it covers
+ *   the whole task set, including the `loose-objects` and `incremental-repack`
+ *   tasks, which are the ones that pack.
+ * - `gc.auto=0` is the gate for git predating that task set, which reaches the
+ *   repository through `git gc --auto` instead. On git 2.55 it also suppresses
+ *   the modern spawn on its own, so what failed in CI is not established to be
+ *   this key being the weaker one; what is established is that a single key was
+ *   not enough on the git that ran there.
  * - `gc.autoDetach=false` is the fallback for both: a run that starts anyway
  *   finishes before the command that triggered it returns, so it can neither
  *   outlive the test nor race the next `git commit`. `maintenance.autoDetach`
@@ -121,11 +123,27 @@ const SANDBOX_GIT_CONFIG: [string, string][] = [
 ];
 
 /**
- * The gates the control repository omits, so it still spawns what the sandbox
- * suppresses. Named here, beside the list it subtracts from, so the two cannot
- * drift into disagreeing about which entries are the gates.
+ * The gates, paired with the value that explicitly turns each one off.
+ *
+ * The control repository cannot establish "ungated" by leaving these out.
+ * Repo-local config beats global, so the sandbox is immune to whatever the
+ * machine's own `~/.gitconfig` says, but a control that merely omits these
+ * keys inherits it, and `gc.auto = 0` is a common thing to carry in a personal
+ * dotfile. The control would then spawn nothing and the arm asserting git
+ * still spawns maintenance would fail against a fixture behaving perfectly.
+ * Writing git's own defaults into the control makes its condition its own.
+ *
+ * Named beside the list it subtracts from so the two cannot drift into
+ * disagreeing about which entries are the gates.
  */
-const MAINTENANCE_GATES = new Set(['gc.auto', 'maintenance.auto']);
+const MAINTENANCE_GATE_DEFAULTS: [string, string][] = [
+  ['gc.auto', '6700'],
+  ['maintenance.auto', 'true'],
+];
+
+const MAINTENANCE_GATES = new Set(
+  MAINTENANCE_GATE_DEFAULTS.map(([key]) => key)
+);
 
 /** Initialize one repository this fixture owns, suppression included. */
 const initSandboxRepo = (root: string, omit?: ReadonlySet<string>): void => {
@@ -779,18 +797,25 @@ describe('wiki commit-classify', () => {
 });
 
 /**
- * Every `git maintenance` child process git's own trace recorded.
+ * Every auto-maintenance child process git's own trace recorded.
  *
  * `GIT_TRACE2_EVENT` writes a `child_start` event, carrying the child's argv,
  * into the trace of the process that spawned it, so a run detached with
  * `--detach` is still visible without waiting on it or racing its exit. An
  * absent file means git spawned nothing and so wrote nothing.
+ *
+ * Both spellings count. Modern git spawns `git maintenance run --auto`; git
+ * predating that task set spawns `git gc --auto`, which the config list above
+ * names as a version it suppresses, so a filter matching only the first would
+ * assert nothing on exactly the git the second entry exists for.
  */
-const maintenanceSpawns = (tracePath: string): string[] =>
+const autoMaintenanceSpawns = (tracePath: string): string[] =>
   (existsSync(tracePath) ? readFileSync(tracePath, 'utf8') : '')
     .split('\n')
     .filter(
-      (line) => line.includes('"child_start"') && line.includes('maintenance')
+      (line) =>
+        line.includes('"child_start"') &&
+        (line.includes('"maintenance"') || line.includes('"gc"'))
     );
 
 /**
@@ -841,11 +866,17 @@ describe('commit-classify sandbox fixture', () => {
     let sandbox: Sandbox | undefined;
 
     try {
-      // Everything the sandbox sets except the gates. `gc.autoDetach` is not a
-      // gate and so stays, which keeps the control's own maintenance run a
-      // foreground child; without it this test would leak the very orphaned
-      // background process it exists to keep out of the suite.
+      // Everything the sandbox sets except the gates, which are then written
+      // back at git's own defaults so the control's ungated state is its own
+      // rather than inherited from the machine's global config. `gc.autoDetach`
+      // is not a gate and so stays, which keeps the control's own maintenance
+      // run a foreground child; without it this test would leak the very
+      // orphaned background process it exists to keep out of the suite.
       initSandboxRepo(controlRoot, MAINTENANCE_GATES);
+
+      for (const [key, value] of MAINTENANCE_GATE_DEFAULTS) {
+        sandboxGit(controlRoot, ['config', key, value]);
+      }
 
       const controlTrace = path.join(traceRoot, 'control.json');
       vi.stubEnv('GIT_TRACE2_EVENT', controlTrace);
@@ -854,14 +885,14 @@ describe('commit-classify sandbox fixture', () => {
         controlRoot
       );
 
-      expect(maintenanceSpawns(controlTrace).length).toBeGreaterThan(0);
+      expect(autoMaintenanceSpawns(controlTrace).length).toBeGreaterThan(0);
 
       const sandboxTrace = path.join(traceRoot, 'sandbox.json');
       vi.stubEnv('GIT_TRACE2_EVENT', sandboxTrace);
       sandbox = setupSandbox();
       commitManyTo(sandbox, 4, 'docs: prose', 'notes/thing.md');
 
-      expect(maintenanceSpawns(sandboxTrace)).toEqual([]);
+      expect(autoMaintenanceSpawns(sandboxTrace)).toEqual([]);
     } finally {
       vi.unstubAllEnvs();
       sandbox?.cleanup();

--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -6,7 +6,14 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * then ask the handler to classify them since the initial baseline. We
  * snapshot the suggestion + reason for each commit and assert against it.
  */
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
@@ -37,7 +44,11 @@ const describeSandbox = (root: string): string => {
     try {
       return execGaiaGit(args, root).replaceAll('\n', ' ');
     } catch (error) {
-      return `<${(error instanceof Error ? error.message : String(error)).split('\n', 1)[0]}>`;
+      // Keep the whole message, collapsed to this row's single line. Node puts
+      // the failed command on the first line and git's own explanation on the
+      // lines after it, so taking only the first line reports that `fsck`
+      // failed while discarding the one thing that says why.
+      return `<${(error instanceof Error ? error.message : String(error)).replaceAll('\n', ' ').trim()}>`;
     }
   };
 
@@ -70,18 +81,66 @@ const sandboxGit = (root: string, args: string[]): string => {
   }
 };
 
+/**
+ * Every git config a repository this fixture creates needs, identity included.
+ *
+ * The maintenance entries are the load-bearing ones. Every `git commit`
+ * otherwise spawns a detached `git maintenance run --auto --quiet --detach`,
+ * so a 25-commit scenario leaves background git processes running against a
+ * sandbox that `afterEach` deletes out from under them, and one that repacks
+ * while the next `git commit` is running leaves the repository holding several
+ * packfiles and a HEAD whose commit object that commit can no longer parse.
+ *
+ * One key alone will not do it, because the spelling that gates this moved
+ * when `git maintenance` replaced `git gc --auto`, and the git the fixture
+ * runs under is whatever the machine or the CI runner supplies:
+ *
+ * - `maintenance.auto=false` is the gate on modern git, and it covers the whole
+ *   task set. `gc.auto` governs only the gc heuristic, so it says nothing about
+ *   the `loose-objects` and `incremental-repack` tasks, and those are the ones
+ *   that pack.
+ * - `gc.auto=0` is the same gate for git predating that task set, which reaches
+ *   the repository through `git gc --auto` instead.
+ * - `gc.autoDetach=false` is the fallback for both: a run that starts anyway
+ *   finishes before the command that triggered it returns, so it can neither
+ *   outlive the test nor race the next `git commit`. `maintenance.autoDetach`
+ *   is deliberately absent, every git new enough to read it also honors
+ *   `maintenance.auto=false` above.
+ *
+ * Measured on git 2.55, over the whole list rather than per entry: one spawned
+ * maintenance run per commit with none of these set, zero with them. The test
+ * at the bottom of this file is what keeps that true.
+ */
+const SANDBOX_GIT_CONFIG: [string, string][] = [
+  ['user.email', 'test@example.com'],
+  ['user.name', 'Test'],
+  ['commit.gpgsign', 'false'],
+  ['gc.auto', '0'],
+  ['maintenance.auto', 'false'],
+  ['gc.autoDetach', 'false'],
+];
+
+/**
+ * The gates the control repository omits, so it still spawns what the sandbox
+ * suppresses. Named here, beside the list it subtracts from, so the two cannot
+ * drift into disagreeing about which entries are the gates.
+ */
+const MAINTENANCE_GATES = new Set(['gc.auto', 'maintenance.auto']);
+
+/** Initialize one repository this fixture owns, suppression included. */
+const initSandboxRepo = (root: string, omit?: ReadonlySet<string>): void => {
+  sandboxGit(root, ['init', '-q', '-b', 'main']);
+
+  for (const [key, value] of SANDBOX_GIT_CONFIG) {
+    if (!omit?.has(key)) {
+      sandboxGit(root, ['config', key, value]);
+    }
+  }
+};
+
 const setupSandbox = (): Sandbox => {
   const root = mkdtempSync(path.join(tmpdir(), 'gaia-wiki-classify-'));
-  sandboxGit(root, ['init', '-q', '-b', 'main']);
-  sandboxGit(root, ['config', 'user.email', 'test@example.com']);
-  sandboxGit(root, ['config', 'user.name', 'Test']);
-  sandboxGit(root, ['config', 'commit.gpgsign', 'false']);
-  // Every `git commit` otherwise spawns a detached
-  // `git maintenance run --auto --quiet --detach`, so a 25-commit scenario
-  // leaves background git processes running against a sandbox that `afterEach`
-  // deletes out from under them. `gc.auto=0` suppresses the spawn outright
-  // (measured: 3 spawns per commit by default, 0 with this set).
-  sandboxGit(root, ['config', 'gc.auto', '0']);
+  initSandboxRepo(root);
 
   const commit = (message: string, files: Record<string, string>): string => {
     for (const [relativePath, contents] of Object.entries(files)) {
@@ -720,6 +779,21 @@ describe('wiki commit-classify', () => {
 });
 
 /**
+ * Every `git maintenance` child process git's own trace recorded.
+ *
+ * `GIT_TRACE2_EVENT` writes a `child_start` event, carrying the child's argv,
+ * into the trace of the process that spawned it, so a run detached with
+ * `--detach` is still visible without waiting on it or racing its exit. An
+ * absent file means git spawned nothing and so wrote nothing.
+ */
+const maintenanceSpawns = (tracePath: string): string[] =>
+  (existsSync(tracePath) ? readFileSync(tracePath, 'utf8') : '')
+    .split('\n')
+    .filter(
+      (line) => line.includes('"child_start"') && line.includes('maintenance')
+    );
+
+/**
  * The fixture's own hermeticity. Every scenario above takes it on faith that
  * the repository it commits into is the one `setupSandbox` created; nothing
  * asserted it, and a bare `execFileSync('git', ...)` hands that assumption to
@@ -728,9 +802,7 @@ describe('wiki commit-classify', () => {
 describe('commit-classify sandbox fixture', () => {
   test('commits into its own repository under an ambient GIT_DIR', () => {
     const decoy = mkdtempSync(path.join(tmpdir(), 'gaia-wiki-classify-decoy-'));
-    execGaiaGit(['init', '-q', '-b', 'main'], decoy);
-    execGaiaGit(['config', 'user.email', 'decoy@example.com'], decoy);
-    execGaiaGit(['config', 'user.name', 'Decoy'], decoy);
+    initSandboxRepo(decoy);
     execGaiaGit(
       ['commit', '-q', '--allow-empty', '-m', 'decoy baseline'],
       decoy
@@ -750,6 +822,51 @@ describe('commit-classify sandbox fixture', () => {
       vi.unstubAllEnvs();
       sandbox?.cleanup();
       rmSync(decoy, {force: true, recursive: true});
+    }
+  });
+
+  // A bare "no maintenance was spawned" assertion passes just as well when the
+  // trace recorded nothing at all, which is how a guard against a background
+  // process goes vacuous without anyone noticing. The control repository, which
+  // sets everything the sandbox sets except the two suppression gates, proves in
+  // the same run that git still spawns maintenance on commit and that the trace
+  // captures it.
+  test('the sandbox config suppresses maintenance a bare repo spawns', () => {
+    const traceRoot = mkdtempSync(
+      path.join(tmpdir(), 'gaia-wiki-classify-trace-')
+    );
+    const controlRoot = mkdtempSync(
+      path.join(tmpdir(), 'gaia-wiki-classify-control-')
+    );
+    let sandbox: Sandbox | undefined;
+
+    try {
+      // Everything the sandbox sets except the gates. `gc.autoDetach` is not a
+      // gate and so stays, which keeps the control's own maintenance run a
+      // foreground child; without it this test would leak the very orphaned
+      // background process it exists to keep out of the suite.
+      initSandboxRepo(controlRoot, MAINTENANCE_GATES);
+
+      const controlTrace = path.join(traceRoot, 'control.json');
+      vi.stubEnv('GIT_TRACE2_EVENT', controlTrace);
+      execGaiaGit(
+        ['commit', '-q', '--allow-empty', '-m', 'control baseline'],
+        controlRoot
+      );
+
+      expect(maintenanceSpawns(controlTrace).length).toBeGreaterThan(0);
+
+      const sandboxTrace = path.join(traceRoot, 'sandbox.json');
+      vi.stubEnv('GIT_TRACE2_EVENT', sandboxTrace);
+      sandbox = setupSandbox();
+      commitManyTo(sandbox, 4, 'docs: prose', 'notes/thing.md');
+
+      expect(maintenanceSpawns(sandboxTrace)).toEqual([]);
+    } finally {
+      vi.unstubAllEnvs();
+      sandbox?.cleanup();
+      rmSync(controlRoot, {force: true, recursive: true});
+      rmSync(traceRoot, {force: true, recursive: true});
     }
   });
 });

--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -103,11 +103,17 @@ const sandboxGit = (root: string, args: string[]): string => {
  *   the modern spawn on its own, so what failed in CI is not established to be
  *   this key being the weaker one; what is established is that a single key was
  *   not enough on the git that ran there.
- * - `gc.autoDetach=false` is the fallback for both: a run that starts anyway
- *   finishes before the command that triggered it returns, so it can neither
- *   outlive the test nor race the next `git commit`. `maintenance.autoDetach`
- *   is deliberately absent, every git new enough to read it also honors
- *   `maintenance.auto=false` above.
+ * - `gc.autoDetach=false` and `maintenance.autoDetach=false` are the fallback
+ *   for both: a run that starts anyway finishes before the command that
+ *   triggered it returns, so it can neither outlive the test nor race the next
+ *   `git commit`. Both spellings are here for the control repository below
+ *   rather than for the sandbox, which needs neither once the gates hold.
+ *   Neither is a gate, so the control inherits both, and the control is the one
+ *   repository that deliberately leaves maintenance switched on. Modern git
+ *   resolves `maintenance.autoDetach` ahead of `gc.autoDetach`, so dropping it
+ *   as redundant would let a global `maintenance.autoDetach = true` detach the
+ *   control's run and leave it working in a directory `rmSync` is about to
+ *   delete, which is the orphan this whole list exists to prevent.
  *
  * Measured on git 2.55, over the whole list rather than per entry: one spawned
  * maintenance run per commit with none of these set, zero with them. The test
@@ -120,6 +126,7 @@ const SANDBOX_GIT_CONFIG: [string, string][] = [
   ['gc.auto', '0'],
   ['maintenance.auto', 'false'],
   ['gc.autoDetach', 'false'],
+  ['maintenance.autoDetach', 'false'],
 ];
 
 /**


### PR DESCRIPTION
Closes #1216

## What was wrong

The `commit-classify` sandbox's only defence against git's own background maintenance was `gc.auto=0`. That governs the gc heuristic, not the maintenance task set, so it says nothing about the `loose-objects` and `incremental-repack` tasks, and those are the ones that pack.

CI found the sandbox holding two packfiles and 93 in-pack objects roughly 24 commits into a repository created seconds earlier, with a HEAD whose commit object `git commit` could no longer parse. A detached maintenance run had repacked the repository underneath the suite and reddened a pull request whose diff cannot reach this file.

## Mechanism, as far as the evidence establishes it

Measured rather than inferred, on git 2.55:

- `gc.auto=0` **does** suppress the spawn outright here, which is what the comment it carried claimed. The defence is one version-dependent heuristic, and the CI evidence proves it did not hold there.
- `maintenance.auto=false` is the documented gate on the spawn itself and covers the whole task set.
- Tracing the entire suite with `GIT_TRACE2_EVENT` showed exactly **one** unsuppressed `git maintenance run --auto --quiet --detach` per run today, from the decoy repository in the hermeticity test, which set no suppression at all and which `rmSync` then deletes out from under. That is the same hazard class, presently reproducible, and it is now closed.

## What changed

- Suppression is stated in the spelling each git generation reads: `maintenance.auto` for the task set, `gc.auto` for git predating it, and `gc.autoDetach` so a run that starts anyway finishes before its triggering command returns rather than outliving the test or racing the next commit. `maintenance.autoDetach` is deliberately absent: every git new enough to read it also honors `maintenance.auto=false`.
- Every repository the fixture creates now goes through one initializer, so none can be the one that quietly skips it.
- `describeSandbox`'s probe rows keep git's own explanation. They truncated to the first line, which is why the CI report says `fsck` failed while naming no cause, and why this took a second failure to diagnose rather than the first.

## Verification

- Full CLI suite green: 131 files, 1982 passed. Root typecheck, root lint, CLI typecheck, CLI lint, root tests (156), and `pnpm build` all green.
- The new guard was proven falsifiable on **both** arms, per the pre-dispatch rule:
  - removing the gates from the shared config list fails the subject arm (`expected [ …(5) ] to deeply equal []`, one spawn per commit);
  - giving the control repository the full suppression fails the control arm (`expected 0 to be greater than 0`).
- The control exists because a bare "no maintenance was spawned" assertion passes just as well against a trace that recorded nothing. It proves in the same run that git still spawns maintenance on commit and that the trace captures it.

Playwright was not run: the diff is one file in the `.gaia/cli` workspace, which no `app/` code imports and no browser flow can reach.

## Known follow-up (out of scope here)

Seventeen other `.gaia/cli/src` suites build git sandboxes the same way and carry no suppression. Their exposure is lower (5-12 commits per sandbox, against 25+ here, and the maintenance auto-conditions are threshold-based), but the class is real. Promoting this config to a shared fixture touches all of them and is its own change, filed separately rather than folded into a single-issue debt fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit rounds

Four rounds of `code-audit-maintainer-node`, each finding addressed:

1. **Important** the control repository established its ungated state by omission, so a machine whose `~/.gitconfig` carries `gc.auto = 0` (a common dotfile) would give the control the very gate it must lack and redden the suite against a fixture behaving perfectly. Fixed: the gates now carry git's own defaults beside them and the control writes those back. Two Suggestions on prose accuracy and the trace filter's spelling coverage were applied in the same round.
2. **Important** the same defect one key over: the control's *foreground* state was still inherited. Modern git resolves `maintenance.autoDetach` ahead of `gc.autoDetach`, so a global `maintenance.autoDetach = true` detached the control's run and the cleanup then deleted its directory out from under a live git. Fixed by restoring `maintenance.autoDetach`, with the docblock now recording why it is not the redundant key it looks like.
3. **Suggestion** the control arm asserted a spawn count and never the argv, so round 2's hazard had prose behind it and nothing else. Applied: the arm now also asserts no spawn carries `--detach`, proven to fail by dropping the key under that global.

### Accepted and noted, not fixed

Round 4 was clean (no Critical, no Important) with one Suggestion the member itself recommended no change for, recorded here instead:

- `.gaia/cli/src/wiki/commit-classify.test.ts:903` the `--detach` assertion reads the child's argv, so it detects detachment only on a git that spells it there. Git predating the maintenance task set daemonizes inside `git gc --auto` with no argv flag, so that arm passes because the flag is absent from argv, not because that git cannot detach. Reaching it needs both an ancient git and a future edit dropping `gc.autoDetach`, and no such git was installed to test against.
