### PR TITLE
docs(rules): cut the always-loaded dispatch rule to its instructions

### DIFF
--- a/.claude/rules/subagent-dispatch.md
+++ b/.claude/rules/subagent-dispatch.md
@@ -1,24 +1,18 @@
 # Subagent Dispatch
 
-When a dispatched agent's output is something you will act on, do not ask for it in the reply.
+When a dispatched agent's output is something you will act on, do not ask for it in the reply. An absent report is indistinguishable from a clean result, and the likeliest reading of a missing one is "it found nothing", the conclusion you must not draw.
 
-**Give it a file.** Pre-clear an output path (`rm -f`), instruct the agent to write its full result there and return only a thin digest, then classify the file after the dispatch:
+**Give it a file.** Pre-clear an output path (`rm -f`), have the agent write its result there and return only a thin digest, then classify the file:
 
 ```bash
 bash .gaia/scripts/audit-noop-detect.sh --shape agent-report-file --path <path> \
   [--report-key <key>] [--expect-count <n> | --min-count <n>]
 ```
 
-Exit 0 is a real result, 1 is a no-op, 2 is a usage error. On a no-op, re-dispatch **exactly once** against the re-cleared path; on a second no-op, do the work inline rather than proceeding as though the agent found nothing.
+Exit 0 real, 1 no-op, 2 usage error. On a no-op, re-dispatch **exactly once** against the re-cleared path; on a second, do the work inline.
 
-**Assert your own denominator.** Pass `--expect-count` (or `--min-count`) whenever you know how many entries the report should hold. Existence-plus-parses is not enough on its own: a truncated write parses fine and reads as a real result, which reproduces the same collapse inside a file that exists.
+**Pass a count when you know one.** A truncated write parses fine and reads as a real result, so existence-plus-parses alone reproduces the same collapse inside a file that exists.
 
-**Poll the file, not the notification.** Because the artifact is on disk, read it on your own schedule instead of blocking on a completion signal that may never arrive.
+**Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive.
 
-The `## No-op guard (detection, retry, inline fallback)` section of `.claude/skills/gaia/references/spec.md` carries the whole contract, including the literal hardened retry prefix; step 7a's lens fan-out is the worked instance of it. Read it there rather than reconstructing it from here.
-
-## Why
-
-An absent report is indistinguishable from a clean result. A caller that dispatched three agents and received nothing knows something broke; a caller that dispatched eight and silently lost one does not, and the likeliest reading of the gap is "that agent found nothing" — the one conclusion the caller must not draw. The failure is biased toward false confidence, which is why the fallback is an artifact on disk rather than a more carefully worded prompt.
-
-The flows that already do this get it from their own step-level instructions, so a dispatch composed on the fly inherits none of it. That is the case this rule covers, and it is why the rule carries no `paths:` glob: the decision is made while composing a dispatch, which no file edit announces, so a path-scoped rule would be absent from context at exactly the moment it is needed.
+Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. This rule is deliberately not path-scoped; the decision happens while composing a dispatch, which no file edit announces.


### PR DESCRIPTION
`.claude/rules/subagent-dispatch.md` carries no `paths:` glob, so it loads into every session. Prose that persuades rather than instructs is charged once per session forever, and roughly 45% of the file was doing no work in that position. Prose drops from ~342 words to ~184.

## What was cut, and why each earned nothing there

**The `## Why` section (~133 words, 39% of the file).** Two paragraphs of persuasion aimed at a reader who is already obeying the rule. Its three-agents-versus-eight illustration is vivid, but vividness convinces a human once and bills every session after. The one operative fact, that a missing report is indistinguishable from a clean one, moves into the opening paragraph where the instruction already lives.

**The provenance sentence.** "The flows that already do this get it from their own step-level instructions, so a dispatch composed on the fly inherits none of it" is the originating issue's problem statement. It directs nothing.

**Three explanatory second-sentences** that restate their own bolded lead ("Because the artifact is on disk, read it on your own schedule" after "Poll the file, not the notification").

## What was compressed rather than cut

**The no-glob rationale**, down to one clause. It addresses someone editing the rule rather than anyone composing a dispatch, so it is the wrong reader for an always-loaded file, but deleting it outright is worse: with no note at all, the missing `paths:` glob reads as an oversight and invites a future prune to "repair" it into a path-scoped rule that would be absent from context at exactly the moment it is needed.

## One defect fixed in passing

The rule quoted the target as `## No-op guard (detection, retry, inline fallback)` while `.claude/skills/gaia/references/spec.md:159` uses `###`. A reader grepping the literal string would not match the heading. Now quoted as `No-op guard`, with no level and no parenthetical.

## Every instruction survives

The trigger, the pre-clear (`rm -f`), the write-there-return-a-digest contract, the command with all three optional flags, the exit-code meanings, retry-exactly-once-then-inline, the count assertion, the polling rule, and the pointer to the full contract.

## Verification

- `.claude/skills/gaia/references/spec.md` still carries `### No-op guard (detection, retry, inline fallback)` at line 159, so the compressed pointer resolves.
- The documented command runs green against the committed fixture (`--shape agent-report-file --expect-count 3` returns `real`).
- `bash .gaia/scripts/audit-rules-changed-complete.sh` exit 0; the file keeps its merely-shared tier.
- `release manifest --check` reports no `missing` / `extra` / `drift`, so the shipping boundary is unchanged and no `/distribution-audit` answer is owed.
- `bash .gaia/tests/shell-lint.sh` passes.
- Quality Gate skips by its own rule: the only staged file is Markdown.
- No CHANGELOG entry. The rule has not shipped in a release yet, and its `## [Unreleased]` entry already describes the feature; trimming unreleased prose is below Keep a Changelog altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)