### PR TITLE
docs(audit-tests): recover the extract_step_body family by shape rather than by name

### DIFF
--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -291,10 +291,15 @@ EOF
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -n "sed 's/^          //'" -- '*.bats'
+#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
 #
-# Of what that returns, the copies this one must agree with are those whose
-# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
+# extractor. A whole-block extractor stops at the same `- name:` boundary but
+# keeps the block undedented, so it answers to a different contract and is
+# deliberately out of the set; keying on the boundary would pull it in, and
+# keying on the dedent would drop a member that extracts the body without one.
+# Of what the grep returns, the copies this one must agree with are those whose
+# workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"

--- a/.github/audit/tests/ci-status-member-gate.bats
+++ b/.github/audit/tests/ci-status-member-gate.bats
@@ -291,13 +291,16 @@ EOF
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
+#   git grep -nF 'run: \|' -- '*.bats'
 #
 # Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
 # extractor. A whole-block extractor stops at the same `- name:` boundary but
 # keeps the block undedented, so it answers to a different contract and is
 # deliberately out of the set; keying on the boundary would pull it in, and
 # keying on the dedent would drop a member that extracts the body without one.
+# The detector is matched WITHOUT a trailing anchor, since a copy is free to
+# spell its own regex without one and still be bound by this agreement. The
+# backslash is what keeps fixture YAML out: fixtures spell `run: |` plain.
 # Of what the grep returns, the copies this one must agree with are those whose
 # workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.

--- a/.github/audit/tests/ci-workflow-self-mod.bats
+++ b/.github/audit/tests/ci-workflow-self-mod.bats
@@ -63,10 +63,15 @@ setup() {
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -n "sed 's/^          //'" -- '*.bats'
+#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
 #
-# Of what that returns, the copies this one must agree with are those whose
-# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
+# extractor. A whole-block extractor stops at the same `- name:` boundary but
+# keeps the block undedented, so it answers to a different contract and is
+# deliberately out of the set; keying on the boundary would pull it in, and
+# keying on the dedent would drop a member that extracts the body without one.
+# Of what the grep returns, the copies this one must agree with are those whose
+# workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"

--- a/.github/audit/tests/ci-workflow-self-mod.bats
+++ b/.github/audit/tests/ci-workflow-self-mod.bats
@@ -56,11 +56,18 @@ setup() {
 }
 
 # Extract one step's `run:` shell body from the workflow YAML and dedent it.
-# Matches the `- name:` line EXACTLY. Same shape as the helpers in
-# .github/audit/tests/self-heal-scope-gate.bats and
-# .github/audit/tests/ci-status-member-gate.bats; not sourced from either (bats
-# files do not share function definitions across files), so the three are kept
-# in agreement about what "extract the real step body" means by hand.
+# Matches the `- name:` line EXACTLY.
+#
+# Several other bats files carry a near-identical copy of this helper. None of
+# them share it (bats files do not define functions across files), so they are
+# kept in agreement about what "extract the real step body" means by hand.
+# Recover the live set rather than trusting a list written here, which decays:
+#
+#   git grep -n "sed 's/^          //'" -- '*.bats'
+#
+# Of what that returns, the copies this one must agree with are those whose
+# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '

--- a/.github/audit/tests/ci-workflow-self-mod.bats
+++ b/.github/audit/tests/ci-workflow-self-mod.bats
@@ -63,13 +63,16 @@ setup() {
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
+#   git grep -nF 'run: \|' -- '*.bats'
 #
 # Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
 # extractor. A whole-block extractor stops at the same `- name:` boundary but
 # keeps the block undedented, so it answers to a different contract and is
 # deliberately out of the set; keying on the boundary would pull it in, and
 # keying on the dedent would drop a member that extracts the body without one.
+# The detector is matched WITHOUT a trailing anchor, since a copy is free to
+# spell its own regex without one and still be bound by this agreement. The
+# backslash is what keeps fixture YAML out: fixtures spell `run: |` plain.
 # Of what the grep returns, the copies this one must agree with are those whose
 # workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.

--- a/.github/audit/tests/self-heal-scope-gate.bats
+++ b/.github/audit/tests/self-heal-scope-gate.bats
@@ -112,11 +112,18 @@ EOF
 }
 
 # Extract one step's `run:` shell body from the workflow YAML and dedent it.
-# Matches the `- name:` line EXACTLY. Same shape as the helpers in
-# .github/audit/tests/ci-status-member-gate.bats and
-# .github/audit/tests/ci-workflow-self-mod.bats; not sourced from either (bats
-# files do not share function definitions across files), so the three are kept
-# in agreement about what "extract the real step body" means by hand.
+# Matches the `- name:` line EXACTLY.
+#
+# Several other bats files carry a near-identical copy of this helper. None of
+# them share it (bats files do not define functions across files), so they are
+# kept in agreement about what "extract the real step body" means by hand.
+# Recover the live set rather than trusting a list written here, which decays:
+#
+#   git grep -n "sed 's/^          //'" -- '*.bats'
+#
+# Of what that returns, the copies this one must agree with are those whose
+# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"
   awk -v want="      - name: ${step_name}" '

--- a/.github/audit/tests/self-heal-scope-gate.bats
+++ b/.github/audit/tests/self-heal-scope-gate.bats
@@ -119,10 +119,15 @@ EOF
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -n "sed 's/^          //'" -- '*.bats'
+#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
 #
-# Of what that returns, the copies this one must agree with are those whose
-# $WORKFLOW is .github/workflows/code-review-audit.yml; a copy over a different
+# Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
+# extractor. A whole-block extractor stops at the same `- name:` boundary but
+# keeps the block undedented, so it answers to a different contract and is
+# deliberately out of the set; keying on the boundary would pull it in, and
+# keying on the dedent would drop a member that extracts the body without one.
+# Of what the grep returns, the copies this one must agree with are those whose
+# workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.
 extract_step_body() {
   local step_name="$1" out="$BATS_TEST_TMPDIR/step.sh"

--- a/.github/audit/tests/self-heal-scope-gate.bats
+++ b/.github/audit/tests/self-heal-scope-gate.bats
@@ -119,13 +119,16 @@ EOF
 # kept in agreement about what "extract the real step body" means by hand.
 # Recover the live set rather than trusting a list written here, which decays:
 #
-#   git grep -nF 'run: \|[[:space:]]*$' -- '*.bats'
+#   git grep -nF 'run: \|' -- '*.bats'
 #
 # Keyed on the `run: |` detector, because that is what makes a copy a step-BODY
 # extractor. A whole-block extractor stops at the same `- name:` boundary but
 # keeps the block undedented, so it answers to a different contract and is
 # deliberately out of the set; keying on the boundary would pull it in, and
 # keying on the dedent would drop a member that extracts the body without one.
+# The detector is matched WITHOUT a trailing anchor, since a copy is free to
+# spell its own regex without one and still be bound by this agreement. The
+# backslash is what keeps fixture YAML out: fixtures spell `run: |` plain.
 # Of what the grep returns, the copies this one must agree with are those whose
 # workflow is .github/workflows/code-review-audit.yml; a copy over a different
 # workflow answers to that workflow's shape and is free to diverge.


### PR DESCRIPTION
Closes #1453

## What

Two `extract_step_body` headers stated the family size by naming its members, and the roster was short one. `.github/audit/tests/ci-guard-paths.bats` defines `phase_step_body`, the same extraction over the same workflow under a different function name, so a name-keyed roster cannot see it. A maintainer changing what "extract the real step body" means and following either header updates three copies and leaves the fourth silently divergent.

## Why the miscount is not the defect

The headers restate a membership nothing recomputes. That is what regenerated: an earlier correction took the roster from one sibling to two, which is what wrote the current "three", and the correction did not survive the next reader.

## The change

The two headers, plus the `ci-status-member-gate.bats` copy they were modelled on, now carry a shape-keyed recovery recipe instead of a roster: a `git grep` for the `run: |` detector, plus the criterion naming which of its hits the copy must agree with. That recovers the live set on every read, so a copy added or renamed later is found without editing a comment.

All three copies of the comment block are byte-identical, which is the property the issue is about.

## The recipe key took three rounds to get right, and each round was a real finding

The key shipped in the first commit was wrong in exactly the way the issue describes, so the audit's findings on it are recorded here rather than summarized away.

| Key | Members recovered | Missed |
|---|---|---|
| dedent `sed 's/^          //'` | 4 | `debt-origin-contract.bats:501`, which extracts the body without dedenting |
| `run: \|[[:space:]]*$` | 5 | `cra-status-upsert.bats:156`, which spells the detector without a trailing anchor |
| `run: \|` (shipped) | 6 | none known |

The member's round-1 Suggestion proposed keying on the awk `- name:` boundary instead. Running it showed that over-recovers, pulling in `extract_step_block` copies and `ci-clean-no-push-status.bats`, whole-block extractors under a different contract, so the `run: |` detector was used instead as the term that actually discriminates.

## Accepted residual, filed as #1464

Three rounds of hand-verified greps each recovering one more member is evidence that a comment cannot check itself. The shipped key is correct against every live copy, but that correctness is a property of today's tree: a copy spelling the detector as `index($0, "run: |")` would be invisible to the recipe and to CI alike, with nothing going red.

The durable repair is a test that enumerates the step-body extractors over `code-review-audit.yml` and fails on an unregistered one. That is a different change from the two headers this issue asked for, and it has to settle the membership criterion the recipe has been repeatedly wrong about, so it is filed as #1464 rather than folded in. The disposition was written into `c465fb82`'s commit message before the round that could have triggered it, not after its findings were on the table.

The audit member reviewed that reasoning independently and agreed filing beats a fourth comment edit.

## Verification

- `git grep -nF 'run: \|' -- '*.bats'` resolves six members over `code-review-audit.yml` plus the one correct exclusion over `distribution-audit-pr.yml`
- bats under bash 5 across the touched suites: 128/128 pass
- `bash .gaia/tests/whole-tree-invariants.sh`: pass
- `bash .gaia/tests/shell-lint.sh`: pass
- Quality Gate: skipped by its own rule, no source file staged (comment-only change to three `.bats` files)
- Code Audit Team: `code-audit-maintainer-shell`, three rounds, clean pass with marker on each

No CHANGELOG entry: `.github/audit/tests/` is release-excluded, so nothing here reaches an adopter.