### PR TITLE
test(janitor): prove sweep #8's memo-file removal arm

### DIFF
--- a/.gaia/tests/hooks/local-janitor-worktree-reap-mutations.md
+++ b/.gaia/tests/hooks/local-janitor-worktree-reap-mutations.md
@@ -331,6 +331,36 @@ provable.
 Checksum before: `190bc11fbccfb6d28b76b05ab4e3dcc5e107b18f7abd689389efb3ea5228b5d3`.
 Checksum after revert: `190bc11fbccfb6d28b76b05ab4e3dcc5e107b18f7abd689389efb3ea5228b5d3`. Match.
 
+## Mutation 13: a run with no misses removes the memo file
+
+The memo is rewritten from scratch on every run rather than appended to, so a run that records no
+miss at all must leave no memo behind. Keeping the previous file in that case would hold entries for
+candidates the run no longer saw — including a worktree it just reaped — and those stale entries
+suppress the upstream scan for as long as both memoized tips sit still. This is the sweep's one
+destructive path arriving at its quietest moment: nothing to record is the state in which a stale
+record is easiest to leave and hardest to notice.
+
+Guard line, verbatim:
+
+```
+    rm -f "$wt_memo_file" 2>/dev/null || true
+```
+
+Edit: replace that line with `true`, leaving the `else` arm reached but inert.
+
+Test that goes red: `reaps a memoized candidate once its work genuinely lands upstream`.
+
+What stays green, and why: every other test in the suite, all 45 of them. The arm is only reached by
+a run in which no candidate records a miss, and the reap in that fixture's second run is what
+produces the condition: the memoized candidate's work has landed upstream, so it is reaped rather
+than declined, and no other candidate remains to record one. Every other fixture either records at
+least one miss — taking the non-empty arm, which this mutation does not touch — or never writes a
+memo in the first place. The red is attributable to this arm alone: the reap itself still happens
+under the mutation, and the failing assertion is the memo file's continued existence afterwards.
+
+Checksum before: `190bc11fbccfb6d28b76b05ab4e3dcc5e107b18f7abd689389efb3ea5228b5d3`.
+Checksum after revert: `190bc11fbccfb6d28b76b05ab4e3dcc5e107b18f7abd689389efb3ea5228b5d3`. Match.
+
 ## Arms with no test that reds them
 
 ### Row 2: the merge-base read's status and emptiness, together

--- a/.gaia/tests/hooks/local-janitor-worktree-reap.bats
+++ b/.gaia/tests/hooks/local-janitor-worktree-reap.bats
@@ -1186,6 +1186,10 @@ land_squash() {
   run bash "$HOOK_ABS"
   [ "$status" -eq 0 ]
   branch_exists "plan/spec-923-lands" && return 1
+  # The reap left this run with no misses to record, so the memo has nothing left
+  # to say and the file is removed rather than left holding an entry for a
+  # worktree that no longer exists.
+  [ ! -f "$(memo_file)" ]
   [ ! -e "$wt" ]
 }
 


### PR DESCRIPTION
## What

Sweep #8 of `.claude/hooks/local-janitor.sh` rewrites the negative merge-evidence memo on every run, and removes the memo file outright when a run records no misses at all. That `else` arm shipped in #1259 with no test that reds it: replacing its `rm -f` with `true` left all 46 tests green.

The arm is reachable, and cheaply. `reaps a memoized candidate once its work genuinely lands upstream` already drives its second janitor run to zero recorded misses, which is exactly the condition that takes the arm. It just never asserted the file was gone afterwards. This adds that one assertion.

## What changed

- `.gaia/tests/hooks/local-janitor-worktree-reap.bats`: one assertion added to an existing test. Test count stays 46.
- `.gaia/tests/hooks/local-janitor-worktree-reap-mutations.md`: a new `## Mutation 13` recording the observed red.

**No source change.** `.claude/hooks/local-janitor.sh` is untouched: the mutation was applied, observed, and reverted, so every checksum in the mutation record stays `190bc11f…`.

## Verification

- `bash .gaia/scripts/bats5.sh .gaia/tests/hooks/local-janitor-worktree-reap.bats` — 46/46 green, re-run after the last edit including the prose.
- Mutation applied (`rm -f "$wt_memo_file" 2>/dev/null || true` → `true`): exactly `reaps a memoized candidate once its work genuinely lands upstream` red, the other 45 green. Reverted; `git diff` on the janitor is empty and `shasum -a 256` matches.
- `bash .gaia/tests/shell-lint.sh` — passes.

## Notes

This resolves the cross-remit Suggestion accepted as a residual on #1259, which described the arm as unprovable rather than merely untested. It is provable, so it is proven rather than left as a permanent caveat on the janitor's one destructive path.

No CHANGELOG entry: test-only change to maintainer-only, release-excluded infrastructure with no adopter-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)