### PR TITLE
debt(comments): sweep the comment residue and correct the audit-cron claim

### DIFF
--- a/.gaia/cli/src/argv-lookup-guard.test.ts
+++ b/.gaia/cli/src/argv-lookup-guard.test.ts
@@ -123,9 +123,11 @@ const offendersIn = (relative: string): string[] =>
   );
 
 /**
- * Every file declaring a subcommand dispatch table, derived rather than
- * listed: a dispatcher added later has to earn its own negative control, and a
- * hand-kept list would give it none while still reporting a full sweep.
+ * Every file declaring a `SUBCOMMAND_HANDLERS` table, derived rather than
+ * listed: a dispatcher added later under that name has to earn its own
+ * negative control, and a hand-kept list would give it none while still
+ * reporting a full sweep. A dispatch table spelled otherwise is scanned for a
+ * bare index like any other, but earns no negative control here.
  */
 const dispatchers = (): string[] =>
   sourceFiles().filter((file) =>

--- a/.gaia/cli/src/update/regen-regions.ts
+++ b/.gaia/cli/src/update/regen-regions.ts
@@ -22,33 +22,16 @@
  * against an adversary who controls the manifest.
  *
  * **Write confinement.** A region's regeneration command legitimately rewrites
- * every path it owns, but nothing else. Before the spawn, this command hashes
- * every regular file and reads every symlink under the union of the declared
- * paths' parent directories (the "snapshot scope"); after the spawn, any path
- * in scope the spawn newly created is removed, and then anything in scope that
- * is not one of the region's declared paths and no longer matches its pre-image
- * is put back, whether the spawn rewrote it or deleted it. Undoing the
- * creations first is what leaves an ordinary run with real directories to
- * resolve through, so a link the spawn left behind is gone before any pre-image
- * is written near it.
- * Three rules hold the guarantee whatever order anything happens in. Neither
- * snapshot pass traverses a symlink, inside the scope or above it, so a link
- * is recorded and restored as itself and nothing behind one is read or
- * written; a scope directory that is a link, or is reached through one, is
- * recorded but never walked, since reading through a link the writes will not
- * resolve through is what would put an out-of-tree pre-image inside the
- * repository. Every write first asks whether the components between the root
- * and the key are real directories, reporting rather than resolving through one
- * that is not, so a scope key can never name one place while the bytes land in
- * another. And a path is deleted as a spawn creation only where
- * `collectScopeDigests`' removal invariant permits it, stated in full there and
- * not restated here. Anything else is reported rather than deleted.
+ * every path it owns, but nothing else. The guarantee spans two functions and
+ * neither states it alone, so read both before moving either:
+ * `collectScopeDigests` takes the before/after snapshot and owns the removal
+ * invariant, and `sweepScope` reverts what the spawn touched outside the
+ * region's declared paths. Each is stated in full at its own function, with
+ * its limits, rather than restated here.
  *
- * A `git status --porcelain -z` before/after pair also catches a
- * write anywhere else in the tree; that has no pre-image to restore from, so
- * it is only reported, never reverted. The spawn never runs through a shell
- * and never takes a shell-interpreted string: it is always a fixed argv array,
- * and it is bounded in output and runtime.
+ * `reportOutOfScopeWrites` covers the rest of the tree from a
+ * `git status --porcelain -z` before/after pair, which has no pre-image to
+ * restore from.
  *
  * Exit codes: 0 for every refusal, skip, spawn failure, or non-zero program
  * exit; 1 only when the flags or `--manifest` itself are unusable.

--- a/.gaia/scripts/state-registry-lib.sh
+++ b/.gaia/scripts/state-registry-lib.sh
@@ -254,7 +254,7 @@ gaia_registry_integrity_snapshot() {
   jq -r '.integrity_snapshot[]?.path' "$registry"
 }
 
-# gaia_registry_recognizes <relpath> <type: f|d>: see the header contract above.
+# gaia_registry_recognizes: see the header contract above.
 gaia_registry_recognizes() {
   local relpath="${1:-}" reqtype="${2:-}"
   [ -n "$relpath" ] || return 0
@@ -303,7 +303,7 @@ gaia_registry_recognizes() {
   return 1
 }
 
-# gaia_registry_classify <relpath>: see the header contract above.
+# gaia_registry_classify: see the header contract above.
 gaia_registry_classify() {
   local relpath="${1:-}"
   [ -n "$relpath" ] || {

--- a/wiki/dependencies/pnpm-audit.md
+++ b/wiki/dependencies/pnpm-audit.md
@@ -33,7 +33,7 @@ Two filters keep the same unfixable transitive advisory from spamming every revi
 
 ## Distinct from the CI blocking path
 
-This local check is read-only. GAIA CI's automation runs its own `pnpm audit` cron that opens review-required security PRs and issues for high/critical advisories; that is the blocking placement, on the network side. The local check duplicates none of it: it opens no PR, files no issue, bumps no package. CI blocks the merge train; the local run only informs one review.
+This local check is read-only. GAIA's automation renders a scheduled `pnpm audit` workflow that opens review-required security PRs and issues for high/critical advisories; that is the blocking placement, on the network side. It is generated per project from `.gaia/automation.json` by `gaia automation render-workflows`, so it runs only where a project has configured it. The local check duplicates none of it: it opens no PR, files no issue, bumps no package. Where that workflow is rendered, CI blocks the merge train; the local run only informs one review.
 
 ## Acting on output
 


### PR DESCRIPTION
PLAN-015 Unit 3, the residue sweep. Comment-only in every source file it touches, plus one wiki correction riding along. Six pockets were scoped; four produced a diff, two produced a measurement correction instead.

## Maintainer rulings this unit was blocked on

Both were answered before any sweeping began.

1. **Issue references (#1324).** A number paired with a description of the failure mode earns its place and stays verbatim; a bare number does not, and its line is deleted rather than truncated. The three `.github/audit/tests/` test names carrying issue numbers are **exempt** and stay byte-identical.
2. **The header-contract refrain (#1325).** KEEP, and make all eight instances identical.

## What shipped

**Pocket 1, `regen-regions.ts`'s module docblock (#1322).** 55 lines to 38. The four claims #1322 named as header-versus-site duplicates are gone from the header, each with a named surviving home: the write-confinement mechanism and removal invariant at `collectScopeDigests`, the guarantee and its six limits at `sweepScope`, the shell-free spawn at `trySpawn`, the runtime/output bounds at `SpawnBounds`, the ordering rule at the sweep's own site comment, and the whole-root git-status half at `reportOutOfScopeWrites`. The header now points at them rather than paraphrasing.

The **trust-model note stays**, against the general method. `checkOperand`'s docblock says "See the module doc's trust-model note", so the site is the pointer and the header is the single statement. Deleting it would have orphaned that pointer, which is the exact class `code-comments.md`'s "Editing an existing comment" section exists to prevent. Found by grepping the file for back-references before cutting, as that section requires.

**Pocket 3, the refrain (#1325).** Real count differs from the record: 6 of the 8 were **already** identical to the canonical form. Only 2 carried an argument signature (`<relpath>`, `<relpath> <type: f|d>`) that the file header documents 100 lines above. 2 lines changed, not 8.

**Pocket 5, `dispatchers()`'s overclaim** (carried over from Unit 6's round 3). Narrowed to `SUBCOMMAND_HANDLERS` and it now states the limit plainly. The derivation is untouched: widening it was deliberately dropped, not deferred, because the scanner is already proven to see `wiki/chain.ts`'s `ACTIONS`. The sentence does **not** name `ACTIONS` or `wiki/chain.ts`, so it adds no new pointer to rot.

**Pocket 6, `wiki/dependencies/pnpm-audit.md`.** The claim was false. It said GAIA CI runs its own `pnpm audit` cron opening security PRs and issues. The workflow does carry a `schedule: cron` trigger, but only as `gaia-ci-pnpm-audit.yml.tmpl`, rendered per project from `.gaia/automation.json` and gated behind `enable_security_pr`. This repo has **zero** scheduled workflows.

## What did not ship, and why

**Pocket 2, the issue references (#1324): zero deletions.** Re-counted from scratch: **83** references, not the recorded 78 (`.gaia/tests/**` is 28, not 23; the other three surfaces match at 21 / 17 / 17). Under the ruling, **every one of the 83 is PAIRED** and stays. FOLLOWUP predicted pairing would be at or near 100% on the newly-characterized surfaces; that prediction held across all four. The ruling did exactly what it was written to do, which is preserve what a literal reading of the no-inline-references rule would have destroyed.

Two lines were examined closely and kept:

- `.gaia/scripts/tests/lint-diff-name-only-quoting.bats:92`, `"before PR #1227 fixed it"`, is historical narration by shape but load-bearing by function: the test reds against a **pre-fix** form, and the PR reference is what identifies which historical form the fixture reproduces. Removing it makes "as it stood" unresolvable.
- `.gaia/tests/distribution/09-exclude-parser-parity.sh:51` looks like a bare-number comment and **is not a comment at all**. It sits inside a `cat > "$EXCLUDE_FILE" <<'FIXTURE_EOF'` heredoc, so it is fixture data for the exclude-list parser. Editing it would have been a code change.

That second one is worth flagging beyond this PR: the shell oracle for this unit asserts that every changed shell line is a comment, and a heredoc line beginning with `#` **passes that assertion**. The oracle would not have caught the mistake. It was caught by reading context, not by tooling.

**Pocket 4, the held-back surfaces: not swept, and the premise is wrong.** Scoped here on the assumption that "held back by PR #1319" implies "still holds residue". Measured, `.github/forensics/` plus `.gaia/tests/sandbox|concurrency|prose-audit` carry roughly **2,000 comment lines across 29 files**, five times this entire unit's 200-400 line budget. It is a second corpus, not a residue pocket.

More to the point, the densest files are the reason it was held. `neutralize-untrusted.sh` is 37 comment lines against 55 total, and they are the specification of a security control: which characters are defanged and why, the exact regexes the neutralization defeats, the defense-in-depth sentinel, the bash 3.2 constraint. `operational-enforcement.bats` is entirely honest-limit notes about why it must skip rather than vacuously pass in CI. These are `code-comments.md`'s "Earns its place" bullets almost line for line.

Sweeping this properly is its own unit with its own budget. Sweeping it partially, under this unit's budget, on security-control files, is how PR #1319's round 2 produced sixteen self-authored defects. Left whole and reported rather than half-done.

## Verification

No code change rides this branch, and that is checked rather than asserted.

- **TypeScript**: `ts.createPrinter({removeComments: true})` byte comparison, HEAD versus working tree. Both changed files report byte-identical. The oracle was then **falsified against this file's own real shape**: mutating `HELP_TOKENS` in `regen-regions.ts` made it report `CODE CHANGED`, and it returned to clean after restore. Not a synthetic fixture, per Unit 6's lesson.
- **Free second oracle**: `pnpm -C .gaia/cli bundle` leaves `.gaia/cli/gaia` and `.gaia/cli/gaia-maintainer` byte-identical, so **no bundle rebuild commit is owed**. `verify-cli-bundle-fresh.sh` passes from the repo root.
- **Shell**: 0 non-comment changed lines across the diff.
- **bats**: no `.bats` file changed, so the sorted `@test` name-list is trivially unchanged. The three exempt test names carrying issue numbers are byte-identical.
- **Suites**: 2,113 CLI tests pass (140 files); 58 registry bats tests pass under **bash 5** via `.gaia/scripts/bats5.sh`; `shell-lint.sh` clean.
- **Quality Gate**: typecheck, lint, test, build, Playwright (8 passed, 1 pre-existing skip), and the dev smoke test (HTTP 200) all green. CLI lint and typecheck were run on a **cold** eslint cache.

## CHANGELOG

No entry. The gate's own text lists comment-only edits as not worthy, and the one non-comment change is a wiki correction with no adopter-visible behavior.

## Issue disposition

#1322 and #1325 are resolved by this PR. #1324 is resolved as **ruled and measured**: the ruling stands, and applying it to the tree correctly removes nothing.

## Audit gate

Two members dispatched (`code-audit-maintainer-node`, `code-audit-maintainer-shell`), resolved by `resolve-audit-spawn.sh` rather than assumed. Both returned a **clean pass with zero findings**: no Critical, no Important, no Suggestions, no cross-remit findings. Both sidecars carry an empty `findings[]`, both markers are earned, and the spawn set is now empty.

The node member independently resolved every deleted header claim to its surviving home and every surviving pointer to a real symbol, and separately confirmed that the term "snapshot scope" (whose parenthetical definition the header deleted) is still defined in-file and used by name at five sites plus the test suite. It also confirmed the two inbound cross-file pointers still resolve.

The shell member confirmed both signature drops orphan nothing: each survives in three prose places plus the dispatcher's own runtime usage string. It also reconciled the refrain count from inside the file, 7 in `state-registry-lib.sh` plus 1 in `main-root-lib.sh`, and verified all eight are now byte-identical in form.

### Accepted observation, not filed

The shell member generalized the oracle blind spot reported above. Heredocs are not the sharpest vector for this file: a multi-line single-quoted `jq` program is, and a `#` line inside one would read as a comment to any trimmed-prefix test exactly as heredoc fixture data would. It declined to file this, correctly, since the oracle is not a committed file in this diff. Recorded here because it is worth carrying into any future comment sweep: the durable fix is to assert against a real parse, or at minimum track quote state, rather than a line prefix.
