### PR TITLE
docs(wiki): record the sharded CI matrix, its constraints, and how to measure it

### DIFF
--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -97,6 +97,10 @@ wiki/concepts/Release Workflow.md
 wiki/concepts/Release-Notes.md
 wiki/decisions/Bundle-time Scrub.md
 wiki/decisions/CLI-Binary-Split.md
+# Describes .github/workflows/audit-ci-tests.yml, which is itself
+# release-excluded, so on an adopter clone every claim here is about a
+# workflow they do not have.
+wiki/decisions/Sharded CI Test Matrix.md
 wiki/decisions/Folding Shell Scripts into the CLI Binary.md
 wiki/decisions/Forensics Triage Workflow.md
 

--- a/.gaia/release-exclude
+++ b/.gaia/release-exclude
@@ -97,12 +97,12 @@ wiki/concepts/Release Workflow.md
 wiki/concepts/Release-Notes.md
 wiki/decisions/Bundle-time Scrub.md
 wiki/decisions/CLI-Binary-Split.md
+wiki/decisions/Folding Shell Scripts into the CLI Binary.md
+wiki/decisions/Forensics Triage Workflow.md
 # Describes .github/workflows/audit-ci-tests.yml, which is itself
 # release-excluded, so on an adopter clone every claim here is about a
 # workflow they do not have.
 wiki/decisions/Sharded CI Test Matrix.md
-wiki/decisions/Folding Shell Scripts into the CLI Binary.md
-wiki/decisions/Forensics Triage Workflow.md
 
 # --- 3. Test harnesses and audit reports ---
 # Smoke / observability harnesses run by maintainers in CI; never invoked

--- a/wiki/decisions/Sharded CI Test Matrix.md
+++ b/wiki/decisions/Sharded CI Test Matrix.md
@@ -1,0 +1,78 @@
+---
+type: decision
+status: active
+priority: 2
+date: 2026-08-13
+created: 2026-08-13
+updated: 2026-08-13
+tags: [decision, ci, performance, github-actions, bats]
+---
+
+# Decision: Sharded CI Test Matrix
+
+`Audit CI Tests` is the whole pull-request critical path. It runs as a fan-out matrix of eleven legs plus a thin aggregator that carries the declared-required check name, because the bats work saturates a single runner's cores and the remaining lever is more runners.
+
+## Shape
+
+`.github/workflows/audit-ci-tests.yml` declares two jobs:
+
+- `shards`, a matrix of eleven legs: nine bats shards (`hooks-1` to `hooks-4`, `scripts-1`, `scripts-2`, `audit`, `lib`, `misc`), the `.gaia/tests/sandbox` conformance tree, and the INV-7 concurrency meter.
+- `audit-ci-tests`, which reads `needs.shards.result` and exits non-zero for anything other than `success`.
+
+Splitting the required check name off the work is what lets `fail-fast: false` stop one failing shard from cancelling its siblings without also cancelling the check. The aggregator compares against `success` rather than enumerating failure states, so a conclusion GitHub adds later fails closed, and `always()` on its `if:` stops a skip-on-dependency-failure from satisfying a required context that ran nothing.
+
+`.gaia/tests/bats-shards.sh` owns shard assignment by discovering `.bats` files rather than reading a manifest, so a newly added suite joins a shard automatically instead of silently running nowhere. `.gaia/tests/install-bats.sh` installs bats pinned by version and digest.
+
+## The constraint any further restructuring hits first
+
+The `needs:` chain sits at **exactly its ceiling with zero headroom**, and this is the first thing to check before proposing any new CI structure here.
+
+- The self-heal poller window is 25 minutes (see [[Dispatched-Check Rollup via Polling]]).
+- `.gaia/scripts/tests/retrigger-reachability.bats` charges `POLLER_MARGIN_MIN=5` **per hop**, so the ceiling is `25 - 5 x hops`. At two hops that is 15 minutes.
+- The caps are 13 (shards) + 2 (aggregator) = 15. Exactly the ceiling.
+
+Consequences, each load-bearing:
+
+- **A third hop is unavailable.** Any design that inserts a job between or before these two drops the ceiling to 10 minutes while raising the chain total, and reds that suite immediately.
+- **Neither cap can rise** without the other falling by the same amount.
+- **An expression-valued `timeout-minutes` reads as uncapped** and reds, so caps stay integer literals.
+
+The zero headroom is deliberate: it fails loudly and locally rather than silently, and the heaviest leg gets a 13-minute budget on a box it no longer shares.
+
+## Measuring this workflow
+
+Two traps make naive measurement useless:
+
+- **Push-to-`main` runs skip.** The job's `if:` admits only `pull_request` and `workflow_dispatch`, so a push run completes in about a second with no duration and no logs. `gh run list --branch main` yields nothing usable; source baselines from `--event pull_request`.
+- **`Per-suite results:` reports exit codes, not counts.** The `0 in Ns` figure is the suite's exit status plus elapsed seconds. Assertion counts come from the TAP plan lines (`1..N`) that follow each `##[group]` header, or by counting `ok ` lines per job.
+
+A useful reconciliation is the sum of per-shard TAP plans against the pre-existing per-directory totals: a partition change that loses a file shows up as a count drop, where every check still greens.
+
+## Where the time goes
+
+Measured per leg on a clean run: the slowest shard is around 154 seconds, the aggregator about 3, and fixed per-leg overhead (runner provisioning, checkout, install) is on the order of 10 seconds. The install step spans roughly 10 to 20 seconds; the sandbox leg, which runs no apt, finishes it first. The concurrency leg runs 66 to 69 seconds against its 13-minute cap, so the cap constraint above binds the declared numbers rather than any real runtime.
+
+Suite cost is uneven, which is why the shard split is not a naive equal division: the hooks and scripts directories dominate, and `local-janitor.bats` is heavy enough to be pinned alone as `hooks-1`.
+
+## Levers not taken, and why
+
+- **A setup job that fetches shared state once.** Adds a third hop; see the ceiling above.
+- **Per-shard narrowed paths filters.** All eleven legs share one `steps:` block, so the filter is defined once and evaluated per leg. Narrowing per shard also breaks `.gaia/scripts/tests/workflow-filter-coverage.bats`, which requires every gate on a step to reach every literal path that step names, independently. `audit-ci-shards.bats` W7 pins the count at exactly one filter step.
+- **A checked-in shard manifest.** Fails silently: a new suite runs in no shard, every check greens, the pass count quietly drops.
+- **A per-shard package list.** Also a silent-green hazard, because the suites that need `python3-yaml` fail rather than skip when it is absent while the ones needing `zsh` skip quietly. The install is split by leg kind instead, and W9 pins the sandbox leg's reduced set.
+- **`bats --jobs`.** A live lever rather than a closed question. The reasoning that excludes it, that the runner is already CPU-saturated, describes six suites sharing one box; a shard now runs one suite serially on its own four-core box, leaving cores idle.
+
+## Fan-out has its own costs
+
+Widening the matrix is not free, and two costs are measured rather than theoretical:
+
+- **Shared-host bursts.** Every bats leg fetches the same pinned archive within seconds of its siblings, and GitHub's codeload answers part of that burst with `503`. The download carries bounded exponential backoff, which converts the failure into latency (up to roughly two minutes on an affected leg) rather than removing it. Any change that adds legs widens this burst.
+- **Fixed overhead multiplies.** Each leg pays provisioning, checkout, and install. Below roughly a minute of real work, a leg is mostly overhead.
+
+Total machine time rises with fan-out even as wall-clock falls. The thing being optimized here is human-facing latency on the critical path, not runner minutes.
+
+## Related
+
+- [[Dispatched-Check Rollup via Polling]] for the poller window this workflow's caps are derived from.
+- [[Code Audit Team]] for the merge gate that runs alongside it.
+- [[Quality Gate]] for the local gate, which has nothing to check on a YAML/bash/bats change.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -104,12 +104,12 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Content Security Policy]]: per-request nonce CSP; Report-Only pending an upstream React Router fix; documents the `unsafe-inline` and no-`report-uri` trade-offs.
 - [[Dispatched-Check Rollup via Polling]]: in-loop pollers stamp dispatched-workflow jobs via the Checks API so they land in `statusCheckRollup`; documents why a `workflow_run` listener is not viable under `GITHUB_TOKEN`.
 - [[Code Audit Team]]: config-driven auditor roster + dispatch resolver; AND-aggregation across dispatched members at the merge gate; maintainer-only shell/node members.
-- [[Sharded CI Test Matrix]]: `Audit CI Tests` as an 11-leg fan-out plus a thin aggregator; the zero-headroom 2-hop cap arithmetic any restructuring hits first, how to measure this workflow without the two traps, and the levers already weighed.
 - [[Deliberate Configuration Asymmetries]]: config that differs from its siblings on purpose; the `.claude/hooks/` Edit carve-out, the skill `model:` pinning criterion, the non-opt-outable update check, and the seeded agent-teams flag.
 <!-- gaia:maintainer-only:start -->
 - [[CLI-Binary-Split]]
 - [[Folding Shell Scripts into the CLI Binary]]: considered and declined; the manifest is a never-merged sentinel and the fold is a delete, so it cannot deliver simpler diffs.
 - [[Forensics Triage Workflow]]
+- [[Sharded CI Test Matrix]]: `Audit CI Tests` as an 11-leg fan-out plus a thin aggregator; the zero-headroom 2-hop cap arithmetic any restructuring hits first, how to measure this workflow without the two traps, and the levers already weighed.
 <!-- gaia:maintainer-only:end -->
 - [[Quality Gate]]
 - [[pnpm]]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -104,6 +104,7 @@ Master catalog of every page in the wiki. Newly created pages must be added here
 - [[Content Security Policy]]: per-request nonce CSP; Report-Only pending an upstream React Router fix; documents the `unsafe-inline` and no-`report-uri` trade-offs.
 - [[Dispatched-Check Rollup via Polling]]: in-loop pollers stamp dispatched-workflow jobs via the Checks API so they land in `statusCheckRollup`; documents why a `workflow_run` listener is not viable under `GITHUB_TOKEN`.
 - [[Code Audit Team]]: config-driven auditor roster + dispatch resolver; AND-aggregation across dispatched members at the merge gate; maintainer-only shell/node members.
+- [[Sharded CI Test Matrix]]: `Audit CI Tests` as an 11-leg fan-out plus a thin aggregator; the zero-headroom 2-hop cap arithmetic any restructuring hits first, how to measure this workflow without the two traps, and the levers already weighed.
 - [[Deliberate Configuration Asymmetries]]: config that differs from its siblings on purpose; the `.claude/hooks/` Edit carve-out, the skill `model:` pinning criterion, the non-opt-outable update check, and the seeded agent-teams flag.
 <!-- gaia:maintainer-only:start -->
 - [[CLI-Binary-Split]]


### PR DESCRIPTION
The knowledge from the CI sharding work (#1343) lived only in a gitignored plan folder that the SessionStart janitor age-reaps, so a future pass at CI speed would have re-derived it from scratch.

Adds `wiki/decisions/Sharded CI Test Matrix.md`, carrying the parts that are expensive to rediscover rather than a narrative of the change:

- **The cap ceiling any restructuring hits first.** The 2-hop chain sits at exactly its ceiling (25-minute poller window, 5-minute margin per hop, 13 + 2 = 15) with zero headroom, so a third job is unavailable and neither cap can rise alone. This is the constraint that kills the obvious 'add a setup job' designs before they are drafted.
- **Two measurement traps.** Push-to-`main` runs skip, so `--branch main` yields nothing usable and baselines must come from `--event pull_request`; and `Per-suite results:` reports exit codes, not assertion counts, which come from the TAP plan lines.
- **Where the time actually goes**, per leg, including the fixed ~10s overhead that makes very small legs mostly overhead.
- **Levers already weighed and why they were left**, so they are not re-litigated: shared setup job, per-shard narrowed filters, a checked-in manifest, per-shard package lists, and `bats --jobs` (which is now a live lever rather than a closed question).
- **That fan-out has its own costs**: the codeload burst, and total machine time rising as wall-clock falls.

Distribution boundary: `wiki/decisions/` ships, but this page describes `audit-ci-tests.yml`, which is release-excluded, so on an adopter clone every claim in it would be about a workflow they do not have. The page is added to `.gaia/release-exclude` and its index entry sits inside the existing maintainer-only block, so the bundle carries neither the page nor a dead link to it. `.gaia/manifest.json` is untouched.

No CHANGELOG entry: maintainer-only internal documentation, no adopter-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)