### PR TITLE
debt(ci): describe the two redundant workflow paths-filter entries honestly (#1238)

### DIFF
--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -92,16 +92,28 @@ jobs:
           filters: |
             code:
               - '.github/audit/**'
+              # This job's own definition. The filter above, the step conditions
+              # below and the bats invocations they arm all live here, so an edit
+              # to this file changes what every suite in this job runs, and
+              # retrigger-reachability.bats reads it as one of the workflows it
+              # scans. Redundant today: the `.github/workflows/**` catch-all below
+              # already matches it. Listed deliberately anyway, the same
+              # convention the `sandbox:` filter uses for its own redundant
+              # entries, so that narrowing that glob later cannot silently drop
+              # this file. It is documentation of the self-coverage, not the thing
+              # arming it.
               - '.github/workflows/audit-ci-tests.yml'
               # ci-status-member-gate.bats EXECUTES `run:` bodies extracted from
               # code-review-audit.yml, so that workflow is a source this suite
               # guards, not just a consumer of it. Its structural lock pins the
               # set of steps that POST a `pending` GAIA-Audit status and fails on
-              # an unguarded new one -- but the edit that adds such a step touches
-              # only the workflow, which matches none of the other paths here, so
-              # without this line the filter would report `code=false`, skip every
-              # bats step, and green the job having run zero tests. Same test-dir/
-              # source-dir pairing as the three instruction files below.
+              # an unguarded new one. Redundant today: the `.github/workflows/**`
+              # catch-all below already matches it. Listed deliberately anyway,
+              # the same convention the `sandbox:` filter uses for its own
+              # redundant entries, so that narrowing that glob later cannot
+              # silently drop this source. It is documentation of the test-dir/
+              # source-dir pairing, the same pairing as the three instruction
+              # files below, not the thing arming it.
               - '.github/workflows/code-review-audit.yml'
               # distribution-audit-pr-gate.bats (.gaia/scripts/tests/) EXECUTES
               # the `run:` body extracted from distribution-audit-pr.yml, so that


### PR DESCRIPTION
## Problem

`audit-ci-tests.yml`'s `code:` paths filter lists `.github/workflows/audit-ci-tests.yml` and `.github/workflows/code-review-audit.yml` as siblings of a `.github/workflows/**` catch-all. `dorny/paths-filter` ORs every pattern within one output, so neither named entry changes how any input evaluates: remove either and the filter answers identically on every possible changed-file set.

The `code-review-audit.yml` entry nonetheless carried a multi-line comment asserting the opposite as fact ("without this line the filter would report `code=false`, skip every bats step, and green the job having run zero tests"), and the `audit-ci-tests.yml` entry carried no justification at all. Nine other entries in the same filter carry that style of justification and those ones *are* real, so a maintainer auditing filter completeness had no way to tell the two classes apart.

## Fix

Both entries now read the way the `distribution-audit-pr.yml` entry and the `sandbox:` filter already do: they state the test-to-source pairing they document, name the catch-all that makes them redundant today, and say they are listed deliberately so that narrowing that glob later cannot silently drop a guarded source. The `code-review-audit.yml` comment keeps its real content (ci-status-member-gate.bats executes `run:` bodies extracted from that workflow) and drops only the false causal clause.

Deleting the two entries was the other defensible answer; it costs that documentation, so this PR takes the treatment the issue recommends and the file already uses in a third place.

## Verification

- Parsed the filter before and after: semantics identical, 52 `code:` patterns and 10 `sandbox:` patterns either way. The change is comment-only.
- `.gaia/tests/lib/lint-yaml.bats` and `.gaia/scripts/tests/retrigger-reachability.bats` pass under bash 5 (28 tests).
- `bash .gaia/tests/shell-lint.sh` passes.
- No suite pins the replaced comment text.

Quality Gate skipped: no staged source or gate-affecting config (single `.yml` workflow file). No CHANGELOG entry: `audit-ci-tests.yml` is release-excluded maintainer CI and this is a comment-only change with no adopter-observable effect.

Closes #1238