### PR TITLE
wiki: sync through 6d79501

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "74b6af9527f85422d3366cb83d0b1a6e59929e7e",
-  "last_evaluated_at": "2026-08-09T04:51:55Z",
+  "last_evaluated_sha": "6d795010fb1065e6946b0aaf95a016f29f34ce1d",
+  "last_evaluated_at": "2026-08-11T00:44:23Z",
   "last_consolidated_sha": "baad8972ee9d300aee847b84f17d72e45c1fbddf",
   "last_consolidated_at": "2026-07-29T05:58:30Z"
 }

--- a/wiki/concepts/Update Workflow.md
+++ b/wiki/concepts/Update Workflow.md
@@ -3,7 +3,7 @@ type: concept
 title: Update Workflow
 status: active
 created: 2026-04-22
-updated: 2026-08-03
+updated: 2026-08-11
 tags: [release, claude, adopter, drift]
 ---
 
@@ -113,6 +113,8 @@ The refresh is a **3-way text classify** (the audit template is static, so there
 | `conflict` | `A` matches neither, or baseline unavailable        | Write `.gaia-merge/code-review-audit.yml.patch`; never write. |
 
 The audit workflow is **adopter-tunable**: `conflict` never clobbers adopter edits (self-hosted runners, extra secrets wiring, concurrency, extra steps), it emits a sidecar patch and defers to a manual `/setup-gaia` refresh, mirroring the `shared` drift rule. The scheduled `gaia-ci-*` workflows stay disposable (regenerated wholesale on `/setup-gaia --reconfigure`); only the audit workflow gets the 3-way.
+
+The `gaia-ci-*` templates pin their third-party actions (checkout, setup-node, and siblings) by full commit SHA with a resolved-tag comment, not by a mutable major tag, so a force-moved upstream tag cannot execute in an adopter's job holding that job's token. A CLI guard keeps the pins from drifting from the maintainer's own live workflows: it asserts every template action is SHA-pinned and that each pin equals the one the corresponding live workflow runs, so a weekly action bump has to land in the live workflow first and fails the guard until the template pin is mirrored to match. `/setup-gaia` (not `/update-gaia`) is what delivers a re-rendered `gaia-ci-*` workflow to an adopter, since these templates regenerate wholesale rather than merge.
 
 Re-rendering the workflow makes the update PR self-modifying, so [[Code Review Audit CI]]'s `claude-code-action` refuses to audit it and the run self-mod-skips. This is a UX/ordering cleanup: it replaces a wasted full audit under the stale workflow plus a manual refresh step with one expected skip. It does **not** earn a clean CI `GAIA-Audit` stamp; the merge proceeds on a local audit marker / trailer or the out-of-scope bypass (see [[PR Merge Workflow]]).
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,19 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-08-11 6d795010 SKIP - maintainer-only release-scrub scope widening (excluded-workflow-ref now scans .github/actions/**); existing wiki/decisions/Bundle-time Scrub.md prose remains accurate
+- 2026-08-11 ca3fc02b SKIP - CI perf/plumbing (parallel bats suites, single Storybook build, shared setup-node composite); wiki/dependencies/Chromatic.md already describes the resulting behavior
+- 2026-08-11 f67f5e11 SKIP - bug fix restoring the already-documented findings-block posting behavior (gh api -f vs -F); no architecture change
+- 2026-08-11 bcc550fe WORTHY - adopter gaia-ci-* CI action pinning by SHA + parity guard, previously undocumented → wiki/concepts/Update Workflow.md
+- 2026-08-11 cc67e8bc SKIP - ci: dependency bump only
+- 2026-08-11 b415a22a SKIP - ci: CI plumbing (job runtime bounds, workflow token default-deny, bundle-gate dedup)
+- 2026-08-11 bca83b6a SKIP - internal code-review-audit.yml refactor (five GAIA-Audit status writers consolidated to one); behavior unchanged per commit message
+- 2026-08-11 23c73016 WORTHY - widened self-heal refusal from .github/workflows to the whole .github tree; commit self-edited wiki/concepts/PR Merge Workflow.md directly, already current
+- 2026-08-11 356b0c61 SKIP - internal code-review-audit.yml refactor (preconditions computed once, status-comment upserter extracted to its own script); behavior unchanged, no prior wiki coverage to correct
+- 2026-08-11 711b66a7 WORTHY - added Code Audit Team roster ownerless-path coverage invariant; commit self-edited wiki/decisions/Code Audit Team.md directly, already current
+- 2026-08-11 5d7179bf SKIP - CLI test-infra hardening (git auto-maintenance suppression during test runs); no wiki-visible architecture change
+- 2026-08-11 7af22fc2 SKIP - tests-only: bats hook-delivery idiom consolidation in the concurrency suite
+- 2026-08-11 285b5511 SKIP - prior wiki-sync's own landed commit; wiki edits already merged, nothing further to sync
 - 2026-08-09 74b6af95 SKIP - new shell-lint guard for unquoted diff --name-only call sites, wired into CI; internal hardening below the wiki's stated gate-description level
 - 2026-08-09 4f2fcf54 SKIP - adds a structural guard for docblock-before-import placement and sweeps 74 files; internal hygiene test, no wiki-tracked fact
 - 2026-08-09 c9b5cbc8 SKIP - internal reachability-guard regex widened to admit a quoted invocation; maintainer test-infra hardening, no documented contract change


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to 6d79501.