### PR TITLE
debt(ci): name the statusline suite's full guarded surface in its paths filter (#1252)

### DIFF
--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -265,8 +265,16 @@ jobs:
               - '.claude/skills/gaia/references/forensics*'
               - '.github/forensics/**'
               # The statusline suite (.gaia/tests/statusline/) exercises the
-              # shipped .gaia/statusline/gaia-statusline.sh worktree detection;
-              # trigger on both the test dir and the script it guards.
+              # shipped .gaia/statusline/gaia-statusline.sh worktree gate and
+              # segment rendering, and it runs real copies of the two
+              # refreshers that feed those segments:
+              # .gaia/scripts/check-updates.sh (the hardenUnclassifiedCount
+              # segment, and the audit nudge's project_drift suppression) and
+              # .gaia/scripts/debt-count-refresh.sh (the coveredPaths that
+              # suppression keys on). Both refreshers are already covered by
+              # the .gaia/scripts/** glob above, so only the two statusline
+              # dirs need listing here -- but narrowing that glob would stop
+              # arming this suite on two of the three sources it guards.
               - '.gaia/statusline/**'
               - '.gaia/tests/statusline/**'
               # retrigger-reachability.bats (.gaia/scripts/tests/) reads every


### PR DESCRIPTION
## What

The `code` paths-filter comment in `.github/workflows/audit-ci-tests.yml` described the statusline suite as guarding only `.gaia/statusline/gaia-statusline.sh` worktree detection. The suite also runs real copies of `.gaia/scripts/check-updates.sh` (the `hardenUnclassifiedCount` segment and the audit nudge's `project_drift` suppression) and `.gaia/scripts/debt-count-refresh.sh` (the `coveredPaths` that suppression keys on).

The comment now names all three guarded sources and states why only the two statusline dirs are listed at that spot: the `.gaia/scripts/**` glob above already arms the suite for both refreshers.

## Why it matters

There is no live failure. The trigger is already correct. The comment is the only place a reader is told what that suite covers, so it is load-bearing exactly when someone is deciding whether the `.gaia/scripts/**` glob can be narrowed. A false statement there lets that pruning drop coverage for the two scripts the audit-nudge suppression suite exists to guard, silently.

## Scope

Comment only. No filter change, no behavior change. `.github/workflows/audit-ci-tests.yml` is maintainer-only and release-excluded, so nothing mirrors to an adopter template.

## Verification

- `.gaia/tests/lib/lint-yaml.bats` + `.gaia/scripts/tests/retrigger-reachability.bats` under bash 5: 28/28 pass
- `bash .gaia/tests/shell-lint.sh`: passed
- Quality Gate skipped per its own skip logic (no staged source or gate-affecting config; a YAML comment is not inspectable by typecheck/lint/test/build)

Closes #1252