### PR TITLE
wiki: sync through f515288

### DIFF
--- a/wiki/.state.json
+++ b/wiki/.state.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "last_evaluated_sha": "d2016b5fa7dde0acc5bae24b504886534b57cbde",
-  "last_evaluated_at": "2026-08-12T21:00:25Z",
+  "last_evaluated_sha": "f51528835eff7c3094adc19c3734ee4eec80f328",
+  "last_evaluated_at": "2026-08-13T13:26:30Z",
   "last_consolidated_sha": "baad8972ee9d300aee847b84f17d72e45c1fbddf",
   "last_consolidated_at": "2026-07-29T05:58:30Z"
 }

--- a/wiki/decisions/Code Audit Team.md
+++ b/wiki/decisions/Code Audit Team.md
@@ -4,7 +4,7 @@ status: active
 priority: 1
 date: 2026-07-09
 created: 2026-07-09
-updated: 2026-08-05
+updated: 2026-08-13
 tags: [decision, claude, audit, ci]
 ---
 
@@ -28,6 +28,8 @@ The twelve files under `.gaia/cli/templates/workflows/` are deliberately ownerle
 ## Ownership classifier
 
 Roster parsing and per-path ownership live in one shared, sourced module, `.claude/hooks/lib/audit-scope.sh`, that every dispatch resolver and the merge gate itself consult, rather than each parsing the roster on its own. It parses the roster (`.gaia/audit-ci.yml`'s `auditors:` block when present and non-empty, else the same built-in default roster, itself marker-wrapped for the maintainer-only entries) exactly once per run, and answers three separately-named questions that are never interchangeable: which paths the merge gate's out-of-scope allowlist covers, an ordered three-way classification for the `/update-gaia` self-mod bypass (out-of-scope / the audit workflow itself / in-scope), and which member, if any, owns a given path, resolved in the two precedence tiers above (every claimant's glob first, first-match-wins over roster order, then the default member's own declared globs, otherwise ownerless). Conflating any two of those questions is a merge-gate bypass, which is why they stay three distinct predicates in the one module instead of one generalized check.
+
+The out-of-scope allowlist names the lens-less root bookkeeping files no member's globs are meant to reach: `.gitignore`, `.editorconfig`, and `LICENSE`. `public/**` is deliberately not on it, since the tree carries executable JavaScript (a service-worker registration) under that prefix, so it stays in scope, owned by the default member's catch-all. One predicate serves three consumers, the merge gate's legacy fallback branch, the spawn oracle's ownerless probe, and the default member's digest fold, so widening the allowlist has to move all three together or a merge deadlocks: a path allowlisted in one but not the others resolves an empty dispatched set in one place and a nonzero one in another. The spawn oracle's ownerless probe distinguishes two states the naive git-exit-status read collapses into one: an **unresolvable base** still dispatches the default member (fail-closed), where an **empty range** (the base resolved, nothing changed against it) dispatches nobody. The merge gate does not mirror the empty-range half, since it derives its own base independently and can fall back to a local default branch already carrying the diff's commits.
 
 A sibling module, `.claude/hooks/lib/audit-machinery.sh`, holds the one list of **audit-machinery paths**: every file whose bytes can change what a member reviews, who reviews it, where a clearance lands, or whether a clearance is believed (the roster, the classifier and machinery modules themselves, the clearance writer and reader, the merge gate, the CI workflow and its bundled templates, the agent definitions, among others). A `.bats` suite is deliberately excluded, its bytes decide none of those four things; the suites are covered instead by the roster's own `.bats` globs (see below), which dispatch a real member to review them.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -11,6 +11,21 @@ tags: [meta, log]
 
 ## [Unreleased]
 
+- 2026-08-13 f5152883 WORTHY - bats shards now split by weight not file count → wiki/decisions/Sharded CI Test Matrix.md updated in-commit
+- 2026-08-13 e0dc86d9 WORTHY - closed marker-strip coverage gap, cut CLI lint/apt cost → wiki/concepts/Release Workflow.md updated in-commit
+- 2026-08-13 44b74175 SKIP - test-only fix anchoring registry-path assertion on resolved main root, no behavior change
+- 2026-08-13 c01fa4b8 SKIP - worktree ledger-write instruction self-correction in skill prose; architecture already covered in wiki/concepts/Task Orchestration.md
+- 2026-08-13 b2946155 WORTHY - widened out-of-scope allowlist + ownerless-probe fail-closed/fail-open split → added to wiki/decisions/Code Audit Team.md
+- 2026-08-13 e7bf1c23 WORTHY - hand bats runner now driven from the shard partition → wiki/decisions/Sharded CI Test Matrix.md updated in-commit
+- 2026-08-13 46402f5e WORTHY - gated whole-repo oracles + CI breadcrumbs on non-empty/CI → wiki/concepts/Code Review Audit Agent.md, Code Review Audit CI.md updated in-commit
+- 2026-08-13 fd3616d3 SKIP - bats-suites-excluded-from-machinery fix already documented in wiki/decisions/Code Audit Team.md
+- 2026-08-13 ddeb38e2 WORTHY - scoped node audit oracles to CLI, parallelized shell-lint, batched-fixes guidance → wiki/concepts/PR Merge Workflow.md updated in-commit
+- 2026-08-13 b0479060 WORTHY - widened maintainer-path leak check to bare directories → wiki/concepts/GAIA Init Workflow.md updated in-commit
+- 2026-08-13 4116ba06 SKIP - test relocation + shard-coverage guard (S13), release-excluded .gaia/tests/, no adopter-facing fact
+- 2026-08-13 764ddebd WORTHY - vendored pinned bats archive, no leg fetches it → wiki/decisions/Sharded CI Test Matrix.md updated in-commit
+- 2026-08-13 05fd9a8f SKIP - widened array-guard scan to .gaia/tests already documented in wiki/concepts/Claude Hooks.md maintainer block
+- 2026-08-13 a2cb3db3 SKIP - wiki prose-only placeholder fix on Code Audit Team.md, already applied
+- 2026-08-13 fd087ad2 SKIP - prior wiki maintenance-chain commit (sync+lint through 4c58377), no new fact to sync
 - 2026-08-12 1459d7667 SKIP - moves comment standard into its own rule and deletes the guard; instruction-prose only
 - 2026-08-12 d2016b5fa WORTHY - adds wiki/decisions/Sharded CI Test Matrix.md ADR and wiki/index.md entry
 - 2026-08-12 24bfa7bfe WORTHY - shards Audit CI Tests across a job matrix and pins the bats install; documented by follow-up commit's new ADR wiki/decisions/Sharded CI Test Matrix.md


### PR DESCRIPTION
Automated wiki sync landed via `gaia wiki sync land --branch-aware`. State advanced to f515288.