### PR TITLE
debt(cli): suppress git auto-maintenance for the whole CLI test run (#1235)

### DIFF
--- a/.gaia/cli/src/util/git-maintenance-env.test.ts
+++ b/.gaia/cli/src/util/git-maintenance-env.test.ts
@@ -9,9 +9,13 @@
  *
  * Two arms, because a bare "no maintenance was spawned" assertion passes just
  * as well when the trace recorded nothing at all. The control arm clears
- * `GIT_CONFIG_COUNT` for one commit into the same repository, which is the only
- * variable that changes between the arms, so a spawn there proves both that the
- * repository is genuinely ungated and that the trace can see a spawn.
+ * `GIT_CONFIG_COUNT` and commits into an identically configured repository, so
+ * a spawn there proves both that such a repository is genuinely ungated and
+ * that the trace can see a spawn. What holds every other variable fixed is the
+ * shared `beforeEach`, not a shared repository: each arm gets its own
+ * `mkdtempSync` repo, built from the same list and deleted in `afterEach`. They
+ * are deliberately not hoisted into a `beforeAll`, which would let the control
+ * arm's own maintenance run touch the object store the subject arm measures.
  */
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {mkdtempSync, rmSync} from 'node:fs';

--- a/.gaia/cli/src/util/git-maintenance-env.test.ts
+++ b/.gaia/cli/src/util/git-maintenance-env.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The run-wide git auto-maintenance suppression, proved against git itself.
+ *
+ * `git-maintenance-env.ts` is a vitest `setupFiles` entry, so nothing imports
+ * it and no assertion about its exports would show that it reached a git
+ * subprocess. This asserts the effect instead: a repository carrying git's own
+ * defaults for both gates, committed into from inside this run, spawns no
+ * maintenance.
+ *
+ * Two arms, because a bare "no maintenance was spawned" assertion passes just
+ * as well when the trace recorded nothing at all. The control arm clears
+ * `GIT_CONFIG_COUNT` for one commit into the same repository, which is the only
+ * variable that changes between the arms, so a spawn there proves both that the
+ * repository is genuinely ungated and that the trace can see a spawn.
+ */
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {execGaiaGit} from './git-env.js';
+import {
+  autoMaintenanceSpawns,
+  detachedSpawns,
+  MAINTENANCE_GATE_DEFAULTS,
+} from './git-maintenance.js';
+
+/**
+ * Enough config to commit, with the gates left at git's own defaults.
+ *
+ * `MAINTENANCE_GATE_DEFAULTS` carries the gates, so what makes this repository
+ * ungated is stated once, in the module both maintenance guards read it from.
+ *
+ * `gc.autoDetach` and `maintenance.autoDetach` are not gates and are set here,
+ * which keeps the control arm's own maintenance run a foreground child so it
+ * cannot outlive the test into the `rmSync` in `afterEach`. Both spellings,
+ * because modern git resolves `maintenance.autoDetach` ahead of `gc.autoDetach`.
+ */
+const UNGATED_CONFIG: [string, string][] = [
+  ['user.email', 'test@example.com'],
+  ['user.name', 'Test'],
+  ['commit.gpgsign', 'false'],
+  ['gc.autoDetach', 'false'],
+  ['maintenance.autoDetach', 'false'],
+  ...MAINTENANCE_GATE_DEFAULTS,
+];
+
+describe('run-wide git maintenance suppression', () => {
+  let root: string;
+  let traceRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'gaia-git-maint-'));
+    traceRoot = mkdtempSync(path.join(tmpdir(), 'gaia-git-maint-trace-'));
+    execGaiaGit(['init', '-q', '-b', 'main'], root);
+
+    for (const [key, value] of UNGATED_CONFIG) {
+      execGaiaGit(['config', key, value], root);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(root, {force: true, recursive: true});
+    rmSync(traceRoot, {force: true, recursive: true});
+  });
+
+  const commitTraced = (traceName: string, message: string): string[] => {
+    const tracePath = path.join(traceRoot, traceName);
+    vi.stubEnv('GIT_TRACE2_EVENT', tracePath);
+    execGaiaGit(['commit', '-q', '--allow-empty', '-m', message], root);
+
+    return autoMaintenanceSpawns(tracePath);
+  };
+
+  test('a repository at git defaults spawns maintenance without the run env', () => {
+    vi.stubEnv('GIT_CONFIG_COUNT', '0');
+    const spawns = commitTraced('control.json', 'control baseline');
+
+    expect(spawns.length).toBeGreaterThan(0);
+    // The control's own run must stay in the foreground, or `afterEach` deletes
+    // the repository out from under a live background git. A count alone cannot
+    // see that: the parent records the child either way, so this arm would pass
+    // green while leaking the orphan the suppression exists to prevent.
+    expect(detachedSpawns(spawns)).toEqual([]);
+  });
+
+  test('the run env suppresses maintenance in that same repository', () => {
+    expect(commitTraced('subject.json', 'subject baseline')).toEqual([]);
+  });
+});

--- a/.gaia/cli/src/util/git-maintenance-env.ts
+++ b/.gaia/cli/src/util/git-maintenance-env.ts
@@ -1,0 +1,82 @@
+/**
+ * Suppress git's background auto-maintenance for every git subprocess this
+ * vitest run spawns.
+ *
+ * Wired as the `setupFiles` entry in `.gaia/cli/vitest.config.ts`, so nothing
+ * imports it; vitest evaluates it once per test file, before that file's own
+ * imports. `git-maintenance-env.test.ts` is what proves it reaches git.
+ *
+ * ## Why this is run-wide rather than per-fixture
+ *
+ * `#1216` established the hazard: a sandbox built by `mkdtempSync` + `git init`
+ * + a run of `git commit`s is exposed to git's own maintenance, because every
+ * `git commit` spawns `git maintenance run --auto --quiet --detach` unless the
+ * repository gates it. A detached run has two ways to hurt a suite. It repacks
+ * the object store while the next `git commit` is still running, which is what
+ * corrupted HEAD in `#1216`, and it outlives the test into an `afterEach` that
+ * `rmSync`s the repository out from under it.
+ *
+ * Nineteen files under `src/` build such a sandbox and commit into it, and only
+ * `wiki/commit-classify.test.ts` gates it in its own config. That is the
+ * argument for the environment rather than for a shared fixture every sandbox
+ * has to remember to call: `GIT_CONFIG_*` reaches every git subprocess in the
+ * run regardless of `cwd`, so a sandbox added later inherits the suppression
+ * without opting in, and the hand-written list of which files need it, which
+ * has already been drawn once and come out short, stops being load-bearing.
+ *
+ * ## Why these four keys
+ *
+ * The spelling that gates this moved when `git maintenance` replaced
+ * `git gc --auto`, and the git a run gets is whatever the machine or the CI
+ * runner supplies:
+ *
+ * - `maintenance.auto=false` is the documented gate on the spawn, covering the
+ *   whole task set including `loose-objects` and `incremental-repack`, the two
+ *   that pack.
+ * - `gc.auto=0` is the gate for git predating that task set, which reaches the
+ *   repository through `git gc --auto` instead.
+ * - `gc.autoDetach=false` and `maintenance.autoDetach=false` are the fallback
+ *   for both. Neither is a gate; they matter only for a run that starts anyway,
+ *   which then finishes before the command that triggered it returns and so can
+ *   neither outlive the test nor race the next `git commit`. Both spellings,
+ *   because modern git resolves `maintenance.autoDetach` ahead of
+ *   `gc.autoDetach`.
+ *
+ * ## What this deliberately does not do
+ *
+ * It sets no identity or signing config. A sandbox still owns those, and a
+ * suite testing what git does without them keeps working.
+ *
+ * It is also not in `execGaiaGit` (`git-env.ts`), which is production code the
+ * shipped CLI runs against adopters' real repositories; suppressing maintenance
+ * there would disable auto-gc in every checkout GAIA touches. The seam is
+ * test-side, which is what makes an environment variable set by a test-run
+ * setup file the right altitude.
+ *
+ * ## Opting out
+ *
+ * `GIT_CONFIG_COUNT` set to `0` for the duration of a call restores git's own
+ * resolution, which a test proving the suppression works needs and nothing else
+ * should. `wiki/commit-classify.test.ts`'s control repository is the one such
+ * caller: an environment entry outranks repo-local config, the same way
+ * `git -c` does, so a repository that writes the gates at git's defaults still
+ * inherits the suppression from here.
+ *
+ * The assignment below overwrites an ambient `GIT_CONFIG_*` rather than
+ * appending to it, which is deliberate: the run owns its own git configuration,
+ * and appending would make which slots this file writes depend on what the
+ * calling shell happened to set.
+ */
+const MAINTENANCE_SUPPRESSION: [string, string][] = [
+  ['gc.auto', '0'],
+  ['maintenance.auto', 'false'],
+  ['gc.autoDetach', 'false'],
+  ['maintenance.autoDetach', 'false'],
+];
+
+process.env.GIT_CONFIG_COUNT = String(MAINTENANCE_SUPPRESSION.length);
+
+MAINTENANCE_SUPPRESSION.forEach(([key, value], index) => {
+  process.env[`GIT_CONFIG_KEY_${index}`] = key;
+  process.env[`GIT_CONFIG_VALUE_${index}`] = value;
+});

--- a/.gaia/cli/src/util/git-maintenance-env.ts
+++ b/.gaia/cli/src/util/git-maintenance-env.ts
@@ -62,10 +62,24 @@
  * `git -c` does, so a repository that writes the gates at git's defaults still
  * inherits the suppression from here.
  *
- * The assignment below overwrites an ambient `GIT_CONFIG_*` rather than
- * appending to it, which is deliberate: the run owns its own git configuration,
- * and appending would make which slots this file writes depend on what the
- * calling shell happened to set.
+ * ## Ambient `GIT_CONFIG_*` is overwritten, not appended to
+ *
+ * Stated as a tradeoff rather than left to be inferred from the code. The
+ * assignment below forces the count and writes slots 0-3, so an entry the
+ * environment already supplied is dropped for this run. The case that would
+ * bite is a containerized runner exporting `safe.directory` this way: every git
+ * command in the suite would then fail on ownership. Nothing in this repository
+ * or its CI sets `GIT_CONFIG_*`, and the failure would be loud rather than a
+ * silent behaviour change.
+ *
+ * Appending at the ambient count is the alternative and it does work. It does
+ * not compound across the suite, because vitest evaluates a setup file once per
+ * test file in a **fresh process** (measured: three test files, three pids,
+ * each seeing its own first run), so `process.env` never carries an earlier
+ * file's count forward. It is declined here as machinery for a condition this
+ * repository does not produce, and taking it would also mean the two opt-out
+ * call sites restoring an ambient count rather than the literal `0` they can
+ * hard-code today.
  */
 const MAINTENANCE_SUPPRESSION: [string, string][] = [
   ['gc.auto', '0'],

--- a/.gaia/cli/src/util/git-maintenance.ts
+++ b/.gaia/cli/src/util/git-maintenance.ts
@@ -1,0 +1,73 @@
+/**
+ * The test-side vocabulary of git's background auto-maintenance.
+ *
+ * Test-only. Two guards prove the suppression works, the run-wide one in
+ * `git-maintenance-env.test.ts` and the repository-local one in
+ * `wiki/commit-classify.test.ts`. Each builds a control repository that
+ * deliberately leaves maintenance switched on, so both need the same answers to
+ * "which keys are the gates", "what are git's own defaults for them", and "what
+ * did git actually spawn". They live here so the two cannot drift into
+ * disagreeing.
+ */
+import {existsSync, readFileSync} from 'node:fs';
+
+/**
+ * The gates, paired with the value that explicitly turns each one off.
+ *
+ * A control repository cannot establish "ungated" by leaving these out.
+ * Repo-local config beats global, so a sandbox that sets them is immune to
+ * whatever the machine's own `~/.gitconfig` says, but a control that merely
+ * omits them inherits it, and `gc.auto = 0` is a common thing to carry in a
+ * personal dotfile. The control would then spawn nothing and the arm asserting
+ * git still spawns maintenance would fail against a fixture behaving perfectly.
+ * Writing git's own defaults into the control makes its condition its own.
+ */
+export const MAINTENANCE_GATE_DEFAULTS: [string, string][] = [
+  ['gc.auto', '6700'],
+  ['maintenance.auto', 'true'],
+];
+
+/**
+ * Just the keys, for subtracting the gates from a suppression list.
+ *
+ * Named beside the list it subtracts from so the two cannot drift into
+ * disagreeing about which entries are the gates.
+ */
+export const MAINTENANCE_GATES = new Set(
+  MAINTENANCE_GATE_DEFAULTS.map(([key]) => key)
+);
+
+/**
+ * Every auto-maintenance child process git's own trace recorded.
+ *
+ * `GIT_TRACE2_EVENT` writes a `child_start` event, carrying the child's argv,
+ * into the trace of the process that spawned it, so a run detached with
+ * `--detach` is still visible without waiting on it or racing its exit. An
+ * absent file means git spawned nothing and so wrote nothing.
+ *
+ * Both spellings count, because the spelling depends on the git that runs it:
+ * modern git spawns `git maintenance run --auto`, and git predating that task
+ * set reaches the repository through `git gc --auto` instead. Both suppression
+ * lists name a key for each, so a filter matching only the first would assert
+ * nothing on exactly the git the other key exists for.
+ */
+export const autoMaintenanceSpawns = (tracePath: string): string[] =>
+  (existsSync(tracePath) ? readFileSync(tracePath, 'utf8') : '')
+    .split('\n')
+    .filter(
+      (line) =>
+        line.includes('"child_start"') &&
+        (line.includes('"maintenance"') || line.includes('"gc"'))
+    );
+
+/**
+ * The subset of those spawns that git detached.
+ *
+ * A control repository leaves the gates off on purpose, so it spawns a
+ * maintenance run and the test that built it must show that run stayed in the
+ * foreground; a detached one outlives the test into the `rmSync` that deletes
+ * the repository out from under it. Returning the offending lines rather than a
+ * boolean is what puts the argv in the failure message.
+ */
+export const detachedSpawns = (spawns: string[]): string[] =>
+  spawns.filter((line) => line.includes('"--detach"'));

--- a/.gaia/cli/src/util/git-maintenance.ts
+++ b/.gaia/cli/src/util/git-maintenance.ts
@@ -21,6 +21,14 @@ import {existsSync, readFileSync} from 'node:fs';
  * personal dotfile. The control would then spawn nothing and the arm asserting
  * git still spawns maintenance would fail against a fixture behaving perfectly.
  * Writing git's own defaults into the control makes its condition its own.
+ *
+ * Measured on git 2.55: `maintenance.auto` is the entry that decides here, and
+ * an explicit `maintenance.auto = true` spawns a run even alongside
+ * `gc.auto = 0`, which is what makes a control carrying both genuinely ungated.
+ * `gc.auto` is not dead weight; it is what leaves a control ungated on git
+ * predating the maintenance task set, where it is the only spelling. It is also
+ * why mutating this entry on its own cannot red either guard on 2.55, the
+ * sibling still forces the spawn, while mutating `maintenance.auto` reds both.
  */
 export const MAINTENANCE_GATE_DEFAULTS: [string, string][] = [
   ['gc.auto', '6700'],

--- a/.gaia/cli/src/wiki/commit-classify.test.ts
+++ b/.gaia/cli/src/wiki/commit-classify.test.ts
@@ -6,19 +6,18 @@
  * snapshot the suggestion + reason for each commit and assert against it.
  */
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {EXIT_CODES} from '../exit.js';
 import {COMMIT_TYPES} from '../util/conventional-commit.js';
 import {execGaiaGit} from '../util/git-env.js';
+import {
+  autoMaintenanceSpawns,
+  detachedSpawns,
+  MAINTENANCE_GATE_DEFAULTS,
+  MAINTENANCE_GATES,
+} from '../util/git-maintenance.js';
 import {run} from './commit-classify.js';
 import type {CommitClassification} from './commit-classify.js';
 
@@ -117,7 +116,14 @@ const sandboxGit = (root: string, args: string[]): string => {
  *
  * Measured on git 2.55, over the whole list rather than per entry: one spawned
  * maintenance run per commit with none of these set, zero with them. The test
- * at the bottom of this file is what keeps that true.
+ * at the bottom of this file is what keeps that true, and it clears
+ * `GIT_CONFIG_COUNT` so that what it measures is this list.
+ *
+ * A second mechanism covers the same hazard for the whole run,
+ * `util/git-maintenance-env.ts`, which puts the four maintenance keys in the
+ * environment so the eighteen other files building a sandbox get them without
+ * opting in. This list is not redundant under it: it is what this fixture's own
+ * hermeticity rests on, and it is the thing the test at the bottom measures.
  */
 const SANDBOX_GIT_CONFIG: [string, string][] = [
   ['user.email', 'test@example.com'],
@@ -128,29 +134,6 @@ const SANDBOX_GIT_CONFIG: [string, string][] = [
   ['gc.autoDetach', 'false'],
   ['maintenance.autoDetach', 'false'],
 ];
-
-/**
- * The gates, paired with the value that explicitly turns each one off.
- *
- * The control repository cannot establish "ungated" by leaving these out.
- * Repo-local config beats global, so the sandbox is immune to whatever the
- * machine's own `~/.gitconfig` says, but a control that merely omits these
- * keys inherits it, and `gc.auto = 0` is a common thing to carry in a personal
- * dotfile. The control would then spawn nothing and the arm asserting git
- * still spawns maintenance would fail against a fixture behaving perfectly.
- * Writing git's own defaults into the control makes its condition its own.
- *
- * Named beside the list it subtracts from so the two cannot drift into
- * disagreeing about which entries are the gates.
- */
-const MAINTENANCE_GATE_DEFAULTS: [string, string][] = [
-  ['gc.auto', '6700'],
-  ['maintenance.auto', 'true'],
-];
-
-const MAINTENANCE_GATES = new Set(
-  MAINTENANCE_GATE_DEFAULTS.map(([key]) => key)
-);
 
 /** Initialize one repository this fixture owns, suppression included. */
 const initSandboxRepo = (root: string, omit?: ReadonlySet<string>): void => {
@@ -804,28 +787,6 @@ describe('wiki commit-classify', () => {
 });
 
 /**
- * Every auto-maintenance child process git's own trace recorded.
- *
- * `GIT_TRACE2_EVENT` writes a `child_start` event, carrying the child's argv,
- * into the trace of the process that spawned it, so a run detached with
- * `--detach` is still visible without waiting on it or racing its exit. An
- * absent file means git spawned nothing and so wrote nothing.
- *
- * Both spellings count. Modern git spawns `git maintenance run --auto`; git
- * predating that task set spawns `git gc --auto`, which the config list above
- * names as a version it suppresses, so a filter matching only the first would
- * assert nothing on exactly the git the second entry exists for.
- */
-const autoMaintenanceSpawns = (tracePath: string): string[] =>
-  (existsSync(tracePath) ? readFileSync(tracePath, 'utf8') : '')
-    .split('\n')
-    .filter(
-      (line) =>
-        line.includes('"child_start"') &&
-        (line.includes('"maintenance"') || line.includes('"gc"'))
-    );
-
-/**
  * The fixture's own hermeticity. Every scenario above takes it on faith that
  * the repository it commits into is the one `setupSandbox` created; nothing
  * asserted it, and a bare `execFileSync('git', ...)` hands that assumption to
@@ -873,6 +834,14 @@ describe('commit-classify sandbox fixture', () => {
     let sandbox: Sandbox | undefined;
 
     try {
+      // Opt out of the run-wide suppression (`util/git-maintenance-env.ts`) for
+      // the whole test, so what runs here is this file's own config list and
+      // nothing else. An environment entry outranks repo-local config the way
+      // `git -c` does, so without this the control below would inherit the
+      // gates it exists to leave off and report a fixture that spawns nothing,
+      // which is the vacuous green this test was written to prevent.
+      vi.stubEnv('GIT_CONFIG_COUNT', '0');
+
       // Everything the sandbox sets except the gates, which are then written
       // back at git's own defaults so the control's ungated state is its own
       // rather than inherited from the machine's global config. `gc.autoDetach`
@@ -902,9 +871,7 @@ describe('commit-classify sandbox fixture', () => {
       // git predating the task set spawns `git gc --auto`, which carries no
       // detach flag at all and passes, while modern git catches a
       // `maintenance.autoDetach` that a later edit dropped as redundant.
-      expect(controlSpawns.some((line) => line.includes('"--detach"'))).toBe(
-        false
-      );
+      expect(detachedSpawns(controlSpawns)).toEqual([]);
 
       const sandboxTrace = path.join(traceRoot, 'sandbox.json');
       vi.stubEnv('GIT_TRACE2_EVENT', sandboxTrace);

--- a/.gaia/cli/vitest.config.ts
+++ b/.gaia/cli/vitest.config.ts
@@ -3,5 +3,9 @@ import {defineConfig} from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['./src/**/*.test.{ts,tsx}', './test-fixtures/**/*.test.{ts,tsx}'],
+    // Suppresses git's background auto-maintenance for every git subprocess the
+    // run spawns. Its own docblock carries the rationale, and
+    // `src/util/git-maintenance-env.test.ts` proves it reaches git.
+    setupFiles: ['./src/util/git-maintenance-env.ts'],
   },
 });


### PR DESCRIPTION
Closes #1235

Nineteen files under `.gaia/cli/src` build a git sandbox and commit into it, and only `wiki/commit-classify.test.ts` gated git's background auto-maintenance. A detached maintenance run repacks the object store while the next `git commit` is still running, which is what corrupted HEAD in #1216, or outlives the test into the `afterEach` that deletes the repository out from under it.

## The design question, settled before authoring

The issue asked for one fork to be settled first and the code does not settle it: a shared fixture module adopted opt-in across the population, or a run-wide environment. **Settled by the maintainer: the run-wide environment.** A `setupFiles` entry in `.gaia/cli/vitest.config.ts` puts the four maintenance keys in `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n`, which reaches every git subprocess in the run regardless of `cwd`, so a sandbox added later inherits the suppression without opting in.

The measurement that drove it: **the issue's own enumeration of which files need the fix came out short**, missing `wiki/sync-await.test.ts`. The opt-in arm's stated risk ("a suite added later can still miss it") was already realised at filing time, by the author who had just read the code. Under the env arm that hand-written list stops being load-bearing. Both corrections are recorded on the issue rather than only here.

The suppression is deliberately **not** in `execGaiaGit` (`util/git-env.ts`), which is production code the shipped CLI runs against adopters' real repositories.

## The consequence the issue flagged, and the shape of the fix

An environment entry outranks repo-local config, the same way `git -c` does. `commit-classify.test.ts`'s control repository deliberately leaves the gates off to prove git still spawns maintenance, so under the env it would inherit the suppression and report a fixture behaving perfectly. It now clears `GIT_CONFIG_COUNT` for that whole test, so what the test measures is that file's own config list and nothing else. Whole-test scope rather than per-call is deliberate: a narrower opt-out would leave the env active for the sandbox arm and make its assertion vacuous.

The gate vocabulary both guards need (`MAINTENANCE_GATE_DEFAULTS`, `MAINTENANCE_GATES`, `autoMaintenanceSpawns`, `detachedSpawns`) moves to `util/git-maintenance.ts` so the two cannot drift on what counts as ungated or as a spawn.

## Verification

TDD: red observed before the setup file existed (`expected [ Array(1) ] to deeply equal []`), green after. The predicted break in `commit-classify` was reproduced (`expected 0 to be greater than 0`) before being fixed, not assumed.

**Seven mutants, each restored with `cp` and verified byte-identical**, never `git checkout -- <path>`:

| mutant | result |
|---|---|
| setup file's `GIT_CONFIG_COUNT` set to `'0'` | RED, subject arm |
| setup file's two gate values set to git's defaults | RED, subject arm |
| control opt-out removed from `git-maintenance-env.test.ts` | RED, control arm |
| control opt-out removed from `commit-classify.test.ts` | RED, maintenance test |
| shared `maintenance.auto` default flipped to `false` | RED, **both** consumers |
| control repo set to detach (`maintenance.autoDetach=true`) | RED, foreground assertion |
| shared `gc.auto` default flipped to `0` | **GREEN, survived in both consumers** |

**The surviving mutant is recorded rather than papered over**, and it is a version-specific coverage limit rather than a defect. Measured on git 2.55 against `GIT_TRACE2_EVENT`: `gc.auto=0` suppresses on its own when `maintenance.auto` is unset (0 spawns), but an **explicit** `maintenance.auto=true` spawns a run alongside it (1 spawn). The control writes both explicitly, so `maintenance.auto` is the entry that decides and mutating its sibling cannot be observed on this git. `gc.auto` is not dead weight, it is the only spelling on git predating the maintenance task set, so it is what leaves a control ungated there. The docblock says so, and names both the mutant that survives and the one that reds.

**Quality Gate**, run from `wiki/decisions/Quality Gate.md` rather than memory: typecheck (root and CLI), `lint` + `lint:cli`, app vitest 30 files / 156 passed, **CLI vitest 136 files / 2050 passed / 1 skipped**, `pw` 8 passed, dev smoke 200, `build` and `.gaia/cli bundle`. The CLI suite is the one that matters here, since it runs entirely under the new setup file.

**CI-gated suites, all green**: `.github/audit/tests/` 165, `.gaia/scripts/tests/` 1495, `.gaia/tests/hooks/` 1370, `.gaia/tests/lib/` 448, `.gaia/tests/statusline/` 36, `shell-lint.sh`, `distribution/run-all.sh` 17/17, and the rebuild-from-src check. Run through the bash-5 guard so local matches CI.

## Scope

**CHANGELOG: no entry.** `.gaia/cli/src` and `.gaia/cli/vitest.config.ts` are both in `.gaia/release-exclude` (lines 129 and 135) with zero manifest entries, no shipped behaviour changes, and `pnpm bundle` reproduces `gaia`, `gaia-maintainer` and `templates/` byte-identical to what is committed. Test-only.

**Bound stated rather than hidden:** this covers the `.gaia/cli` vitest project. Git sandboxes built by the bats suites under `.gaia/tests/` are outside it, and outside #1235, which is scoped to `.gaia/cli/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
