### PR TITLE
debt(tests): drop the decaying call-site count from the version-lib contract comment

### DIFF
--- a/.gaia/tests/hooks/gaia-version-lib.bats
+++ b/.gaia/tests/hooks/gaia-version-lib.bats
@@ -68,7 +68,7 @@ setup() {
 }
 
 # The absent-file and empty-file cases are one contract, not two: both yield
-# the empty string and exit 0, because the five call sites disagree on what a
+# the empty string and exit 0, because the call sites disagree on what a
 # missing file means and the helper must not flatten those policies.
 
 @test "an absent file yields the empty string and exits 0" {


### PR DESCRIPTION
## What

`.gaia/tests/hooks/gaia-version-lib.bats` justifies treating the absent-file and empty-file cases as one contract by saying "the five call sites disagree on what a missing file means". `gaia_read_version` has eight call sites, across `.claude/hooks/`, `.gaia/scripts/`, `.github/audit/`, and `.github/workflows/release.yml`.

No runtime effect. The comment exists precisely to tell a reader how far the caller-owned absent-file policy reaches, so a reader who trusts the count under-states the blast radius of changing it by three call sites.

## Why drop the number instead of correcting it to eight

A bare count is a claim that decays on every new caller and that nothing in the repo re-checks; correcting it to eight would re-arm the same trap for the ninth. The sibling helper header (`.claude/hooks/lib/gaia-version.sh`) already states this same contract with no count, naming the three live policies instead, so the two copies now agree about their own subject.

## Verification

- `.gaia/scripts/bats5.sh .gaia/tests/hooks/gaia-version-lib.bats` — 10/10 pass under bash 5
- `bash .gaia/tests/shell-lint.sh` — passed

Quality Gate not applicable: the diff is a single comment line in a `.bats` file, no staged source or gate-affecting config.

No CHANGELOG entry: `.gaia/tests/` is release-excluded maintainer-only test infrastructure, and the change is comment-only with no adopter-observable behavior.

Closes #1390