### PR TITLE
debt(cli): guard that a module docblock precedes the first import (#1163)

### DIFF
--- a/.gaia/cli/src/a11y-structural/check-a11y-triviality.test.ts
+++ b/.gaia/cli/src/a11y-structural/check-a11y-triviality.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, describe, expect, test} from 'vitest';
 /**
  * Tests for the structural a11y-triviality floor AST helper
  * (`.gaia/scripts/a11y-structural/check-a11y-triviality.mjs`).
@@ -22,6 +21,7 @@ import {afterEach, describe, expect, test} from 'vitest';
  * bytes); a stories fixture is written to a temp file and passed via
  * `--stories <path>`.
  */
+import {afterEach, describe, expect, test} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/audit-ledger/append-worthiness.test.ts
+++ b/.gaia/cli/src/audit-ledger/append-worthiness.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 /**
  * Tests for the worthiness-audit ledger writer
  * (`.gaia/scripts/audit-ledger/append-worthiness.mjs`).
@@ -17,6 +16,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
  * from `node_modules`; this `.gaia/cli` workspace carries its own `typescript`
  * devDependency, so the test runner can exec it.
  */
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/automation/__tests__/audit-template-dogfood.test.ts
+++ b/.gaia/cli/src/automation/__tests__/audit-template-dogfood.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Maintainer drift-guard: asserts that the in-tree
  * `.github/workflows/code-review-audit.yml` is byte-identical to the
@@ -9,6 +8,7 @@ import {describe, expect, test} from 'vitest';
  * must match; any divergence means either the live gate or the install
  * source was edited without updating the other.
  */
+import {describe, expect, test} from 'vitest';
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';

--- a/.gaia/cli/src/automation/__tests__/gaia-ci-template-refs.test.ts
+++ b/.gaia/cli/src/automation/__tests__/gaia-ci-template-refs.test.ts
@@ -1,9 +1,3 @@
-import {describe, expect, test} from 'vitest';
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
-import path from 'node:path';
-import type {ToolId} from '../../schemas/automation-config.js';
-import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
-import {workflowTemplatePath} from '../paths.js';
 /**
  * Maintainer drift-guard for the outbound references in the four
  * `gaia-ci-*` workflow templates.
@@ -49,6 +43,12 @@ import {workflowTemplatePath} from '../paths.js';
  * checkout where the templates or routers are missing, mirroring the
  * sibling guards.
  */
+import {describe, expect, test} from 'vitest';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import type {ToolId} from '../../schemas/automation-config.js';
+import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
+import {workflowTemplatePath} from '../paths.js';
 
 type TemplateContract = {
   readonly cli: readonly string[];

--- a/.gaia/cli/src/classifier/classify-determinism.test.ts
+++ b/.gaia/cli/src/classifier/classify-determinism.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Tests for the determinism classifier AST helper
  * (`.gaia/scripts/classifier/classify-determinism.mjs`).
@@ -18,6 +17,7 @@ import {describe, expect, test} from 'vitest';
  * supplies the bytes). The three named real fixtures are classified from disk by
  * repo-relative path.
  */
+import {describe, expect, test} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';

--- a/.gaia/cli/src/command-reachability.test.ts
+++ b/.gaia/cli/src/command-reachability.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Maintainer guards for the CLI subcommand surface. Two of them, sharing one
  * router scan: a reachability guard (is each command invoked from anywhere?)
@@ -66,6 +65,7 @@ import {describe, expect, test} from 'vitest';
  * for those lines this guard checks only that the command is documented and
  * dispatched, never that the verbs after it are complete.
  */
+import {describe, expect, test} from 'vitest';
 import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';

--- a/.gaia/cli/src/harden/__tests__/marker.test.ts
+++ b/.gaia/cli/src/harden/__tests__/marker.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Guard for the frozen provenance marker (`marker.ts`).
  *
@@ -8,6 +7,7 @@ import {describe, expect, test} from 'vitest';
  * every copy plus the regex to `markerComment(...)` so a drifted copy fails the
  * suite instead of silently breaking one binder.
  */
+import {describe, expect, test} from 'vitest';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/harden/__tests__/severity-map.test.ts
+++ b/.gaia/cli/src/harden/__tests__/severity-map.test.ts
@@ -1,10 +1,3 @@
-import {describe, expect, test} from 'vitest';
-import {readdirSync, readFileSync} from 'node:fs';
-import path from 'node:path';
-import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
-import {SEVERITIES} from '../parse-findings-block.js';
-import {SEVERITY_BY_GRADING} from '../severity-map.js';
-
 /**
  * UAT-035's divergence test. Every `code-audit-*.md` agent file carries one
  * machine-readable declaration of the gradings it can emit (README FC-7):
@@ -26,6 +19,12 @@ import {SEVERITY_BY_GRADING} from '../severity-map.js';
  * its byte-identical check: there is no context in which this file runs with
  * only the two adopter-scope agents on disk.
  */
+import {describe, expect, test} from 'vitest';
+import {readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {resolveRepoRootFromImportMeta} from '../../util/repo-root-fixture.js';
+import {SEVERITIES} from '../parse-findings-block.js';
+import {SEVERITY_BY_GRADING} from '../severity-map.js';
 
 const GRADINGS_MARKER = '<!-- gaia-audit:gradings:';
 

--- a/.gaia/cli/src/init/bootstrap-env.test.ts
+++ b/.gaia/cli/src/init/bootstrap-env.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init bootstrap-env`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdtempSync,

--- a/.gaia/cli/src/init/configure-automation.test.ts
+++ b/.gaia/cli/src/init/configure-automation.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init configure-automation`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import assert from 'node:assert/strict';
 import {existsSync, mkdtempSync, readFileSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/init/configure-i18n.test.ts
+++ b/.gaia/cli/src/init/configure-i18n.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init configure-i18n`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   mkdirSync,
   mkdtempSync,

--- a/.gaia/cli/src/init/finalize.test.ts
+++ b/.gaia/cli/src/init/finalize.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init finalize`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/init/index.test.ts
+++ b/.gaia/cli/src/init/index.test.ts
@@ -1,10 +1,10 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia init` router, and specifically for its target guard.
  *
  * The guard answers "where is this running", which every per-step precondition
  * leaves unasked: they all ask only whether their own rewrite is doable.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/init/rename.test.ts
+++ b/.gaia/cli/src/init/rename.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init rename`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   copyFileSync,
   mkdirSync,

--- a/.gaia/cli/src/init/resume.test.ts
+++ b/.gaia/cli/src/init/resume.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init resume`.
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * can assert ordering + skip-if-complete + argv reconstruction without
  * spinning up real filesystem fixtures for each step.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/init/strip-branding.test.ts
+++ b/.gaia/cli/src/init/strip-branding.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init strip-branding`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/init/wire-statusline.test.ts
+++ b/.gaia/cli/src/init/wire-statusline.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia init wire-statusline`.
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * (the merged result is byte-stable) and a global-mode test that uses a
  * temp $HOME so we never touch the real one.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Maintainer guard: a module docblock precedes the file's first import.
+ *
+ * A `/** … *\/` block placed *below* the first import no longer documents the
+ * module. JSDoc binds by adjacency, so it attaches to whatever follows it —
+ * usually the next `import` statement — and the file's primary explanation is
+ * silently misattributed to a dependency.
+ *
+ * # Why this needs a guard rather than a sweep
+ *
+ * The class recreates itself out of ordinary editing, so fixing the instances
+ * alone buys a diff that decays. Imports are sorted by specifier, and a
+ * docblock written above what was then the first import is left behind the
+ * moment an import that sorts higher is added. Nobody chooses this and nothing
+ * reports it: 81 files had accumulated when `#1163` measured the class, against
+ * a single instance (`#1034`) that had been fixed one-at-a-time on the
+ * assumption it was unique.
+ *
+ * The convention is therefore asserted rather than merely swept: 126 files led
+ * with their docblock deliberately, and every file that did not was an artifact
+ * of the sort. `#1034` had already accepted the correctness argument.
+ *
+ * # What counts as an offense
+ *
+ * A `/**`-opening block comment inside the file's LEADING import block that is
+ * followed by a blank line or by another import. Both are positions no author
+ * picks for a declaration's JSDoc, so both indicate a module docblock that the
+ * sort has stranded.
+ *
+ * The leading import block is the header region only: it ends at the first
+ * statement that is not an import, a comment, or blank. A file may open with
+ * its docblock, import, and then import again further down beside the code that
+ * needs it (`setup-ci/__tests__/sandbox.ts`); the later import is not part of
+ * the header and a JSDoc beside it is not this defect.
+ *
+ * # Scope boundary (v1), and it is a floor rather than a clean bill of health
+ *
+ * A docblock sitting immediately above the first declaration — no blank line
+ * between them — is NOT reported, because at that position a module docblock
+ * and an ordinary JSDoc for that declaration are textually identical and only a
+ * reader can tell them apart. `schemas/zod-error.ts` documents its one export
+ * from there and is correct; `release/exclude-parser-parity.test.ts` describes
+ * the whole file from there and arguably is not. Reporting the position would
+ * make the guard demand that every documented first export lose its JSDoc, so
+ * the ambiguous case is deliberately left to judgment.
+ *
+ * Repair, when this goes red: move the reported docblock to line 1, above every
+ * import. `eslint --fix` leaves it there; the sort has no reason to move a
+ * comment that precedes the block it sorts.
+ *
+ * Maintainer-only by construction: `.gaia/cli/src` is release-excluded, so an
+ * adopter clone carries neither these sources nor this test, and the suite skips
+ * there. Mirrors `command-reachability.test.ts`.
+ */
+import {describe, expect, test} from 'vitest';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
+
+/**
+ * Reports the 1-based line of the first stranded module docblock, or `null`
+ * when the file's header is well-formed. Exported for the fixture tests below,
+ * which are what prove this can report anything at all.
+ */
+export const findStrandedDocblock = (source: string): number | null => {
+  const lines = source.split('\n');
+  let index = 0;
+  let firstImport = -1;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? '';
+
+    if (line.trim() === '' || line.startsWith('//')) {
+      index += 1;
+      continue;
+    }
+
+    if (line.startsWith('/*')) {
+      let end = index;
+
+      while (end < lines.length && !(lines[end] ?? '').includes('*/')) {
+        end += 1;
+      }
+
+      const next = lines[end + 1] ?? '';
+      const stranded =
+        line.startsWith('/**') &&
+        firstImport >= 0 &&
+        (next.trim() === '' || next.startsWith('import'));
+
+      if (stranded) return index + 1;
+
+      index = end + 1;
+      continue;
+    }
+
+    if (line.startsWith('import')) {
+      if (firstImport < 0) firstImport = index;
+
+      let end = index;
+
+      while (end < lines.length && !(lines[end] ?? '').trimEnd().endsWith(';')) {
+        end += 1;
+      }
+
+      index = end + 1;
+      continue;
+    }
+
+    // The first non-import statement closes the header region.
+    return null;
+  }
+
+  return null;
+};
+
+const collectSourceFiles = (root: string): readonly string[] =>
+  (readdirSync(root, {recursive: true}) as string[])
+    .filter((entry) => entry.endsWith('.ts'))
+    .sort();
+
+const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
+const cliSrc = path.join(repoRoot, '.gaia', 'cli', 'src');
+const sourcesPresent = existsSync(cliSrc);
+
+describe('module docblock placement', () => {
+  // Maintainer-only guard: `sourcesPresent` is false on an adopter clone,
+  // where `.gaia/cli/src` is release-excluded.
+  test.skipIf(!sourcesPresent)(
+    'every module docblock precedes the first import',
+    () => {
+      const stranded = collectSourceFiles(cliSrc).flatMap((relative) => {
+        const line = findStrandedDocblock(
+          readFileSync(path.join(cliSrc, relative), 'utf8')
+        );
+
+        return line === null ? [] : [`.gaia/cli/src/${relative}:${line}`];
+      });
+
+      expect(stranded).toEqual([]);
+    }
+  );
+
+  // No `skipIf`: these run against fixture strings, so they hold on any clone
+  // and they are what establish that the detector above can report at all.
+  // A corpus that happens to be clean would otherwise green a broken detector.
+  test('reports a docblock stranded between imports', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(2);
+  });
+
+  test('reports a docblock stranded below the whole import block', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '',
+      '/**',
+      ' * What this module is.',
+      ' */',
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(3);
+  });
+
+  test('accepts a docblock above the first import', () => {
+    const source = [
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import {z} from 'zod';",
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  // The scope boundary, pinned so a later widening is a deliberate act rather
+  // than an accident: at this position the docblock is indistinguishable from
+  // JSDoc for the declaration it sits on.
+  test('accepts a docblock attached to the first declaration', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '',
+      '/**',
+      ' * What the export below does.',
+      ' */',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  // A second import block beside the code that needs it is not the header, so
+  // a JSDoc down there is an ordinary one. Without this the detector would
+  // report `setup-ci/__tests__/sandbox.ts`, whose docblock is already correct.
+  test('ignores a JSDoc beside a later, non-header import', () => {
+    const source = [
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import {z} from 'zod';",
+      '',
+      'export const first = 1;',
+      '',
+      '/** Doc for the helper. */',
+      'export const helper = () => 2;',
+      '',
+      "import fs from 'node:fs';",
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  test('ignores a file with no imports at all', () => {
+    const source = ['/**', ' * Constants.', ' */', '', 'export const x = 1;'].join(
+      '\n'
+    );
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+});

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -79,8 +79,8 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
  * `// eslint-disable-line` added by ordinary editing would have disabled this
  * guard for that whole file, silently.
  *
- * Two shapes are outside it, both known and both failing silent-green (#1273's
- * sibling, tracked): a trailing block comment left open to a later line, and a
+ * Two shapes are outside it, both known and both failing silent-green (tracked
+ * in #1275): a trailing block comment left open to a later line, and a
  * `;` appearing inside a comment on a continuation line of a multi-line import,
  * which terminates that import early. Closing either means stripping comment
  * content before the test, and doing that correctly needs string awareness as
@@ -91,12 +91,15 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
 const STATEMENT_END = /;\s*(?:\/\/.*|\/\*.*\*\/)?$/;
 
 /**
- * `import` as a whole word, so neither `importantThing();` nor `import.meta`
- * is read as an import declaration. `\b` is not enough: it matches between `t`
- * and `.`, so `import.meta.hot?.accept();` would hold the header open and the
- * docblock below it would be reported stranded when it is not.
+ * An import DECLARATION at the start of a line.
+ *
+ * The three excluded characters are the three ways `import` starts something
+ * that is not a declaration, and each one misread the header differently:
+ * `\w` for `importantThing();`, `.` for `import.meta.hot?.accept();`, and `(`
+ * for a dynamic `import('./x');`. No import declaration is ever followed by any
+ * of them. `\b` alone is not enough, since it matches between `t` and `.`.
  */
-const IMPORT_START = /^import(?![.\w])/;
+const IMPORT_START = /^import(?![.\w(])/;
 
 /**
  * Line index of the last line of the import statement opening at `start`.
@@ -353,6 +356,20 @@ describe('module docblock placement', () => {
       ' */',
       '',
       'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  // A dynamic `import(...)` is an expression, not a declaration, so the
+  // docblock above it is JSDoc for that call and the header has closed.
+  test('a dynamic import call closes the header', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '/**',
+      ' * Doc for the dynamic import below.',
+      ' */',
+      "import('./side-effect.js');",
     ].join('\n');
 
     expect(findStrandedDocblock(source)).toBeNull();

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -69,6 +69,21 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
 };
 
 /**
+ * A statement terminator, tolerating a trailing line or block comment.
+ *
+ * A bare `endsWith(';')` misses `import x from 'y'; // note`, and missing it is
+ * not a near-miss: the scan then runs past the docblock below that import to
+ * the NEXT import's terminator, steps over the docblock entirely, and the guard
+ * reports the file clean on exactly the defect it exists to catch. One
+ * `// eslint-disable-line` added by ordinary editing would have disabled this
+ * guard for that whole file, silently.
+ */
+const STATEMENT_END = /;\s*(?:\/\/.*|\/\*.*\*\/)?$/;
+
+/** `import` as a whole word, so `importantThing();` is not read as an import. */
+const IMPORT_START = /^import\b/;
+
+/**
  * Line index of the last line of the import statement opening at `start`.
  * A multi-line `import {…} from '…';` ends on its own closing line, so the
  * scan runs to the first line that terminates a statement.
@@ -76,7 +91,7 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
 const importEnd = (lines: readonly string[], start: number): number => {
   let end = start;
 
-  while (end < lines.length && !(lines[end] ?? '').trimEnd().endsWith(';')) {
+  while (end < lines.length && !STATEMENT_END.test((lines[end] ?? '').trim())) {
     end += 1;
   }
 
@@ -92,9 +107,9 @@ const nextStatement = (lines: readonly string[], from: number): number => {
   let index = from;
 
   while (index < lines.length) {
-    const line = lines[index] ?? '';
+    const line = (lines[index] ?? '').trim();
 
-    if (line.trim() === '' || line.startsWith('//')) {
+    if (line === '' || line.startsWith('//')) {
       index += 1;
     } else if (line.startsWith('/*')) {
       index = blockCommentEnd(lines, index) + 1;
@@ -118,22 +133,27 @@ const nextStatement = (lines: readonly string[], from: number): number => {
  */
 const detachesDocblock = (lines: readonly string[], end: number): boolean =>
   (lines[end + 1] ?? '').trim() === '' ||
-  (lines[nextStatement(lines, end + 1)] ?? '').startsWith('import');
+  IMPORT_START.test((lines[nextStatement(lines, end + 1)] ?? '').trim());
 
 /**
  * Reports the 1-based line of the first stranded module docblock, or `null`
- * when the file's header is well-formed. Exported for the fixture tests below,
- * which are what prove this can report anything at all.
+ * when the file's header is well-formed.
+ *
+ * Every line is classified on its trimmed form. Classifying on the raw line
+ * fails open in both directions: an indented `/**` falls through to the closing
+ * branch and ends the header early, so a docblock stranded below it reads as
+ * clean, while `importantThing();` matches a bare `startsWith('import')` and
+ * holds the header open past where it closes.
  */
-export const findStrandedDocblock = (source: string): null | number => {
+const findStrandedDocblock = (source: string): null | number => {
   const lines = source.split('\n');
   let index = 0;
   let sawImport = false;
 
   while (index < lines.length) {
-    const line = lines[index] ?? '';
+    const line = (lines[index] ?? '').trim();
 
-    if (line.trim() === '' || line.startsWith('//')) {
+    if (line === '' || line.startsWith('//')) {
       index += 1;
     } else if (line.startsWith('/*')) {
       const end = blockCommentEnd(lines, index);
@@ -143,7 +163,7 @@ export const findStrandedDocblock = (source: string): null | number => {
       }
 
       index = end + 1;
-    } else if (line.startsWith('import')) {
+    } else if (IMPORT_START.test(line)) {
       sawImport = true;
       index = importEnd(lines, index) + 1;
     } else {
@@ -237,6 +257,89 @@ describe('module docblock placement', () => {
     ].join('\n');
 
     expect(findStrandedDocblock(source)).toBe(2);
+  });
+
+  // A trailing comment on the import above means the line does not end with
+  // `;`. Scanning for a bare `;` ran past this docblock to the next import's
+  // terminator and stepped over it, so the guard reported clean on the defect
+  // it exists to catch.
+  test('reports a docblock stranded below a commented import line', () => {
+    const source = [
+      "import {z} from 'zod'; // eslint-disable-line",
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(2);
+  });
+
+  test('reports a docblock stranded below a block-commented import line', () => {
+    const source = [
+      "import {z} from 'zod'; /* keep */",
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(2);
+  });
+
+  // Classifying on the raw line let an indented `/**` close the header early,
+  // so anything stranded below it read as clean.
+  test('does not let an indented block comment close the header', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '  /* an indented note */',
+      '/**',
+      ' * What this module is.',
+      ' */',
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(3);
+  });
+
+  // The mirror image: a bare `startsWith('import')` matched `importantThing();`
+  // and held the header open past the statement that closes it, so the docblock
+  // below was reported as stranded when the header had in fact already ended.
+  // The trailing blank line is what makes this discriminate: without it the
+  // docblock binds to the declaration and both readings agree on `null`.
+  test('an import-prefixed identifier closes the header', () => {
+    const source = [
+      "import {z} from 'zod';",
+      'importantThing();',
+      '/**',
+      ' * Not a module docblock: the header closed above.',
+      ' */',
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  // Same word-boundary bug reached through the other caller: if the next
+  // statement below a docblock is read as an import, the docblock is reported
+  // stranded when it is really JSDoc for the call it sits on.
+  test('an import-prefixed identifier does not detach the docblock above it', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '/**',
+      ' * Doc for the call below.',
+      ' */',
+      'importantThing();',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
   });
 
   test('accepts a docblock above the first import', () => {

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -170,7 +170,15 @@ describe('module docblock placement', () => {
   test.skipIf(!sourcesPresent)(
     'every module docblock precedes the first import',
     () => {
-      const stranded = collectSourceFiles(cliSrc).flatMap((relative) => {
+      const sources = collectSourceFiles(cliSrc);
+
+      // A scan that reaches nothing reports nothing, so the empty result below
+      // would read as a clean corpus. `.gaia/cli/src` has held hundreds of
+      // `.ts` files for the life of the CLI; a count this low means the walk
+      // or the extension filter broke, not that the tree shrank.
+      expect(sources.length).toBeGreaterThan(50);
+
+      const stranded = sources.flatMap((relative) => {
         const line = findStrandedDocblock(
           readFileSync(path.join(cliSrc, relative), 'utf8')
         );

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -84,11 +84,41 @@ const importEnd = (lines: readonly string[], start: number): number => {
 };
 
 /**
- * Whether the line following a docblock leaves it attached to nothing. A blank
- * line detaches it outright, and an `import` makes it JSDoc for a dependency.
+ * Line index of the first line that carries a statement, skipping the content
+ * the header treats as transparent: blank lines, `//` notes, and further block
+ * comments. Returns `lines.length` when the file ends first.
  */
-const detachesDocblock = (next: string): boolean =>
-  next.trim() === '' || next.startsWith('import');
+const nextStatement = (lines: readonly string[], from: number): number => {
+  let index = from;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? '';
+
+    if (line.trim() === '' || line.startsWith('//')) {
+      index += 1;
+    } else if (line.startsWith('/*')) {
+      index = blockCommentEnd(lines, index) + 1;
+    } else {
+      return index;
+    }
+  }
+
+  return lines.length;
+};
+
+/**
+ * Whether a docblock closing at `end` is left attached to nothing.
+ *
+ * A blank line immediately below detaches it outright. Otherwise the question
+ * is what it actually binds to, which is the next STATEMENT rather than the
+ * next line: an `import` makes it JSDoc for a dependency, and any other
+ * statement is the ambiguous case the scope boundary leaves alone. Reading the
+ * next line alone would let a `// group banner` between the docblock and its
+ * import hide the very thing this guard exists to report.
+ */
+const detachesDocblock = (lines: readonly string[], end: number): boolean =>
+  (lines[end + 1] ?? '').trim() === '' ||
+  (lines[nextStatement(lines, end + 1)] ?? '').startsWith('import');
 
 /**
  * Reports the 1-based line of the first stranded module docblock, or `null`
@@ -108,11 +138,7 @@ export const findStrandedDocblock = (source: string): null | number => {
     } else if (line.startsWith('/*')) {
       const end = blockCommentEnd(lines, index);
 
-      if (
-        sawImport &&
-        line.startsWith('/**') &&
-        detachesDocblock(lines[end + 1] ?? '')
-      ) {
+      if (sawImport && line.startsWith('/**') && detachesDocblock(lines, end)) {
         return index + 1;
       }
 
@@ -185,6 +211,24 @@ describe('module docblock placement', () => {
     ].join('\n');
 
     expect(findStrandedDocblock(source)).toBe(3);
+  });
+
+  // A comment between the docblock and its import must not hide it. Reading
+  // only the line below the docblock reported `null` here, which is the shape
+  // an `import/order` group banner or an `eslint-disable-next-line` produces.
+  test('reports a docblock stranded above a commented import', () => {
+    const source = [
+      "import {z} from 'zod';",
+      '/**',
+      ' * What this module is.',
+      ' */',
+      '// Node builtins',
+      "import fs from 'node:fs';",
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBe(2);
   });
 
   test('accepts a docblock above the first import', () => {

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -69,7 +69,8 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
 };
 
 /**
- * A statement terminator, tolerating a trailing line or block comment.
+ * A statement terminator, tolerating a trailing comment that closes on the same
+ * line.
  *
  * A bare `endsWith(';')` misses `import x from 'y'; // note`, and missing it is
  * not a near-miss: the scan then runs past the docblock below that import to
@@ -77,11 +78,25 @@ const blockCommentEnd = (lines: readonly string[], start: number): number => {
  * reports the file clean on exactly the defect it exists to catch. One
  * `// eslint-disable-line` added by ordinary editing would have disabled this
  * guard for that whole file, silently.
+ *
+ * Two shapes are outside it, both known and both failing silent-green (#1273's
+ * sibling, tracked): a trailing block comment left open to a later line, and a
+ * `;` appearing inside a comment on a continuation line of a multi-line import,
+ * which terminates that import early. Closing either means stripping comment
+ * content before the test, and doing that correctly needs string awareness as
+ * well, since `import x from 'https://cdn/x.js';` would otherwise have its
+ * specifier eaten. That is a tokenizer, and a tokenizer is the argument for
+ * reading this from the TypeScript AST rather than from lines at all.
  */
 const STATEMENT_END = /;\s*(?:\/\/.*|\/\*.*\*\/)?$/;
 
-/** `import` as a whole word, so `importantThing();` is not read as an import. */
-const IMPORT_START = /^import\b/;
+/**
+ * `import` as a whole word, so neither `importantThing();` nor `import.meta`
+ * is read as an import declaration. `\b` is not enough: it matches between `t`
+ * and `.`, so `import.meta.hot?.accept();` would hold the header open and the
+ * docblock below it would be reported stranded when it is not.
+ */
+const IMPORT_START = /^import(?![.\w])/;
 
 /**
  * Line index of the last line of the import statement opening at `start`.
@@ -317,6 +332,22 @@ describe('module docblock placement', () => {
     const source = [
       "import {z} from 'zod';",
       'importantThing();',
+      '/**',
+      ' * Not a module docblock: the header closed above.',
+      ' */',
+      '',
+      'export const value = 1;',
+    ].join('\n');
+
+    expect(findStrandedDocblock(source)).toBeNull();
+  });
+
+  // `\b` matches between `t` and `.`, so a word-boundary test alone reads
+  // `import.meta` as an import declaration and holds the header open.
+  test('an import.meta statement closes the header', () => {
+    const source = [
+      "import {z} from 'zod';",
+      'import.meta.hot?.accept();',
       '/**',
       ' * Not a module docblock: the header closed above.',
       ' */',

--- a/.gaia/cli/src/module-docblock-placement.test.ts
+++ b/.gaia/cli/src/module-docblock-placement.test.ts
@@ -57,58 +57,73 @@ import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {resolveRepoRootFromImportMeta} from './util/repo-root-fixture.js';
 
+/** Line index of the `*\/` closing the block comment opened at `start`. */
+const blockCommentEnd = (lines: readonly string[], start: number): number => {
+  let end = start;
+
+  while (end < lines.length && !(lines[end] ?? '').includes('*/')) {
+    end += 1;
+  }
+
+  return end;
+};
+
+/**
+ * Line index of the last line of the import statement opening at `start`.
+ * A multi-line `import {…} from '…';` ends on its own closing line, so the
+ * scan runs to the first line that terminates a statement.
+ */
+const importEnd = (lines: readonly string[], start: number): number => {
+  let end = start;
+
+  while (end < lines.length && !(lines[end] ?? '').trimEnd().endsWith(';')) {
+    end += 1;
+  }
+
+  return end;
+};
+
+/**
+ * Whether the line following a docblock leaves it attached to nothing. A blank
+ * line detaches it outright, and an `import` makes it JSDoc for a dependency.
+ */
+const detachesDocblock = (next: string): boolean =>
+  next.trim() === '' || next.startsWith('import');
+
 /**
  * Reports the 1-based line of the first stranded module docblock, or `null`
  * when the file's header is well-formed. Exported for the fixture tests below,
  * which are what prove this can report anything at all.
  */
-export const findStrandedDocblock = (source: string): number | null => {
+export const findStrandedDocblock = (source: string): null | number => {
   const lines = source.split('\n');
   let index = 0;
-  let firstImport = -1;
+  let sawImport = false;
 
   while (index < lines.length) {
     const line = lines[index] ?? '';
 
     if (line.trim() === '' || line.startsWith('//')) {
       index += 1;
-      continue;
-    }
+    } else if (line.startsWith('/*')) {
+      const end = blockCommentEnd(lines, index);
 
-    if (line.startsWith('/*')) {
-      let end = index;
-
-      while (end < lines.length && !(lines[end] ?? '').includes('*/')) {
-        end += 1;
-      }
-
-      const next = lines[end + 1] ?? '';
-      const stranded =
+      if (
+        sawImport &&
         line.startsWith('/**') &&
-        firstImport >= 0 &&
-        (next.trim() === '' || next.startsWith('import'));
-
-      if (stranded) return index + 1;
-
-      index = end + 1;
-      continue;
-    }
-
-    if (line.startsWith('import')) {
-      if (firstImport < 0) firstImport = index;
-
-      let end = index;
-
-      while (end < lines.length && !(lines[end] ?? '').trimEnd().endsWith(';')) {
-        end += 1;
+        detachesDocblock(lines[end + 1] ?? '')
+      ) {
+        return index + 1;
       }
 
       index = end + 1;
-      continue;
+    } else if (line.startsWith('import')) {
+      sawImport = true;
+      index = importEnd(lines, index) + 1;
+    } else {
+      // The first non-import statement closes the header region.
+      return null;
     }
-
-    // The first non-import statement closes the header region.
-    return null;
   }
 
   return null;
@@ -117,7 +132,7 @@ export const findStrandedDocblock = (source: string): number | null => {
 const collectSourceFiles = (root: string): readonly string[] =>
   (readdirSync(root, {recursive: true}) as string[])
     .filter((entry) => entry.endsWith('.ts'))
-    .sort();
+    .toSorted((a, b) => a.localeCompare(b));
 
 const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
 const cliSrc = path.join(repoRoot, '.gaia', 'cli', 'src');
@@ -224,9 +239,13 @@ describe('module docblock placement', () => {
   });
 
   test('ignores a file with no imports at all', () => {
-    const source = ['/**', ' * Constants.', ' */', '', 'export const x = 1;'].join(
-      '\n'
-    );
+    const source = [
+      '/**',
+      ' * Constants.',
+      ' */',
+      '',
+      'export const x = 1;',
+    ].join('\n');
 
     expect(findStrandedDocblock(source)).toBeNull();
   });

--- a/.gaia/cli/src/ping/__tests__/index.test.ts
+++ b/.gaia/cli/src/ping/__tests__/index.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia ping` argument parsing and per-event payload shape.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/ping/__tests__/send.test.ts
+++ b/.gaia/cli/src/ping/__tests__/send.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the shared `postPing` core.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/react-perf/reduce.test.ts
+++ b/.gaia/cli/src/react-perf/reduce.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia react-perf reduce` Reduce layer.
  *
@@ -7,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * cover file reading, alien-shape rejection, determinism, and the frame-budget
  * flag. Fixtures live in `test-fixtures/react-perf/`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';

--- a/.gaia/cli/src/react-perf/reduce.ts
+++ b/.gaia/cli/src/react-perf/reduce.ts
@@ -1,4 +1,3 @@
-import type {z} from 'zod';
 /**
  * `gaia react-perf reduce <raw.json> [--frame-budget-ms <n>]`.
  *
@@ -15,6 +14,7 @@ import type {z} from 'zod';
  * flag, which false-positives. Timing filters out the trivial; it never flags
  * a cheap memo defeat on its own.
  */
+import type {z} from 'zod';
 import {readFileSync} from 'node:fs';
 import {EXIT_CODES} from '../exit.js';
 import {

--- a/.gaia/cli/src/release/bump.test.ts
+++ b/.gaia/cli/src/release/bump.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release bump`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/release/changelog.test.ts
+++ b/.gaia/cli/src/release/changelog.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release changelog`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';

--- a/.gaia/cli/src/release/commit-and-tag.test.ts
+++ b/.gaia/cli/src/release/commit-and-tag.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release commit-and-tag`.
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * runners (for the tag-push path, where pushing to a remote isn't
  * portable in CI).
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/release/distribution-guards.test.ts
+++ b/.gaia/cli/src/release/distribution-guards.test.ts
@@ -1,8 +1,3 @@
-import {describe, expect, test} from 'vitest';
-import {existsSync, readFileSync} from 'node:fs';
-import path from 'node:path';
-import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';
-
 /**
  * Static text-scan guards for the maintainer-side ship-or-withhold command.
  *
@@ -18,6 +13,10 @@ import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';
  * sandbox: every assertion below reads a committed file's text and matches
  * against it.
  */
+import {describe, expect, test} from 'vitest';
+import {existsSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {resolveRepoRootFromImportMeta} from '../util/repo-root-fixture.js';
 
 const repoRoot = resolveRepoRootFromImportMeta(import.meta.url);
 const commandPath = path.join(

--- a/.gaia/cli/src/release/exclude-regex.test.ts
+++ b/.gaia/cli/src/release/exclude-regex.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release exclude-regex`.
  *
@@ -12,6 +11,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * here that reach the emit path deliberately avoid rejected metacharacters
  * so they don't collide with the fail-closed / UAT-006 assertions below.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/release/manifest-answers.test.ts
+++ b/.gaia/cli/src/release/manifest-answers.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Unit tests for the pure answer machinery behind the `release manifest`
  * refusal gate.
@@ -9,6 +8,7 @@ import {describe, expect, test} from 'vitest';
  * is X" or "the file has twelve categories" would be a test of today's
  * distribution boundary rather than of this module.
  */
+import {describe, expect, test} from 'vitest';
 import {
   applyWithholds,
   parseExcludeCategories,

--- a/.gaia/cli/src/release/manifest-cli-args.test.ts
+++ b/.gaia/cli/src/release/manifest-cli-args.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia-maintainer release manifest` CLI's flag grammar: argv
  * parsing, unknown-flag rejection, and flag-combination validation, all
@@ -7,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * The check/emit execution tests (manifest content, `--check` reporting, the
  * answer gate) live in `manifest-cli.test.ts`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/release/manifest-cli-check.test.ts
+++ b/.gaia/cli/src/release/manifest-cli-check.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia-maintainer release manifest --check` path: drift
  * reporting (missing/extra/class/version drift), classifier-set overlap and
@@ -8,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * `--out`/`--stdout`) live in `manifest-cli.test.ts`. The flag-grammar tests
  * live in `manifest-cli-args.test.ts`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   mkdirSync,

--- a/.gaia/cli/src/release/manifest-cli-check.ts
+++ b/.gaia/cli/src/release/manifest-cli-check.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * `gaia-maintainer release manifest --check`: report rendering and the check
  * itself.
@@ -14,6 +13,7 @@ import {z} from 'zod';
  * `manifest-cli.ts`'s emit/answer-gate path, which reads the same committed
  * manifest before validating answers against it.
  */
+import {z} from 'zod';
 import {existsSync, readFileSync} from 'node:fs';
 import {EXIT_CODES} from '../exit.js';
 import {structuredError} from '../stderr.js';

--- a/.gaia/cli/src/release/manifest-cli.test.ts
+++ b/.gaia/cli/src/release/manifest-cli.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia-maintainer release manifest` CLI's emit/answer-gate
  * path: `run(...)` (the refusal/answer gate, `--ship`/`--withhold`/
@@ -9,6 +8,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * flags) live in `manifest-cli-args.test.ts`. The classifier / build / lint
  * tests live in `manifest.test.ts`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/release/manifest.test.ts
+++ b/.gaia/cli/src/release/manifest.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 /**
  * Tests for the `gaia-maintainer release manifest` classifier, exclude
  * parsing, build, and lints.
@@ -9,6 +8,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
  *
  * The CLI (`run`) tests live in `manifest-cli.test.ts`.
  */
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/release/manifest.ts
+++ b/.gaia/cli/src/release/manifest.ts
@@ -1,5 +1,3 @@
-import {load as parseYaml} from 'js-yaml';
-import {z} from 'zod';
 /**
  * Classifier, exclude-pattern parsing, manifest build, and drift engine for
  * `gaia-maintainer release manifest`.
@@ -21,6 +19,8 @@ import {z} from 'zod';
  * The CLI flag grammar, `--check` report rendering, and the `run` entrypoint
  * that consume the pieces here live in `manifest-cli.ts`.
  */
+import {load as parseYaml} from 'js-yaml';
+import {z} from 'zod';
 import {execFileSync} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';

--- a/.gaia/cli/src/release/preflight.test.ts
+++ b/.gaia/cli/src/release/preflight.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release preflight`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync} from 'node:fs';

--- a/.gaia/cli/src/release/region-registry.test.ts
+++ b/.gaia/cli/src/release/region-registry.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 /**
  * Tests for `region-registry.ts`: the hand-authored region declarations and
  * `rosterAgentPaths`, the roster-derived `rewrites` set for the `audit-remit`
@@ -7,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
  * Fixtures are built in a temp dir, not against the real repo, so the roster-
  * shape cases are hermetic.
  */
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/release/region-scan.test.ts
+++ b/.gaia/cli/src/release/region-scan.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Tests for `region-scan.ts`'s `scanRegionDeclarations`.
  *
@@ -12,6 +11,7 @@ import {describe, expect, test} from 'vitest';
  * and that an unparseable roster reaches the maintainer as a YAML error. Both
  * still build their fixtures in the temp dir.
  */
+import {describe, expect, test} from 'vitest';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/release/runtime-deps.test.ts
+++ b/.gaia/cli/src/release/runtime-deps.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release runtime-deps`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   chmodSync,
   mkdirSync,

--- a/.gaia/cli/src/release/scrub-wiki.test.ts
+++ b/.gaia/cli/src/release/scrub-wiki.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release scrub-wiki`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   mkdirSync,
   mkdtempSync,

--- a/.gaia/cli/src/release/scrub.test.ts
+++ b/.gaia/cli/src/release/scrub.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia-maintainer release scrub`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   mkdirSync,
   mkdtempSync,

--- a/.gaia/cli/src/release/scrub.ts
+++ b/.gaia/cli/src/release/scrub.ts
@@ -1,5 +1,3 @@
-import {load as parseYaml} from 'js-yaml';
-import {z} from 'zod';
 /**
  * `gaia-maintainer release scrub` handler.
  *
@@ -34,6 +32,8 @@ import {z} from 'zod';
  *       staging dir, malformed config flags)
  *   2: unexpected (config parse error, filesystem IO failure)
  */
+import {load as parseYaml} from 'js-yaml';
+import {z} from 'zod';
 import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';

--- a/.gaia/cli/src/sandbox/__tests__/index.test.ts
+++ b/.gaia/cli/src/sandbox/__tests__/index.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia sandbox` CLI surface (detect/seed/apply/record/status).
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * `resolveMainWorktreeRoot`, which shells `git`), exercise the verbs against
  * `.claude/settings.local.json` and `.gaia/local/sandbox.json`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/sandbox/__tests__/marker.test.ts
+++ b/.gaia/cli/src/sandbox/__tests__/marker.test.ts
@@ -1,10 +1,10 @@
-/* eslint-disable no-bitwise -- POSIX file modes are bitfields; `& 0o777` is
-   the standard idiom for masking off the permission bits. */
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 /**
  * Tests for the `.gaia/local/sandbox.json` marker reader/writer
  * (UAT-012 mechanism).
  */
+/* eslint-disable no-bitwise -- POSIX file modes are bitfields; `& 0o777` is
+   the standard idiom for masking off the permission bits. */
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {
   existsSync,
   mkdtempSync,

--- a/.gaia/cli/src/schemas/automation-config.ts
+++ b/.gaia/cli/src/schemas/automation-config.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * Zod schema + read helpers for `.gaia/automation.json`, the committed
  * file carrying GAIA CI configuration and team-level GAIA preferences.
@@ -8,6 +7,7 @@ import {z} from 'zod';
  * result. The `read*` helpers therefore never throw; callers branch on
  * the discriminated `status` field.
  */
+import {z} from 'zod';
 import {existsSync, readFileSync} from 'node:fs';
 import {automationConfigPath} from '../automation/paths.js';
 import {summarizeZodError} from './zod-error.js';

--- a/.gaia/cli/src/schemas/decline-ledger.ts
+++ b/.gaia/cli/src/schemas/decline-ledger.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * Zod schema + read/write helpers for the machine-local decline ledger.
  *
@@ -15,6 +14,7 @@ import {z} from 'zod';
  * symlink, so a decline recorded from a linked worktree lands in the main
  * checkout's copy and survives that worktree's removal.
  */
+import {z} from 'zod';
 import {existsSync, mkdirSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {atomicWriteFileSync} from '../util/atomic-write.js';

--- a/.gaia/cli/src/schemas/finding-class.ts
+++ b/.gaia/cli/src/schemas/finding-class.ts
@@ -1,5 +1,3 @@
-import {z} from 'zod';
-
 /**
  * A `finding_class` is a stable, machine-stable identifier for a kind of
  * code-audit-frontend finding. Recurrence (the policy-memory loop) keys on it,
@@ -16,6 +14,7 @@ import {z} from 'zod';
  *   finding only becomes a countable class once it has a seeded member; an
  *   unseeded member is rejected so free-text drift never reaches the tally.
  */
+import {z} from 'zod';
 
 export const FINDING_CLASS_PREFIXES = [
   'react-doctor',

--- a/.gaia/cli/src/schemas/local-automation.ts
+++ b/.gaia/cli/src/schemas/local-automation.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * Zod schema + read helpers for `.gaia/local/automation.json`, the
  * gitignored personal nudge state.
@@ -7,6 +6,7 @@ import {z} from 'zod';
  * `/setup-gaia` (a later slice). The path constant + read helper
  * exist now so all later slices share one canonical source.
  */
+import {z} from 'zod';
 import {existsSync, readFileSync} from 'node:fs';
 import {localAutomationPath} from '../automation/paths.js';
 import {summarizeZodError} from './zod-error.js';

--- a/.gaia/cli/src/schemas/revert-ledger.ts
+++ b/.gaia/cli/src/schemas/revert-ledger.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * Zod schema + read/write helpers for the revert-attempt ledger.
  *
@@ -11,6 +10,7 @@ import {z} from 'zod';
  * consults `attempts[<original_pr>]` before doing any git/`gh` work and
  * refuses to re-open if an entry already exists.
  */
+import {z} from 'zod';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/setup/__tests__/link-worktree.test.ts
+++ b/.gaia/cli/src/setup/__tests__/link-worktree.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia setup link-worktree` (SPEC-005 Phase 1).
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * a real main checkout + linked worktree under one `mkdtemp`'d parent so
  * `git rev-parse --git-common-dir` resolves correctly.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   copyFileSync,

--- a/.gaia/cli/src/setup/__tests__/setup-worktree.test.ts
+++ b/.gaia/cli/src/setup/__tests__/setup-worktree.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Worktree-aware coverage for the `gaia setup` CLI surface.
  *
@@ -10,6 +9,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * Strategy: each test gets a fresh `setupWorktreeSandbox()` that creates BOTH
  * a main checkout and a linked worktree under one `mkdtemp`'d parent.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/setup/__tests__/setup.test.ts
+++ b/.gaia/cli/src/setup/__tests__/setup.test.ts
@@ -1,10 +1,10 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for the `gaia setup` CLI surface.
  *
  * Strategy: tmp git repo per test, exercise status / mark-step / finalize
  * sequentially against `.gaia/local/setup-state.json`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/setup/__tests__/state-file.test.ts
+++ b/.gaia/cli/src/setup/__tests__/state-file.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 /**
  * Tests for `.gaia/cli/src/setup/util/state-file.ts`'s retired-step
  * migration: `readStateFile` must tolerate a persisted
@@ -7,6 +6,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
  * Also covers `resolveMainWorktreeRoot`'s validation hardening (task 8.3);
  * that resolver now lives in `.gaia/cli/src/util/main-root.ts`.
  */
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   mkdirSync,

--- a/.gaia/cli/src/update/merge-audit-ci.test.ts
+++ b/.gaia/cli/src/update/merge-audit-ci.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia update merge-audit-ci`.
  *
@@ -8,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * no on-disk side effects to assert (the `/update-gaia` skill applies
  * `applied[]` via the Edit tool to preserve comments and order).
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/update/merge-audit-ci.ts
+++ b/.gaia/cli/src/update/merge-audit-ci.ts
@@ -1,4 +1,3 @@
-import {load as parseYaml} from 'js-yaml';
 /**
  * `gaia update merge-audit-ci --baseline <file> --latest <file> --current <file>`
  * handler.
@@ -44,6 +43,7 @@ import {load as parseYaml} from 'js-yaml';
  *
  * Object-map dispatch and no-switch style per the project's typescript rules.
  */
+import {load as parseYaml} from 'js-yaml';
 import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';

--- a/.gaia/cli/src/update/merge-region.test.ts
+++ b/.gaia/cli/src/update/merge-region.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia update merge-region`.
  *
@@ -8,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * verdict is the assertable surface, the working-tree consequences are the
  * skill's prose and are prose-verified elsewhere.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/update/merge-workspace.test.ts
+++ b/.gaia/cli/src/update/merge-workspace.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia update merge-workspace`.
  *
@@ -8,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * there are no on-disk side effects to assert (the `/update-gaia` skill
  * applies `applied[]` via the Edit tool to preserve comments and order).
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';

--- a/.gaia/cli/src/update/merge-workspace.ts
+++ b/.gaia/cli/src/update/merge-workspace.ts
@@ -1,4 +1,3 @@
-import {load as parseYaml} from 'js-yaml';
 /**
  * `gaia update merge-workspace --baseline <file> --latest <file> --current <file>`
  * handler.
@@ -28,6 +27,7 @@ import {load as parseYaml} from 'js-yaml';
  *
  * Object-map dispatch and no-switch style per the project's typescript rules.
  */
+import {load as parseYaml} from 'js-yaml';
 import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';

--- a/.gaia/cli/src/update/regen-regions.test.ts
+++ b/.gaia/cli/src/update/regen-regions.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia update regen-regions`.
  *
@@ -10,6 +9,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * Numbered tests below map to the task doc's "Hostile-input coverage" /
  * "Behavior coverage" obligation list (1-22).
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   chmodSync,

--- a/.gaia/cli/src/update/region-markers.test.ts
+++ b/.gaia/cli/src/update/region-markers.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Tests for `region-markers.ts`'s whole-line marker parser.
  *
@@ -6,6 +5,7 @@ import {describe, expect, test} from 'vitest';
  * `maskRegion` against them directly. Pure functions, no I/O and nothing to
  * set up or tear down.
  */
+import {describe, expect, test} from 'vitest';
 import {maskRegion, REGION_PLACEHOLDER, scanRegion} from './region-markers.js';
 
 const START = '<!-- gaia:test:start -->';

--- a/.gaia/cli/src/wiki/chain.test.ts
+++ b/.gaia/cli/src/wiki/chain.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki chain <begin|commit|finish>`.
  *
@@ -8,6 +7,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * keyed off argv. Each test asserts the handler's exit code and the exact
  * sequence of git/gh invocations the fake observed.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/wiki/classify-paths.ts
+++ b/.gaia/cli/src/wiki/classify-paths.ts
@@ -1,4 +1,3 @@
-import {z} from 'zod';
 /**
  * The path vocabulary `commit-classify`'s rules 6/7 discriminate on, declared
  * as a repo-configurable input instead of `app/**` literals.
@@ -20,6 +19,7 @@ import {z} from 'zod';
  * heuristic pre-filter ahead of an expensive per-commit read, so a malformed
  * config must degrade to the shipped behavior rather than fail a sync.
  */
+import {z} from 'zod';
 import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {summarizeZodError} from '../schemas/zod-error.js';

--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki commit-classify`.
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * then ask the handler to classify them since the initial baseline. We
  * snapshot the suggestion + reason for each commit and assert against it.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {
   existsSync,
   mkdirSync,

--- a/.gaia/cli/src/wiki/empty-sections.test.ts
+++ b/.gaia/cli/src/wiki/empty-sections.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki empty-sections`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/frontmatter.test.ts
+++ b/.gaia/cli/src/wiki/frontmatter.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki frontmatter`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/log-prepend.test.ts
+++ b/.gaia/cli/src/wiki/log-prepend.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki log-prepend`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   mkdirSync,

--- a/.gaia/cli/src/wiki/near-collisions.test.ts
+++ b/.gaia/cli/src/wiki/near-collisions.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki near-collisions`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/orphans.test.ts
+++ b/.gaia/cli/src/wiki/orphans.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki orphans`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/page-index.test.ts
+++ b/.gaia/cli/src/wiki/page-index.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki page-index`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/state-bump.test.ts
+++ b/.gaia/cli/src/wiki/state-bump.test.ts
@@ -1,10 +1,10 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki state-bump`.
  *
  * Strategy: build a sandbox repo with a bare git init and a `wiki/.state.json`
  * file, then exercise the handler against that sandbox via the `cwd` option.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   mkdirSync,

--- a/.gaia/cli/src/wiki/state-init.test.ts
+++ b/.gaia/cli/src/wiki/state-init.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki state-init`.
  *
@@ -6,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * commit so refs resolve, then exercise the handler against that
  * sandbox via the `cwd` option.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {
   existsSync,

--- a/.gaia/cli/src/wiki/state.test.ts
+++ b/.gaia/cli/src/wiki/state.test.ts
@@ -1,7 +1,7 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki state`.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';

--- a/.gaia/cli/src/wiki/sync-await.test.ts
+++ b/.gaia/cli/src/wiki/sync-await.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki sync await`.
  *
@@ -9,6 +8,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * polls). `sleep` is always a no-op; the real `waitForMerge` budget is
  * minutes long and no test should block on it.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/wiki/sync-land.test.ts
+++ b/.gaia/cli/src/wiki/sync-land.test.ts
@@ -1,4 +1,3 @@
-import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 /**
  * Tests for `gaia wiki sync land`.
  *
@@ -10,6 +9,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
  * proving the CLI shapes the call pipeline correctly without depending
  * on a real `gh` binary or remote.
  */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {execFileSync} from 'node:child_process';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {

--- a/.gaia/cli/src/wiki/util/branch.test.ts
+++ b/.gaia/cli/src/wiki/util/branch.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Tests for `inspectWorkingTree`.
  *
@@ -10,6 +9,7 @@ import {describe, expect, test} from 'vitest';
  * wiki page (nearly every GAIA wiki page has a space in its filename) on the
  * wiki side of the split.
  */
+import {describe, expect, test} from 'vitest';
 import type {SpawnSyncReturns} from 'node:child_process';
 import {inspectWorkingTree} from './branch.js';
 import type {CommandRunner} from './branch.js';

--- a/.gaia/cli/src/wiki/util/land.test.ts
+++ b/.gaia/cli/src/wiki/util/land.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test} from 'vitest';
 /**
  * Tests for the merge-wait budget arithmetic and `cleanupAfterMerge` reuse.
  *
@@ -9,6 +8,7 @@ import {describe, expect, test} from 'vitest';
  * judgment. `cleanupAfterMerge` must stay reusable (exported, callable with
  * an injected runner) and singly-defined across the repository.
  */
+import {describe, expect, test} from 'vitest';
 import type {SpawnSyncReturns} from 'node:child_process';
 import type {CommandRunner} from './branch.js';
 import {


### PR DESCRIPTION
Closes #1163

## Problem

A module docblock placed below a file's first `import` no longer documents the module. JSDoc binds
by adjacency, so it attaches to whatever follows it, usually the next `import`, and the file's
primary explanation is silently misattributed to a dependency.

**The class recreates itself.** Imports sort by specifier, so a docblock written above what was
then the first import is stranded the moment an import that sorts higher is added. Nobody chooses
this and nothing reported it: `#1034` fixed one instance and asserted it was unique; **74 files**
carried it when this branch measured.

## Fix

A vitest structural guard plus the sweep that greens it, in that order.

- `.gaia/cli/src/module-docblock-placement.test.ts` asserts that no module docblock sits inside a
  file's leading import block, across every `.ts` file under `.gaia/cli/src`. It sits beside the
  two structural guards already at that level, `command-reachability.test.ts` and
  `lint-pin-parity.test.ts`.
- 74 files move their docblock to line 1.

**The guard is the sweep's oracle**, which is why they land together: the sweep is provably
complete exactly when the guard goes green. Landing them separately would leave the sweep with no
oracle at all and the guard trivially green.

## Decisions

`#1163` is a DECISION OWED row. Three arms, none left to emerge from the implementation.

- **The convention is docblock-first**, settled from the code. The issue frames it as open at
  "122 to 81, a majority but not an overwhelming one", and that counts the wrong thing: the
  non-conforming files are artifacts of the import sort, not positions anyone took. Counting
  deliberate choices it is 126 to roughly zero, and `#1034` had already accepted the correctness
  argument.
- **A vitest guard, not a custom ESLint rule**, settled by the maintainer. It is the repo's
  existing idiom for a structural convention over `src/**`, needs no rule authoring, and changes
  no ruleset, so no later CLI change is gated under a rule this PR invented.
- **One PR, guard and sweep together**, settled by the maintainer, for the oracle reason above.

## Scope boundary, stated because it is a floor rather than a clean bill of health

A docblock sitting immediately above the first declaration, with no blank line between, is **not**
reported. At that position a module docblock and ordinary JSDoc for that declaration are textually
identical and only a reader can tell them apart: `schemas/zod-error.ts` documents its one export
from there and is correct, `release/exclude-parser-parity.test.ts` describes the whole file from
there and arguably is not. Reporting the position would make the guard demand that every
documented first export lose its JSDoc. The boundary is pinned by its own fixture so widening it
later is a deliberate act.

## Verification

**The diff is provably zero-behavior.** Every swept file's non-blank line multiset is unchanged, so
the sweep is a pure reordering of lines; `git diff --check` is clean; and the only non-docblock
comment that moves is a file-level `eslint-disable` in `sandbox/__tests__/marker.test.ts` that
still precedes all code. No file carries a `#!` shebang or a `@vitest-environment` pragma that the
move could have displaced, and all 74 now begin with `/**`.

**Quality Gate**, per `wiki/decisions/Quality Gate.md`: `typecheck` clean, `lint` clean,
`lint:cli` clean, app suite **156 passed / 1 skipped** across 30 files, CLI suite **2048 passed /
1 skipped across 135 files**, `build` clean, Playwright **8 passed / 1 skipped**, dev smoke
**HTTP 200**.

`lint:cli` initially failed on nine real errors in the new file (`no-continue` x3, cognitive
complexity 22 against a limit of 15, a union sort, two sort rules, two prettier). Fixing them
decomposed the header scan into `blockCommentEnd` / `importEnd` / `detachesDocblock`, so the lint
failure produced a better design than the one it rejected.

**CI-gated bats roots**, all through `.gaia/scripts/bats5.sh`, counted by `not ok` rather than by a
tail: `.github/audit/tests/` 165/165, `.gaia/scripts/tests/` 1458/1458, `.gaia/tests/hooks/` 1370/1370,
`.gaia/tests/lib/` 448/448 (one skip, `flock` absent on this machine, the `mkdir` fallback is the
load-bearing path), `.gaia/tests/statusline/` 36/36, `region-marker-conformance` 6/6,
`shell-lint.sh` exit 0, distribution harness **17 PASS / 0 FAIL**. Read from the per-scenario
summary rather than a tail, so a second failure could not hide behind the first.

**Mutation proof, five mutants, all killed.** Each `cp`-backed from a `mktemp -d` and restored the
same way, never `git checkout --`, and each carries a hard assert that the mutation applied.

| Mutant | Killed by |
|---|---|
| M1 strand a real docblock behind a new first import (`release/manifest.ts`) | corpus assertion |
| M2 strand it with a `// Node builtins` banner between docblock and import | corpus assertion, reported `manifest.ts:2` |
| M3 stop `nextStatement` skipping comments | the banner fixture |
| M4 drop the blank-line arm of `detachesDocblock` | the below-the-block fixture |
| M5 break the source walk's extension filter | the floor assertion |

**M2 is the one that matters.** It proves the widening is load-bearing on real source rather than
only against a fixture string. My first attempt at M2 was a copy-paste of M1's mutation and would
have certified nothing; the diff stat is what exposed it.

**The guard was authored red and watched go green**, rather than written after the sweep: it
reported all 74 offenders before a single docblock moved.

## Audit gate: four rounds, and every finding landed on the guard rather than the sweep

`code-audit-maintainer-node` was the only member `resolve-audit-spawn.sh` named across all four
rounds, which is plausible for a diff that is entirely `.gaia/cli/src/**`. It is advisory-only, so
it repaired nothing and returned a byte-identical tree each time.

| Round | Result | Findings |
|---|---|---|
| 1 | clean pass | 1 Important, 2 Suggestions |
| 2 | clean pass | 0 Critical, 0 Important, 3 Suggestions |
| 3 | clean pass | 0 Critical, 0 Important, 2 Suggestions |
| 4 | clean pass | **zero at every severity**, empty findings sidecar |

**Not one finding in four rounds landed on the 74-file sweep.** Every one was a blind spot in the
guard's own line-based scanner, and all but two are fixed here.

Round 1's Important is the one worth reading: `importEnd` scanned for a bare `;`, so an import
carrying a trailing comment did not terminate it, the scan ran past the docblock below to the next
import's terminator, and **the guard reported the file clean on exactly the defect it exists to
catch**. One `// eslint-disable-line` would have disabled it for a whole file, silently. The member
proved it with a runnable probe rather than asserting it.

Rounds 2 and 3 fixed `import.meta` and a dynamic `import(` being read as import declarations, and
corrected two false claims in this PR's own prose: a `STATEMENT_END` docblock that implied coverage
it does not have, and a residual note citing the wrong issue number.

**A stopping rule was pre-committed before round 2 and capped at round 4**, on the ground that the
direction of the repairs was the real finding: the same move (narrow a lookahead, widen a
terminator) kept being correct, which is a detector at a local optimum rather than one unravelling.
Round 4 came back clean, and the member independently endorsed the cap with a sharper argument than
the one it was written on: the guard fully covers **its own threat model**, the import sort, and the
two accepted residuals need shapes the sort does not produce and `eslint --fix` does not survive. A
guard that fully covers its generating mechanism and partially covers shapes outside it has a
documented boundary, not a hole.

## What review found in this PR's own work

The `simplify` pass found a hole in the guard I had just written. `detachesDocblock` peeked exactly
one line past a docblock's close, while the header scan beside it treats `//` notes and further
block comments as transparent. So a docblock followed by an import-group banner evaded the guard
entirely: the detection check's notion of "what follows" was narrower than the parser's own notion
of "header", and nothing said so. It now binds to the next **statement** through a shared
`nextStatement` skip.

**The corpus gained no new offender**, so the sweep stands. The hole was reachable by ordinary
editing rather than already live, which is the honest reading of it.

A second self-inflicted risk was closed in the same pass: a scan that reaches nothing reports
nothing, so a broken walk or extension filter would have read as a clean corpus. A floor assertion
now turns that into a red (M5).

## CHANGELOG

**No entry owed**, verified rather than reasoned. `.gaia/release-exclude:121` lists
`.gaia/cli/src`, and `.gaia/manifest.json` carries **0** entries under it against 35 under
`.gaia/cli/`. Nothing here reaches an adopter, so there is no behavior change and nothing at Keep a
Changelog altitude.

**No bundle rebuild owed**, also checked: `findStrandedDocblock` and `nextStatement` return 0
occurrences in both committed bundles, since a `.test.ts` is in neither entry graph, and this
branch modifies neither binary.

## Filed, not fixed here

**#1273**, `severity:suggestion` / `difficulty:hard` / `surface:maintainer`. The Quality Gate's
Playwright run surfaced a flake in `.playwright/e2e/react-perf-smoke.spec.ts:149`: the StrictMode
canary asserts `strictAvg > relaxedAvg * 1.1` on wall-clock render aggregates while its own comment
records the observed effect as ~1.2, so the whole tolerance is ~0.1 of a noisy measurement.
Measured at 2 failures in 11 full `pnpm pw` runs, against 0 in 19 on `main`; the branch/main split
is sampling noise, since this spec imports nothing under `.gaia/cli/src` and this PR's only
executable change is a vitest file Playwright never runs. **Filed rather than waived** because
`.playwright/` is not a path this PR changes, so the touched-file waive does not reach it.

## Accepted residuals

Two audit Suggestions accepted rather than fixed, and **filed as #1275** rather than only recorded:
a waive records but does not track, and DRAIN's override says a finding already observed to spread
gets filed even where a waive is licensed. Five detector blind spots across two rounds is that
observation. Both are named explicitly in `STATEMENT_END`'s docblock so the boundary is stated
rather than implied.

<!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/cli/src/module-docblock-placement.test.ts line=91 -->
- **A trailing block comment left open to a later line**, and **a `;` inside a comment on a
  continuation line of a multi-line import.** Both fail silent-green. They are one finding, not
  two: closing either means stripping comment content before the terminator test, and doing that
  correctly needs string awareness as well (`import x from 'https://cdn/x.js';`), at which point
  the guard contains a tokenizer. `#1275` proposes reading the header from the TypeScript AST
  instead, which is already a direct `.gaia/cli` dependency.

One further observation the round-4 member deliberately did not file, recorded here for the same
reason: `import ('./x');` with whitespace before the paren is still read as a declaration. Its
failure direction is a false positive (loud red), no formatter here emits it, and `#1275`'s
direction closes it for free.

## Declined, recorded so a reviewer need not re-derive them

Both are `simplify` suggestions on this PR's own new file, declined deliberately.

<!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/cli/src/module-docblock-placement.test.ts line=61 -->
- **Folding `blockCommentEnd` and `importEnd` into one higher-order `scanUntil`.** They share a
  loop shape and nothing else; they take different predicates and never need to agree. The
  extraction trades two six-line functions for a callback plus two wrappers, which is not simpler,
  and the two were split out of one loop in the first place only because `no-continue` and
  cognitive complexity required it.

<!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/cli/src/module-docblock-placement.test.ts line=248 -->
- **Deleting the no-imports fixture as redundant branch coverage.** It is redundant on branches, as
  reported. It is kept because it pins a real input class: the guard applies only to files that
  have imports at all, and that contract is otherwise stated nowhere.
