### PR TITLE
debt(cli): give the region scanner a single unbalanced emitter

### DIFF
--- a/.gaia/cli/gaia
+++ b/.gaia/cli/gaia
@@ -27559,27 +27559,30 @@ var scanRegion = (source, startMarker, endMarker) => {
   if (startMarker.trim() === "" || endMarker.trim() === "") {
     return { kind: "absent" };
   }
-  const startLines = [];
-  const endLines = [];
-  source.split("\n").forEach((line, index) => {
-    if (line === startMarker) startLines.push(index + 1);
-    if (line === endMarker) endLines.push(index + 1);
-  });
-  if (startLines.length > 1) {
+  let startLine = null;
+  let endLine = null;
+  let startCount = 0;
+  let endCount = 0;
+  for (const [index, line] of source.split("\n").entries()) {
+    if (line === startMarker) {
+      startCount += 1;
+      startLine ??= index + 1;
+    }
+    if (line === endMarker) {
+      endCount += 1;
+      endLine ??= index + 1;
+    }
+  }
+  if (startCount > 1) {
     return { kind: "malformed", reason: "duplicate-start" };
   }
-  if (endLines.length > 1) {
+  if (endCount > 1) {
     return { kind: "malformed", reason: "duplicate-end" };
   }
-  if (startLines.length === 0 && endLines.length === 0) {
+  if (startLine === null && endLine === null) {
     return { kind: "absent" };
   }
-  if (startLines.length !== endLines.length) {
-    return { kind: "malformed", reason: "unbalanced" };
-  }
-  const [startLine] = startLines;
-  const [endLine] = endLines;
-  if (startLine === void 0 || endLine === void 0) {
+  if (startLine === null || endLine === null) {
     return { kind: "malformed", reason: "unbalanced" };
   }
   if (startLine >= endLine) {

--- a/.gaia/cli/gaia-maintainer
+++ b/.gaia/cli/gaia-maintainer
@@ -20903,27 +20903,30 @@ var scanRegion = (source, startMarker, endMarker) => {
   if (startMarker.trim() === "" || endMarker.trim() === "") {
     return { kind: "absent" };
   }
-  const startLines = [];
-  const endLines = [];
-  source.split("\n").forEach((line, index) => {
-    if (line === startMarker) startLines.push(index + 1);
-    if (line === endMarker) endLines.push(index + 1);
-  });
-  if (startLines.length > 1) {
+  let startLine = null;
+  let endLine = null;
+  let startCount = 0;
+  let endCount = 0;
+  for (const [index, line] of source.split("\n").entries()) {
+    if (line === startMarker) {
+      startCount += 1;
+      startLine ??= index + 1;
+    }
+    if (line === endMarker) {
+      endCount += 1;
+      endLine ??= index + 1;
+    }
+  }
+  if (startCount > 1) {
     return { kind: "malformed", reason: "duplicate-start" };
   }
-  if (endLines.length > 1) {
+  if (endCount > 1) {
     return { kind: "malformed", reason: "duplicate-end" };
   }
-  if (startLines.length === 0 && endLines.length === 0) {
+  if (startLine === null && endLine === null) {
     return { kind: "absent" };
   }
-  if (startLines.length !== endLines.length) {
-    return { kind: "malformed", reason: "unbalanced" };
-  }
-  const [startLine] = startLines;
-  const [endLine] = endLines;
-  if (startLine === void 0 || endLine === void 0) {
+  if (startLine === null || endLine === null) {
     return { kind: "malformed", reason: "unbalanced" };
   }
   if (startLine >= endLine) {

--- a/.gaia/cli/src/update/region-markers.test.ts
+++ b/.gaia/cli/src/update/region-markers.test.ts
@@ -62,9 +62,9 @@ describe('scanRegion', () => {
   });
 
   test('identical start and end markers → inverted, and maskRegion leaves the source alone', () => {
-    // One line lands in both the start and end lists, so `startLine ===
-    // endLine`. Without the `>=` guard this scans as a zero-length region and
-    // maskRegion duplicates the marker line while masking nothing.
+    // One line matches both markers, so `startLine === endLine`. Without the
+    // `>=` guard this scans as a zero-length region and maskRegion duplicates
+    // the marker line while masking nothing.
     const source = ['a', START, 'b', 'c'].join('\n');
     expect(scanRegion(source, START, START)).toEqual({
       kind: 'malformed',

--- a/.gaia/cli/src/update/region-markers.ts
+++ b/.gaia/cli/src/update/region-markers.ts
@@ -54,41 +54,43 @@ export const scanRegion = (
     return {kind: 'absent'};
   }
 
-  const startLines: number[] = [];
-  const endLines: number[] = [];
+  let startLine: null | number = null;
+  let endLine: null | number = null;
+  let startCount = 0;
+  let endCount = 0;
 
-  source.split('\n').forEach((line, index) => {
-    if (line === startMarker) startLines.push(index + 1);
-    if (line === endMarker) endLines.push(index + 1);
-  });
+  for (const [index, line] of source.split('\n').entries()) {
+    if (line === startMarker) {
+      startCount += 1;
+      startLine ??= index + 1;
+    }
 
-  if (startLines.length > 1) {
+    if (line === endMarker) {
+      endCount += 1;
+      endLine ??= index + 1;
+    }
+  }
+
+  if (startCount > 1) {
     return {kind: 'malformed', reason: 'duplicate-start'};
   }
 
-  if (endLines.length > 1) {
+  if (endCount > 1) {
     return {kind: 'malformed', reason: 'duplicate-end'};
   }
 
-  if (startLines.length === 0 && endLines.length === 0) {
+  if (startLine === null && endLine === null) {
     return {kind: 'absent'};
   }
 
-  if (startLines.length !== endLines.length) {
+  if (startLine === null || endLine === null) {
     return {kind: 'malformed', reason: 'unbalanced'};
   }
 
-  const [startLine] = startLines;
-  const [endLine] = endLines;
-
-  if (startLine === undefined || endLine === undefined) {
-    return {kind: 'malformed', reason: 'unbalanced'};
-  }
-
-  // `>=`, not `>`: identical start and end markers put one line in both lists,
-  // so `startLine === endLine` describes a zero-length region that masks
-  // nothing while duplicating its own marker line. Equal markers are the only
-  // way to reach it, since a line cannot equal two different strings.
+  // `>=`, not `>`: identical start and end markers make one line both the start
+  // and the end, so `startLine === endLine` describes a zero-length region that
+  // masks nothing while duplicating its own marker line. Equal markers are the
+  // only way to reach it, since a line cannot equal two different strings.
   if (startLine >= endLine) {
     return {kind: 'malformed', reason: 'inverted'};
   }


### PR DESCRIPTION
## What

`scanRegion` in `.gaia/cli/src/update/region-markers.ts` had two paths returning the `unbalanced` malformation:

- a live length-mismatch check (`startLines.length !== endLines.length`), and
- an unreachable `undefined` guard three conditions below it.

Both emitted the same outcome. Two emitters of one result is a silent-divergence trap: a later edit to either one changes the message or the reason for some inputs and not others, and nothing fails. The dead one also read as load-bearing, so a reader auditing this parser counted a check that cannot run.

## Why the guard existed, and why the fix is a reshape rather than a deletion

The guard is fallout from #1323 / #1328, the `noUncheckedIndexedAccess` migration. It destructured the first element of two `number[]` accumulators, which the flag types as `number | undefined`, so the guard was the mechanical way to satisfy the compiler.

Deleting it outright is not available: without it the destructure needs a non-null `!` assertion, which is a tracked finding class in this repo. That migration's own commit message states the standard it had no room to apply here, *"where a loop could be reshaped so the read is provably defined, the guard is absent rather than unreachable."* This is that deferred reshape.

`scanRegion` now tracks a nullable first-match line plus an occurrence count per marker instead of building two arrays. No index read happens at all, so no `undefined` can enter the type, and `unbalanced` has exactly one emitter. The function is six lines shorter and the `RegionScan` type is untouched, so no caller changes.

## Verification

Behavior is unchanged, established by differential execution rather than by inspection:

- **137,284 old-vs-new pairs, zero divergence.** Exhaustive enumeration of line sequences up to length 5 drawn from an alphabet covering both markers, a non-marker line, blank and whitespace-only lines, and near-miss lines (leading-space and trailing-text variants of the start marker), crossed with seven marker pairs including identical start/end, empty, and whitespace-only markers, plus trailing-newline and empty-source cases.
- **All six outcomes reachable** by the new implementation: `region`, `absent`, and all four malformations. The `unbalanced` arm specifically, the one this PR consolidates, is reached.
- `.gaia/scripts/tests/region-marker-conformance.bats`, which binds this parser's semantics to the two bash whole-line parsers, passes unchanged (6/6).

Quality Gate, all steps green: root `typecheck` / `lint` / `test` (156 passed) / `build`, `.gaia/cli` `typecheck` / `lint` (cold cache) / `test` (2073 passed, 138 files), Playwright (8 passed, 1 skipped), dev-server smoke HTTP 200. Bundles rebuilt and committed; `verify-cli-bundle-fresh.sh` exits 0 from the repo root.

## CHANGELOG

No `## [Unreleased]` entry. The change is behavior-preserving by construction and verified as such; there is nothing an adopter would observe, no migration, and no flag or command surface moves. An entry here would describe implementation mechanics, which is below Keep a Changelog altitude.

## Not in this PR

`maskRegion` calls `source.split('\n')` a second time after `scanRegion` already split it. Pre-existing, untouched by this diff, and noise at these call volumes: both callers run once per file per CLI invocation, dominated by process spawn and disk I/O. Recorded here rather than fixed, per Surgical Changes.
