### PR TITLE
debt(forensics-tests): make three absence assertions fail independent of position

### DIFF
--- a/.github/forensics/tests/handlers.bats
+++ b/.github/forensics/tests/handlers.bats
@@ -276,7 +276,8 @@ first_captured_body() {
   grep -qF 'reason: `fix-abort`' "$body_path"
   grep -qF 'GAIA-FIX-ABORT' "$body_path"
   # Must NOT be mislabeled as a scope violation (the pre-CMP-3 bug).
-  ! grep -qF 'outside the auto-fix allowlist' "$body_path"
+  grep -qF 'outside the auto-fix allowlist' "$body_path" && return 1
+  true
 }
 
 @test "needs-human: comment names the reason-code no-change (CMP-3)" {
@@ -288,7 +289,8 @@ first_captured_body() {
   grep -qF 'reason: `no-change`' "$body_path"
   grep -qF 'produced no diff' "$body_path"
   # Must NOT be mislabeled as a scope violation (the pre-CMP-3 bug).
-  ! grep -qF 'outside the auto-fix allowlist' "$body_path"
+  grep -qF 'outside the auto-fix allowlist' "$body_path" && return 1
+  true
 }
 
 @test "needs-human: gaia-triaged is the LAST mutation" {
@@ -437,7 +439,8 @@ first_captured_body() {
   grep -qF 'missing-section' "$body_path"
   # User-facing comment must not surface internal UAT identifiers, they
   # rot as UATs are renumbered and confuse adopters who file issues by hand.
-  ! grep -qE 'UAT-[0-9]+' "$body_path"
+  grep -qE 'UAT-[0-9]+' "$body_path" && return 1
+  true
 }
 
 @test "malformed-body: comment names malformed sections from parser output" {


### PR DESCRIPTION
Closes #1501

## What

Three assertions in `.github/forensics/tests/handlers.bats` (`:279`, `:291`, `:440`) were written as a bare `!`-negated `grep`. POSIX `set -e` exempts a `!`-inverted exit status from the abort, and bats runs each `@test` body under `set -e`, so an assertion of that shape is only live while it is the test's final command.

All three genuinely were final, so all three were live. The issue states this honestly and so does this PR: there is no correctness bug being fixed here. What it cost was future-proofing. Any edit appending a line after one of them silently converts a live assertion into a no-op, with no test failure to announce it.

## How

Each is rewritten as the positive match the bad case would satisfy, ending the branch with an explicit `return 1`, and the test closes with `true` so an absent needle does not leave `grep`'s own non-zero status as the test's return value.

This is the form `.claude/rules/bats-assertions.md` prescribes for exactly this class, including the trailing-`true` rule for the final-statement case, and it is the idiom the sibling `.github/audit/tests/` and `.github/forensics/tests/render-prompt.bats` suites already use at roughly two dozen sites. It is not the literal `run grep` + `[ "$status" -ne 0 ]` the issue suggested: that form works too, but it clobbers `$status` mid-test and is not what the repo's own path-scoped rule prescribes.

## Verification

- `.github/forensics/tests/` under bash 5 via `.gaia/scripts/bats5.sh`: 176/176 pass, exit 0.
- `bash .gaia/tests/whole-tree-invariants.sh`: exit 0 (shell-lint included).
- `shellcheck -S style` on the file: SC2314 x3 before, zero after. Only the pre-existing structural SC2016 (info-tier, below the gate's bats `warning` floor) remains.
- Quality Gate: skipped on a positive answer. No staged file matches the source or gate-affecting-config globs.

Adversarial fixtures, built as temporary copies of the suite and removed after, proving the assertions can fail rather than assuming it:

| Fixture | Expected | Result |
| --- | --- | --- |
| New form + forbidden string injected into the captured body | fail | 3 tests fail |
| **Old** `!` form + injection + one statement appended after the assertion | fail | **39/39 pass**, the latent defect reproduced |
| New form + injection + one statement appended after the assertion | fail | 3 tests fail |

Row 2 is the point of the change: it is the exact future edit that would have hollowed the assertions, and it demonstrates the old form greening on a bad case. Row 3 shows the new form is position-independent.

## Notes, not changed here

- The issue's secondary claim that these three lines "keep a standing shellcheck exclusion alive" does not hold as written. There is no SC2314 exclusion. SC2314 is a `style`-tier code and `.gaia/tests/shell-lint.sh` lints `*.bats` at the `warning` floor, so it never fired on these lines. The header comment in `shell-lint.sh` lists SC2314 among the codes its `warning` floor catches, which is inaccurate for the same reason. Out of scope for this issue and left alone.
- `.github/forensics/tests/run-quality-gate.bats:243` carries a fourth instance of the same shape. Out of scope (different file, and the issue scopes to `handlers.bats`), so it is named rather than fixed.

No CHANGELOG entry: the suite is maintainer-only and release-excluded, the change adds no mechanism and alters no behavior, matching the practice of the comparable recent debt PRs (#1503, #1497, #1496, #1495).