### PR TITLE
debt(audit-base): record why the member reset's trigger is the whole definition file

### DIFF
--- a/.github/audit/resolve-audit-base.sh
+++ b/.github/audit/resolve-audit-base.sh
@@ -622,17 +622,18 @@ if [ -n "$reset_hit" ]; then
   IFS="$TAB" read -r reset_tier reset_path <<<"$reset_hit"
   # The member tier's trigger is the whole file: any change to
   # .claude/agents/<member>.md re-arms this reset, a reworded sentence as
-  # readily as a rewritten remit, and the member then re-reads its entire
-  # owned surface instead of one commit's delta. That breadth is chosen, and
-  # it is the expensive choice: a round of prose repairs spanning several
-  # definitions pays a full re-review for every member it touches.
+  # readily as a rewritten remit, and the member then re-reviews the whole
+  # pull request's diff against its remit instead of the delta since its
+  # anchor. That breadth is chosen, and it is the expensive choice: a round of
+  # prose repairs spanning several definitions pays that widened re-review for
+  # every member it touches.
   #
   # It is chosen because a member definition is an instruction file, where the
   # prose IS the logic and no syntactic split separates a comment-only edit
   # from a behavior-changing one. "Prefer" becoming "always" inside a remit
   # rewrites what the member looks for, and only the surrounding sentence says
-  # so. Two narrowings look attractive and neither survives. Resetting only
-  # outside regions marked non-normative has no region to key on: the
+  # so. The narrowings that look attractive fail on their own terms. Resetting
+  # only outside regions marked non-normative has no region to key on: the
   # gaia:maintainer-only markers mark AUDIENCE, a maintainer-only paragraph
   # still instructs, and most member definitions carry no marker at all, so a
   # new convention would rest the reset on whoever remembered to mark a

--- a/.github/audit/resolve-audit-base.sh
+++ b/.github/audit/resolve-audit-base.sh
@@ -620,6 +620,36 @@ if [ -n "$reset_hit" ]; then
   reset_tier=""
   reset_path=""
   IFS="$TAB" read -r reset_tier reset_path <<<"$reset_hit"
+  # The member tier's trigger is the whole file: any change to
+  # .claude/agents/<member>.md re-arms this reset, a reworded sentence as
+  # readily as a rewritten remit, and the member then re-reads its entire
+  # owned surface instead of one commit's delta. That breadth is chosen, and
+  # it is the expensive choice: a round of prose repairs spanning several
+  # definitions pays a full re-review for every member it touches.
+  #
+  # It is chosen because a member definition is an instruction file, where the
+  # prose IS the logic and no syntactic split separates a comment-only edit
+  # from a behavior-changing one. "Prefer" becoming "always" inside a remit
+  # rewrites what the member looks for, and only the surrounding sentence says
+  # so. Two narrowings look attractive and neither survives. Resetting only
+  # outside regions marked non-normative has no region to key on: the
+  # gaia:maintainer-only markers mark AUDIENCE, a maintainer-only paragraph
+  # still instructs, and most member definitions carry no marker at all, so a
+  # new convention would rest the reset on whoever remembered to mark a
+  # region. Exempting a member's own round-trip repair is backwards, because
+  # the member reviewed under the OLD definition and its correction is what
+  # changes the instructions it runs under next.
+  #
+  # The direction of the miss settles it. Resetting too often costs tokens and
+  # wall-clock, and both are visible in the run that pays them. Resetting too
+  # rarely lets a member earn a clearance marker over a surface narrower than
+  # its changed instructions warrant, and the merge gate believes the marker
+  # rather than re-deriving the scope behind it, so nothing downstream catches
+  # that one.
+  #
+  # What stays open is the number of resets rather than the trigger: batching
+  # a round's definition repairs into one commit pays one reset, not one per
+  # commit.
   if [ "$reset_tier" = "member" ]; then
     echo "resolve-audit-base: ${member}'s own agent definition changed between ${winner} and HEAD (${reset_path}); resetting to full scope (${main_ref})." >&2
     emit "$main_ref" rules-reset-member ""


### PR DESCRIPTION
Closes #1420

## What this settles

`rules-reset-member` resets a member's review base to `$main_ref` whenever that member's own agent definition changed between the anchor and HEAD. The trigger is a whole-file exact path match (`audit_path_is_member_rule`), so a one-word prose correction re-arms it as readily as a rewritten remit, and the member re-reads its entire owned surface instead of one commit's delta.

The issue asks whether that breadth should be the trigger, and names "no change, cost accepted" as a legitimate resolution. **The resolution is no change**, recorded at the reset site so the next reader knows the breadth is chosen rather than incidental.

## Why no change

A member definition is an instruction file, where the prose *is* the logic. No syntactic split separates a comment-only edit from a behavior-changing one, so both candidate narrowings fail on their own terms:

- **Reset only outside regions marked non-normative.** There is no region to key on. The `gaia:maintainer-only` markers mark *audience*, not normativity, and a maintainer-only paragraph still instructs. The convention is not even universal: only 2 of the 5 member definitions carry a marker at all. A new convention would rest the reset's correctness on whoever remembered to mark a region, and a mis-mark fails green.
- **Exempt a member's own round-trip repair.** Backwards. The member reviewed under the *old* definition, and its correction is what changes the instructions it runs under next.

The direction of the miss settles it. Resetting too often costs tokens and wall-clock, both visible in the run that pays them. Resetting too rarely lets a member earn a clearance marker over a surface narrower than its changed instructions warrant, and the merge gate believes the marker rather than re-deriving the scope behind it, so nothing downstream catches that one. The third candidate is the one that stays open, and it is a count lever rather than a trigger change: batching a round's definition repairs into one commit pays one reset instead of one per commit.

## Verification notes

- The issue cites `resolve-audit-base.sh:597`. That line is now blank: #1440 (which closed #1057) landed in the same file on 2026-08-16 and shifted the `rules-reset-member` arm to line 624. The cited construct is byte-identical, so the premise is intact; the comment lands at the relocated arm.
- The body's "Verified by" says commits `20756c33` and `1a0176e3` were both prose edits to member definitions. `1a0176e3` is exactly that (one line across all five definitions). `20756c33` touched a `.bats` file, which `audit_path_is_global_rule` excludes unconditionally, so it forced no reset of its own. The observation still holds, because the anchor-to-HEAD delta spanning both commits carries `1a0176e3`.

## Checks

Comment-only `.sh` change, so the Quality Gate's staged-source check returns empty and the gate skips. Shell-side verification run instead, all green:

- `.gaia/tests/shell-lint.sh` -- passed (the one shellcheck SC1090 is pre-existing at line 452, untouched)
- `bash -n` -- clean
- bats under bash 5: `resolve-audit-base.bats`, `check-audit-base-derivation.bats`, `audit-base-agreement.bats`, `audit-rules-changed-lib.bats` -- 150 tests, 0 failures
- `.gaia/scripts/lint-shipped-issue-refs.sh` -- clean
- `.gaia/tests/whole-tree-invariants.sh` -- all invariants pass

No CHANGELOG entry: no adopter-observable behavior changes.

## Audit round 1

`code-audit-maintainer-shell` cleared the diff and raised one Suggestion, applied in `742240b0`:

The comment described a reset as making the member "re-read its entire owned surface instead of one commit's delta". Both halves overstate. The member arm emits `$main_ref`, so a reset scopes the review to `merge-base(origin/main, HEAD)...HEAD` filtered to the member's remit -- the whole PR's diff, not everything the member owns -- and the non-reset scope is the delta since the member's anchor, which can span several commits. Verified independently against `code-audit-maintainer-shell.md:96-110`, where `changed` is `git diff --name-only "${BASE_SHA}...HEAD"`.

Folded into the same commit: the "two narrowings" count was rephrased so the sentence does not go stale if a third candidate is ever weighed. The digest was rotating for the Suggestion anyway, so the de-staling rode a re-dispatch already being paid for.
