### PR TITLE
debt(audit-ci): stop hand-counting the suites that carry a require_yaml_parser gate

### DIFF
--- a/.gaia/tests/lib/audit-ci-shards.bats
+++ b/.gaia/tests/lib/audit-ci-shards.bats
@@ -508,6 +508,42 @@ with open(out, 'w', encoding='utf-8') as handle:
 PY
 }
 
+# The parser gate above is the single point where every parser-gated test in
+# this file, W10 among them, can be turned off at once, and nothing else here
+# would notice if it started skipping on CI: a lib leg that lost python3-yaml
+# would report `ok ... # skip` for each of them and green the job with the
+# shard-list invariant retired. This test is what makes that weakening red.
+# Same shape as the sibling gates' own proving tests in lint-yaml.bats,
+# workflow-filter-coverage.bats, retrigger-reachability.bats, and
+# block-invalid-yaml-write.bats. Not itself gated.
+
+@test "the parser gate fails on a CI runner and still skips off CI" {
+  local shim="$BATS_TEST_TMPDIR/no-parser" rc
+  mkdir -p "$shim"
+  # python3 present, but its `import yaml` fails: the shape a runner takes when
+  # python3-yaml is dropped from the apt line, not one where python3 is missing
+  # outright. The shebang is absolute so the stripped PATH below cannot affect it.
+  printf '#!/bin/sh\nexit 1\n' > "$shim/python3"
+  chmod +x "$shim/python3"
+
+  # Calling the gate in a subshell is what keeps its `skip` arm from marking this
+  # test skipped -- bats' `skip` exits 0, so the subshell's status is exactly the
+  # discriminator wanted here: non-zero is the CI failure, 0 is the off-CI skip.
+  rc=0
+  ( PATH="$shim" GITHUB_ACTIONS=true; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "the gate skipped on a CI runner with no YAML parser; every parser-gated test here would report green" >&2
+    return 1
+  }
+
+  rc=0
+  ( PATH="$shim"; unset GITHUB_ACTIONS; require_yaml_parser ) >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "the gate failed off CI, where a missing parser must still skip" >&2
+    return 1
+  }
+}
+
 # W1. Exactly one job carries the required context name, byte-exact at four
 # spaces -- the literal shape retrigger-reachability.bats' workflow_for_context
 # resolves the context by.

--- a/.github/workflows/audit-ci-tests.yml
+++ b/.github/workflows/audit-ci-tests.yml
@@ -587,15 +587,15 @@ jobs:
               - '**/*.yml'
               - '**/*.yaml'
       # python3-yaml pins the parser (python3+pyyaml) that every
-      # `require_yaml_parser` gate on this runner needs. Three suites carry one:
-      # block-invalid-yaml-write.bats, whose gate sits in setup() and so covers
-      # all of its tests with no fallback; retrigger-reachability.bats, which
-      # gates 15 of its tests behind it, also with no fallback; and
-      # lint-yaml.bats, whose gate also accepts `yq`, so on a runner carrying yq
-      # that suite still parses. All three FAIL rather than `skip` when
-      # GITHUB_ACTIONS is set, precisely so dropping this package reds the run
-      # here instead of retiring the whole self-heal reachability invariant, and
-      # the YAML-write hook's coverage, behind `ok ... # skip`. Those gates are
+      # `require_yaml_parser` gate on this runner needs. How many suites carry
+      # one is deliberately not written down here: a hand-kept count drifts as
+      # suites are added, and W10 below already derives the live set from the
+      # suites themselves via `shard_package_needs`. Every such gate FAILs
+      # rather than `skip`s when GITHUB_ACTIONS is set, precisely so dropping
+      # this package reds the run here instead of retiring the invariants
+      # behind it, the self-heal reachability one and the YAML-write hook's
+      # coverage among them, behind `ok ... # skip`. A gate that accepts `yq`
+      # as a second parser reds only when neither is present. Those gates are
       # what enforce this line; this comment only explains it. Pin the package
       # here rather than resting on whatever the runner image happens to
       # preinstall.


### PR DESCRIPTION
The comment above the `python3-yaml` apt step in `.github/workflows/audit-ci-tests.yml` claimed "Three suites carry one" and enumerated three `.bats` files. Five suites actually define or invoke a `require_yaml_parser` gate: those three plus `.gaia/scripts/tests/workflow-filter-coverage.bats` (leg `scripts-3`) and `.gaia/tests/lib/audit-ci-shards.bats` (leg `lib`). A maintainer weighing whether the package is still worth installing undercounted the blast radius by two suites and two legs.

Not live-breaking: W10 recomputes the leg list from the suites and reds on a wrong list regardless of what the prose claims, so the damage was to the reader.

## What changed

**The comment.** Dropped the count and the enumeration rather than restating them at five. A hand-kept count with nothing checking it is the thing that drifted; W10 already derives the live set from the suites themselves via `shard_package_needs`, so the comment now points at that derivation. What the code cannot say is kept: why every such gate FAILs rather than `skip`s under `GITHUB_ACTIONS`, and that a gate accepting `yq` as a second parser reds only when neither is present.

**The fifth gate's proving test.** The reworded comment speaks for all five gates, and four of them back that claim with a `the parser gate fails on a CI runner and still skips off CI` test. `.gaia/tests/lib/audit-ci-shards.bats` had none, so weakening its CI branch to a plain `skip` red nothing: a `lib` leg that lost `python3-yaml` would report `ok ... # skip` for W10 and every other parser-gated test there and green the job with the shard-list invariant retired. Added that test, mirroring `workflow-filter-coverage.bats`, whose gate this one already matches shape for shape. Surfaced by the `code-audit-github-workflows` gate round and repaired in scope: the claim is one this change extends over that gate, so it is not untouched-sibling debt.

## Verification

- `grep -rlE 'require_yaml_parser' --include='*.bats' .gaia` hits six files; `distribution-audit-pr-gate.bats` names the helper only inside a comment, the other five define or invoke the gate.
- No test parses the workflow comment's prose, so that edit is inert to the suites.
- The new test was proved able to fail in both directions: weakening the gate's CI arm to a plain `skip` reds it, and making its off-CI arm return non-zero instead of skipping reds it. Tree restored clean after each.
- Green: `audit-ci-shards.bats` (33 tests, W10 included), `workflow-filter-coverage.bats`, `retrigger-reachability.bats`, `region-marker-conformance.bats`, `.gaia/tests/whole-tree-invariants.sh`, `.gaia/tests/shell-lint.sh`.
- Quality Gate skipped by its own rule: no staged source or gate-affecting config file.
- CHANGELOG: no entry owed. Both touched files are release-excluded and absent from the manifest, so nothing adopter-visible changed.

Closes #1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)