### PR TITLE
debt(capability-oracle): record why bash 3.2 loses reach, and why the guard is the repair

### DIFF
--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -13,23 +13,25 @@
 # else, beyond the bash-version refusal below.
 #
 # Needs bash 5. On bash 3.2 the scan over a file's logical lines does not end
-# early, it dies: the process segfaults on the child side of a fork, before
-# exec, inside the system notify library's atfork handler, and takes every
-# record past that point with it. It exits 133 and prints nothing, and a
-# consumer reading the walk over a pipe or a process substitution sees an
+# early, it dies, and takes every record past that point with it. The process
+# takes SIGTRAP on the child side of a fork before exec, exiting 133, and the
+# allocator names the cause itself: `BUG IN CLIENT OF LIBMALLOC: memory
+# corruption of free block`, raised out of realloc. It prints nothing on stderr,
+# and a consumer reading the walk over a pipe or a process substitution sees an
 # ordinary end of input, so reach comes back under-reported rather than
-# over-reported. That is the direction that cannot surface as a finding, so
-# this refuses instead of answering.
+# over-reported. That is the direction that cannot surface as a finding, so this
+# refuses instead of answering. The same workload also presents as a plain
+# segmentation fault with a different stack, which is what a corrupted heap does
+# rather than a second defect.
 #
 # The dependency is on a bash that does not crash, and no restructuring here
 # removes it. Reading the outer input through an explicit descriptor and
 # buffering it ahead of the loop each leave the walk short by the same record,
 # and no single detector triggers it either: the write scan and the invocation
 # scan are clean alone and crash only together. The crash point also moves with
-# edits to the loop body that cannot affect it causally, which is the signature
-# of heap corruption rather than of a descriptor this code owns. The version
-# guard is the repair; a change that appears to fix the crash has only
-# perturbed the allocation pattern, and the next unrelated edit re-rolls it.
+# edits to the loop body that cannot affect it causally. The version guard is
+# the repair; a change that appears to fix the crash has only perturbed the
+# allocation pattern, and the next unrelated edit re-rolls it.
 #
 # Measure any such attempt end to end, through the check's own --print-reach
 # over the live working checkout, and compare the bash 3.2 output against the

--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -23,13 +23,21 @@
 #
 # The dependency is on a bash that does not crash, and no restructuring here
 # removes it. Reading the outer input through an explicit descriptor and
-# buffering it ahead of the loop both leave the crash where it was, and no
-# single detector triggers it: the write scan and the invocation scan are each
-# clean alone and crash only together. The crash point also moves with edits to
-# the loop body that cannot affect it causally, which is the signature of heap
-# corruption rather than of a descriptor this code owns. The version guard is
-# the repair; a code change that appears to fix it has only perturbed the
-# allocation pattern, and the next unrelated edit re-rolls it.
+# buffering it ahead of the loop each leave the walk short by the same record,
+# and no single detector triggers it either: the write scan and the invocation
+# scan are clean alone and crash only together. The crash point also moves with
+# edits to the loop body that cannot affect it causally, which is the signature
+# of heap corruption rather than of a descriptor this code owns. The version
+# guard is the repair; a change that appears to fix the crash has only
+# perturbed the allocation pattern, and the next unrelated edit re-rolls it.
+#
+# Measure any such attempt end to end, through the check's own --print-reach
+# over the live working checkout, and compare the bash 3.2 output against the
+# bash 5 output. Two narrower controls both report success against a walk that
+# still loses the record: calling _gaia_capcheck_file_sites directly rather
+# than through the closure that normally consumes it, and walking an extraction
+# rather than a checkout, since an extraction carries no untracked or ignored
+# paths and so is not the tree that fails.
 #
 # A library cannot re-exec on its own behalf, so each executable entry point
 # carries its own discovery-and-re-exec block ahead of sourcing this file and

--- a/.gaia/scripts/capability-oracle-lib.sh
+++ b/.gaia/scripts/capability-oracle-lib.sh
@@ -12,15 +12,29 @@
 # declaration agree". Sourcing this file defines its functions and does nothing
 # else, beyond the bash-version refusal below.
 #
-# Needs bash 5. On bash 3.2 the scan loop over a file's logical lines ends
-# early, because an inner process substitution in the loop body consumes the
-# outer one's descriptor, so every record past that point is lost and reach is
-# under-reported rather than over-reported. That is the direction that cannot
-# surface as a finding, so this refuses instead of answering. A library cannot
-# re-exec on its own behalf, so each executable entry point carries its own
-# discovery-and-re-exec block ahead of sourcing this file and never reaches
-# here; this is the backstop that gives a future consumer the refusal without
-# it having to remember the guard.
+# Needs bash 5. On bash 3.2 the scan over a file's logical lines does not end
+# early, it dies: the process segfaults on the child side of a fork, before
+# exec, inside the system notify library's atfork handler, and takes every
+# record past that point with it. It exits 133 and prints nothing, and a
+# consumer reading the walk over a pipe or a process substitution sees an
+# ordinary end of input, so reach comes back under-reported rather than
+# over-reported. That is the direction that cannot surface as a finding, so
+# this refuses instead of answering.
+#
+# The dependency is on a bash that does not crash, and no restructuring here
+# removes it. Reading the outer input through an explicit descriptor and
+# buffering it ahead of the loop both leave the crash where it was, and no
+# single detector triggers it: the write scan and the invocation scan are each
+# clean alone and crash only together. The crash point also moves with edits to
+# the loop body that cannot affect it causally, which is the signature of heap
+# corruption rather than of a descriptor this code owns. The version guard is
+# the repair; a code change that appears to fix it has only perturbed the
+# allocation pattern, and the next unrelated edit re-rolls it.
+#
+# A library cannot re-exec on its own behalf, so each executable entry point
+# carries its own discovery-and-re-exec block ahead of sourcing this file and
+# never reaches here; this is the backstop that gives a future consumer the
+# refusal without it having to remember the guard.
 #
 # Every detector here is deliberately incomplete in one direction and says so in
 # its own header. The oracle is lexical: it does not evaluate, it does not model
@@ -31,7 +45,8 @@
 
 if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
   printf 'capability-oracle-lib: requires bash >= 5, found %s\n' "${BASH_VERSION}" >&2
-  printf '  the scan loop ends early there, so reach is under-reported.\n' >&2
+  printf '  bash 3.2 crashes partway through the walk, so reach is\n' >&2
+  printf '  under-reported.\n' >&2
   exit 2
 fi
 

--- a/.gaia/scripts/check-script-capabilities.sh
+++ b/.gaia/scripts/check-script-capabilities.sh
@@ -50,12 +50,14 @@
 # Exit 0 clean, 1 on at least one finding, 2 on the check's own failure.
 
 # Needs bash 5, for the reason capability-oracle-lib.sh's own guard states: on
-# bash 3.2 the oracle's scan loop ends early inside a file and the records past
-# that point are lost, which under-reports reach. Re-exec under a Homebrew bash
-# 5 when there is one, the way .gaia/scripts/bats5.sh discovers it, and refuse
-# rather than answer wrongly when there is not. This runs BEFORE the lib is
-# sourced, so the entry point gets its re-exec instead of the lib's bare
-# refusal; only a consumer with no guard of its own falls through to that.
+# bash 3.2 the oracle crashes partway through a file's walk and the records past
+# that point are lost, which under-reports reach. The lib's header carries the
+# crash's shape and why no restructuring there removes the dependency. Re-exec
+# under a Homebrew bash 5 when there is one, the way .gaia/scripts/bats5.sh
+# discovers it, and refuse rather than answer wrongly when there is not. This
+# runs BEFORE the lib is sourced, so the entry point gets its re-exec instead of
+# the lib's bare refusal; only a consumer with no guard of its own falls
+# through to that.
 if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
   # Recorded only once the version probe passes, never read off the loop
   # variable: that keeps whatever path was tried last, so a candidate that
@@ -70,8 +72,8 @@ if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
     break
   done
   printf 'check-script-capabilities: requires bash >= 5, found %s\n' "${BASH_VERSION}" >&2
-  printf '  bash 3.2 ends the oracle scan early inside a file, so reach past\n' >&2
-  printf '  that point is lost.\n' >&2
+  printf '  bash 3.2 crashes partway through the walk of a file, so reach\n' >&2
+  printf '  past that point is lost.\n' >&2
   if [ -n "$_gaia_capcheck_bash5_found" ]; then
     printf '  %s is a bash 5. The re-exec is only available when this file is\n' "$_gaia_capcheck_bash5_found" >&2
     printf '  run, not sourced, so run it through that bash instead.\n' >&2

--- a/.gaia/scripts/tests/capability-oracle-termination.bats
+++ b/.gaia/scripts/tests/capability-oracle-termination.bats
@@ -769,12 +769,15 @@ EOF
 # ========== The bash-version backstop ==========
 #
 # Lexical, not behavioural: the runners are bash 5, so there is no bash 3.2 to
-# drive the refusal on. Under 3.2 the scan loop ends early inside a file and
-# under-reports reach, which is the direction that cannot surface as a finding,
-# so each executable entry point re-execs under a bash 5 and this library
-# refuses outright for any consumer that sources it without a guard of its own.
-# That refusal is the only structural defence a future consumer inherits, and
-# deleting it leaves every other test in the tree green, so it is pinned here.
+# drive the refusal on. Under 3.2 the oracle crashes partway through the walk of
+# a file and under-reports reach, which is the direction that cannot surface as
+# a finding, so each executable entry point re-execs under a bash 5 and this
+# library refuses outright for any consumer that sources it without a guard of
+# its own. The guard is the repair rather than a stopgap, because the crash is
+# not something the oracle's own structure can avoid; capability-oracle-lib.sh's
+# header carries that reasoning and the controls behind it. That refusal is the
+# only structural defence a future consumer inherits, and deleting it leaves
+# every other test in the tree green, so it is pinned here.
 
 @test "backstop: the oracle refuses to be sourced under a bash older than 5" {
   grep -qE -- '^if \[ "\$\{BASH_VERSINFO\[0\]\}" -lt 5 \]; then' "$ORACLE"


### PR DESCRIPTION
Closes #1529

## What the issue asked for, and what the investigation found

#1529 asks to find why the oracle's scan loop terminates early under bash 3.2 and remove the dependency rather than widen the guard, on the hypothesis that an inner process substitution in the loop body consumes the outer one's descriptor.

The loop does not terminate early. The process **crashes**, and the allocator names the cause itself.

Under `/bin/bash` 3.2.57 (arm64), the subshell running `_gaia_capcheck_file_sites` dies with `SIGTRAP`, exit status **133**, on the child side of a `fork()` before `exec`:

```
exception:  EXC_BREAKPOINT (SIGTRAP)
asi:        libsystem_malloc.dylib: "BUG IN CLIENT OF LIBMALLOC:
                                     memory corruption of free block"
            libsystem_c.dylib:      "crashed on child side of fork pre-exec"
frames:     _xzm_xzone_malloc_freelist_outlined -> xzm_realloc
            -> malloc_type_realloc -> bash
```

It prints nothing on stderr. A consumer reading the walk over a pipe or a process substitution sees an ordinary end of input, which is exactly why the loss reads as a short answer instead of a failure, and why it lands in the one direction that can never surface as a finding. The same workload also presents as a plain segmentation fault with a different stack, which is what a corrupted heap does rather than a second defect.

## The issue's premise re-verified first

The cited location and failure both hold. `.gaia/scripts/capability-oracle-lib.sh:1131` is the inner `< <(...)` inside the outer scan loop, as described. Against the live working checkout, with the version guard stripped:

| | records | lost |
|---|---|---|
| `/bin/bash` (3.2) | 43 | `invokes:.claude/hooks/post-audit-status.sh` |
| `bash` (5.3) | 44 | |

Deterministic across 10 runs, and in a minimal environment. `_gaia_capcheck_file_sites` on `.gaia/scripts/audit-write-clearance.sh` stops after line 409 and loses the `CALL` edge at `:626`, precisely the record the issue names. (The absolute totals are 43/44 rather than the issue's 41/42 because the tree has moved since filing; the one-record split and the named lost edge re-derive exactly.)

## Why no repair belongs in this code

Both repairs the issue suggests were built and measured **end to end**, through `--print-reach` over the live working checkout:

| variant | bash 3.2 | bash 5 | lost record |
|---|---|---|---|
| unchanged | 43 | 44 | `post-audit-status.sh` edge |
| buffer the logical lines ahead of the loop | 43 | 44 | same |
| read the outer input through an explicit descriptor (`exec 9< <(…)`) | 43 | 44 | same |

Neither moves the failure. Two further controls place it outside anything this code can restructure:

- **No single detector triggers it.** The write scan alone is clean. The invocation scan alone is clean. Together they crash. There is no call to avoid.
- **The crash point moves with edits that cannot affect it causally** — skipping one unrelated detector flips a crashing run into a clean one and back.

Heap corruption in the shell, surfacing at the next allocation, is not a descriptor this file owns. The dependency is on a bash that does not crash, and it cannot be restructured away from this side.

### The control that lies

Worth calling out, because it is the natural first probe and it reports success. Calling `_gaia_capcheck_file_sites` **directly**, rather than through the closure that normally consumes it, makes the explicit-descriptor variant walk the whole file cleanly under bash 3.2 — 12 records, deterministic. Measured end to end, the same variant still loses the identical record. This is the same shape of trap the issue already documents for `git archive` extractions, in a new place, so the header now names both and states what the honest measurement is.

## What this PR changes

Prose only, at the four sites that record the mechanism:

- `.gaia/scripts/capability-oracle-lib.sh` — header now carries the crash's actual signature, the controls behind it, the conclusion that the version guard **is** the repair rather than a stopgap, and the two narrow controls that report a false success.
- `.gaia/scripts/check-script-capabilities.sh` — guard comment and refusal message likewise, pointing at the lib header for the reasoning.
- `.gaia/scripts/tests/capability-oracle-termination.bats` — the backstop section header states why deleting the guard is not something a future fix unlocks.

`.gaia/scripts/check-hook-capabilities.sh` is deliberately untouched: its guard comment describes the symptom ("loses whole files' records") and asserts no mechanism, so it is not wrong.

The value here is that the finding has already been mis-attributed twice by independent controls, per the issue's own account, and a third attempt has a control waiting that will tell it the fix worked. Leaving three shipped sites pointing at a descriptor bug that does not exist invites exactly that, and the most likely outcome is deleting the guard on the strength of a run that happened not to crash.

## Verification

- `.gaia/scripts/tests/capability-oracle-termination.bats` — 53/53
- `.gaia/scripts/tests/check-script-capabilities.bats` — 60/60, including the byte-identical `--print-reach` regression pin, which confirms computed reach does not move
- `.gaia/scripts/tests/check-hook-capabilities.bats` — 40/40
- `bash .gaia/tests/whole-tree-invariants.sh` — pass
- `bash .gaia/tests/shell-lint.sh` — pass
- `shellcheck -x` on both changed shell files — clean
- `check-script-capabilities.sh` under bash 5 — exit 0, clean
- Both reworded refusal messages rendered under bash 3.2

**Audit:** first round passed clean with one Suggestion (the header had fused two crash signatures, pairing the segmentation fault's mechanism with the `SIGTRAP` exit status). Confirmed against fresh crash reports and applied in `36b6ab97`; the corrected paragraph leads with libmalloc's own diagnosis, which is stronger evidence for the heap-corruption reading than the circumstantial argument beneath it.

**CHANGELOG:** no `## [Unreleased]` entry. No behavior changes, no adopter action, no migration; the only adopter-visible surface is a reworded refusal message on an unguarded local run.

**Quality Gate:** skipped on a positive answer — no staged `.ts|tsx|js|jsx|mjs|cjs|css` or gate-affecting config.