### PR TITLE
docs(rules): tell the dispatch watch when to stop

### DIFF
--- a/.claude/rules/subagent-dispatch.md
+++ b/.claude/rules/subagent-dispatch.md
@@ -15,4 +15,4 @@ Exit 0 real, 1 no-op, 2 usage error. On a no-op, re-dispatch **exactly once** ag
 
 **Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive. Tear down each watch you arm the moment you hold its artifact: a report you end up reading somewhere else leaves the loop with no exit condition left to satisfy.
 
-Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. Path-scoping it would break it: the decision happens while composing a dispatch, which no file edit announces.
+Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. Path-scoping this rule would break it: the decision happens while composing a dispatch, which no file edit announces.

--- a/.claude/rules/subagent-dispatch.md
+++ b/.claude/rules/subagent-dispatch.md
@@ -13,6 +13,6 @@ Exit 0 real, 1 no-op, 2 usage error. On a no-op, re-dispatch **exactly once** ag
 
 **Pass a count when you know one.** A truncated write parses fine and reads as a real result, so existence-plus-parses alone reproduces the same collapse inside a file that exists.
 
-**Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive. Tear down each watch you arm the moment you hold its artifact: a report you end up reading somewhere else leaves the loop with no exit condition left to satisfy, and it spins until a human notices.
+**Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive. Tear down each watch you arm the moment you hold its artifact: a report you end up reading somewhere else leaves the loop with no exit condition left to satisfy.
 
 Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. This rule is deliberately not path-scoped; the decision happens while composing a dispatch, which no file edit announces.

--- a/.claude/rules/subagent-dispatch.md
+++ b/.claude/rules/subagent-dispatch.md
@@ -13,6 +13,6 @@ Exit 0 real, 1 no-op, 2 usage error. On a no-op, re-dispatch **exactly once** ag
 
 **Pass a count when you know one.** A truncated write parses fine and reads as a real result, so existence-plus-parses alone reproduces the same collapse inside a file that exists.
 
-**Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive.
+**Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive. Tear down each watch you arm the moment you hold its artifact: a report you end up reading somewhere else leaves the loop with no exit condition left to satisfy, and it spins until a human notices.
 
 Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. This rule is deliberately not path-scoped; the decision happens while composing a dispatch, which no file edit announces.

--- a/.claude/rules/subagent-dispatch.md
+++ b/.claude/rules/subagent-dispatch.md
@@ -15,4 +15,4 @@ Exit 0 real, 1 no-op, 2 usage error. On a no-op, re-dispatch **exactly once** ag
 
 **Poll the file, not the notification.** The artifact is on disk, so never block on a completion signal that may not arrive. Tear down each watch you arm the moment you hold its artifact: a report you end up reading somewhere else leaves the loop with no exit condition left to satisfy.
 
-Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. This rule is deliberately not path-scoped; the decision happens while composing a dispatch, which no file edit announces.
+Full contract, including the hardened retry prefix: the `No-op guard` section of `.claude/skills/gaia/references/spec.md`. Path-scoping it would break it: the decision happens while composing a dispatch, which no file edit announces.


### PR DESCRIPTION
## What

The subagent-dispatch rule tells you to poll the artifact on disk instead of blocking on a completion signal that may not arrive. It never says to stop polling once the artifact is in hand.

One sentence rides the existing **Poll the file, not the notification.** paragraph: tear down each watch you arm the moment you hold its artifact.

## Why

The rule's own advice produced a leak in the session that wrote it. Four background `until <artifact appears>; do sleep; done` watches were armed as disk-based fallbacks, each member's report was then consumed through the reply channel when it did arrive, and none of the watches was torn down. With the exit condition satisfied somewhere else, they spun until a human noticed and asked.

The full contract in the spec's `No-op guard` section never mentions polling, so the rule is the only surface that tells you to arm a watch, which makes it the only surface that can tell you to stop one.

## Scope

- Prose-only, one sentence added. The rule carries no `paths:` glob, so it loads into every session; the recent trim to its instructions stands, no new section.
- Already registered in `AUDIT_MERELY_SHARED_PATHS` and classified `owned` in the manifest, so a content-only edit owes no registration change and no `/distribution-audit` answer. `audit-rules-changed-complete.sh` re-run green with the file staged.
- Quality Gate skips by its own check: Markdown is the only staged file.
- No CHANGELOG entry: the rule has not shipped in a release and the existing `## [Unreleased]` entry already covers the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)