### PR TITLE
wiki: sync through 09a0c93

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "b027e62df7b9e814d7f0ad3928c2b7f9b9d0559a",
-  "last_evaluated_at": "2026-08-05T05:19:27Z",
+  "last_evaluated_sha": "09a0c932c69a26fd20f6f917a9db35edb4a1244c",
+  "last_evaluated_at": "2026-08-06T02:25:43Z",
   "last_consolidated_sha": "baad8972ee9d300aee847b84f17d72e45c1fbddf",
   "last_consolidated_at": "2026-07-29T05:58:30Z"
 }

--- a/wiki/concepts/Release Workflow.md
+++ b/wiki/concepts/Release Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Release Workflow
 status: active
 created: 2026-04-22
-updated: 2026-07-17
+updated: 2026-08-06
 tags: [release, claude, maintainer, versioning]
 ---
 
@@ -188,6 +188,8 @@ The classifier is in `.gaia/cli/src/release/manifest.ts`, `ADOPTER_OWNED_SENTINE
 `.github/workflows/distribution-audit-pr.yml` enforces the manifest answer-contract at PR time. A feature PR that adds a git-tracked, non-release-excluded, classified file, one that would newly ship to adopters, must acknowledge it in `.gaia/manifest.json` before it merges, so the ship-or-withhold decision lands with the feature that creates the file rather than accumulating as an unanswered backlog left for a later, unrelated `/distribution-audit` run.
 
 The gate runs `gaia-maintainer release manifest --check --json` and reads its `missing` array (every classified file the committed manifest has never acknowledged). It fails only on the intersection of `missing` with the files the PR touches: a pre-existing backlog inherited from earlier merges is not the current PR's to drain, so a PR is never blocked by a file it did not introduce. To clear a failure, run `/distribution-audit`, answer ship-or-withhold for each named file, and commit the regenerated manifest (and `.gaia/release-exclude` for any withheld file) to the branch.
+
+The CI workflow and its local mirror, `.claude/hooks/distribution-preflight-check.sh`, derive the PR's changed-file list with `git diff --name-only -z --diff-filter=ACMR` piped through `tr '\0' '\n'`, NUL-delimited rather than newline-delimited. Git's default `core.quotePath` C-quotes any path carrying non-ASCII or control bytes, and `missing` arrives raw through `jq -r`; a quoted token would never intersect the raw set, so an unacknowledged file with such a path would pass both gates with no ship-or-withhold answer.
 
 This is the PR-time complement to release Step 10, which regenerates the manifest with `--allow-undecided`: the release path must never start failing on a tree that carries a new file, so it takes the escape hatch by design, while the per-PR gate is where a newly-shipping file is actually answered.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,16 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-08-06 09a0c932 WORTHY - NUL-delimit changed-file diff on both distribution gates (#1228, #1230) -> wiki/concepts/Release Workflow.md
+- 2026-08-06 297771f6 SKIP - tests-only
+- 2026-08-06 4d0bc9a2 SKIP - tests-only
+- 2026-08-06 cfebcec5 SKIP - tests-only
+- 2026-08-06 47184ebf SKIP - tests-only: assertion hardening across bats/vitest suites (#1201, #1209, #1214)
+- 2026-08-06 466ccbb5 SKIP - quote-safe RT-006 reset + worthiness gate (#1224, #1225); scripts not documented at command level in wiki
+- 2026-08-06 473c1790 WORTHY - mutation-restore hazard + stopping rule (#1226) -> wiki/concepts/PR Merge Workflow.md (edited in-commit)
+- 2026-08-06 8b4bdc2e WORTHY - quote-safe audit membership diffs (#1213) -> wiki/concepts/Code Review Audit Agent.md, wiki/concepts/PR Merge Workflow.md (edited in-commit)
+- 2026-08-06 74667407 SKIP - CLI help-summary drift fix (#1166); internal consistency only, no documented interface changed
+- 2026-08-06 c8dec9a4 SKIP - wiki: self-referential sync commit
 - 2026-08-05 b027e62d SKIP - eslint.config guard rewrite (#1153) already documented in-commit across wiki/concepts/Claude Hooks.md, ESLint Fixes.md, wiki/decisions/Code Audit Team.md, pnpm.md, wiki/dependencies/Storybook.md, gaia-lint.md, wiki/modules/Claude Integration.md; verified accurate
 - 2026-08-05 7e801785 SKIP - internal correctness fix, trailing-newline preservation; existing wiki description accurate at its abstraction level
 - 2026-08-05 ae974ea0 SKIP - internal correctness fix, whole-file reconstruction for Edit/MultiEdit; existing wiki description accurate at its abstraction level


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 09a0c93.