### PR TITLE
docs(audit-tests): name both same-shape siblings in the extract_step_body header (#1446)

### DIFF
--- a/.github/audit/tests/ci-workflow-self-mod.bats
+++ b/.github/audit/tests/ci-workflow-self-mod.bats
@@ -56,10 +56,11 @@ setup() {
 }
 
 # Extract one step's `run:` shell body from the workflow YAML and dedent it.
-# Matches the `- name:` line EXACTLY. Deliberately identical to the helper in
-# .github/audit/tests/self-heal-scope-gate.bats (bats files do not share
-# function definitions across files), so the two never disagree about what
-# "extract the real step body" means.
+# Matches the `- name:` line EXACTLY. Same shape as the helpers in
+# .github/audit/tests/self-heal-scope-gate.bats and
+# .github/audit/tests/ci-status-member-gate.bats; not sourced from either (bats
+# files do not share function definitions across files), so the three are kept
+# in agreement about what "extract the real step body" means by hand.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '


### PR DESCRIPTION
## What

The `extract_step_body` header in `.github/audit/tests/ci-workflow-self-mod.bats` named one sibling helper and claimed byte-identity with it, while three same-shape helpers extract a `run:` body from `.github/workflows/code-review-audit.yml`: this one, `self-heal-scope-gate.bats`, and `ci-status-member-gate.bats`.

## Why

There is no live failure mode: the two named copies really are byte-identical, and `ci-status-member-gate.bats`'s copy omits one `grab && !inrun && !/run: |/ { next }` rule that changes no output. The cost is directional. A maintainer changing the extraction contract from this file's vantage read "the two", synced one sibling, and left `ci-status-member-gate.bats` behind. The sibling's own header already names all three and says "same shape" rather than "identical", so reading from that vantage found the third. This mirrors that wording here so both vantages agree.

A fourth helper of the same shape, `.gaia/scripts/tests/distribution-audit-pr-gate.bats:108`, extracts from `distribution-audit-pr.yml` instead, so it is outside this family and the count of three is correct.

## Scope

Comment-only, one file, release-excluded maintainer test infrastructure. No behavior change, so no CHANGELOG entry.

## Verification

- `bash .gaia/tests/shell-lint.sh` clean
- `.github/audit/tests/ci-workflow-self-mod.bats` 8/8 passing under bash 5

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Out-of-scope machinery findings (recorded, not filed)

- `.github/audit/tests/ci-workflow-self-mod.bats:219` (also 220, 232, 233) - shellcheck SC2016 info on the four `grep -qF '...${{ ... }}...'` assertions. The single quotes are correct: the assertions exist to match the *unexpanded* workflow-expression text, so expanding would break the check. No live failure mode; shellcheck exits 0. Pre-existing lines, untouched by this diff.
  <!-- gaia-debt-key: v1 class=holistic/unclassified path=.github/audit/tests/ci-workflow-self-mod.bats line=219 -->
  <!-- gaia-debt-origin: branch=debt/1446-extract-step-body-header mode=drain unit=1446 changed=1 head=587db9c736da94efdb784aa4450335ad11e00cfb -->

## Out-of-scope findings filed

- #1451 - `.github/audit/tests/ci-status-member-gate.bats:285` carries no sibling pointer, so the `extract_step_body` family is only half cross-referenced. Not waive-eligible: the path is neither gate machinery nor a file this PR changes.
