### PR TITLE
debt(tests): pin the full-cycle price table by absolute path (#1204)

### DIFF
--- a/.gaia/scripts/tests/token-rollup.bats
+++ b/.gaia/scripts/tests/token-rollup.bats
@@ -118,6 +118,11 @@ setup() {
   SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
   SCRIPT="$SCRIPT_DIR/token-rollup.sh"
   FIX="$(cd "$(dirname "$BATS_TEST_FILENAME")/fixtures/token-rollup" && pwd)"
+  # The hermetic price table the full-cycle case pins, resolved from the test
+  # file's own location like every other fixture path here. bats runs each test
+  # in whatever directory bats was invoked from, so a path written relative to
+  # the repo root resolves only for a run launched there.
+  RATES="$(cd "$(dirname "$BATS_TEST_FILENAME")/fixtures/token-price" && pwd)/rates.json"
 
   export GIT_AUTHOR_NAME="GAIA Test"
   export GIT_AUTHOR_EMAIL="gaia-test@example.com"
@@ -205,8 +210,11 @@ setup() {
   # --show-toplevel to decide rate_table_ok FIRST, so an absent/invalid
   # committed table would flip this fixture's dollar line to "unavailable
   # (rate table unreadable)" instead of the "records predate" line this test
-  # asserts. These fixture rows have no by_model either way (SPEC-019).
-  run bash "$SCRIPT" --spec-id SPEC-220 --ledger "$FIX/full-cycle.jsonl" --rate-table .gaia/scripts/tests/fixtures/token-price/rates.json
+  # asserts. An unreadable pinned table degrades to that same line, which is
+  # why $RATES is absolute: the reader `cat`s the --rate-table value as given,
+  # so a relative one makes the assertion depend on the caller's directory.
+  # These fixture rows have no by_model either way (SPEC-019).
+  run bash "$SCRIPT" --spec-id SPEC-220 --ledger "$FIX/full-cycle.jsonl" --rate-table "$RATES"
   [ "$status" -eq 0 ]
   [[ "$output" == *"spec:       37,000   (elapsed 10m0s)"* ]]
   [[ "$output" == *"plan:       38,300   (elapsed 11m40s)"* ]]


### PR DESCRIPTION
## What

`token-rollup.bats`'s `full-cycle` case passed its `--rate-table` fixture as a path relative to the repo root. `token-rollup.sh` `cat`s that value as given, so the pinned hermetic table resolved only for a bats run launched from the repo root. From anywhere else the reader set `rate_table_ok=false` and printed `Est. cost (USD): unavailable (rate table unreadable)`, so the test's `records predate per-model attribution` assertion failed.

Resolve the fixture from the test file's own location (the same `$RATES` idiom `token-price.bats` already uses). The assertion itself is untouched: the SPEC-019 guarantee it states, that a legacy row degrades to a marked unavailable line and never a fabricated number, is unchanged.

## Mechanism, and why the filed hypothesis was wrong

The issue correlated the failure with concurrent load and suspected a live-session write reaching a run that believed it was sandboxed. That is not the cause. The trigger is the **caller's working directory**, and it reproduces deterministically:

| Invocation | `Est. cost (USD)` line | Test |
| --- | --- | --- |
| bats from repo root (before) | `unavailable (records predate per-model attribution)` | ok |
| bats from a repo subdirectory (before) | `unavailable (rate table unreadable)` | **not ok**, line 223 |
| bats from outside any repo (before) | `unavailable (rate table unreadable)` | **not ok**, line 223 |
| all three, after | `unavailable (records predate per-model attribution)` | ok |

This is the suite's only red from a subdirectory, matching the reported whole-directory run's `1400 ok / 1 not ok`: line 209 held the only relative fixture path in any tracked `.bats` suite, and `committed-rate-smoke` still greens there because it resolves its table through `git rev-parse --show-toplevel`. A session whose shell had moved out of the repo root (the condition `.claude/rules/shell-cwd.md` exists to prevent) reproduces the report exactly, which also explains why the same test greened on re-run and on the pristine clones.

## Verification

- `bats5 .gaia/scripts/tests/token-rollup.bats` from the repo root: 20/20.
- Same suite from a repo subdirectory: 20/20 (before the fix: 19/20, `full-cycle` red at line 223).
- Same suite from `/tmp`: 19/20; the one red is `committed-rate-smoke`, which resolves the live committed table via `--show-toplevel` and therefore requires a repo working directory by design. Not a defect, and not in scope here.
- `bash .gaia/tests/shell-lint.sh`: passed.
- Quality Gate: skipped, no staged source or gate-affecting config (one `.bats` file).

Closes #1204

## Audit dispositions

`code-audit-maintainer-shell` passed clean (no Critical, no Important) and raised two Suggestions. Both land on the file this PR already changes, so they are recorded here rather than filed:

1. **`committed-rate-smoke` keeps an ambient-CWD dependence.** It passes no `--rate-table` and resolves through `git rev-parse --show-toplevel`, so it degrades from outside any checkout. No supported invocation hits it: CI runs from the workspace root and the #1204 trigger was a repo subdirectory, both of which resolve fine (20/20 confirmed from the subdirectory). Resolving the live committed table is the test's entire purpose, so requiring a repo working directory is the property, not a defect.
2. **shellcheck `SC2016` (info) on the literal-dollar assertions** at the `$1.30` globs. Correct as written, since the assertions want a literal `$` and double-quoting would expand `$1`. Pre-existing, outside this PR's changed ranges, and below the shell-lint gate's `severity=warning` threshold for `.bats`.
