### PR TITLE
docs(audit-tests): name both siblings and the family criterion in ci-status-member-gate's extract_step_body header (#1451)

### DIFF
--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -288,11 +288,13 @@ EOF
 # shape as the helpers in .github/audit/tests/ci-workflow-self-mod.bats and
 # .github/audit/tests/self-heal-scope-gate.bats; not sourced from either (bats
 # files do not share function definitions across files), so the three are kept
-# in agreement about what "extract the real step body" means by hand. Reading
-# .github/workflows/code-review-audit.yml is the family criterion: a same-shape
-# copy that extracts from a different workflow, as
-# .gaia/scripts/tests/distribution-audit-pr-gate.bats does, is outside the three
-# and free to diverge.
+# in agreement about what "extract the real step body" means by hand. Membership
+# takes both terms together, this awk's shape AND reading
+# .github/workflows/code-review-audit.yml, because each term alone admits a
+# non-member: .gaia/scripts/tests/distribution-audit-pr-gate.bats is the same
+# shape over a different workflow, and cra-status-upsert.bats's `step_body` reads
+# this workflow with a different shape (no dedent, no tmpfile). Both are outside
+# the three and free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '

--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -284,17 +284,18 @@ EOF
 
 # Extract one step's `run:` shell body from the workflow YAML and dedent it.
 # Matches the `- name:` line EXACTLY, so "Write GAIA-Audit commit status" does
-# not also match its "(clean, no push)" / "(out-of-scope skip)" siblings. Same
-# shape as the helpers in .github/audit/tests/ci-workflow-self-mod.bats and
-# .github/audit/tests/self-heal-scope-gate.bats; not sourced from either (bats
-# files do not share function definitions across files), so the three are kept
-# in agreement about what "extract the real step body" means by hand. Membership
-# takes both terms together, this awk's shape AND reading
-# .github/workflows/code-review-audit.yml, because each term alone admits a
-# non-member: .gaia/scripts/tests/distribution-audit-pr-gate.bats is the same
-# shape over a different workflow, and cra-status-upsert.bats's `step_body` reads
-# this workflow with a different shape (no dedent, no tmpfile). Both are outside
-# the three and free to diverge.
+# not also match its "(clean, no push)" / "(out-of-scope skip)" siblings.
+#
+# Several other bats files carry a near-identical copy of this helper. None of
+# them share it (bats files do not define functions across files), so they are
+# kept in agreement about what "extract the real step body" means by hand.
+# Recover the live set rather than trusting a list written here, which decays:
+#
+#   git grep -n "sed 's/^          //'" -- '*.bats'
+#
+# Of what that returns, the copies this one must agree with are those whose
+# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '

--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -284,7 +284,15 @@ EOF
 
 # Extract one step's `run:` shell body from the workflow YAML and dedent it.
 # Matches the `- name:` line EXACTLY, so "Write GAIA-Audit commit status" does
-# not also match its "(clean, no push)" / "(out-of-scope skip)" siblings.
+# not also match its "(clean, no push)" / "(out-of-scope skip)" siblings. Same
+# shape as the helpers in .github/audit/tests/ci-workflow-self-mod.bats and
+# .github/audit/tests/self-heal-scope-gate.bats; not sourced from either (bats
+# files do not share function definitions across files), so the three are kept
+# in agreement about what "extract the real step body" means by hand. Reading
+# .github/workflows/code-review-audit.yml is the family criterion: a same-shape
+# copy that extracts from a different workflow, as
+# .gaia/scripts/tests/distribution-audit-pr-gate.bats does, is outside the three
+# and free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '


### PR DESCRIPTION
## What

`.github/audit/tests/ci-status-member-gate.bats`'s `extract_step_body` header now explains how to recover the hand-kept helper family instead of listing it: a shape-keyed grep on the dedent idiom, plus the `$WORKFLOW` term that says which of its hits this copy must stay in agreement with.

## Why

The other two copies each name their counterparts and say the three are kept in agreement by hand. This one named none, so which copy a maintainer started from decided whether they found the others, and from this vantage they found none.

The first pass at this added the same named roster the siblings carry. Two audit rounds showed why that form keeps regenerating findings: reading `code-review-audit.yml` alone admits `cra-status-upsert.bats`'s differently-shaped `step_body`, and the roster itself was already short one member, `ci-guard-paths.bats:329`'s `phase_step_body` (same shape, same workflow, different function name, so a name-keyed roster cannot see it). The grep recovers the live set on every read and cannot go stale the way the list already had.

Comment-only; no behavior change. Release-excluded path, so nothing reaches an adopter clone.

## Verification

- `.gaia/scripts/bats5.sh .github/audit/tests/ci-status-member-gate.bats` — 89/89 pass under bash 5
- `bash .gaia/tests/shell-lint.sh` — passed
- The recipe the comment prescribes was run: it recovers all five copies, and the `$WORKFLOW` filter resolves them into the four members plus one correct exclusion
- Quality Gate: skipped by its own positive check (no staged source or gate-affecting config)

## Audit disposition

Three `code-audit-maintainer-shell` rounds, all clean. Rounds 1 and 2 each raised an in-scope Suggestion against the text this PR authors; both were verified against the tree and applied.

Round 3's Suggestion is out of scope and **filed**, not waived: the two sibling headers (`ci-workflow-self-mod.bats:62`, `self-heal-scope-gate.bats:118`) still carry the named roster and still say three. Neither waive term fires — `.github/audit/tests/**` is not a gate-machinery path, and this PR does not change those files — and the defect is latent at this PR's fork point, so it is untouched-sibling debt. Filed as #1453.

Closes #1451