### PR TITLE
debt(tests): give the concurrency meter one hook-delivery idiom (#1232)

### DIFF
--- a/.gaia/scripts/tests/concurrency-harness-helpers.bats
+++ b/.gaia/scripts/tests/concurrency-harness-helpers.bats
@@ -20,6 +20,14 @@
 # Assertion style (`.claude/rules/bats-assertions.md`): POSIX `[ ]` and explicit
 # `return 1`, never a bare `[[ ]]`, so these fail correctly under macOS's bash
 # 3.2 as well as CI's bash 5.
+#
+# The misuse arms pin the exact status 64 rather than merely a non-zero one, and
+# each names the refusal it expects. A `-ne 0` check greens on 127 or 1 as
+# readily as on 64, so the documented status would drift unnoticed; and a test
+# that names no message can be satisfied by a different arm firing, which is how
+# a guard disappears with its own test still green. Test 11 is the exception: its
+# message is bash's own `not a valid identifier` wording, which is not safe to
+# pin across bash versions.
 
 setup() {
   THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
@@ -103,12 +111,12 @@ SH
 # --- run_with, the misuse arms. Each must fail LOUDLY, never green ----------
 #
 # These are the assertions that would have caught the silent-green defect. Each
-# checks a non-zero status AND that the command never ran, because a status
-# check alone would pass on any failure including the wrong one.
+# checks the exact status AND that the command never ran, because a status check
+# alone would pass on any failure including the wrong one.
 
 @test "run_with refuses a missing -- separator rather than eating the command" {
   run run_with STUBVAR=x gaia_deliver_hook '{"c":3}' "$HOOK"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 64 ]
   grep -qF -- 'missing -- separator' <<<"$output"
   # The hook must not have run: its output would carry PAYLOAD=.
   grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
@@ -117,20 +125,24 @@ SH
 
 @test "run_with refuses when nothing follows the separator" {
   run run_with STUBVAR=x --
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 64 ]
   grep -qF -- 'no command after --' <<<"$output"
 }
 
 @test "run_with refuses an empty assignment rather than running without it" {
   run run_with "" -- gaia_deliver_hook 'x' "$HOOK"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 64 ]
+  # Name the arm. Without this the `case` arm could be deleted and this test
+  # would stay green, because `export ""` fails on its own and the `|| exit 64`
+  # beside it would catch that instead.
+  grep -qF -- 'not an assignment' <<<"$output"
   grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
   return 0
 }
 
 @test "run_with refuses a malformed assignment rather than running without it" {
   run run_with 'FOO-BAR=1' -- gaia_deliver_hook 'x' "$HOOK"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 64 ]
   grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
   return 0
 }
@@ -140,7 +152,7 @@ SH
   # and applies no value, so without an explicit check the command would run
   # with its override silently absent, which is this suite's whole subject.
   run run_with STUBVAR -- gaia_deliver_hook 'x' "$HOOK"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 64 ]
   grep -qF -- 'not an assignment' <<<"$output"
   grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
   return 0

--- a/.gaia/scripts/tests/concurrency-harness-helpers.bats
+++ b/.gaia/scripts/tests/concurrency-harness-helpers.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# The delivery primitives in .gaia/tests/concurrency/lib/concurrency-harness.sh:
+# `gaia_deliver_hook` and the `run_with` runner it composes with.
+#
+# Why these are pinned here rather than in the concurrency meter itself: the
+# meter's scenario list and its `target` denominator are frozen
+# (.gaia/tests/concurrency/README.md, expected-status.txt), so a primitive's own
+# unit coverage cannot be added there without moving a number that moves only by
+# the maintainer's word. This sits beside bats-files-helper.bats, which pins the
+# other cross-suite bats primitive for the same reason.
+#
+# The failure mode being pinned is specific and it is NOT "the meter goes red".
+# The meter cannot see this class at all. Under bats' `run` errexit is off, so a
+# `run_with` that silently accepted a missing `--` would eat the command as
+# environment assignments, invoke no hook, and still report status 0 with empty
+# output; a scenario asserting `[ "$status" -eq 0 ]` plus an absence then passes
+# against a hook that never ran. That is the vacuous green the whole primitive
+# exists to prevent, so it is asserted directly here.
+#
+# Assertion style (`.claude/rules/bats-assertions.md`): POSIX `[ ]` and explicit
+# `return 1`, never a bare `[[ ]]`, so these fail correctly under macOS's bash
+# 3.2 as well as CI's bash 5.
+
+setup() {
+  THIS_DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" && pwd )"
+  REPO_ROOT="$( cd "$THIS_DIR/../../.." && pwd )"
+  . "$REPO_ROOT/.gaia/tests/concurrency/lib/concurrency-harness.sh"
+
+  # A stand-in hook: echoes what it was handed on stdin, plus one environment
+  # variable, so a test can tell "delivered" from "never ran".
+  HOOK="$BATS_TEST_TMPDIR/hook.sh"
+  cat > "$HOOK" <<'SH'
+printf 'PAYLOAD=[%s] STUB=[%s]\n' "$(cat)" "${STUBVAR:-unset}"
+SH
+}
+
+# --- gaia_deliver_hook -----------------------------------------------------
+
+@test "gaia_deliver_hook delivers the payload on stdin byte-exact" {
+  run gaia_deliver_hook '{"a":1}' "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -qF -- 'PAYLOAD=[{"a":1}]' <<<"$output"
+}
+
+@test "gaia_deliver_hook delivers a payload carrying quotes and shell metacharacters" {
+  # The whole reason the payload is positional rather than interpolated: any of
+  # these would terminate a quoted wrapper early and deliver something else.
+  payload='it'"'"'s {"k":"v"} $(boom) `boom` "quoted"'
+  run gaia_deliver_hook "$payload" "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -qF -- 'PAYLOAD=[it'"'"'s {"k":"v"} $(boom) `boom` "quoted"]' <<<"$output"
+}
+
+@test "gaia_deliver_hook propagates the hook's own exit status" {
+  printf 'exit 7\n' > "$HOOK"
+  run gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -eq 7 ]
+}
+
+# --- run_with, the happy path ----------------------------------------------
+
+@test "run_with applies an assignment and runs the command" {
+  run run_with STUBVAR=applied -- gaia_deliver_hook '{"b":2}' "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -qF -- 'PAYLOAD=[{"b":2}]' <<<"$output"
+  grep -qF -- 'STUB=[applied]' <<<"$output"
+}
+
+@test "run_with applies a value containing whitespace and quotes" {
+  run run_with STUBVAR="a b'\"c" -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -qF -- 'STUB=[a b'"'"'"c]' <<<"$output"
+}
+
+@test "run_with leaks no assignment into the caller" {
+  run run_with STUBVAR=leaked -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -eq 0 ]
+  [ -z "${STUBVAR:-}" ]
+}
+
+@test "run_with composes inside run_in without losing either the cwd or the env" {
+  dir="$BATS_TEST_TMPDIR/sub"
+  mkdir -p "$dir"
+  printf 'printf "CWD=[%%s] STUB=[%%s]\\n" "$(pwd -P)" "${STUBVAR:-unset}"\n' > "$HOOK"
+
+  run run_in "$dir" -- run_with STUBVAR=nested -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -eq 0 ]
+  grep -qF -- "CWD=[$(cd "$dir" && pwd -P)]" <<<"$output"
+  grep -qF -- 'STUB=[nested]' <<<"$output"
+}
+
+# --- run_with, the misuse arms. Each must fail LOUDLY, never green ----------
+#
+# These are the assertions that would have caught the silent-green defect. Each
+# checks a non-zero status AND that the command never ran, because a status
+# check alone would pass on any failure including the wrong one.
+
+@test "run_with refuses a missing -- separator rather than eating the command" {
+  run run_with STUBVAR=x gaia_deliver_hook '{"c":3}' "$HOOK"
+  [ "$status" -ne 0 ]
+  grep -qF -- 'missing -- separator' <<<"$output"
+  # The hook must not have run: its output would carry PAYLOAD=.
+  grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
+  return 0
+}
+
+@test "run_with refuses when nothing follows the separator" {
+  run run_with STUBVAR=x --
+  [ "$status" -ne 0 ]
+  grep -qF -- 'no command after --' <<<"$output"
+}
+
+@test "run_with refuses an empty assignment rather than running without it" {
+  run run_with "" -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -ne 0 ]
+  grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
+  return 0
+}
+
+@test "run_with refuses a malformed assignment rather than running without it" {
+  run run_with 'FOO-BAR=1' -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -ne 0 ]
+  grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
+  return 0
+}

--- a/.gaia/scripts/tests/concurrency-harness-helpers.bats
+++ b/.gaia/scripts/tests/concurrency-harness-helpers.bats
@@ -73,9 +73,20 @@ SH
 }
 
 @test "run_with leaks no assignment into the caller" {
-  run run_with STUBVAR=leaked -- gaia_deliver_hook 'x' "$HOOK"
-  [ "$status" -eq 0 ]
-  [ -z "${STUBVAR:-}" ]
+  # Deliberately NOT wrapped in `run`. bats' `run` executes its command inside a
+  # command-substitution subshell, which isolates the export on its own however
+  # `run_with` is written, so a `run`-wrapped version of this test passes even
+  # against a `run_with` whose own `( )` has been removed. It is this suite's
+  # only coverage of the containment, and the meter depends on it: C5-01, C5-04
+  # and C7-02 each carry later assertions inside the same @test body that a
+  # leaked HOME or PATH would silently change.
+  run_with STUBVAR=leaked -- gaia_deliver_hook 'x' "$HOOK" >/dev/null
+
+  [ -z "${STUBVAR:-}" ] || return 1
+  # The helper's own loop variables are contained by the same `( )`.
+  [ -z "${_rw_found:-}" ] || return 1
+  [ -z "${_rw_arg:-}" ] || return 1
+  return 0
 }
 
 @test "run_with composes inside run_in without losing either the cwd or the env" {
@@ -120,6 +131,17 @@ SH
 @test "run_with refuses a malformed assignment rather than running without it" {
   run run_with 'FOO-BAR=1' -- gaia_deliver_hook 'x' "$HOOK"
   [ "$status" -ne 0 ]
+  grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
+  return 0
+}
+
+@test "run_with refuses a bare name rather than applying nothing" {
+  # The one malformed shape `export` itself accepts: `export STUBVAR` succeeds
+  # and applies no value, so without an explicit check the command would run
+  # with its override silently absent, which is this suite's whole subject.
+  run run_with STUBVAR -- gaia_deliver_hook 'x' "$HOOK"
+  [ "$status" -ne 0 ]
+  grep -qF -- 'not an assignment' <<<"$output"
   grep -qF -- 'PAYLOAD=' <<<"$output" && return 1
   return 0
 }

--- a/.gaia/tests/concurrency/README.md
+++ b/.gaia/tests/concurrency/README.md
@@ -906,7 +906,11 @@ the next unrelated PR the first to notice.
   when any test fails; this one exits zero with scenarios red.
 - `lib/concurrency-harness.sh` — the fixture builder: a main checkout plus N linked
   worktrees off one base, seeded `.gaia/local` state, real hooks/scripts/libs copied in
-  at their repo-relative paths, and a run-in-tree helper. Sourced by the suite.
+  at their repo-relative paths, the `run_in` / `run_with` runners, and
+  `gaia_deliver_hook`, the suite's one quote-safe hook-invocation idiom. Sourced by the
+  suite. A scenario driving a hook composes a runner with the delivery rather than
+  hand-rolling a `bash -c` pipeline; the helper's own comment says why the payload must
+  stay positional, and names its `.gaia/tests/hooks/helpers/run-hook.sh` twin.
 
 ## Model
 

--- a/.gaia/tests/concurrency/concurrency.bats
+++ b/.gaia/tests/concurrency/concurrency.bats
@@ -104,7 +104,7 @@ count_autocommits() {
   # target naming a different tree.
   json="$(jq -n --arg c "$B" --arg p "$A/README.md" \
     '{tool_name: "Edit", cwd: $c, tool_input: {file_path: $p}}')"
-  run bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$MAIN/.claude/hooks/block-worktree-path-mismatch.sh"
+  run gaia_deliver_hook "$json" "$MAIN/.claude/hooks/block-worktree-path-mismatch.sh"
   [ "$status" -eq 0 ]
 
   # Target: denied (payload cwd names B, target resolves to a different real
@@ -138,7 +138,7 @@ count_autocommits() {
   # treeA and allowed, even though the hook process runs in treeB.
   json="$(jq -n --arg c "$A" --arg p "$A/README.md" \
     '{tool_name: "Edit", cwd: $c, tool_input: {file_path: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output" && return 1
 
@@ -148,7 +148,7 @@ count_autocommits() {
   # from its own process cwd would see treeB writing into treeB and allow it.
   json="$(jq -n --arg c "$A" --arg p "$B/README.md" \
     '{tool_name: "Edit", cwd: $c, tool_input: {file_path: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output" || return 1
 
@@ -157,7 +157,7 @@ count_autocommits() {
   # falls back to the process cwd, treeB, and a target in treeA is denied.
   json="$(jq -n --arg c "$outside" --arg p "$A/README.md" \
     '{tool_name: "Edit", cwd: $c, tool_input: {file_path: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output" || return 1
 
@@ -167,7 +167,7 @@ count_autocommits() {
   # an identity it could not confirm. The contract every block-*.sh guard shares.
   json="$(jq -n --arg c "$outside" --arg p "$A/README.md" \
     '{tool_name: "Edit", cwd: $c, tool_input: {file_path: $p}}')"
-  run run_in "$outside" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$outside" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -672,7 +672,8 @@ test("adds two numbers c407", () => {
     local payload
     payload=$(jq -nc --arg c "pnpm test --run $test_rel" --arg d "$tree" \
       '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d, tool_response:{stdout:"", stderr:"", interrupted:false}}')
-    run bash -c "cd '$tree' && export RED_CAPTURE_JSON_OVERRIDE='$canned'; printf '%s' '$payload' | bash '$tree/.claude/hooks/capture-red-observations.sh'"
+    run run_in "$tree" -- run_with RED_CAPTURE_JSON_OVERRIDE="$canned" -- \
+      gaia_deliver_hook "$payload" "$tree/.claude/hooks/capture-red-observations.sh"
   }
 
   # Drive the REAL check hook for a `git commit` PreToolUse, FROM <tree>'s OWN
@@ -684,7 +685,7 @@ test("adds two numbers c407", () => {
     local payload
     payload=$(jq -nc --arg c "git commit -m change" --arg d "$tree" \
       '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
-    run bash -c "cd '$tree' && printf '%s' '$payload' | bash '$tree/.claude/hooks/red-verify-commit-check.sh'"
+    run run_in "$tree" -- gaia_deliver_hook "$payload" "$tree/.claude/hooks/red-verify-commit-check.sh"
   }
 
   # ---------------------------------------------------------------------------
@@ -917,7 +918,7 @@ test("adds two numbers c407", () => {
   # Half A, the kept nudge.
   mkdir -p "$MAIN/.gaia/local"
   jq -n '{completed_at: null}' > "$MAIN/.gaia/local/setup-state.json"
-  run env HOME="$home_dir" bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$B/.gaia/statusline/gaia-statusline.sh"
+  run run_with HOME="$home_dir" -- gaia_deliver_hook "$json" "$B/.gaia/statusline/gaia-statusline.sh"
   [ "$status" -eq 0 ]
   grep -qF 'setup-gaia' <<< "$output"
 
@@ -926,7 +927,7 @@ test("adds two numbers c407", () => {
   jq -n '{completed_at: "2026-01-01T00:00:00Z"}' > "$MAIN/.gaia/local/setup-state.json"
   jq -n '{schema: 1, openCount: 3, computedAt: 0}' > "$MAIN/.gaia/local/debt/count.json"
   jq -n '{outdatedCount: 3}' > "$MAIN/.gaia/local/cache/shared/update-check.json"
-  run env HOME="$home_dir" bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$B/.gaia/statusline/gaia-statusline.sh"
+  run run_with HOME="$home_dir" -- gaia_deliver_hook "$json" "$B/.gaia/statusline/gaia-statusline.sh"
   [ "$status" -eq 0 ]
   grep -qF 'gaia-debt' <<< "$output" && return 1
   grep -qF 'update-deps' <<< "$output" && return 1
@@ -960,12 +961,12 @@ test("adds two numbers c407", () => {
   # 1. wiki-drift-check.sh: real drift exists; a live hook prints the
   # reminder and stamps its own marker.
   json="$(jq -n '{session_id: "S1"}')"
-  out="$(run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$MAIN/.claude/hooks/wiki-drift-check.sh")"
+  out="$(run_in "$B" -- gaia_deliver_hook "$json" "$MAIN/.claude/hooks/wiki-drift-check.sh")"
   grep -qF '[wiki state]' <<< "$out" || dead="$dead wiki-drift-check"
 
   # 2. wiki-commit-nudge.sh: fires on a Bash `git commit` PostToolUse call.
   json="$(jq -n --arg c 'git commit -m "x"' '{tool_name: "Bash", tool_input: {command: $c}}')"
-  out="$(run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$MAIN/.claude/hooks/wiki-commit-nudge.sh")"
+  out="$(run_in "$B" -- gaia_deliver_hook "$json" "$MAIN/.claude/hooks/wiki-commit-nudge.sh")"
   grep -qF '[wiki nudge]' <<< "$out" || dead="$dead wiki-commit-nudge"
 
   # 3. wiki-session-stop.sh: a session-start marker recording HEAD before a
@@ -976,7 +977,7 @@ test("adds two numbers c407", () => {
   git -C "$B" add wiki/page.md
   git -C "$B" commit -q -m "wiki page"
   json="$(jq -n '{session_id: "S1"}')"
-  out="$(run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$MAIN/.claude/hooks/wiki-session-stop.sh")"
+  out="$(run_in "$B" -- gaia_deliver_hook "$json" "$MAIN/.claude/hooks/wiki-session-stop.sh")"
   grep -qF 'WIKI_CHANGED' <<< "$out" || dead="$dead wiki-session-stop"
 
   # 4. wiki-squash-autocommits.sh: two consecutive `wiki: auto-commit` commits
@@ -1201,7 +1202,7 @@ test("adds two numbers c407", () => {
   # where settings.json names it by a path relative to the session's cwd.
   reentry_payload="$(jq -nc --arg p "$B" \
     '{tool_name: "EnterWorktree", cwd: $p, tool_response: {worktreePath: $p}}')"
-  ( cd "$B" && printf '%s' "$reentry_payload" | bash "$B/.claude/hooks/provision-worktree.sh" ) >/dev/null 2>&1
+  run_in "$B" -- gaia_deliver_hook "$reentry_payload" "$B/.claude/hooks/provision-worktree.sh" >/dev/null 2>&1
 
   # Target: repaired to a correct symlink at main's real .gaia/local, on
   # re-entry, without manual intervention.
@@ -1256,7 +1257,7 @@ SH
   # worktree and whose tool_response names the path outright.
   entry_payload="$(jq -nc --arg p "$wt" \
     '{tool_name: "EnterWorktree", cwd: $p, tool_response: {worktreePath: $p}}')"
-  ( cd "$wt" && printf '%s' "$entry_payload" | bash "$wt/.claude/hooks/provision-worktree.sh" ) >/dev/null 2>&1
+  run_in "$wt" -- gaia_deliver_hook "$entry_payload" "$wt/.claude/hooks/provision-worktree.sh" >/dev/null 2>&1
 
   # Target: generated build types are present and current before first use.
   [ -f "$wt/.react-router/types/.stamp" ]
@@ -1290,7 +1291,7 @@ SH
   # tracked file main carries) names "gaia", exactly the name the registry
   # would resolve to main. Denied, naming B's own root as the correct value.
   json="$(jq -n --arg c "$B" '{tool_name: "mcp__serena__activate_project", cwd: $c, tool_input: {project: "gaia"}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output"
   grep -qF -- "$B" <<< "$output"
@@ -1298,7 +1299,7 @@ SH
   # (2) PATH ARM, the main checkout. The same silent-wrong-tree shape by
   # absolute path instead of by name.
   json="$(jq -n --arg c "$B" --arg p "$MAIN" '{tool_name: "mcp__serena__activate_project", cwd: $c, tool_input: {project: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output"
   grep -qF -- "$B" <<< "$output"
@@ -1306,13 +1307,13 @@ SH
   # (3) PATH ARM, a sibling worktree -- the case the original simulated
   # scenario named (tree A, not only main).
   json="$(jq -n --arg c "$B" --arg p "$A" '{tool_name: "mcp__serena__activate_project", cwd: $c, tool_input: {project: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output"
 
   # (4) PATH ARM, B's own root: the correct activation, allowed.
   json="$(jq -n --arg c "$B" --arg p "$B" '{tool_name: "mcp__serena__activate_project", cwd: $c, tool_input: {project: $p}}')"
-  run run_in "$B" -- bash -c 'printf %s "$1" | bash "$2"' _ "$json" "$guard"
+  run run_in "$B" -- gaia_deliver_hook "$json" "$guard"
   [ "$status" -eq 0 ]
   grep -qF -- '"permissionDecision": "deny"' <<< "$output" && return 1
   return 0
@@ -1380,7 +1381,8 @@ SH
   # step.
   entry_payload="$(jq -nc --arg p "$B" \
     '{tool_name: "EnterWorktree", cwd: $p, tool_response: {worktreePath: $p}}')"
-  ( cd "$B" && printf '%s' "$entry_payload" | PATH="$stub_dir:$PATH" bash "$B/.claude/hooks/provision-worktree.sh" ) >/dev/null 2>&1
+  run_in "$B" -- run_with PATH="$stub_dir:$PATH" -- \
+    gaia_deliver_hook "$entry_payload" "$B/.claude/hooks/provision-worktree.sh" >/dev/null 2>&1
 
   # Target: a test run inside B resolves its dependencies from B's own tree,
   # never silently against main's when they differ. A bare "resolution

--- a/.gaia/tests/concurrency/lib/concurrency-harness.sh
+++ b/.gaia/tests/concurrency/lib/concurrency-harness.sh
@@ -151,13 +151,17 @@ run_in() {
 # It exists for one reason: `env` is an external binary and cannot invoke a
 # shell function, so a scenario needing both an environment override and
 # gaia_deliver_hook below has no way to compose the two without this.
-# Misuse exits 64 rather than returning, and the checks are not decoration. Under
-# bats' `run` errexit is off, so a bare `shift` on an empty list and a `"$@"` that
-# expands to zero words both yield status 0: dropping the `--` would eat the
-# command as assignments, never invoke the hook, and leave `status` 0 with the
-# scenario green. That is the vacuous pass this whole primitive exists to prevent,
-# so the separator is enforced rather than merely documented, and `exit` is used so
-# the failure is fatal whatever the caller's errexit state.
+# Every misuse fails with status 64 and runs no command, and the checks are not
+# decoration. Under bats' `run` errexit is off, so a bare `shift` on an empty list
+# and a `"$@"` that expands to zero words both yield status 0: dropping the `--`
+# would eat the command as assignments, never invoke the hook, and leave `status` 0
+# with the scenario green. That is the vacuous pass this whole primitive exists to
+# prevent, so every arm is enforced rather than merely documented.
+#
+# On the status: `exit` ends run_with's OWN subshell, so run_with then RETURNS 64 to
+# its caller. Under `run` that is captured into `$status`; at an unwrapped call site
+# it is bats' own errexit that makes it fatal. `exit` rather than `return` is still
+# the right verb, because it cannot be swallowed by the `||` it sits behind.
 run_with() {
   (
     # The separator is checked BEFORE anything is exported, by an exact scan
@@ -174,7 +178,19 @@ run_with() {
     [ "$_rw_found" -eq 1 ] || { printf 'run_with: missing -- separator\n' >&2; exit 64; }
 
     while [ "$1" != "--" ]; do
-      export "${1:?run_with: empty assignment}" || exit 64
+      # A bare name carrying no `=` is the one malformed shape `export` accepts:
+      # `export STUBVAR` succeeds and applies nothing, so the command would run
+      # with the override silently absent. Refuse it here rather than let it
+      # through. This also catches the empty string, which matches no `*=*`.
+      case "$1" in
+        *=*) ;;
+        *) printf 'run_with: not an assignment: %s\n' "$1" >&2; exit 64 ;;
+      esac
+      # `${1?}` rather than a bare `$1` is shellcheck's own documented way to
+      # quiet SC2163 on a deliberate export-by-word. It asserts nothing here:
+      # the `case` above is what validates, and `|| exit 64` is what catches an
+      # export that still fails (a value-carrying but invalid name, `1FOO=x`).
+      export "${1?}" || exit 64
       shift
     done
     shift

--- a/.gaia/tests/concurrency/lib/concurrency-harness.sh
+++ b/.gaia/tests/concurrency/lib/concurrency-harness.sh
@@ -151,13 +151,34 @@ run_in() {
 # It exists for one reason: `env` is an external binary and cannot invoke a
 # shell function, so a scenario needing both an environment override and
 # gaia_deliver_hook below has no way to compose the two without this.
+# Misuse exits 64 rather than returning, and the checks are not decoration. Under
+# bats' `run` errexit is off, so a bare `shift` on an empty list and a `"$@"` that
+# expands to zero words both yield status 0: dropping the `--` would eat the
+# command as assignments, never invoke the hook, and leave `status` 0 with the
+# scenario green. That is the vacuous pass this whole primitive exists to prevent,
+# so the separator is enforced rather than merely documented, and `exit` is used so
+# the failure is fatal whatever the caller's errexit state.
 run_with() {
   (
-    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
-      export "${1?}"
+    # The separator is checked BEFORE anything is exported, by an exact scan
+    # rather than a pattern over "$*", so that a missing `--` reports itself
+    # instead of surfacing as whichever later word first failed to parse as an
+    # assignment, and so that no word is exported on the way to that refusal.
+    _rw_found=0
+    for _rw_arg in "$@"; do
+      if [ "$_rw_arg" = "--" ]; then
+        _rw_found=1
+        break
+      fi
+    done
+    [ "$_rw_found" -eq 1 ] || { printf 'run_with: missing -- separator\n' >&2; exit 64; }
+
+    while [ "$1" != "--" ]; do
+      export "${1:?run_with: empty assignment}" || exit 64
       shift
     done
     shift
+    [ "$#" -gt 0 ] || { printf 'run_with: no command after --\n' >&2; exit 64; }
     "$@"
   )
 }

--- a/.gaia/tests/concurrency/lib/concurrency-harness.sh
+++ b/.gaia/tests/concurrency/lib/concurrency-harness.sh
@@ -6,7 +6,8 @@
 # linked worktrees off one base, seeds .gaia/local/, copies the real registry
 # and whichever hooks/scripts/libs a scenario drives into the fixture at their
 # real repo-relative paths (so their own internal `source`/relative-path calls
-# resolve exactly as they do in the real repo), and provides a run_in helper.
+# resolve exactly as they do in the real repo), and provides the run_in /
+# run_with runners plus the suite's one hook-delivery idiom, gaia_deliver_hook.
 #
 # GAIA_REPO_ROOT_REAL is resolved once from this file's own location:
 # lib/ -> concurrency/ -> tests/ -> .gaia/ -> repo root (four levels up).
@@ -139,6 +140,59 @@ run_in() {
     shift
   fi
   ( cd "$dir" && "$@" )
+}
+
+# run_with <VAR=VALUE> [...] -- <cmd...>: run <cmd...> with the given
+# environment assignments applied, in a subshell so the caller's own
+# environment is never disturbed. The environment analogue of run_in, and the
+# `--` separator is REQUIRED here rather than optional, because an assignment
+# list is otherwise indistinguishable from the command that follows it.
+#
+# It exists for one reason: `env` is an external binary and cannot invoke a
+# shell function, so a scenario needing both an environment override and
+# gaia_deliver_hook below has no way to compose the two without this.
+run_with() {
+  (
+    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+      export "${1?}"
+      shift
+    done
+    shift
+    "$@"
+  )
+}
+
+# gaia_deliver_hook <payload> <hook>: deliver <payload> on stdin to <hook>.
+# This is the ONE hook-invocation idiom for this suite; reach for it rather
+# than hand-rolling a delivery, and compose it with whichever runner the
+# scenario needs. It calls neither bats' `run` nor `cd` itself, so the caller
+# supplies that:
+#
+#   run gaia_deliver_hook "$json" "$hook"                    status + output
+#   run run_in "$B" -- gaia_deliver_hook "$json" "$hook"     ... from a tree
+#   run run_with HOME="$h" -- gaia_deliver_hook "$json" "$hook"   ... with env
+#   out="$(run_in "$B" -- gaia_deliver_hook "$json" "$hook")"     stdout alone
+#   run_in "$B" -- gaia_deliver_hook "$json" "$hook" >/dev/null   side effect
+#
+# WHY THE PAYLOAD IS POSITIONAL, which is not a style preference. The payload
+# and the hook path are ARGUMENTS to the inner `bash -c`, never interpolated
+# into its script. A payload spliced into a quoted string terminates that
+# string early the moment a fixture carries a quote of its own, and the hook
+# then reads a DIFFERENT payload than the one the fixture spells: it denies for
+# the wrong reason, or never parses the payload at all, and the scenario greens
+# having proved nothing about the property it is named for. This suite is the
+# hardest place to notice that, because its assertions are about WHICH TREE a
+# guard attributes a write to rather than about payload text.
+#
+# THE TWIN, deliberately not shared. .gaia/tests/hooks/helpers/run-hook.sh's
+# `invoke_hook` is the same one-line idiom for the .gaia/tests/hooks/ suites.
+# It calls `run` itself, which those suites want and this one cannot use: only
+# one scenario here invokes a hook with no runner wrapped around it, while the
+# rest need run_in, run_with, a `$( )` capture, or no capture at all. Two
+# implementations of one line is the accepted cost of two harnesses with
+# different composition needs; keep them in step by name.
+gaia_deliver_hook() {
+  bash -c 'printf %s "$1" | bash "$2"' _ "$1" "$2"
 }
 
 # gaia_teardown: remove every registered worktree (force, best-effort), then

--- a/.gaia/tests/hooks/helpers/run-hook.sh
+++ b/.gaia/tests/hooks/helpers/run-hook.sh
@@ -41,6 +41,15 @@
 # for an absence. A bare `[[ ]]` and a `!`-negation both fail to fail on a
 # non-final assertion line.
 
+# THE TWIN, deliberately not shared. The INV-7 concurrency meter carries the
+# same one-line idiom as `gaia_deliver_hook` in
+# .gaia/tests/concurrency/lib/concurrency-harness.sh. The two are not merged
+# because the forms below call bats' `run` themselves, which every suite here
+# wants and that suite cannot use: its scenarios wrap delivery in a
+# tree-scoped or environment-scoped runner, capture stdout alone, or drive a
+# hook purely for its side effect. Keep the two in step by name; a change to
+# the invocation below almost certainly applies there too.
+
 # invoke_hook PAYLOAD HOOK
 # Pipes PAYLOAD to HOOK, capturing status/output through bats' `run`.
 invoke_hook() {


### PR DESCRIPTION
The INV-7 concurrency meter hand-rolled the hook-invocation idiom at every site that drives a hook, with no shared primitive to reach for. The next scenario added to it copies a neighbour or invents a variant, which is exactly how the sibling `.gaia/tests/hooks/` directory acquired the drift `#1219` documents: 29 hand-copies, two incompatible deny contracts, three different matchers.

Closes #1232

## The inventory was understated, and it is corrected on the issue

The issue reports 14 delivery sites, all of them "already the quote-safe positional form". Measured with `grep -n "printf.*|.*bash" .gaia/tests/concurrency/concurrency.bats`, there are **19**, and two of them are not quote-safe:

| Shape | Sites | Count |
|---|---|---|
| bare `run` | 107 | 1 |
| `run run_in DIR --` | 141, 151, 160, 170, 1293, 1301, 1309, 1315 | 8 |
| `run env HOME=` | 920, 929 | 2 |
| `$(run_in DIR -- …)`, no bats `run` at all | 963, 968, 979 | 3 |
| plain subshell, output discarded, one with a `PATH=` prefix | 1204, 1259, 1383 | 3 |
| **interpolated, not quote-safe** | 675, 687 | 2 |

Sites 675 and 687 read `run bash -c "cd '$tree' && … printf '%s' '$payload' | bash '$tree/…'"`, splicing the payload into a quoted string. That is the shape `run-hook.sh`'s "WHY THE PAYLOAD IS POSITIONAL" block warns against. It is **latent rather than live**: both payloads are `jq -nc` output over fixed strings and mktemp paths, so no single quote reaches them today. The issue's framing survives, but the file already contained two instances of the shape rather than zero. Recorded as a comment on `#1232` so the record carries the contradiction rather than only the conclusion.

## The decision this issue owed

The issue offered three options. This takes the third, and the code settles it rather than taste:

1. `invoke_hook` in `.gaia/tests/hooks/helpers/run-hook.sh` calls bats' `run` itself, so its contract fits **1 of the 19** sites here. The other 18 need `run_in`, an environment prefix, a `$( )` capture, or no capture at all: four capture modes.
2. The suite already has a primitive home, `lib/concurrency-harness.sh`, sourced from `setup()` and already owning `run_in`. Delivery belongs beside the runner it has to compose with.
3. Option 1 as written ("have both directories use it") costs either rewriting `run-hook.sh` against 33 suites and 98 `invoke_hook` / `invoke_hook_in` call sites, or sourcing the hooks suite's private helper cross-directory. This repo's convention for a cross-directory bats helper is `.gaia/tests/helpers/` (`files.sh`, sourced by 9 suites across 3 directories via `$REPO_ROOT`), not reaching into `hooks/helpers/`. The genuinely shared surface is one line of bash and pays for neither.
4. Option 2 is the one the issue flags as most likely to grow the artifact for no behavioural gain, and the four capture modes are why.
5. "Change nothing" rested on the quote-safety claim above, which is false.

Both files now name the other, so two implementations of one idiom is a recorded decision rather than drift.

## What landed

- `gaia_deliver_hook PAYLOAD HOOK` in `lib/concurrency-harness.sh`: the invocation only, no `run` and no `cd`, so the caller supplies the runner. Carries the positional-payload rationale.
- `run_with VAR=VALUE... -- CMD...`: the environment analogue of the existing `run_in`, same subshell rationale, `--` required rather than optional. It exists because `env` is an external binary and cannot invoke a shell function, and three sites carry an `env HOME=` / `PATH=` prefix. Not speculative: those three sites are its only justification.
- All 19 sites routed through them, including the two interpolated ones.
- The README `## Files` entry and the harness header updated to name the primitive.

The form was chosen against the linter rather than by preference. At the `.sh` `style` floor the function pair lints clean with **zero** suppressions, while a string constant needs three (SC2089/SC2090/SC2016) and an array two (SC2034/SC2016).

Fifteen other `bash -c` sites in the same file source a lib or run a command rather than delivering a payload to a hook. Different idiom, deliberately untouched.

## Verification

- **The meter, which is the oracle this issue names**: `bash .gaia/tests/concurrency/meter-gate.sh` reads **23 / 23**, exit 0, matching `expected-status.txt` in both directions. Baselined at 23/23 **before** the first edit, so the number is a comparison rather than an assertion. No `## Published assertion changes` entry is owed: delivery mechanics changed, no scenario's assertion moved.
- **Vacuity proof, because a green suite is not the property at risk here.** The risk of this change is a scenario that still passes while delivering nothing, so `gaia_deliver_hook` was mutated to deliver an **empty** payload and the meter re-run. It read **18 / 23**, exit 1, with five scenarios red: `C3-02`, `C3-03`, `C4-07`, `C5-02`, `C7-01`. Those five are proved load-bearing on delivery.

  The other four converted scenarios (`C5-01`, `C6-02`, `C6-03`, `C7-02`) stayed green under that mutation, so they were checked separately rather than assumed: their hooks resolve the acting tree from **cwd**, which `run_in` supplies, so an empty payload does not change what they assert. This is a pre-existing property of those scenarios, not something this change introduced, and it is the reason the mutation alone could not speak for them. Delivery at those five call sites was proved directly instead, by instrumenting the primitive to record what it is handed and re-running exactly those scenarios: five payloads recorded for five call sites, every one non-empty and well-formed (three `EnterWorktree` payloads of ~300 bytes, two statusline `workspace.current_dir` payloads). Combined with a standalone probe showing the primitive delivers a payload carrying `'`, `"`, `$( )` and backticks byte-exact, that closes the path from call site to hook stdin.

  Both the mutation and the instrumentation were restored with `cp` rather than `git checkout --`, and the restore was verified with `git diff --quiet` returning byte-identity against the commit, then the meter re-run clean.
- `bash .gaia/tests/shell-lint.sh`: passed, 197 `.sh`, 194 `.bats`, husky, and both repo-authored guards clean.
- The five bats roots CI runs (`.github/audit/tests/`, `.gaia/scripts/tests/`, `.gaia/tests/hooks/`, `.gaia/tests/lib/`, `.gaia/tests/statusline/`), run locally through `bats5.sh` so local matches CI's bash 5. **All five pass, zero failures**, and CI runs the same set on this push.
- Quality Gate skipped, correctly: its documented grep over the staged set returns empty, no `.ts|tsx|js|jsx|mjs|cjs|css` and no gate-affecting config.

## CHANGELOG

No entry. Every file here is under `.gaia/tests/`, which is release-excluded (`.gaia/release-exclude:104`) and carries zero manifest entries, and no gate's behaviour changes. This is the CHANGELOG gate's "test-only changes that alter no shipped behavior" case.

## Audit round 1, and what it changed

`code-audit-maintainer-shell` (the whole resolved member set) **refused**, on one Important finding in `run_with`, the helper this PR introduces. It is worth stating plainly because it is the same defect class the PR exists to remove, reintroduced by the fix for it:

**`run_with` documented `--` as required and did not enforce it, and the unenforced path failed open at status 0.** Under bats' `run` errexit is off, so dropping the separator made the loop eat the command as environment assignments; the hook never ran, `status` was 0, and `output` held only export noise. A scenario asserting `[ "$status" -eq 0 ]` plus an absence check then passes against a hook that never ran. `meter-gate.sh` cannot see this, because it reports green. The member reproduced it under bats 1.13.0 on both bash 3.2.57 and 5.3.15.

Beside it, `${1?}` was inert: it fires only on an *unset* parameter, which the loop condition already precludes, so an empty or malformed assignment reached `export`, failed non-fatally under `run`, and the command then ran **without** its override.

Both are fixed. Misuse now exits 64, and the separator is validated by an exact scan **before** anything is exported. That ordering was itself a second iteration: checking inside the export loop made the diagnostic report whichever later word first failed to parse, and exported the valid-identifier words on the way to refusing. My own new test caught that, not review.

**A regression suite now pins both primitives**, at `.gaia/scripts/tests/concurrency-harness-helpers.bats`. It cannot live in the concurrency meter, whose scenario list and `target` denominator are frozen and move only by the maintainer's word, so it sits beside `bats-files-helper.bats`, which pins the other cross-suite bats primitive for the same reason. Eleven tests: delivery byte-exactness (including a payload carrying `'`, `"`, `$( )` and backticks), status propagation, `run_with`'s happy path, non-leakage, `run_in`+`run_with` nesting, and four misuse arms that must fail loudly.

Every new assertion is proved by mutation rather than asserted to work: dropping the separator check reds test 8 alone, dropping the after-separator check reds test 9 alone, and reverting the assignment guard to `${1?}` reds tests 10 and 11 alone. Verified on bash 3.2.57 and 5.3.15.

The member also confirmed all four points I asked it to check independently, found no cross-remit and no out-of-scope findings, and noted that the conversion **tightened** C4-07: the old `cd '$tree' && … ; printf …` still ran the delivery from the wrong directory when the `cd` failed, where `run_in`'s `( cd "$dir" && "$@" )` does not.

Re-verified after the fix: meter **23 / 23** exit 0, the full `.gaia/scripts/tests/` root exit 0 with zero failures, `shell-lint.sh` passing over 195 tracked suites (the new file included).

## Audit rounds 3 and 4

**Round 3** cleared on `15f1d8ea` with two Suggestions, both about the new suite asserting less than the helper documents: the five misuse arms checked only a non-zero status while the header promises 64 (mutating every `exit 64` to `exit 1` left all twelve green), and the empty-assignment test named no refusal message, so deleting the assignment check reddened only the bare-name test. Both were applied rather than deferred, because the alternative was not free: under this drain's residue trigger a filing here becomes a whole extra row, which costs more than the one round folding them in cost. Each is now mutation-proved, and the member independently re-derived all nine mutants against a `git archive` extraction rather than trusting the report.

**Round 4 cleared with the marker written**, one Suggestion, recorded below.

Rounds 1 and 2 are described above. The arc is worth stating plainly, since it is this PR's own subject turned on itself: round 1 found the new helper failing open at status 0, round 2 found the test written to catch that could not fail, and rounds 3 and 4 found the assertions weaker than the prose around them. Every one is the same class the PR exists to remove.

## Accepted residuals

Recorded rather than fixed, under the digest economics in `wiki/concepts/PR Merge Workflow.md`: the PR is clean and the member is marked, so folding a comment reword in buys a full re-dispatch to re-earn a marker already earned. Round 4's finding also sits on prose an earlier round of mine wrote, which is the enrichment loop that page names, so the pre-committed stopping rule takes the accept-and-note branch.

<!-- gaia-debt-key: v1 class=holistic/unclassified path=.gaia/scripts/tests/concurrency-harness-helpers.bats line=114 -->
- `.gaia/scripts/tests/concurrency-harness-helpers.bats:114`, the block comment above the misuse arms reads "Each checks the exact status AND that the command never ran". The first clause is true for all five arms; the second is true for four. Test 9 (`no command after --`) carries no absence check, correctly, because nothing follows the separator so no command could have run. A maintainer auditing the suite against its own comment could read coverage into test 9 that is not there. The omission in the test is right and should stay; only the comment overreaches. Suggestion tier, no live failure mode.
